### PR TITLE
Add shop and inventory

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -198,6 +198,7 @@ declare global {
   const useIntersectionObserver: typeof import('@vueuse/core')['useIntersectionObserver']
   const useInterval: typeof import('@vueuse/core')['useInterval']
   const useIntervalFn: typeof import('@vueuse/core')['useIntervalFn']
+  const useInventoryStore: typeof import('./stores/inventory')['useInventoryStore']
   const useKeyModifier: typeof import('@vueuse/core')['useKeyModifier']
   const useLastChanged: typeof import('@vueuse/core')['useLastChanged']
   const useLink: typeof import('vue-router/auto')['useLink']
@@ -519,6 +520,7 @@ declare module 'vue' {
     readonly useIntersectionObserver: UnwrapRef<typeof import('@vueuse/core')['useIntersectionObserver']>
     readonly useInterval: UnwrapRef<typeof import('@vueuse/core')['useInterval']>
     readonly useIntervalFn: UnwrapRef<typeof import('@vueuse/core')['useIntervalFn']>
+    readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>
     readonly useLink: UnwrapRef<typeof import('vue-router/auto')['useLink']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
     ImageByBackground: typeof import('./components/ui/ImageByBackground.vue')['default']
+    ItemCard: typeof import('./components/shop/ItemCard.vue')['default']
     Modal: typeof import('./components/modal/Modal.vue')['default']
     PlayerInfos: typeof import('./components/panels/PlayerInfos.vue')['default']
     ProgressBar: typeof import('./components/ui/ProgressBar.vue')['default']
@@ -30,6 +31,7 @@ declare module 'vue' {
     ShlagemonDetail: typeof import('./components/shlagemon/ShlagemonDetail.vue')['default']
     ShlagemonRarity: typeof import('./components/shlagemon/ShlagemonRarity.vue')['default']
     ShlagemonType: typeof import('./components/shlagemon/ShlagemonType.vue')['default']
+    ShopPanel: typeof import('./components/panels/ShopPanel.vue')['default']
     ThemeToggle: typeof import('./components/ThemeToggle.vue')['default']
   }
 }

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import BattleMain from '~/components/battle/BattleMain.vue'
 import ActiveShlagemon from '~/components/panels/ActiveShlagemon.vue'
+import ShopPanel from '~/components/panels/ShopPanel.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import { useGameStateStore } from '~/stores/gameState'
 
@@ -36,7 +37,10 @@ const gameState = useGameStateStore()
         </div>
       </div>
       <div class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1">
-      <!-- left zone -->
+        <!-- left zone -->
+        <div class="zone-content">
+          <ShopPanel />
+        </div>
       </div>
       <div class="zone" md="col-span-3 row-span-12 col-start-10 row-start-1">
         <!-- right zone -->

--- a/src/components/panels/ShopPanel.vue
+++ b/src/components/panels/ShopPanel.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import ItemCard from '~/components/shop/ItemCard.vue'
+import Button from '~/components/ui/Button.vue'
+import { shopItems } from '~/data/items'
+import { useInventoryStore } from '~/stores/inventory'
+
+const inventory = useInventoryStore()
+const tab = ref<'shop' | 'inventory'>('shop')
+</script>
+
+<template>
+  <div class="h-full flex flex-col">
+    <div class="mb-2 flex justify-center gap-2">
+      <button class="rounded px-2 py-1" :class="tab === 'shop' ? 'bg-primary text-white' : 'bg-gray-200 dark:bg-gray-700'" @click="tab = 'shop'">
+        Boutique
+      </button>
+      <button class="rounded px-2 py-1" :class="tab === 'inventory' ? 'bg-primary text-white' : 'bg-gray-200 dark:bg-gray-700'" @click="tab = 'inventory'">
+        Inventaire
+      </button>
+    </div>
+    <div class="flex flex-col gap-2 overflow-auto">
+      <template v-if="tab === 'shop'">
+        <ItemCard v-for="item in shopItems" :key="item.id" :item="item">
+          <Button class="ml-2" @click="inventory.buy(item.id)">
+            Acheter
+          </Button>
+        </ItemCard>
+      </template>
+      <template v-else>
+        <ItemCard v-for="entry in inventory.list" :key="entry.item.id" :item="entry.item">
+          <div class="flex items-center gap-1">
+            <span class="font-bold">x{{ entry.qty }}</span>
+            <Button class="text-xs" @click="inventory.remove(entry.item.id)">
+              Utiliser
+            </Button>
+            <Button type="danger" class="text-xs" @click="inventory.sell(entry.item.id)">
+              Vendre
+            </Button>
+          </div>
+        </ItemCard>
+      </template>
+    </div>
+  </div>
+</template>

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { Item } from '~/type/item'
+
+const props = defineProps<{ item: Item }>()
+</script>
+
+<template>
+  <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900">
+    <img v-if="props.item.image" :src="props.item.image" :alt="props.item.name" class="h-8 w-8 object-contain">
+    <div class="flex flex-1 flex-col text-left">
+      <span class="font-bold">{{ props.item.name }}</span>
+      <span class="text-xs">{{ props.item.description }}</span>
+    </div>
+    <span class="font-bold">{{ props.item.price }}$</span>
+    <slot />
+  </div>
+</template>

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,0 +1,23 @@
+import type { Item } from '~/type/item'
+
+export const shopItems: Item[] = [
+  {
+    id: 'shlageball',
+    name: 'Shlage Ball',
+    description: 'Permet de capturer des Shlagémons sauvages.',
+    price: 10,
+    image: '/items/shlageball/shlageball.png',
+  },
+  {
+    id: 'potion',
+    name: 'Potion Dégueulasse',
+    description: 'Soigne 50 HP de votre Shlagémon.',
+    price: 5,
+  },
+  {
+    id: 'spray',
+    name: 'Spray Anti-Odeur',
+    description: 'Augmente temporairement la défense.',
+    price: 7,
+  },
+]

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { shopItems } from '~/data/items'
+import { useGameStore } from './game'
+
+export const useInventoryStore = defineStore('inventory', () => {
+  const items = ref<Record<string, number>>({})
+  const game = useGameStore()
+
+  const list = computed(() =>
+    Object.entries(items.value).map(([id, qty]) => ({
+      item: shopItems.find(i => i.id === id)!,
+      qty,
+    })),
+  )
+
+  function add(id: string, qty = 1) {
+    items.value[id] = (items.value[id] || 0) + qty
+  }
+
+  function remove(id: string, qty = 1) {
+    if (!items.value[id])
+      return
+    items.value[id] -= qty
+    if (items.value[id] <= 0)
+      delete items.value[id]
+  }
+
+  function buy(id: string) {
+    const item = shopItems.find(i => i.id === id)
+    if (!item || game.shlagidolar < item.price)
+      return false
+    game.addShlagidolar(-item.price)
+    add(id)
+    return true
+  }
+
+  function sell(id: string) {
+    const item = shopItems.find(i => i.id === id)
+    if (!item || !items.value[id])
+      return
+    remove(id)
+    game.addShlagidolar(Math.floor(item.price / 2))
+  }
+
+  function reset() {
+    items.value = {}
+  }
+
+  return { items, list, add, remove, buy, sell, reset }
+}, {
+  persist: true,
+})

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,5 +1,6 @@
 export * from './button'
 export * from './dialog'
+export * from './item'
 export * from './shlagemon'
 export * from './shlagemonEvolution'
 export * from './shlagemonType'

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -1,0 +1,12 @@
+export interface Item {
+  id: string
+  name: string
+  description: string
+  price: number
+  image?: string
+}
+
+export interface InventoryEntry {
+  itemId: string
+  qty: number
+}


### PR DESCRIPTION
## Summary
- add Item and Inventory types
- add items dataset with Shlage Ball, Potion, and Anti-Odeur spray
- implement `useInventoryStore` with persistence
- create ItemCard component and ShopPanel with shop/inventory views
- integrate ShopPanel into GameGrid

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_68624a19e458832aa90a6aa2731240b8