### PR TITLE
Fix ActiveShlagemon layout in desktop grid

### DIFF
--- a/src/components/panels/ActiveShlagemon.vue
+++ b/src/components/panels/ActiveShlagemon.vue
@@ -8,7 +8,7 @@ const dex = useShlagedexStore()
 <template>
   <div
     v-if="dex.activeShlagemon"
-    class="flex items-center gap-2 rounded bg-white p-2 dark:bg-gray-900"
+    class="w-full flex items-center gap-2 rounded bg-white p-2 dark:bg-gray-900"
     sm="p-3"
   >
     <div class="h-16 w-16 flex-shrink-0" md="h-full">
@@ -19,7 +19,7 @@ const dex = useShlagedexStore()
       >
     </div>
 
-    <div class="info flex">
+    <div class="info flex flex-1 flex-col">
       <span class="font-bold">{{ dex.activeShlagemon.base.name }}</span>
       <span>Lvl {{ dex.activeShlagemon.lvl }}</span>
       <ShlagemonType :value="dex.activeShlagemon.base.type" />


### PR DESCRIPTION
## Summary
- ensure `ActiveShlagemon` spans the full grid width
- keep details stacked and flexible within the panel

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_6861823ecde4832aa0f033f1db55c07d