### PR TITLE
Fix player HP not resetting before battles

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -22,6 +22,7 @@ function startBattle() {
     return
   const base = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
   enemy.value = createDexShlagemon(base)
+  active.hpCurrent = active.hp
   playerHp.value = active.hpCurrent
   enemyHp.value = enemy.value.hp
   battleActive.value = true


### PR DESCRIPTION
## Summary
- ensure active Shlagemon HP is restored before each battle

## Testing
- `pnpm test:unit`
- `pnpm test:e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_68626e300ae0832aad058ab320b93a1c