### PR TITLE
Add dialog manager for middle zone

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -162,6 +162,7 @@ declare global {
   const useDeviceOrientation: typeof import('@vueuse/core')['useDeviceOrientation']
   const useDevicePixelRatio: typeof import('@vueuse/core')['useDevicePixelRatio']
   const useDevicesList: typeof import('@vueuse/core')['useDevicesList']
+  const useDialogStore: typeof import('./stores/dialog')['useDialogStore']
   const useDisplayMedia: typeof import('@vueuse/core')['useDisplayMedia']
   const useDocumentVisibility: typeof import('@vueuse/core')['useDocumentVisibility']
   const useDraggable: typeof import('@vueuse/core')['useDraggable']
@@ -319,6 +320,9 @@ declare global {
   // @ts-ignore
   export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
+  // @ts-ignore
+  export type { DialogDone } from './stores/dialog'
+  import('./stores/dialog')
 }
 
 // for vue template auto import
@@ -479,6 +483,7 @@ declare module 'vue' {
     readonly useDeviceOrientation: UnwrapRef<typeof import('@vueuse/core')['useDeviceOrientation']>
     readonly useDevicePixelRatio: UnwrapRef<typeof import('@vueuse/core')['useDevicePixelRatio']>
     readonly useDevicesList: UnwrapRef<typeof import('@vueuse/core')['useDevicesList']>
+    readonly useDialogStore: UnwrapRef<typeof import('./stores/dialog')['useDialogStore']>
     readonly useDisplayMedia: UnwrapRef<typeof import('@vueuse/core')['useDisplayMedia']>
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,9 +9,11 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
+    AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
     CheckBox: typeof import('./components/ui/CheckBox.vue')['default']
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
+    DialogPanel: typeof import('./components/panels/DialogPanel.vue')['default']
     DialogStarter: typeof import('./components/dialog/DialogStarter.vue')['default']
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']

--- a/src/components/dialog/AnotherShlagemonDialog.vue
+++ b/src/components/dialog/AnotherShlagemonDialog.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import DialogBox from '~/components/dialog/DialogBox.vue'
+import { starters } from '~/data/shlagemons'
+import { useShlagedexStore } from '~/stores/shlagedex'
+
+const emit = defineEmits(['done'])
+const dex = useShlagedexStore()
+const mon = starters[Math.floor(Math.random() * starters.length)]
+
+function imageUrl(id: string) {
+  return `/shlagemons/${id}/${id}.png`
+}
+
+const dialogTree = [
+  {
+    id: 'start',
+    text: `Bravo pour ta richesse ! Prends donc ce ${mon.name}.`,
+    imageUrl: imageUrl(mon.id),
+    responses: [
+      {
+        label: 'Merci professeur !',
+        action: () => {
+          dex.createShlagemon(mon)
+          emit('done')
+        },
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    speaker="Professeur Merdant"
+    avatar-url="/characters/professor/professor.png"
+    :dialog-tree="dialogTree"
+  />
+</template>

--- a/src/components/dialog/DialogStarter.vue
+++ b/src/components/dialog/DialogStarter.vue
@@ -4,6 +4,8 @@ import { starters } from '~/data/shlagemons'
 import { useGameStateStore } from '~/stores/gameState'
 import { useShlagedexStore } from '~/stores/shlagedex'
 
+const emit = defineEmits(['done'])
+
 const gameState = useGameStateStore()
 const dex = useShlagedexStore()
 
@@ -55,6 +57,7 @@ const dialogTree = [
         action: () => {
           dex.createShlagemon(s)
           gameState.setHasPokemon(true)
+          emit('done')
         },
       },
     ],

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -14,7 +14,7 @@ const gameState = useGameStateStore()
   >
     <div class="zone" md="col-span-6 row-span-6 col-start-4 row-start-7">
       <!-- middle B zone -->
-      <DialogStarter v-if="!gameState.hasPokemon" />
+      <DialogPanel />
     </div>
     <div class="zone" md="col-span-6 row-span-1 col-start-4 row-start-1">
       <!-- top zone -->

--- a/src/components/panels/DialogPanel.vue
+++ b/src/components/panels/DialogPanel.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
+import DialogStarter from '~/components/dialog/DialogStarter.vue'
+import { useDialogStore } from '~/stores/dialog'
+import { useGameStore } from '~/stores/game'
+import { useGameStateStore } from '~/stores/gameState'
+
+const dialogStore = useDialogStore()
+const gameState = useGameStateStore()
+const game = useGameStore()
+
+interface DialogItem {
+  id: string
+  component: any
+  condition: () => boolean
+}
+
+const dialogs: DialogItem[] = [
+  {
+    id: 'starter',
+    component: DialogStarter,
+    condition: () => !gameState.hasPokemon,
+  },
+  {
+    id: 'richReward',
+    component: AnotherShlagemonDialog,
+    condition: () => game.shlagidolar >= 100,
+  },
+]
+
+const active = computed(() => {
+  for (const d of dialogs) {
+    if (!dialogStore.isDone(d.id) && d.condition())
+      return d
+  }
+  return null
+})
+
+function markDone(id: string) {
+  dialogStore.markDone(id)
+}
+</script>
+
+<template>
+  <component
+    :is="active?.component"
+    v-if="active"
+    @done="markDone(active.id)"
+  />
+</template>

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+
+export interface DialogDone {
+  [id: string]: boolean
+}
+
+export const useDialogStore = defineStore('dialog', () => {
+  const done = ref<DialogDone>({})
+
+  function isDone(id: string) {
+    return done.value[id] === true
+  }
+
+  function markDone(id: string) {
+    done.value[id] = true
+  }
+
+  return { done, isDone, markDone }
+}, {
+  persist: true,
+})

--- a/test/__snapshots__/component.test.ts.snap
+++ b/test/__snapshots__/component.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`component Header.vue > should render 1`] = `
-"<header class="flex items-center justify-between bg-gray-100 p-4 dark:bg-gray-800"><img src="/logo.png" alt="Logo Shlagémon" class="h-8">
+"<header class="h-12 flex items-center justify-between bg-gray-100 p-4 dark:bg-gray-800"><img src="/logo.png" alt="Logo Shlagémon" class="h-20 -my-4">
   <div class="flex items-center gap-2"><button class="p-1" aria-label="Basculer en thème sombre"><span>☀️</span></button><button class="p-1" aria-label="Reset Save"> 🗑 </button></div>
 </header>"
 `;


### PR DESCRIPTION
## Summary
- create `useDialogStore` to persist completed dialogs
- add `AnotherShlagemonDialog` component for 100 shlagidolar reward
- update `DialogStarter` to emit a `done` event
- manage dialog priority with new `DialogPanel`
- plug panel into `GameGrid`
- update auto-generated types and snapshots

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_6860f8472750832a932100a49229e645