### PR TITLE
Fix active shlagemon selection

### DIFF
--- a/src/components/panels/ActiveShlagemon.vue
+++ b/src/components/panels/ActiveShlagemon.vue
@@ -7,13 +7,15 @@ const dex = useShlagedexStore()
 
 <template>
   <div v-if="dex.activeShlagemon" class="flex items-center gap-2">
-    <div class="aspect-square bg-red">
-      <div class="h-full w-full bg-green">
-        <!-- <img :src="`/shlagemons/${dex.activeShlagemon.id}/${dex.activeShlagemon.id}.png`" :alt="dex.activeShlagemon.name" class="h-full object-contain"> -->
-      </div>
+    <div class="h-16 w-16 flex-shrink-0">
+      <img
+        :src="`/shlagemons/${dex.activeShlagemon.id}/${dex.activeShlagemon.id}.png`"
+        :alt="dex.activeShlagemon.name"
+        class="h-full w-full object-contain"
+      >
     </div>
 
-    <div class="info flex items-center gap-2">
+    <div class="info flex flex-col">
       <span class="font-bold">{{ dex.activeShlagemon.name }}</span>
       <span>Lvl {{ dex.activeShlagemon.lvl }}</span>
       <ShlagemonType :value="dex.activeShlagemon.type" />

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -10,14 +10,15 @@ const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 
 function open(mon: DexShlagemon | null) {
   if (mon) {
+    dex.setActiveShlagemon(mon)
     detailMon.value = mon
     showDetail.value = true
   }
 }
 
-const active = computed({
-  get: () => dex.activeShlagemon?.id === detailMon.value?.id,
-})
+function isActive(mon: DexShlagemon) {
+  return dex.activeShlagemon?.id === mon.id
+}
 </script>
 
 <template>
@@ -31,7 +32,8 @@ const active = computed({
         :key="mon.id"
         class="flex cursor-pointer items-center justify-between border rounded p-2"
         hover="bg-gray-100 dark:bg-gray-800"
-        :class="{ 'bg-primary': dex.activeShlagemon?.id === mon.id }"
+        :class="{ 'bg-primary/20': isActive(mon) }"
+        :style="isActive(mon) ? { backgroundImage: `url(/shlagemons/${mon.id}/${mon.id}.png)`, backgroundRepeat: 'no-repeat', backgroundSize: 'cover', backgroundPosition: 'center' } : {}"
         @click="open(mon)"
       >
         <div class="flex items-center gap-2">
@@ -43,7 +45,12 @@ const active = computed({
             <ShlagemonType :value="mon.type" />
           </div>
         </div>
-        <CheckBox class="ml-2" :active="dex.activeShlagemon?.id === mon.id" :model-value="active" @click.stop="dex.setActiveShlagemon(mon)" />
+        <CheckBox
+          class="ml-2"
+          :model-value="isActive(mon)"
+          @update:model-value="() => dex.setActiveShlagemon(mon)"
+          @click.stop
+        />
       </div>
     </div>
     <Modal v-model="showDetail">


### PR DESCRIPTION
## Summary
- ensure a single active shlagemon in the dex
- show selected shlagemon image as row background
- display active shlagemon sprite in panel

## Testing
- `pnpm lint --fix`
- `pnpm test` *(fails: ELIFECYCLE Test failed)*
- `pnpm typecheck` *(fails: Module has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_6861038159e8832aa5a16f0ead33af1c