### PR TITLE
Affichage niveau ennemi

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -3,7 +3,7 @@ import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { starters } from '~/data/shlagemons'
 import { useGameStore } from '~/stores/game'
 import { useSchlagedexStore } from '~/stores/schlagedex'
-import { applyStats, createDexShlagemon, xpForLevel } from '~/utils/dexFactory'
+import { createDexShlagemon, xpForLevel } from '~/utils/dexFactory'
 
 const dex = useSchlagedexStore()
 const game = useGameStore()
@@ -22,10 +22,6 @@ function startBattle() {
     return
   const base = starters[Math.floor(Math.random() * starters.length)]
   enemy.value = createDexShlagemon(base)
-  if (enemy.value) {
-    enemy.value.lvl = active.lvl
-    applyStats(enemy.value)
-  }
   playerHp.value = active.hp
   enemyHp.value = enemy.value.hp
   battleActive.value = true
@@ -102,7 +98,7 @@ onUnmounted(() => {
       <div v-if="enemy" class="mon flex flex-col items-center" :class="{ flash: flashEnemy }">
         <img :src="`/shlagemons/${enemy.id}/${enemy.id}.png`" class="max-h-32 object-contain" alt="">
         <div class="name">
-          {{ enemy.name }}
+          {{ enemy.name }} - lvl {{ enemy.lvl }}
         </div>
         <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
         <div class="hp text-sm">

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/types/shlagemon'
-import { xpForLevel } from '~/utils/dexFactory'
 
 defineProps<{ mon: DexShlagemon | null, show: boolean }>()
 const emit = defineEmits(['close'])


### PR DESCRIPTION
## Summary
- keep enemies at level 1 when starting a battle
- show the enemy level in the battle UI
- fix lint by removing unused import in `ShlagemonDetail`

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_685fbae6a484832a87fd0a1848c99fac