### PR TITLE
Add typed relations between shlagemon types

### DIFF
--- a/src/data/shlagemons-type.ts
+++ b/src/data/shlagemons-type.ts
@@ -5,8 +5,8 @@ export const moisisme: ShlagemonType = {
   name: 'Moisisme',
   description: 'Type fongique, dégoulinant, qui ronge lentement ses adversaires.',
   color: '#6a9e3f',
-  resistance: ['plastoc', 'flanquant'],
-  weakness: ['vapotonie', 'brico-foutoir'],
+  resistance: [],
+  weakness: [],
   tags: ['collant', 'chaotique'],
   passiveEffects: ['apply-poison'],
 }
@@ -16,8 +16,8 @@ export const plastoc: ShlagemonType = {
   name: 'Plastoc',
   description: 'Type synthétique et tape-à-l’œil, mais pas très écolo.',
   color: '#e86fda',
-  resistance: ['moisisme', 'apéricube'],
-  weakness: ['brico-foutoir', 'trou-noir'],
+  resistance: [],
+  weakness: [],
   tags: ['toxique'],
   passiveEffects: ['reflect-damage'],
 }
@@ -27,8 +27,8 @@ export const yoloide: ShlagemonType = {
   name: 'YOLOïde',
   description: 'Type impulsif qui mise tout sur un coup critique.',
   color: '#ff2222',
-  resistance: ['dramaqueen'],
-  weakness: ['paperasse'],
+  resistance: [],
+  weakness: [],
   tags: ['chaotique'],
   passiveEffects: ['ignore-defense'],
 }
@@ -38,8 +38,8 @@ export const paperasse: ShlagemonType = {
   name: 'Paperasse',
   description: 'Type lent, mais inévitable. Peut paralyser n’importe quelle action.',
   color: '#aaaaaa',
-  resistance: ['dramaqueen', 'brico-foutoir'],
-  weakness: ['vapotonie'],
+  resistance: [],
+  weakness: [],
   tags: ['bureaucratique'],
   passiveEffects: ['lower-accuracy'],
 }
@@ -49,8 +49,8 @@ export const vapotonie: ShlagemonType = {
   name: 'Vapotage',
   description: 'Type flou, flottant et toxique. Disparaît dès qu’on le regarde.',
   color: '#b6d6f2',
-  resistance: ['moisisme'],
-  weakness: ['flanquant'],
+  resistance: [],
+  weakness: [],
   tags: ['intangible'],
   passiveEffects: ['confuse', 'resist-status'],
 }
@@ -60,11 +60,73 @@ export const flanquant: ShlagemonType = {
   name: 'Flanquant',
   description: 'Type gluant et instable. Ne tient jamais en place.',
   color: '#ffcc88',
-  resistance: ['yoloide'],
-  weakness: ['plastoc'],
+  resistance: [],
+  weakness: [],
   tags: ['alimentaire'],
   passiveEffects: ['draw-attacks'],
 }
+
+export const dramaqueen: ShlagemonType = {
+  id: 'dramaqueen',
+  name: 'Dramaqueen',
+  description: 'Type théâtral qui amplifie chaque action.',
+  color: '#f39acb',
+  resistance: [],
+  weakness: [],
+  tags: ['émotif'],
+  passiveEffects: [],
+}
+
+export const bricoFoutoir: ShlagemonType = {
+  id: 'brico-foutoir',
+  name: 'Brico-Foutoir',
+  description: 'Type bricoleur et imprévisible.',
+  color: '#8c7853',
+  resistance: [],
+  weakness: [],
+  tags: ['chaotique'],
+  passiveEffects: [],
+}
+
+export const apericube: ShlagemonType = {
+  id: 'apéricube',
+  name: 'Apéricube',
+  description: 'Type fromage cubique, étonnamment résistant.',
+  color: '#ffd966',
+  resistance: [],
+  weakness: [],
+  tags: ['alimentaire'],
+  passiveEffects: [],
+}
+
+export const trouNoir: ShlagemonType = {
+  id: 'trou-noir',
+  name: 'Trou Noir',
+  description: 'Type cosmique qui aspire toute attaque.',
+  color: '#222222',
+  resistance: [],
+  weakness: [],
+  tags: ['cosmique'],
+  passiveEffects: [],
+}
+
+moisisme.resistance.push(plastoc, flanquant)
+moisisme.weakness.push(vapotonie, bricoFoutoir)
+
+plastoc.resistance.push(moisisme, apericube)
+plastoc.weakness.push(bricoFoutoir, trouNoir)
+
+yoloide.resistance.push(dramaqueen)
+yoloide.weakness.push(paperasse)
+
+paperasse.resistance.push(dramaqueen, bricoFoutoir)
+paperasse.weakness.push(vapotonie)
+
+vapotonie.resistance.push(moisisme)
+vapotonie.weakness.push(flanquant)
+
+flanquant.resistance.push(yoloide)
+flanquant.weakness.push(plastoc)
 
 // ... tu peux continuer à déclarer les autres de cette manière ...
 
@@ -76,4 +138,8 @@ export const shlagemonTypes: ShlagemonType[] = [
   paperasse,
   vapotonie,
   flanquant,
+  dramaqueen,
+  bricoFoutoir,
+  apericube,
+  trouNoir,
 ]

--- a/src/types/shlagemon.ts
+++ b/src/types/shlagemon.ts
@@ -3,8 +3,8 @@ export interface ShlagemonType {
   name: string
   description: string
   color: string
-  resistance: string[]
-  weakness: string[]
+  resistance: ShlagemonType[]
+  weakness: ShlagemonType[]
   tags: string[]
   passiveEffects: string[]
 }


### PR DESCRIPTION
## Summary
- use arrays of `ShlagemonType` for `weakness` and `resistance`
- define missing shlagemon type objects
- build relations after all types are created

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68611dc91b38832aa1438fb5a6d343b7