### PR TITLE
Fix dialog image layout

### DIFF
--- a/src/components/dialog/DialogBox.vue
+++ b/src/components/dialog/DialogBox.vue
@@ -31,8 +31,8 @@ function choose(r: DialogResponse) {
       <div class="flex-1 p-2">
         {{ currentNode?.text }}
       </div>
-      <div v-if="currentNode?.imageUrl" class="my-2 flex justify-center">
-        <img :src="currentNode.imageUrl" alt="illustration" class="max-h-60 object-contain">
+      <div v-if="currentNode?.imageUrl" class="my-2 flex flex-1 justify-center">
+        <img :src="currentNode.imageUrl" alt="illustration" class="h-full w-auto object-contain">
       </div>
       <div class="mt-auto flex justify-center gap-2">
         <Button


### PR DESCRIPTION
## Summary
- resize dialog images via flex to avoid overflow

## Testing
- `pnpm lint`
- `pnpm test` *(fails to fetch web fonts, but unit tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68617429ffe8832a966b825786fca5a6