### PR TITLE
Fix Angular module for standalone component

### DIFF
--- a/src/app/features/battle/battle.module.ts
+++ b/src/app/features/battle/battle.module.ts
@@ -4,8 +4,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MainPanelComponent } from './main-panel/main-panel.component';
 
 @NgModule({
-  declarations: [MainPanelComponent],
-  imports: [CommonModule, MatProgressBarModule],
+  imports: [CommonModule, MatProgressBarModule, MainPanelComponent],
   exports: [MainPanelComponent]
 })
 export class BattleModule {}


### PR DESCRIPTION
## Summary
- ensure `MainPanelComponent` is imported instead of declared

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_6856c9637974832abe276623b9ad1b82