### PR TITLE
Fix duplicate script setup

### DIFF
--- a/src/components/shlagemon/ShlagemonType.vue
+++ b/src/components/shlagemon/ShlagemonType.vue
@@ -2,9 +2,7 @@
 import type { ShlagemonType } from '~/data/shlagemons'
 
 defineProps<{ value: ShlagemonType }>()
-</script>
 
-<script lang="ts" setup>
 const textColor = computed(() => getAdjustedTextColor())
 
 function getAdjustedTextColor(amount = 60) {


### PR DESCRIPTION
## Summary
- combine script setup tags

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_685e7c168a20832ab54dd8315f9eb98a