### PR TITLE
Add selected shlagemon screen

### DIFF
--- a/src/app/features/shlagemon/selected-shlagemon/selected-shlagemon.html
+++ b/src/app/features/shlagemon/selected-shlagemon/selected-shlagemon.html
@@ -1,0 +1,3 @@
+<div class="selected" *ngIf="mon$ | async as mon">
+  <img [src]="imageUrl(mon.id)" [alt]="mon.name" class="selected-img" />
+</div>

--- a/src/app/features/shlagemon/selected-shlagemon/selected-shlagemon.scss
+++ b/src/app/features/shlagemon/selected-shlagemon/selected-shlagemon.scss
@@ -1,0 +1,11 @@
+.selected {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.selected-img {
+  max-width: 100%;
+  max-height: 100%;
+}

--- a/src/app/features/shlagemon/selected-shlagemon/selected-shlagemon.ts
+++ b/src/app/features/shlagemon/selected-shlagemon/selected-shlagemon.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SchlagedexService } from '../schlagedex.service';
+import { Observable, map } from 'rxjs';
+import { DexShlagemon } from '../dex-shlagemon';
+
+@Component({
+  selector: 'app-selected-shlagemon',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './selected-shlagemon.html',
+  styleUrl: './selected-shlagemon.scss'
+})
+export class SelectedShlagemon {
+  mon$!: Observable<DexShlagemon | undefined>;
+
+  constructor(private dex: SchlagedexService) {
+    this.mon$ = this.dex.shlagemons$.pipe(map(mons => mons[0]));
+  }
+
+  imageUrl(id: string) {
+    return `/shlagemons/${id}/${id}.png`;
+  }
+}

--- a/src/app/features/shlagemon/shlagemon-type/shlagemon-type.spec.ts
+++ b/src/app/features/shlagemon/shlagemon-type/shlagemon-type.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Type } from './shlagemon-type';
+import { ShlagemonType } from './shlagemon-type';
 
-describe('Type', () => {
-  let component: Type;
-  let fixture: ComponentFixture<Type>;
+describe('ShlagemonType', () => {
+  let component: ShlagemonType;
+  let fixture: ComponentFixture<ShlagemonType>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Type]
+      imports: [ShlagemonType]
     })
       .compileComponents();
 
-    fixture = TestBed.createComponent(Type);
+    fixture = TestBed.createComponent(ShlagemonType);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/layout/game/game.html
+++ b/src/app/layout/game/game.html
@@ -3,7 +3,8 @@
         left
     </div>
     <div class="zone center">
-        <app-choice-dialog class="full" />
+        <app-choice-dialog *ngIf="!(gameState.hasPokemon$ | async)" class="full" />
+        <app-selected-shlagemon *ngIf="gameState.hasPokemon$ | async" class="full" />
     </div>
     <div class="zone bottom">
 

--- a/src/app/layout/game/game.ts
+++ b/src/app/layout/game/game.ts
@@ -2,17 +2,18 @@ import { Component } from '@angular/core';
 import { Card } from '../card/card';
 import { GameStateService } from '../../core/game-state.service';
 import { ChoiceDialog } from '../../features/shlagemon/choice-dialog/choice-dialog';
+import { SelectedShlagemon } from '../../features/shlagemon/selected-shlagemon/selected-shlagemon';
 import { Schlagedex } from '../../features/shlagemon/schlagedex/schlagedex';
 import { SchlagedexService } from '../../features/shlagemon/schlagedex.service';
 
 @Component({
   selector: 'app-game',
-  imports: [ChoiceDialog, Schlagedex],
+  imports: [ChoiceDialog, SelectedShlagemon, Schlagedex],
   templateUrl: './game.html',
   styleUrl: './game.scss'
 })
 export class Game {
 
-  constructor(private gameState: GameStateService, public dex: SchlagedexService) { }
+  constructor(public gameState: GameStateService, public dex: SchlagedexService) { }
 
 }


### PR DESCRIPTION
## Summary
- show a different screen after the starter is chosen
- display the chosen Shlagémon image in the new screen
- fix `ShlagemonType` test

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68555ef45b54832a929cfdfd327032ba