### PR TITLE
Add Schlagedex management

### DIFF
--- a/src/app/core/game.spec.ts
+++ b/src/app/core/game.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Game } from './game-state.service';
+import { GameStateService } from './game-state.service';
 
-describe('Game', () => {
-  let service: Game;
+describe('GameStateService', () => {
+  let service: GameStateService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(Game);
+    service = TestBed.inject(GameStateService);
   });
 
   it('should be created', () => {

--- a/src/app/features/shlagemon/choice-dialog/choice-dialog.ts
+++ b/src/app/features/shlagemon/choice-dialog/choice-dialog.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { DialogBox } from '../../dialog/dialog-box/dialog-box';
 import { DialogNode } from '../../dialog/dialog.model';
 import { GameStateService } from '../../../core/game-state.service';
+import { SchlagedexService } from '../schlagedex.service';
 
 @Component({
   selector: 'app-choice-dialog',
@@ -11,7 +12,7 @@ import { GameStateService } from '../../../core/game-state.service';
 })
 export class ChoiceDialog {
 
-  constructor(private gameState: GameStateService) { }
+  constructor(private gameState: GameStateService, private dex: SchlagedexService) { }
 
   dialogTree: DialogNode[] = [
     {
@@ -28,7 +29,10 @@ export class ChoiceDialog {
       responses: [
         {
           label: 'Merci professeur Merdant',
-          action: () => this.gameState.setHasPokemon(true)
+          action: () => {
+            this.dex.createShlagemon('Schlartichaut');
+            this.gameState.setHasPokemon(true);
+          }
         }
       ]
     },
@@ -38,7 +42,10 @@ export class ChoiceDialog {
       responses: [
         {
           label: 'Génial !',
-          action: () => this.gameState.setHasPokemon(true)
+          action: () => {
+            this.dex.createShlagemon('Draschlakofeu');
+            this.gameState.setHasPokemon(true);
+          }
         }
       ]
     }

--- a/src/app/features/shlagemon/schlagedex.service.spec.ts
+++ b/src/app/features/shlagemon/schlagedex.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { SchlagedexService } from './schlagedex.service';
+
+describe('SchlagedexService', () => {
+  let service: SchlagedexService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SchlagedexService);
+  });
+
+  it('should create and store a shlagemon', () => {
+    service.createShlagemon('Schlartichaut');
+    const mons = service.getShlagemons();
+    expect(mons.length).toBe(1);
+    expect(mons[0].name).toBe('Schlartichaut');
+  });
+});

--- a/src/app/features/shlagemon/schlagedex.service.ts
+++ b/src/app/features/shlagemon/schlagedex.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Shlagemon } from './shlagemon.model';
+
+@Injectable({ providedIn: 'root' })
+export class SchlagedexService {
+  private monsSubject = new BehaviorSubject<Shlagemon[]>([]);
+  shlagemons$ = this.monsSubject.asObservable();
+
+  createShlagemon(name: string): Shlagemon {
+    const mon: Shlagemon = { id: name.toLowerCase(), name };
+    this.addShlagemon(mon);
+    return mon;
+  }
+
+  addShlagemon(mon: Shlagemon) {
+    this.monsSubject.next([...this.monsSubject.value, mon]);
+  }
+
+  getShlagemons(): Shlagemon[] {
+    return this.monsSubject.value;
+  }
+}

--- a/src/app/features/shlagemon/shlagemon.model.ts
+++ b/src/app/features/shlagemon/shlagemon.model.ts
@@ -1,0 +1,4 @@
+export interface Shlagemon {
+  id: string;
+  name: string;
+}


### PR DESCRIPTION
## Summary
- allow choosing a starter to actually create a Shlagémon
- implement `SchlagedexService` to store created Shlagémons
- clean `GameStateService` spec

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6852a1b9a8f0832ab636b11983590650