### PR TITLE
Fix modal closing duplication

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -26,20 +26,19 @@ watch(() => props.modelValue, (v) => {
       dialog.showModal()
   }
   else {
-    close()
+    if (dialog.open)
+      close()
   }
 })
 
 function close() {
   const dialog = dialogRef.value
-  if (!dialog)
+  if (!dialog || dialog.classList.contains('closing'))
     return
   dialog.classList.add('closing')
   dialog.addEventListener('animationend', () => {
     dialog.classList.remove('closing')
     dialog.close()
-    emit('update:modelValue', false)
-    emit('close')
   }, { once: true })
 }
 </script>


### PR DESCRIPTION
## Summary
- guard close logic so dialog `close` event emits once
- avoid closing if `modelValue` is set to false while dialog already closed

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686393425c84832a86ae233f7986c662