### PR TITLE
Fix grid scrolling

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -9,29 +9,29 @@ const gameState = useGameStateStore()
 
 <template>
   <div
-    class="game h-auto flex flex-col gap-1 p-1"
-    md="grid grid-cols-12 grid-rows-12 h-full gap-2 p-1"
+    class="game h-screen flex flex-col gap-1 overflow-y-auto p-1"
+    md="grid grid-cols-12 grid-rows-12 h-full overflow-hidden gap-2 p-1"
   >
-    <div class="zone" md="col-span-6 row-span-6 col-start-4 row-start-7">
+    <div class="zone fixed" md="col-span-6 row-span-6 col-start-4 row-start-7">
       <!-- middle B zone -->
       <DialogPanel />
     </div>
-    <div class="zone" md="col-span-6 row-span-1 col-start-4 row-start-1">
+    <div class="zone fixed" md="col-span-6 row-span-1 col-start-4 row-start-1">
       <!-- top zone -->
       <PlayerInfos />
     </div>
-    <div class="zone" md="col-span-6 row-span-4 col-start-4 row-start-2">
+    <div class="zone fixed" md="col-span-6 row-span-4 col-start-4 row-start-2">
       <!-- middle A zone -->
       <BattleMain v-if="gameState.hasPokemon" />
     </div>
-    <div class="zone" md="col-span-6 row-span-1 col-start-4 row-start-6">
+    <div class="zone fixed" md="col-span-6 row-span-1 col-start-4 row-start-6">
       <!-- bottom zone -->
       <ActiveShlagemon />
     </div>
-    <div class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1">
+    <div class="zone scrollable" md="col-span-3 row-span-12 col-start-1 row-start-1">
       <!-- left zone -->
     </div>
-    <div class="zone" md="col-span-3 row-span-12 col-start-10 row-start-1">
+    <div class="zone scrollable" md="col-span-3 row-span-12 col-start-10 row-start-1">
       <!-- right zone -->
       <Shlagedex />
     </div>
@@ -40,6 +40,12 @@ const gameState = useGameStateStore()
 
 <style scoped>
 .zone {
-  @apply p-2 rounded bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 overflow-hidden;
+  @apply p-2 rounded bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700;
+}
+.fixed {
+  @apply overflow-hidden;
+}
+.scrollable {
+  @apply md:overflow-y-auto;
 }
 </style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -2,7 +2,7 @@
 </script>
 
 <template>
-  <div class="h-full flex flex-col">
+  <div class="h-full flex flex-col overflow-hidden">
     <Header />
     <GameGrid class="flex-1" />
   </div>


### PR DESCRIPTION
## Summary
- prevent GameGrid parent from overflowing
- make the GameGrid scroll on mobile only
- allow side panels to scroll on desktop only

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails to fetch web fonts but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68616be2f7d4832aae2cb40ab9542da8