### PR TITLE
Fix Shlagedex selection with unique IDs

### DIFF
--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -17,7 +17,7 @@ function open(mon: DexShlagemon | null) {
 }
 
 function isActive(mon: DexShlagemon) {
-  return dex.activeShlagemon?.base.id === mon.base.id
+  return dex.activeShlagemon?.id === mon.id
 }
 </script>
 
@@ -29,7 +29,7 @@ function isActive(mon: DexShlagemon) {
     <div class="flex flex-col gap-2">
       <div
         v-for="mon in dex.shlagemons"
-        :key="mon.base.id"
+        :key="mon.id"
         class="flex cursor-pointer items-center justify-between border rounded p-2"
         hover="bg-gray-100 dark:bg-gray-800"
         :class="{ 'bg-primary/20': isActive(mon) }"
@@ -42,6 +42,7 @@ function isActive(mon: DexShlagemon) {
             <div class="name">
               {{ mon.base.name }}
             </div>
+            <span class="text-xs text-gray-500">ID: {{ mon.id }}</span>
             <ShlagemonType :value="mon.base.type" />
           </div>
         </div>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -35,6 +35,9 @@ const xpLeft = computed(() => props.mon ? maxXp.value - props.mon.xp : 0)
     <h2 class="mb-2 text-lg font-bold">
       {{ mon.base.name }} - lvl {{ mon.lvl }}
     </h2>
+    <p class="mb-2 text-sm text-gray-500">
+      ID: {{ mon.id }}
+    </p>
     <img :src="`/shlagemons/${mon.base.id}/${mon.base.id}.png`" :alt="mon.base.name" class="mx-auto mb-2 max-h-40 object-contain">
     <p class="mb-4 text-sm italic">
       {{ mon.base.description }}

--- a/src/types/shlagemon.ts
+++ b/src/types/shlagemon.ts
@@ -18,6 +18,10 @@ export interface BaseShlagemon {
 }
 
 export interface DexShlagemon {
+  /**
+   * Unique identifier for each captured Shlagémon
+   */
+  id: string
   base: BaseShlagemon
   lvl: number
   xp: number

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -13,6 +13,7 @@ export function applyStats(mon: DexShlagemon) {
 
 export function createDexShlagemon(base: BaseShlagemon): DexShlagemon {
   const mon: DexShlagemon = {
+    id: crypto.randomUUID(),
     base,
     lvl: 1,
     xp: 0,


### PR DESCRIPTION
## Summary
- add `id` property to `DexShlagemon`
- generate unique id in `createDexShlagemon`
- use mon.id in Shlagedex and display it in the UI
- show id in detail modal

## Testing
- `pnpm lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68611d735fe4832a810535a02ef9256b