### PR TITLE
Add footer close option to Modal

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
+import { nextTick } from 'vue'
+import Button from '~/components/ui/Button.vue'
+
 const props = withDefaults(defineProps<{
   modelValue: boolean
   closeOnOutsideClick?: boolean
+  footerClose?: boolean
 }>(), {
   closeOnOutsideClick: true,
+  footerClose: false,
 })
 const emit = defineEmits(['update:modelValue', 'close'])
 const dialogRef = ref<HTMLDialogElement | null>(null)
@@ -13,12 +18,14 @@ function onDialogClick(e: MouseEvent) {
     close()
 }
 
-watch(() => props.modelValue, (v) => {
+watch(() => props.modelValue, async (v) => {
   const dialog = dialogRef.value
   if (!dialog)
     return
   if (v) {
-    dialog.showModal()
+    await nextTick()
+    if (!dialog.open)
+      dialog.showModal()
   }
   else {
     close()
@@ -46,8 +53,9 @@ function close() {
     @click="onDialogClick"
     @close="emit('update:modelValue', false); emit('close')"
   >
-    <div class="modal-content relative">
+    <div class="modal-content relative flex flex-col">
       <button
+        v-if="!props.footerClose"
         type="button"
         class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
         @click.stop="close()"
@@ -55,6 +63,12 @@ function close() {
         &times;
       </button>
       <slot />
+      <div v-if="props.footerClose" class="mt-4 flex justify-end">
+        <Button type="danger" class="flex items-center gap-1" @click.stop="close()">
+          <div i-carbon-close />
+          Fermer
+        </Button>
+      </div>
     </div>
   </dialog>
 </template>

--- a/test/__snapshots__/zone.test.ts.snap
+++ b/test/__snapshots__/zone.test.ts.snap
@@ -6,7 +6,7 @@ exports[`zone panel > renders actions 1`] = `
   <div class="flex flex-col items-center gap-1" md="gap-2"><span class="font-bold">Village Paumé</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs">Entrer le Shop</button></div>
 </div>
 <dialog data-v-b759700c="" class="modal">
-  <div data-v-b759700c="" class="modal-content relative"><button data-v-b759700c="" type="button" class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"> × </button>
+  <div data-v-b759700c="" class="modal-content relative flex flex-col"><button data-v-b759700c="" type="button" class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"> × </button>
     <div class="h-full flex flex-col">
       <h2 class="mb-2 text-center font-bold"> Boutique </h2>
       <div class="flex flex-col gap-2 overflow-auto">
@@ -23,6 +23,7 @@ exports[`zone panel > renders actions 1`] = `
         </div>
       </div>
     </div>
+    <!--v-if-->
   </div>
 </dialog>"
 `;


### PR DESCRIPTION
## Summary
- enhance Modal component with `footerClose` prop
- add asynchronous showModal handling
- update snapshot after markup change

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6862f0244ea8832aa5b941aa0f388608