### PR TITLE
Fix undefined dialogTree in dialog box

### DIFF
--- a/src/components/dialog/DialogBox.vue
+++ b/src/components/dialog/DialogBox.vue
@@ -13,7 +13,8 @@ interface DialogNode {
   imageUrl?: string
 }
 
-defineProps<{ dialogTree: DialogNode[], speaker: string, avatarUrl: string }>()
+const { dialogTree, speaker, avatarUrl }
+  = defineProps<{ dialogTree: DialogNode[], speaker: string, avatarUrl: string }>()
 
 const currentNode = ref<DialogNode | undefined>()
 


### PR DESCRIPTION
## Summary
- correctly destructure props in `DialogBox.vue`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_685e6e729a74832aa593ab9f451ce5e0