### PR TITLE
Move inventory to left panel

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
     ImageByBackground: typeof import('./components/ui/ImageByBackground.vue')['default']
+    InventoryPanel: typeof import('./components/panels/InventoryPanel.vue')['default']
     ItemCard: typeof import('./components/shop/ItemCard.vue')['default']
     Modal: typeof import('./components/modal/Modal.vue')['default']
     PlayerInfos: typeof import('./components/panels/PlayerInfos.vue')['default']

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import BattleMain from '~/components/battle/BattleMain.vue'
 import ActiveShlagemon from '~/components/panels/ActiveShlagemon.vue'
+import InventoryPanel from '~/components/panels/InventoryPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import { useGameStateStore } from '~/stores/gameState'
+import { useInventoryStore } from '~/stores/inventory'
 import { useZoneStore } from '~/stores/zone'
 
 const gameState = useGameStateStore()
 const zone = useZoneStore()
+const inventory = useInventoryStore()
 </script>
 
 <template>
@@ -42,6 +45,7 @@ const zone = useZoneStore()
         <!-- left zone -->
         <div class="zone-content flex flex-col gap-2">
           <ZonePanel />
+          <InventoryPanel v-if="inventory.list.length" />
         </div>
       </div>
       <div class="zone" md="col-span-3 row-span-12 col-start-10 row-start-1">

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import ItemCard from '~/components/shop/ItemCard.vue'
+import Button from '~/components/ui/Button.vue'
+import { useInventoryStore } from '~/stores/inventory'
+
+const inventory = useInventoryStore()
+</script>
+
+<template>
+  <section v-if="inventory.list.length" class="flex flex-col gap-2">
+    <h2 class="mb-2 font-bold">
+      Inventaire
+    </h2>
+    <ItemCard
+      v-for="entry in inventory.list"
+      :key="entry.item.id"
+      :item="entry.item"
+    >
+      <div class="flex items-center gap-1">
+        <span class="font-bold">x{{ entry.qty }}</span>
+        <Button class="text-xs" @click="inventory.useItem(entry.item.id)">
+          Utiliser
+        </Button>
+        <Button
+          type="danger"
+          class="text-xs"
+          @click="inventory.sell(entry.item.id)"
+        >
+          Vendre
+        </Button>
+      </div>
+    </ItemCard>
+  </section>
+</template>

--- a/src/components/panels/ShopPanel.vue
+++ b/src/components/panels/ShopPanel.vue
@@ -6,40 +6,19 @@ import { useInventoryStore } from '~/stores/inventory'
 
 const emit = defineEmits(['close'])
 const inventory = useInventoryStore()
-const tab = ref<'shop' | 'inventory'>('shop')
 </script>
 
 <template>
   <div class="h-full flex flex-col">
-    <div class="mb-2 flex justify-center gap-2">
-      <button class="rounded px-2 py-1" :class="tab === 'shop' ? 'bg-primary text-white' : 'bg-gray-200 dark:bg-gray-700'" @click="tab = 'shop'">
-        Boutique
-      </button>
-      <button class="rounded px-2 py-1" :class="tab === 'inventory' ? 'bg-primary text-white' : 'bg-gray-200 dark:bg-gray-700'" @click="tab = 'inventory'">
-        Inventaire
-      </button>
-    </div>
+    <h2 class="mb-2 text-center font-bold">
+      Boutique
+    </h2>
     <div class="flex flex-col gap-2 overflow-auto">
-      <template v-if="tab === 'shop'">
-        <ItemCard v-for="item in shopItems" :key="item.id" :item="item">
-          <Button class="ml-2" @click="inventory.buy(item.id)">
-            Acheter
-          </Button>
-        </ItemCard>
-      </template>
-      <template v-else>
-        <ItemCard v-for="entry in inventory.list" :key="entry.item.id" :item="entry.item">
-          <div class="flex items-center gap-1">
-            <span class="font-bold">x{{ entry.qty }}</span>
-            <Button class="text-xs" @click="inventory.remove(entry.item.id)">
-              Utiliser
-            </Button>
-            <Button type="danger" class="text-xs" @click="inventory.sell(entry.item.id)">
-              Vendre
-            </Button>
-          </div>
-        </ItemCard>
-      </template>
+      <ItemCard v-for="item in shopItems" :key="item.id" :item="item">
+        <Button class="ml-2" @click="inventory.buy(item.id)">
+          Acheter
+        </Button>
+      </ItemCard>
     </div>
     <div class="mt-2 text-right">
       <Button class="text-xs" @click="emit('close')">

--- a/test/__snapshots__/zone.test.ts.snap
+++ b/test/__snapshots__/zone.test.ts.snap
@@ -8,7 +8,7 @@ exports[`zone panel > renders actions 1`] = `
 <dialog data-v-b759700c="" class="modal">
   <div data-v-b759700c="" class="modal-content">
     <div class="h-full flex flex-col">
-      <div class="mb-2 flex justify-center gap-2"><button class="rounded px-2 py-1 bg-primary text-white"> Boutique </button><button class="rounded px-2 py-1 bg-gray-200 dark:bg-gray-700"> Inventaire </button></div>
+      <h2 class="mb-2 text-center font-bold"> Boutique </h2>
       <div class="flex flex-col gap-2 overflow-auto">
         <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900"><img src="/items/shlageball/shlageball.png" alt="Shlage Ball" class="h-8 w-8 object-contain">
           <div class="flex flex-1 flex-col text-left"><span class="font-bold">Shlage Ball</span><span class="text-xs">Permet de capturer des Shlagémons sauvages.</span></div><span class="font-bold">10$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>


### PR DESCRIPTION
## Summary
- add InventoryPanel and show it in GameGrid
- simplify ShopPanel to only show shop
- update component typings
- update zone panel snapshot

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6862e16318f0832ab01875160cf429f0