### PR TITLE
Add modal close button and outside click

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -1,7 +1,17 @@
 <script setup lang="ts">
-const props = defineProps<{ modelValue: boolean }>()
+const props = withDefaults(defineProps<{
+  modelValue: boolean
+  closeOnOutsideClick?: boolean
+}>(), {
+  closeOnOutsideClick: true,
+})
 const emit = defineEmits(['update:modelValue', 'close'])
 const dialogRef = ref<HTMLDialogElement | null>(null)
+
+function onDialogClick(e: MouseEvent) {
+  if (props.closeOnOutsideClick && e.target === dialogRef.value)
+    close()
+}
 
 watch(() => props.modelValue, (v) => {
   const dialog = dialogRef.value
@@ -30,8 +40,20 @@ function close() {
 </script>
 
 <template>
-  <dialog ref="dialogRef" class="modal" @close="emit('update:modelValue', false); emit('close')">
-    <div class="modal-content">
+  <dialog
+    ref="dialogRef"
+    class="modal"
+    @click="onDialogClick"
+    @close="emit('update:modelValue', false); emit('close')"
+  >
+    <div class="modal-content relative">
+      <button
+        type="button"
+        class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+        @click.stop="close()"
+      >
+        &times;
+      </button>
       <slot />
     </div>
   </dialog>

--- a/src/components/panels/ShopPanel.vue
+++ b/src/components/panels/ShopPanel.vue
@@ -4,7 +4,6 @@ import Button from '~/components/ui/Button.vue'
 import { shopItems } from '~/data/items'
 import { useInventoryStore } from '~/stores/inventory'
 
-const emit = defineEmits(['close'])
 const inventory = useInventoryStore()
 </script>
 
@@ -19,11 +18,6 @@ const inventory = useInventoryStore()
           Acheter
         </Button>
       </ItemCard>
-    </div>
-    <div class="mt-2 text-right">
-      <Button class="text-xs" @click="emit('close')">
-        Fermer
-      </Button>
     </div>
   </div>
 </template>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -39,7 +39,7 @@ function onAction(id: string) {
       </Button>
     </div>
   </div>
-  <Modal v-model="showShop">
-    <ShopPanel @close="showShop = false" />
+  <Modal v-model="showShop" @close="showShop = false">
+    <ShopPanel />
   </Modal>
 </template>

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -52,8 +52,8 @@ function isActive(mon: DexShlagemon) {
         />
       </div>
     </div>
-    <Modal v-model="showDetail">
-      <ShlagemonDetail :mon="detailMon" @close="showDetail = false" />
+    <Modal v-model="showDetail" @close="showDetail = false">
+      <ShlagemonDetail :mon="detailMon" />
     </Modal>
   </section>
 </template>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -4,7 +4,6 @@ import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { xpForLevel } from '~/utils/dexFactory'
 
 const props = defineProps<{ mon: DexShlagemon | null }>()
-const emit = defineEmits(['close'])
 
 const statColors = [
   'bg-red-200 dark:bg-red-700',
@@ -59,11 +58,6 @@ const maxXp = computed(() => props.mon ? xpForLevel(props.mon.lvl) : 0)
         Expérience : {{ mon.xp }} / {{ maxXp }}
       </div>
       <ProgressBar :value="mon.xp" :max="maxXp" class="w-full" />
-    </div>
-    <div class="mt-4 text-right">
-      <button class="bg-primary rounded px-3 py-1 text-white" @click="emit('close')">
-        Fermer
-      </button>
     </div>
   </div>
 </template>

--- a/test/__snapshots__/zone.test.ts.snap
+++ b/test/__snapshots__/zone.test.ts.snap
@@ -6,7 +6,7 @@ exports[`zone panel > renders actions 1`] = `
   <div class="flex flex-col items-center gap-1" md="gap-2"><span class="font-bold">Village Paumé</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs">Entrer le Shop</button></div>
 </div>
 <dialog data-v-b759700c="" class="modal">
-  <div data-v-b759700c="" class="modal-content">
+  <div data-v-b759700c="" class="modal-content relative"><button data-v-b759700c="" type="button" class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"> × </button>
     <div class="h-full flex flex-col">
       <h2 class="mb-2 text-center font-bold"> Boutique </h2>
       <div class="flex flex-col gap-2 overflow-auto">
@@ -22,7 +22,6 @@ exports[`zone panel > renders actions 1`] = `
           <div class="flex flex-1 flex-col text-left"><span class="font-bold">Spray Anti-Odeur</span><span class="text-xs">Augmente temporairement la défense.</span></div><span class="font-bold">7$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>
         </div>
       </div>
-      <div class="mt-2 text-right"><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs"> Fermer </button></div>
     </div>
   </div>
 </dialog>"


### PR DESCRIPTION
## Summary
- add configurable close button to modal
- remove close button from panel components
- update snapshots and modal usage

## Testing
- `pnpm lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6862e93b2ae8832a86802544551253b7