### PR TITLE
Fix ShlagemonType prop usage

### DIFF
--- a/src/components/shlagemon/ShlagemonType.vue
+++ b/src/components/shlagemon/ShlagemonType.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ShlagemonType } from '~/data/shlagemons'
 
-defineProps<{ value: ShlagemonType }>()
+const { value } = defineProps<{ value: ShlagemonType }>()
 
 const textColor = computed(() => getAdjustedTextColor())
 


### PR DESCRIPTION
## Summary
- fix undefined `value` error by capturing props in `ShlagemonType.vue`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_685ec5ae75ec832aafbd34f7393c6dfa