### PR TITLE
Fix grid sizing for ActiveShlagemon image

### DIFF
--- a/src/components/panels/ActiveShlagemon.vue
+++ b/src/components/panels/ActiveShlagemon.vue
@@ -7,7 +7,7 @@ const dex = useShlagedexStore()
 
 <template>
   <div v-if="dex.activeShlagemon" class="flex items-center gap-2">
-    <div class="h-16 w-16 flex-shrink-0">
+    <div class="h-16 w-16 flex-shrink-0" md="h-full">
       <img
         :src="`/shlagemons/${dex.activeShlagemon.id}/${dex.activeShlagemon.id}.png`"
         :alt="dex.activeShlagemon.name"


### PR DESCRIPTION
## Summary
- ensure image does not stretch grid rows by adapting to row height on large screens

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68610c92d7e0832a80f2c13b6c639936