### PR TITLE
Add zone management panel

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -299,6 +299,7 @@ declare global {
   const useWindowFocus: typeof import('@vueuse/core')['useWindowFocus']
   const useWindowScroll: typeof import('@vueuse/core')['useWindowScroll']
   const useWindowSize: typeof import('@vueuse/core')['useWindowSize']
+  const useZoneStore: typeof import('./stores/zone')['useZoneStore']
   const watch: typeof import('vue')['watch']
   const watchArray: typeof import('@vueuse/core')['watchArray']
   const watchAtMost: typeof import('@vueuse/core')['watchAtMost']
@@ -619,6 +620,7 @@ declare module 'vue' {
     readonly useWindowFocus: UnwrapRef<typeof import('@vueuse/core')['useWindowFocus']>
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
+    readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>
     readonly watchArray: UnwrapRef<typeof import('@vueuse/core')['watchArray']>
     readonly watchAtMost: UnwrapRef<typeof import('@vueuse/core')['watchAtMost']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -33,5 +33,6 @@ declare module 'vue' {
     ShlagemonType: typeof import('./components/shlagemon/ShlagemonType.vue')['default']
     ShopPanel: typeof import('./components/panels/ShopPanel.vue')['default']
     ThemeToggle: typeof import('./components/ThemeToggle.vue')['default']
+    ZonePanel: typeof import('./components/panels/ZonePanel.vue')['default']
   }
 }

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -2,6 +2,7 @@
 import BattleMain from '~/components/battle/BattleMain.vue'
 import ActiveShlagemon from '~/components/panels/ActiveShlagemon.vue'
 import ShopPanel from '~/components/panels/ShopPanel.vue'
+import ZonePanel from '~/components/panels/ZonePanel.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import { useGameStateStore } from '~/stores/gameState'
 
@@ -38,7 +39,8 @@ const gameState = useGameStateStore()
       </div>
       <div class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1">
         <!-- left zone -->
-        <div class="zone-content">
+        <div class="zone-content flex flex-col gap-2">
+          <ZonePanel />
           <ShopPanel />
         </div>
       </div>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import Button from '~/components/ui/Button.vue'
+import { useZoneStore } from '~/stores/zone'
+
+const zone = useZoneStore()
+
+function onAction(id: string) {
+  // actions to be implemented later
+  console.warn('zone action', id)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2" md="gap-3">
+    <div class="flex flex-wrap justify-center gap-1" md="gap-2">
+      <button
+        v-for="z in zone.zones"
+        :key="z.id"
+        class="rounded px-2 py-1 text-xs"
+        :class="z.id === zone.current.id ? 'bg-primary text-white' : 'bg-gray-200 dark:bg-gray-700'"
+        @click="zone.setZone(z.id)"
+      >
+        {{ z.name }}
+      </button>
+    </div>
+    <div class="flex flex-col items-center gap-1" md="gap-2">
+      <span class="font-bold">{{ zone.current.name }}</span>
+      <Button
+        v-for="action in zone.current.actions"
+        :key="action.id"
+        class="text-xs"
+        @click="onAction(action.id)"
+      >
+        {{ action.label }}
+      </Button>
+    </div>
+  </div>
+</template>

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -1,0 +1,28 @@
+import type { Zone } from '~/type/zone'
+
+export const zonesData: Zone[] = [
+  {
+    id: 'village',
+    name: 'Village Paumé',
+    type: 'village',
+    actions: [
+      { id: 'shop', label: 'Entrer le Shop' },
+    ],
+  },
+  {
+    id: 'grotte',
+    name: 'Grotte Sombre',
+    type: 'grotte',
+    actions: [
+      { id: 'explore', label: 'Explorer la Grotte' },
+    ],
+  },
+  {
+    id: 'plaine',
+    name: 'Plaine Verdoyante',
+    type: 'sauvage',
+    actions: [
+      { id: 'battle', label: 'Chercher un Shlagémon' },
+    ],
+  },
+]

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -1,0 +1,19 @@
+import type { Zone } from '~/type/zone'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { zonesData } from '~/data/zones'
+
+export const useZoneStore = defineStore('zone', () => {
+  const zones = ref<Zone[]>(zonesData)
+  const current = ref<Zone>(zones.value[0])
+
+  function setZone(id: string) {
+    const zone = zones.value.find(z => z.id === id)
+    if (zone)
+      current.value = zone
+  }
+
+  return { zones, current, setZone }
+}, {
+  persist: true,
+})

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -1,0 +1,13 @@
+export type ZoneType = 'village' | 'grotte' | 'sauvage'
+
+export interface ZoneAction {
+  id: string
+  label: string
+}
+
+export interface Zone {
+  id: string
+  name: string
+  type: ZoneType
+  actions: ZoneAction[]
+}

--- a/test/__snapshots__/zone.test.ts.snap
+++ b/test/__snapshots__/zone.test.ts.snap
@@ -1,0 +1,8 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`zone panel > renders actions 1`] = `
+"<div class="flex flex-col gap-2" md="gap-3">
+  <div class="flex flex-wrap justify-center gap-1" md="gap-2"><button class="rounded px-2 py-1 text-xs bg-primary text-white">Village Paumé</button><button class="rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700">Grotte Sombre</button><button class="rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700">Plaine Verdoyante</button></div>
+  <div class="flex flex-col items-center gap-1" md="gap-2"><span class="font-bold">Village Paumé</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs">Entrer le Shop</button></div>
+</div>"
+`;

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import ZonePanel from '../src/components/panels/ZonePanel.vue'
+import { useZoneStore } from '../src/stores/zone'
+
+describe('zone store', () => {
+  it('changes current zone', () => {
+    setActivePinia(createPinia())
+    const store = useZoneStore()
+    expect(store.current.id).toBe(store.zones[0].id)
+    store.setZone('grotte')
+    expect(store.current.id).toBe('grotte')
+  })
+})
+
+describe('zone panel', () => {
+  it('renders actions', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const wrapper = mount(ZonePanel, {
+      global: { plugins: [pinia] },
+    })
+    expect(wrapper.text()).toContain('Entrer le Shop')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
## Summary
- add types and data for game zones
- create Pinia zone store
- show `ZonePanel` in the grid with actions
- implement unit tests for zone store and panel

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_686258b230d0832ab3006b06d9be973e