### PR TITLE
Implement zone-based battle logic and shop modal

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import BattleMain from '~/components/battle/BattleMain.vue'
 import ActiveShlagemon from '~/components/panels/ActiveShlagemon.vue'
-import ShopPanel from '~/components/panels/ShopPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import { useGameStateStore } from '~/stores/gameState'
+import { useZoneStore } from '~/stores/zone'
 
 const gameState = useGameStateStore()
+const zone = useZoneStore()
 </script>
 
 <template>
@@ -28,7 +29,7 @@ const gameState = useGameStateStore()
       <div class="zone" md="col-span-6 row-span-5 col-start-4 row-start-2">
         <!-- middle A zone -->
         <div class="zone-content">
-          <BattleMain v-if="gameState.hasPokemon" />
+          <BattleMain v-if="gameState.hasPokemon && zone.current.type !== 'village'" />
         </div>
       </div>
       <div class="zone" md="col-span-6 row-span-1 col-start-4 row-start-7">
@@ -41,7 +42,6 @@ const gameState = useGameStateStore()
         <!-- left zone -->
         <div class="zone-content flex flex-col gap-2">
           <ZonePanel />
-          <ShopPanel />
         </div>
       </div>
       <div class="zone" md="col-span-3 row-span-12 col-start-10 row-start-1">

--- a/src/components/panels/ShopPanel.vue
+++ b/src/components/panels/ShopPanel.vue
@@ -4,6 +4,7 @@ import Button from '~/components/ui/Button.vue'
 import { shopItems } from '~/data/items'
 import { useInventoryStore } from '~/stores/inventory'
 
+const emit = defineEmits(['close'])
 const inventory = useInventoryStore()
 const tab = ref<'shop' | 'inventory'>('shop')
 </script>
@@ -39,6 +40,11 @@ const tab = ref<'shop' | 'inventory'>('shop')
           </div>
         </ItemCard>
       </template>
+    </div>
+    <div class="mt-2 text-right">
+      <Button class="text-xs" @click="emit('close')">
+        Fermer
+      </Button>
     </div>
   </div>
 </template>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import ShopPanel from '~/components/panels/ShopPanel.vue'
 import Button from '~/components/ui/Button.vue'
 import { useZoneStore } from '~/stores/zone'
 
 const zone = useZoneStore()
+const showShop = ref(false)
 
 function onAction(id: string) {
-  // actions to be implemented later
-  console.warn('zone action', id)
+  if (id === 'shop') {
+    showShop.value = true
+  }
 }
 </script>
 
@@ -35,4 +39,7 @@ function onAction(id: string) {
       </Button>
     </div>
   </div>
+  <Modal v-model="showShop">
+    <ShopPanel @close="showShop = false" />
+  </Modal>
 </template>

--- a/test/__snapshots__/component.test.ts.snap
+++ b/test/__snapshots__/component.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`component Header.vue > should render 1`] = `
 "<header class="h-12 flex items-center justify-between bg-gray-100 p-4 dark:bg-gray-800"><img src="/logo.png" alt="Logo Shlagémon" class="h-20 -my-4">
-  <div class="flex items-center gap-2"><button aria-label="Changer de thème" class="relative w-12 h-6 rounded-full bg-gray-200 dark:bg-gray-700 transition-colors" type="button"><span class="absolute left-0.5 top-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-white text-yellow-500 transition-all dark:bg-gray-900 dark:text-yellow-300"><div class="i-carbon-sun"></div></span></button><button class="p-1" aria-label="Reset Save">
+  <div class="flex items-center gap-2"><button aria-label="Changer de thème" class="relative h-6 w-12 rounded-full bg-gray-200 transition-colors dark:bg-gray-700" type="button"><span class="absolute left-0.5 top-0.5 h-5 w-5 flex items-center justify-center rounded-full bg-white text-yellow-500 transition-all dark:bg-gray-900 dark:text-yellow-300"><div class="i-carbon-sun"></div></span></button><button class="p-1" aria-label="Reset Save">
       <div class="i-carbon-trash-can text-red"></div>
     </button></div>
 </header>"

--- a/test/__snapshots__/zone.test.ts.snap
+++ b/test/__snapshots__/zone.test.ts.snap
@@ -4,5 +4,26 @@ exports[`zone panel > renders actions 1`] = `
 "<div class="flex flex-col gap-2" md="gap-3">
   <div class="flex flex-wrap justify-center gap-1" md="gap-2"><button class="rounded px-2 py-1 text-xs bg-primary text-white">Village Paumé</button><button class="rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700">Grotte Sombre</button><button class="rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700">Plaine Verdoyante</button></div>
   <div class="flex flex-col items-center gap-1" md="gap-2"><span class="font-bold">Village Paumé</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs">Entrer le Shop</button></div>
-</div>"
+</div>
+<dialog data-v-b759700c="" class="modal">
+  <div data-v-b759700c="" class="modal-content">
+    <div class="h-full flex flex-col">
+      <div class="mb-2 flex justify-center gap-2"><button class="rounded px-2 py-1 bg-primary text-white"> Boutique </button><button class="rounded px-2 py-1 bg-gray-200 dark:bg-gray-700"> Inventaire </button></div>
+      <div class="flex flex-col gap-2 overflow-auto">
+        <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900"><img src="/items/shlageball/shlageball.png" alt="Shlage Ball" class="h-8 w-8 object-contain">
+          <div class="flex flex-1 flex-col text-left"><span class="font-bold">Shlage Ball</span><span class="text-xs">Permet de capturer des Shlagémons sauvages.</span></div><span class="font-bold">10$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>
+        </div>
+        <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900">
+          <!--v-if-->
+          <div class="flex flex-1 flex-col text-left"><span class="font-bold">Potion Dégueulasse</span><span class="text-xs">Soigne 50 HP de votre Shlagémon.</span></div><span class="font-bold">5$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>
+        </div>
+        <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900">
+          <!--v-if-->
+          <div class="flex flex-1 flex-col text-left"><span class="font-bold">Spray Anti-Odeur</span><span class="text-xs">Augmente temporairement la défense.</span></div><span class="font-bold">7$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>
+        </div>
+      </div>
+      <div class="mt-2 text-right"><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs"> Fermer </button></div>
+    </div>
+  </div>
+</dialog>"
 `;


### PR DESCRIPTION
## Summary
- launch battles only outside villages
- open the shop as a modal from ZonePanel
- add close button to ShopPanel
- update snapshots

## Testing
- `pnpm lint`
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_6862d5341184832aabad715ad3b89b31