### PR TITLE
Implement inventory item effects

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -22,7 +22,7 @@ function startBattle() {
     return
   const base = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
   enemy.value = createDexShlagemon(base)
-  playerHp.value = active.hp
+  playerHp.value = active.hpCurrent
   enemyHp.value = enemy.value.hp
   battleActive.value = true
   battleInterval = window.setInterval(tick, 1000)
@@ -44,6 +44,7 @@ function tick() {
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
   playerHp.value = Math.max(0, playerHp.value - enemy.value.attack)
+  dex.activeShlagemon.hpCurrent = playerHp.value
   flashPlayer.value = true
   setTimeout(() => (flashPlayer.value = false), 100)
   checkEnd()
@@ -54,6 +55,8 @@ function checkEnd() {
     if (battleInterval)
       clearInterval(battleInterval)
     battleInterval = undefined
+    if (dex.activeShlagemon)
+      dex.activeShlagemon.hpCurrent = playerHp.value
     if (enemyHp.value <= 0 && playerHp.value > 0) {
       game.addShlagidolar(1)
       if (dex.activeShlagemon && enemy.value)

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -1,11 +1,14 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { shopItems } from '~/data/items'
+import { allShlagemons } from '~/data/shlagemons'
 import { useGameStore } from './game'
+import { useShlagedexStore } from './shlagedex'
 
 export const useInventoryStore = defineStore('inventory', () => {
   const items = ref<Record<string, number>>({})
   const game = useGameStore()
+  const dex = useShlagedexStore()
 
   const list = computed(() =>
     Object.entries(items.value).map(([id, qty]) => ({
@@ -43,11 +46,34 @@ export const useInventoryStore = defineStore('inventory', () => {
     game.addShlagidolar(Math.floor(item.price / 2))
   }
 
+  function useItem(id: string) {
+    if (!items.value[id])
+      return false
+    if (id === 'potion') {
+      dex.healActive(50)
+      remove(id)
+      return true
+    }
+    if (id === 'spray') {
+      dex.boostDefense(5)
+      remove(id)
+      return true
+    }
+    if (id === 'shlageball') {
+      // simple capture of random shlagemon
+      const base = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
+      dex.createShlagemon(base)
+      remove(id)
+      return true
+    }
+    return false
+  }
+
   function reset() {
     items.value = {}
   }
 
-  return { items, list, add, remove, buy, sell, reset }
+  return { items, list, add, remove, buy, sell, useItem, reset }
 }, {
   persist: true,
 })

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -26,12 +26,32 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     activeShlagemon.value = null
   }
 
+  function healActive(amount: number) {
+    if (!activeShlagemon.value)
+      return
+    activeShlagemon.value.hpCurrent = Math.min(
+      activeShlagemon.value.hp,
+      activeShlagemon.value.hpCurrent + amount,
+    )
+  }
+
+  function boostDefense(amount: number, duration = 10000) {
+    if (!activeShlagemon.value)
+      return
+    activeShlagemon.value.defense += amount
+    setTimeout(() => {
+      if (activeShlagemon.value)
+        activeShlagemon.value.defense -= amount
+    }, duration)
+  }
+
   function gainXp(mon: DexShlagemon, amount: number) {
     mon.xp += amount
     while (mon.lvl < 100 && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)
       mon.lvl += 1
       applyStats(mon)
+      mon.hpCurrent = mon.hp
     }
   }
 
@@ -41,7 +61,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return mon
   }
 
-  return { shlagemons, activeShlagemon, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, gainXp }
+  return { shlagemons, activeShlagemon, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, gainXp, healActive, boostDefense }
 }, {
   persist: {
     debug: true,

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -22,4 +22,5 @@ export interface DexShlagemon extends Stats {
   rarity: number
   sex: Sex
   isShiny: boolean
+  hpCurrent: number
 }

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -17,6 +17,7 @@ export function applyStats(mon: DexShlagemon) {
   mon.attack = Math.floor(mon.attack + (mon.lvl - 1) * 2)
   mon.defense = Math.floor(mon.defense + (mon.lvl - 1) * 2)
   mon.smelling = Math.floor(mon.smelling + (mon.lvl - 1) * 0.5)
+  mon.hpCurrent = mon.hp
 }
 
 export function createDexShlagemon(base: BaseShlagemon): DexShlagemon {
@@ -33,6 +34,7 @@ export function createDexShlagemon(base: BaseShlagemon): DexShlagemon {
     smelling: statWithRarityAndCoefficient(baseStats.smelling, base.coefficient, rarity),
     sex: Math.random() < 0.5 ? 'male' : 'female',
     isShiny: Math.random() < 0.0001,
+    hpCurrent: 0,
   }
   applyStats(mon)
   return mon

--- a/test/inventory.test.ts
+++ b/test/inventory.test.ts
@@ -1,0 +1,31 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('inventory actions', () => {
+  it('heals active shlagemon with potion', () => {
+    setActivePinia(createPinia())
+    const inventory = useInventoryStore()
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(mon)
+    mon.hpCurrent = 10
+    inventory.add('potion')
+    const result = inventory.useItem('potion')
+    expect(result).toBe(true)
+    expect(mon.hpCurrent).toBeGreaterThan(10)
+  })
+
+  it('captures shlagemon with shlageball', () => {
+    setActivePinia(createPinia())
+    const inventory = useInventoryStore()
+    const dex = useShlagedexStore()
+    const count = dex.shlagemons.length
+    inventory.add('shlageball')
+    const result = inventory.useItem('shlageball')
+    expect(result).toBe(true)
+    expect(dex.shlagemons.length).toBe(count + 1)
+  })
+})


### PR DESCRIPTION
## Summary
- support current HP for Shlagémons
- implement healing and buffing actions in the shlagedex store
- allow using items from inventory
- track HP during battles
- add unit tests for new inventory actions

## Testing
- `pnpm lint`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_686265c1d37c832aa3526816a28fc78e