### PR TITLE
Update meta for Shlagémon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="apple-touch-icon" href="/pwa-192x192.png" />
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#00aba9" />
-    <meta name="msapplication-TileColor" content="#00aba9" />
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0d9488" />
+    <meta name="msapplication-TileColor" content="#0d9488" />
     <script>
       ;(function () {
         const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,15 +3,15 @@
 // you can use this to manipulate the document head in any components,
 // they will be rendered correctly in the html results with vite-ssg
 useHead({
-  title: 'Vitesse',
+  title: 'Shlagémon',
   meta: [
     {
       name: 'description',
-      content: 'Opinionated Vite Starter Template',
+      content: 'Parodie de Pokémon avec des créatures loufoques',
     },
     {
       name: 'theme-color',
-      content: () => isDark.value ? '#00aba9' : '#ffffff',
+      content: () => isDark.value ? '#0d9488' : '#ffffff',
     },
   ],
   link: [

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 </script>
 
+<route lang="yaml">
+head:
+  title: Shlagémon
+  meta:
+    - name: description
+      content: Parodie de Pokémon avec des créatures loufoques
+</route>
+
 <template>
   <div class="h-full w-full flex items-center justify-center">
     <!-- Main content goes here -->

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -106,9 +106,9 @@ export default defineConfig({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg', 'safari-pinned-tab.svg'],
       manifest: {
-        name: 'Vitesse',
-        short_name: 'Vitesse',
-        theme_color: '#ffffff',
+        name: 'Shlagémon',
+        short_name: 'Shlagémon',
+        theme_color: '#0d9488',
         icons: [
           {
             src: '/pwa-192x192.png',


### PR DESCRIPTION
## Summary
- change site title and description for Shlagémon
- set theme color to teal
- update manifest values

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: exit code 130 after manual cancel)*

------
https://chatgpt.com/codex/tasks/task_e_68610c4a1c98832a9f29865b0a7dca38