### PR TITLE
Add typed dialog buttons

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,6 +11,7 @@ declare module 'vue' {
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
+    Button: typeof import('./components/ui/Button.vue')['default']
     CheckBox: typeof import('./components/ui/CheckBox.vue')['default']
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
     DialogPanel: typeof import('./components/panels/DialogPanel.vue')['default']

--- a/src/components/dialog/AnotherShlagemonDialog.vue
+++ b/src/components/dialog/AnotherShlagemonDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DialogNode } from '~/types/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
 import { starters } from '~/data/shlagemons'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -19,6 +20,7 @@ const dialogTree = [
     responses: [
       {
         label: 'Merci professeur !',
+        type: 'valid',
         action: () => {
           dex.createShlagemon(mon)
           emit('done')
@@ -26,7 +28,7 @@ const dialogTree = [
       },
     ],
   },
-]
+] as DialogNode[]
 </script>
 
 <template>

--- a/src/components/dialog/DialogBox.vue
+++ b/src/components/dialog/DialogBox.vue
@@ -1,17 +1,6 @@
 <script setup lang="ts">
-interface DialogResponse {
-  label: string
-  imageUrl?: string
-  nextId?: string
-  action?: () => void
-  color?: string
-}
-interface DialogNode {
-  id: string
-  text: string
-  responses: DialogResponse[]
-  imageUrl?: string
-}
+import type { DialogNode, DialogResponse } from '~/types/dialog'
+import Button from '~/components/ui/Button.vue'
 
 const { dialogTree, speaker, avatarUrl }
   = defineProps<{ dialogTree: DialogNode[], speaker: string, avatarUrl: string }>()
@@ -46,15 +35,15 @@ function choose(r: DialogResponse) {
         <img :src="currentNode.imageUrl" alt="illustration" class="max-h-60 object-contain">
       </div>
       <div class="mt-auto flex justify-center gap-2">
-        <button
+        <Button
           v-for="r in currentNode?.responses"
           :key="r.label"
-          class="bg-primary hover:bg-primary/80 rounded px-2 py-1 text-white"
+          :type="r.type"
           @click="choose(r)"
         >
           <img v-if="r.imageUrl" :src="r.imageUrl" class="mr-1 h-6 w-6" alt="">
           {{ r.label }}
-        </button>
+        </Button>
       </div>
     </div>
   </div>

--- a/src/components/dialog/DialogStarter.vue
+++ b/src/components/dialog/DialogStarter.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DialogNode } from '~/types/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
 import { starters } from '~/data/shlagemons'
 import { useGameStateStore } from '~/stores/gameState'
@@ -22,14 +23,14 @@ const dialogTree = [
     id: 'start',
     text: 'Salut, je suis le Professeur Merdant, mes amis disent que je sent bon.',
     responses: [
-      { label: 'Tu n\'as pas l\'air très intelligent.', nextId: '2' },
+      { label: 'Tu n\'as pas l\'air très intelligent.', nextId: '2', type: 'primary' },
     ],
   },
   {
     id: '2',
     text: 'Je t\'emmerde mon petit, pour la peine, je vais te forcer à adopter un de mes Shlagémons.',
     responses: [
-      { label: 'Ho nooon, pas un Shlagémon, ils sentent trop mauvais !', nextId: 'choice' },
+      { label: 'Ho nooon, pas un Shlagémon, ils sentent trop mauvais !', nextId: 'choice', type: 'primary' },
     ],
   },
   {
@@ -39,7 +40,7 @@ const dialogTree = [
       label: s.name,
       nextId: nextId(s.id),
       imageUrl: '/items/shlageball/shlageball.png',
-      color: s.color,
+      type: 'primary',
     })),
   },
   ...starters.map(s => ({
@@ -51,9 +52,10 @@ const dialogTree = [
         : 'Attention, il ne sait pas nager.',
     imageUrl: imageUrl(s.id),
     responses: [
-      { label: 'T\'as pas mieux que cette merde ?', nextId: 'choice' },
+      { label: 'T\'as pas mieux que cette merde ?', nextId: 'choice', type: 'danger' },
       {
         label: s.id === 'bulgrosboule' ? 'Je l\'aime pas trop mais ok' : 'Merci professeur Merdant',
+        type: 'valid',
         action: () => {
           dex.createShlagemon(s)
           gameState.setHasPokemon(true)
@@ -62,7 +64,7 @@ const dialogTree = [
       },
     ],
   })),
-]
+] as DialogNode[]
 </script>
 
 <template>

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { ButtonType } from '~/types/button'
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{ type?: ButtonType }>(), {
+  type: 'primary',
+})
+
+const variantClass = computed(() => {
+  switch (props.type) {
+    case 'valid':
+      return 'bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-800'
+    case 'danger':
+      return 'bg-red-600 dark:bg-red-700 hover:bg-red-700 dark:hover:bg-red-800'
+    default:
+      return 'bg-primary hover:bg-primary/80'
+  }
+})
+</script>
+
+<template>
+  <button class="rounded px-2 py-1 text-white" :class="variantClass">
+    <slot />
+  </button>
+</template>

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,0 +1,1 @@
+export type ButtonType = 'primary' | 'valid' | 'danger'

--- a/src/types/dialog.ts
+++ b/src/types/dialog.ts
@@ -1,0 +1,16 @@
+import type { ButtonType } from './button'
+
+export interface DialogResponse {
+  label: string
+  imageUrl?: string
+  nextId?: string
+  action?: () => void
+  type?: ButtonType
+}
+
+export interface DialogNode {
+  id: string
+  text: string
+  responses: DialogResponse[]
+  imageUrl?: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,3 @@
+export * from './button'
+export * from './dialog'
 export * from './shlagemon'


### PR DESCRIPTION
## Summary
- create reusable `Button` component with color variants
- type dialog buttons with `ButtonType`
- hook up new button types in DialogStarter and AnotherShlagemonDialog
- use typed nodes in DialogBox

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `CI=1 pnpm test` *(fails: ENETUNREACH during font fetch)*

------
https://chatgpt.com/codex/tasks/task_e_686121b00550832a8137be7fc90bfbd2