### PR TITLE
Fix modal closing on shlagemon detail

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { nextTick } from 'vue'
 import Button from '~/components/ui/Button.vue'
 
 const props = withDefaults(defineProps<{
@@ -18,12 +17,11 @@ function onDialogClick(e: MouseEvent) {
     close()
 }
 
-watch(() => props.modelValue, async (v) => {
+watch(() => props.modelValue, (v) => {
   const dialog = dialogRef.value
   if (!dialog)
     return
   if (v) {
-    await nextTick()
     if (!dialog.open)
       dialog.showModal()
   }

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -33,7 +33,7 @@ function isActive(mon: DexShlagemon) {
         hover="bg-gray-100 dark:bg-gray-800"
         :class="{ 'bg-primary/20': isActive(mon) }"
         :style="isActive(mon) ? { backgroundImage: `url(/shlagemons/${mon.base.id}/${mon.base.id}.png)`, backgroundRepeat: 'no-repeat', backgroundSize: 'cover', backgroundPosition: 'center' } : {}"
-        @click="open(mon)"
+        @click.stop="open(mon)"
       >
         <div class="flex items-center gap-2">
           <img :src="`/shlagemons/${mon.base.id}/${mon.base.id}.png`" :alt="mon.base.name" class="h-10 w-10 object-contain">


### PR DESCRIPTION
## Summary
- avoid waiting for DOM tick when opening modal
- stop click propagation when opening shlagemon detail

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6862f37c61a4832a82d31d7d2ebeab4b