### PR TITLE
Automate battles with animation

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
+    ProgressBar: typeof import('./components/ui/ProgressBar.vue')['default']
     README: typeof import('./components/README.md')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import ProgressBar from '~/components/ui/ProgressBar.vue'
+import { starters } from '~/data/shlagemons'
 import { useGameStore } from '~/stores/game'
 import { useSchlagedexStore } from '~/stores/schlagedex'
 
@@ -9,43 +11,79 @@ const playerHp = ref(0)
 const enemyHp = ref(0)
 const enemy = ref<ReturnType<typeof dex.createShlagemon> | null>(null)
 const battleActive = ref(false)
+const flashPlayer = ref(false)
+const flashEnemy = ref(false)
+let battleInterval: number | undefined
 
 function startBattle() {
   const active = dex.activeShlagemon
   if (!active)
     return
-  enemy.value = dex.createShlagemon(active)
+  const base = starters[Math.floor(Math.random() * starters.length)]
+  enemy.value = dex.createShlagemon(base)
   playerHp.value = active.hp
   enemyHp.value = enemy.value.hp
   battleActive.value = true
+  battleInterval = window.setInterval(tick, 1000)
 }
 
 function attack() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
   enemyHp.value = Math.max(0, enemyHp.value - dex.activeShlagemon.attack)
+  flashEnemy.value = true
+  setTimeout(() => (flashEnemy.value = false), 100)
+  checkEnd()
+}
+
+function tick() {
+  if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
+    return
+  enemyHp.value = Math.max(0, enemyHp.value - dex.activeShlagemon.attack)
+  flashEnemy.value = true
+  setTimeout(() => (flashEnemy.value = false), 100)
   playerHp.value = Math.max(0, playerHp.value - enemy.value.attack)
+  flashPlayer.value = true
+  setTimeout(() => (flashPlayer.value = false), 100)
+  checkEnd()
+}
+
+function checkEnd() {
   if (enemyHp.value <= 0 || playerHp.value <= 0) {
     battleActive.value = false
+    if (battleInterval)
+      clearInterval(battleInterval)
+    battleInterval = undefined
     if (enemyHp.value <= 0 && playerHp.value > 0)
       game.addShlagidolar(1)
+    setTimeout(startBattle, 1000)
   }
 }
 
-watch(battleActive, (v) => {
-  if (v)
-    startBattle()
+watch(
+  () => dex.activeShlagemon,
+  (mon) => {
+    if (mon && !battleActive.value && battleInterval === undefined)
+      startBattle()
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  if (battleInterval)
+    clearInterval(battleInterval)
 })
 </script>
 
 <template>
   <div class="battle text-center" @click="attack">
     <div v-if="dex.activeShlagemon && enemy" class="flex items-center justify-center gap-4">
-      <div class="mon flex flex-col items-center">
+      <div class="mon flex flex-col items-center" :class="{ flash: flashPlayer }">
         <img :src="`/shlagemons/${dex.activeShlagemon.id}/${dex.activeShlagemon.id}.png`" class="max-h-32 object-contain" alt="">
         <div class="name">
           {{ dex.activeShlagemon.name }}
         </div>
+        <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
         <div class="hp text-sm">
           {{ playerHp }} / {{ dex.activeShlagemon.hp }}
         </div>
@@ -53,11 +91,12 @@ watch(battleActive, (v) => {
       <div class="vs font-bold">
         VS
       </div>
-      <div v-if="enemy" class="mon flex flex-col items-center">
+      <div v-if="enemy" class="mon flex flex-col items-center" :class="{ flash: flashEnemy }">
         <img :src="`/shlagemons/${enemy.id}/${enemy.id}.png`" class="max-h-32 object-contain" alt="">
         <div class="name">
           {{ enemy.name }}
         </div>
+        <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
         <div class="hp text-sm">
           {{ enemyHp }} / {{ enemy.hp }}
         </div>
@@ -68,3 +107,18 @@ watch(battleActive, (v) => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.flash {
+  animation: flash 0.1s ease-in;
+}
+
+@keyframes flash {
+  from {
+    filter: brightness(2);
+  }
+  to {
+    filter: brightness(1);
+  }
+}
+</style>

--- a/src/components/ui/ProgressBar.vue
+++ b/src/components/ui/ProgressBar.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const { value, max, color } = defineProps<{
+  value: number
+  max: number
+  color?: string
+}>()
+const percent = computed(() => max === 0 ? 0 : (value / max) * 100)
+</script>
+
+<template>
+  <div class="h-2 w-full overflow-hidden rounded bg-gray-200 dark:bg-gray-700">
+    <div class="h-full transition-all duration-300" :class="color ?? 'bg-primary'" :style="{ width: `${percent}%` }" />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add reusable `ProgressBar` component
- automate BattleMain to start automatically, tick every second and flash on hit
- update component typings

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError ENETUNREACH during web fonts retrieval)*

------
https://chatgpt.com/codex/tasks/task_e_685fb08728f8832a9968c4cc9fa0097d