### PR TITLE
Add reset for dialog store

### DIFF
--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -15,7 +15,11 @@ export const useDialogStore = defineStore('dialog', () => {
     done.value[id] = true
   }
 
-  return { done, isDone, markDone }
+  function reset() {
+    done.value = {}
+  }
+
+  return { done, isDone, markDone, reset }
 }, {
   persist: true,
 })

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { useDialogStore } from './dialog'
 import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
 import { useShlagedexStore } from './shlagedex'
@@ -7,11 +8,13 @@ export const useSaveStore = defineStore('save', () => {
   const dex = useShlagedexStore()
   const gameState = useGameStateStore()
   const game = useGameStore()
+  const dialog = useDialogStore()
 
   function reset() {
     dex.reset()
     gameState.reset()
     game.reset()
+    dialog.reset()
   }
 
   return { reset }

--- a/test/save-reset.test.ts
+++ b/test/save-reset.test.ts
@@ -1,0 +1,19 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useDialogStore } from '../src/stores/dialog'
+import { useSaveStore } from '../src/stores/save'
+
+describe('useSaveStore.reset', () => {
+  it('should reset dialog store', () => {
+    setActivePinia(createPinia())
+    const dialog = useDialogStore()
+    const save = useSaveStore()
+
+    dialog.markDone('foo')
+    expect(dialog.isDone('foo')).toBe(true)
+
+    save.reset()
+
+    expect(dialog.isDone('foo')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add reset method for dialog store
- reset dialog store when resetting save store
- test the save store reset

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6861609c4880832ab5271e6363afe6f8