### PR TITLE
Store selected theme in local storage

### DIFF
--- a/src/app/layout/theme/theme.service.ts
+++ b/src/app/layout/theme/theme.service.ts
@@ -8,10 +8,16 @@ export class ThemeService {
     const platformId = inject(PLATFORM_ID);
 
     if (isPlatformBrowser(platformId)) {
+      const stored = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const dark = stored ? stored === 'dark' : prefersDark;
+      isDarkTheme.set(dark);
+
       effect(() => {
         const classList = document.documentElement.classList;
         classList.toggle('dark-theme', isDarkTheme());
         classList.toggle('light-theme', !isDarkTheme());
+        localStorage.setItem('theme', isDarkTheme() ? 'dark' : 'light');
       });
     }
   }

--- a/src/app/layout/theme/theme.spec.ts
+++ b/src/app/layout/theme/theme.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Theme } from './theme-toggle.component.ts';
+import { ThemeService } from './theme.service';
 
-describe('Theme', () => {
-  let service: Theme;
+describe('ThemeService', () => {
+  let service: ThemeService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(Theme);
+    service = TestBed.inject(ThemeService);
   });
 
   it('should be created', () => {


### PR DESCRIPTION
## Summary
- persist theme preference in browser local storage
- update the theme spec to test `ThemeService`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528826fc60832aa9b792ac8f8111e3