### PR TITLE
Add detailed view to Schlagedex

### DIFF
--- a/src/app/features/shlagemon/schlagedex/schlagedex.html
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.html
@@ -2,9 +2,25 @@
   <section *ngIf="mons.length > 0" class="schlagedex">
     <h2 class="title">Schlagedex</h2>
     <mat-list class="mon-list" role="list">
-      <mat-list-item role="listitem" *ngFor="let mon of mons">
+      <mat-list-item role="listitem" *ngFor="let mon of mons" (click)="select(mon)">
         {{ mon.name }}
       </mat-list-item>
     </mat-list>
+    <mat-card class="mon-detail" *ngIf="selected">
+      <mat-card-header>
+        <mat-card-title>{{ selected.name }}</mat-card-title>
+        <mat-card-subtitle>{{ selected.type }}</mat-card-subtitle>
+      </mat-card-header>
+      <img mat-card-image [src]="imageUrl(selected)" [alt]="selected.name">
+      <mat-card-content>
+        <p>{{ selected.description }}</p>
+        <mat-list>
+          <mat-list-item>HP: {{ selected.hp }}</mat-list-item>
+          <mat-list-item>Attaque: {{ selected.attack }}</mat-list-item>
+          <mat-list-item>Défense: {{ selected.defense }}</mat-list-item>
+          <mat-list-item>Rareté: {{ selected.rarity }}</mat-list-item>
+        </mat-list>
+      </mat-card-content>
+    </mat-card>
   </section>
 </ng-container>

--- a/src/app/features/shlagemon/schlagedex/schlagedex.scss
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.scss
@@ -7,5 +7,12 @@
     display: flex;
     flex-direction: row;
     gap: 1rem;
+    .mat-list-item {
+      cursor: pointer;
+    }
+  }
+
+  .mon-detail {
+    margin-top: 1rem;
   }
 }

--- a/src/app/features/shlagemon/schlagedex/schlagedex.ts
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.ts
@@ -1,15 +1,27 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatListModule } from '@angular/material/list';
+import { MatCardModule } from '@angular/material/card';
 import { SchlagedexService } from '../schlagedex.service';
+import { DexShlagemon } from '../dex-shlagemon';
 
 @Component({
   selector: 'app-schlagedex',
   standalone: true,
-  imports: [CommonModule, MatListModule],
+  imports: [CommonModule, MatListModule, MatCardModule],
   templateUrl: './schlagedex.html',
   styleUrl: './schlagedex.scss'
 })
 export class Schlagedex {
+  selected?: DexShlagemon;
+
   constructor(public dex: SchlagedexService) {}
+
+  select(mon: DexShlagemon) {
+    this.selected = mon;
+  }
+
+  imageUrl(mon: DexShlagemon) {
+    return `/shlagemons/${mon.id}/${mon.id}.png`;
+  }
 }


### PR DESCRIPTION
## Summary
- show material card with details when selecting a Shlagémon

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685472ba2e08832aa1e2c5d871ed7c6b