### PR TITLE
Add HTML dialog based modal component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
+    Modal: typeof import('./components/modal/Modal.vue')['default']
     ProgressBar: typeof import('./components/ui/ProgressBar.vue')['default']
     README: typeof import('./components/README.md')['default']
     RouterLink: typeof import('vue-router')['RouterLink']

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits(['update:modelValue', 'close'])
+const dialogRef = ref<HTMLDialogElement | null>(null)
+
+watch(() => props.modelValue, (v) => {
+  const dialog = dialogRef.value
+  if (!dialog)
+    return
+  if (v) {
+    dialog.showModal()
+  }
+  else {
+    close()
+  }
+})
+
+function close() {
+  const dialog = dialogRef.value
+  if (!dialog)
+    return
+  dialog.classList.add('closing')
+  dialog.addEventListener('animationend', () => {
+    dialog.classList.remove('closing')
+    dialog.close()
+    emit('update:modelValue', false)
+    emit('close')
+  }, { once: true })
+}
+</script>
+
+<template>
+  <dialog ref="dialogRef" class="modal" @close="emit('update:modelValue', false); emit('close')">
+    <div class="modal-content">
+      <slot />
+    </div>
+  </dialog>
+</template>
+
+<style scoped>
+.modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+  animation: fade-in 0.2s ease forwards;
+}
+.modal.closing {
+  animation: fade-out 0.2s ease forwards;
+}
+.modal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+}
+.modal-content {
+  @apply bg-white dark:bg-gray-900 rounded p-4 w-full max-w-sm shadow-lg;
+}
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes fade-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+</style>

--- a/src/components/shlagemon/Schlagedex.vue
+++ b/src/components/shlagemon/Schlagedex.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/types/shlagemon'
+import Modal from '~/components/modal/Modal.vue'
 import { useSchlagedexStore } from '~/stores/schlagedex'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonType from './ShlagemonType.vue'
@@ -41,6 +42,8 @@ function open(mon: DexShlagemon | null) {
         </button>
       </div>
     </div>
-    <ShlagemonDetail :mon="detailMon" :show="showDetail" @close="showDetail = false" />
+    <Modal v-model="showDetail">
+      <ShlagemonDetail :mon="detailMon" @close="showDetail = false" />
+    </Modal>
   </section>
 </template>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -3,7 +3,7 @@ import type { DexShlagemon } from '~/types/shlagemon'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { xpForLevel } from '~/utils/dexFactory'
 
-const props = defineProps<{ mon: DexShlagemon | null, show: boolean }>()
+const props = defineProps<{ mon: DexShlagemon | null }>()
 const emit = defineEmits(['close'])
 
 const statColors = [
@@ -31,38 +31,36 @@ const xpLeft = computed(() => props.mon ? maxXp.value - props.mon.xp : 0)
 </script>
 
 <template>
-  <div v-if="show && mon" class="fixed inset-0 flex items-center justify-center bg-black/50" @click.self="emit('close')">
-    <div class="max-w-sm w-full rounded bg-white p-4 dark:bg-gray-900">
-      <h2 class="mb-2 text-lg font-bold">
-        {{ mon.name }} - lvl {{ mon.lvl }}
-      </h2>
-      <img :src="`/shlagemons/${mon.id}/${mon.id}.png`" :alt="mon.name" class="mx-auto mb-2 max-h-40 object-contain">
-      <p class="mb-4 text-sm italic">
-        {{ mon.description }}
-      </p>
-      <div class="grid grid-cols-2 gap-2 text-sm">
-        <div
-          v-for="(stat, i) in stats"
-          :key="stat.label"
-          class="flex flex-col items-center rounded p-2 text-gray-900 transition-colors dark:text-white"
-          :class="statColors[i % statColors.length]"
-          hover="opacity-80"
-        >
-          <span class="font-semibold">{{ stat.label }}</span>
-          <span class="text-base">{{ stat.value }}</span>
-        </div>
+  <div v-if="mon" class="max-w-sm w-full rounded bg-white p-4 dark:bg-gray-900">
+    <h2 class="mb-2 text-lg font-bold">
+      {{ mon.name }} - lvl {{ mon.lvl }}
+    </h2>
+    <img :src="`/shlagemons/${mon.id}/${mon.id}.png`" :alt="mon.name" class="mx-auto mb-2 max-h-40 object-contain">
+    <p class="mb-4 text-sm italic">
+      {{ mon.description }}
+    </p>
+    <div class="grid grid-cols-2 gap-2 text-sm">
+      <div
+        v-for="(stat, i) in stats"
+        :key="stat.label"
+        class="flex flex-col items-center rounded p-2 text-gray-900 transition-colors dark:text-white"
+        :class="statColors[i % statColors.length]"
+        hover="opacity-80"
+      >
+        <span class="font-semibold">{{ stat.label }}</span>
+        <span class="text-base">{{ stat.value }}</span>
       </div>
-      <div class="mt-4">
-        <div class="mb-1 text-center text-sm">
-          XP: {{ mon.xp }} / {{ maxXp }} — encore {{ xpLeft }}
-        </div>
-        <ProgressBar :value="mon.xp" :max="maxXp" class="w-full" />
+    </div>
+    <div class="mt-4">
+      <div class="mb-1 text-center text-sm">
+        XP: {{ mon.xp }} / {{ maxXp }} — encore {{ xpLeft }}
       </div>
-      <div class="mt-4 text-right">
-        <button class="bg-primary rounded px-3 py-1 text-white" @click="emit('close')">
-          Fermer
-        </button>
-      </div>
+      <ProgressBar :value="mon.xp" :max="maxXp" class="w-full" />
+    </div>
+    <div class="mt-4 text-right">
+      <button class="bg-primary rounded px-3 py-1 text-white" @click="emit('close')">
+        Fermer
+      </button>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- implement `Modal` component using HTML `<dialog>`
- simplify `ShlagemonDetail` to remove modal logic
- show `ShlagemonDetail` inside new `Modal` in `Schlagedex`

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6860ebdc11c8832a9fd4eee212b6e4ee