### PR TITLE
Fix theme toggle overlay

### DIFF
--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -41,6 +41,7 @@ const toggle = useToggle(isDark)
 }
 
 .theme-toggle {
+  position: relative;
   display: flex;
   align-items: center;
   -webkit-tap-highlight-color: transparent;
@@ -59,6 +60,7 @@ const toggle = useToggle(isDark)
   inset: 0;
   height: 100%;
   transform: translateX(-100%);
+  pointer-events: none;
 }
 
 .theme-toggle-icon,


### PR DESCRIPTION
## Summary
- keep theme toggle icon positioned relative to the button
- prevent overlay from intercepting clicks

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68612102e8f0832a8fdbe71e7169c4d8