### PR TITLE
Fix layout for player panel

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -12,18 +12,21 @@ const gameState = useGameStateStore()
     class="game h-screen flex flex-col gap-1 overflow-y-auto p-1"
     md="grid grid-cols-12 grid-rows-12 h-full overflow-hidden gap-2 p-1"
   >
-    <div class="zone fixed" md="col-span-6 row-span-7 col-start-4 row-start-6">
+    <div class="zone fixed" md="col-span-6 row-span-6 col-start-4 row-start-7">
       <!-- middle B zone -->
       <DialogPanel />
     </div>
-    <div class="zone fixed flex items-center gap-3" md="col-span-6 row-span-1 col-start-4 row-start-1">
+    <div class="zone fixed" md="col-span-6 row-span-1 col-start-4 row-start-1">
       <!-- top zone -->
       <PlayerInfos />
-      <ActiveShlagemon />
     </div>
     <div class="zone fixed" md="col-span-6 row-span-4 col-start-4 row-start-2">
       <!-- middle A zone -->
       <BattleMain v-if="gameState.hasPokemon" />
+    </div>
+    <div class="zone fixed" md="col-span-6 row-span-1 col-start-4 row-start-6">
+      <!-- bottom zone -->
+      <ActiveShlagemon />
     </div>
     <div class="zone scrollable" md="col-span-3 row-span-12 col-start-1 row-start-1">
       <!-- left zone -->

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -12,21 +12,18 @@ const gameState = useGameStateStore()
     class="game h-screen flex flex-col gap-1 overflow-y-auto p-1"
     md="grid grid-cols-12 grid-rows-12 h-full overflow-hidden gap-2 p-1"
   >
-    <div class="zone fixed" md="col-span-6 row-span-6 col-start-4 row-start-7">
+    <div class="zone fixed" md="col-span-6 row-span-7 col-start-4 row-start-6">
       <!-- middle B zone -->
       <DialogPanel />
     </div>
-    <div class="zone fixed" md="col-span-6 row-span-1 col-start-4 row-start-1">
+    <div class="zone fixed flex items-center gap-3" md="col-span-6 row-span-1 col-start-4 row-start-1">
       <!-- top zone -->
       <PlayerInfos />
+      <ActiveShlagemon />
     </div>
     <div class="zone fixed" md="col-span-6 row-span-4 col-start-4 row-start-2">
       <!-- middle A zone -->
       <BattleMain v-if="gameState.hasPokemon" />
-    </div>
-    <div class="zone fixed" md="col-span-6 row-span-1 col-start-4 row-start-6">
-      <!-- bottom zone -->
-      <ActiveShlagemon />
     </div>
     <div class="zone scrollable" md="col-span-3 row-span-12 col-start-1 row-start-1">
       <!-- left zone -->

--- a/src/components/panels/ActiveShlagemon.vue
+++ b/src/components/panels/ActiveShlagemon.vue
@@ -6,7 +6,11 @@ const dex = useShlagedexStore()
 </script>
 
 <template>
-  <div v-if="dex.activeShlagemon" class="flex items-center gap-2">
+  <div
+    v-if="dex.activeShlagemon"
+    class="inline-flex items-center gap-2 rounded bg-white p-2 dark:bg-gray-900"
+    sm="p-3"
+  >
     <div class="h-16 w-16 flex-shrink-0" md="h-full">
       <img
         :src="`/shlagemons/${dex.activeShlagemon.base.id}/${dex.activeShlagemon.base.id}.png`"

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -9,7 +9,7 @@ const totalInDex = starters.length
 
 <template>
   <div
-    class="flex justify-around rounded bg-white p-2 text-xs dark:bg-gray-900"
+    class="inline-flex items-center justify-around gap-3 rounded bg-white p-2 text-xs dark:bg-gray-900"
     sm="text-sm p-3"
   >
     <div class="flex flex-col items-center">


### PR DESCRIPTION
## Summary
- keep PlayerInfos and ActiveShlagemon in the same row
- adjust grid rows after removing redundant zone

## Testing
- `pnpm test:unit`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6861729d2c48832aa8d3b6b5e06519f1