### PR TITLE
Fix HP updating on Pokémon switch

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -70,7 +70,10 @@ function checkEnd() {
 watch(
   () => dex.activeShlagemon,
   (mon) => {
-    if (mon && !battleActive.value && battleInterval === undefined)
+    if (!mon)
+      return
+    playerHp.value = mon.hpCurrent
+    if (!battleActive.value && battleInterval === undefined)
       startBattle()
   },
   { immediate: true },

--- a/test/battle-switch.test.ts
+++ b/test/battle-switch.test.ts
@@ -1,0 +1,34 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import BattleMain from '../src/components/battle/BattleMain.vue'
+import { carapouffe, salamiches } from '../src/data/shlagemons'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('battleMain switch', () => {
+  it('updates hp when active shlagemon changes', async () => {
+    vi.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const mon1 = dex.createShlagemon(carapouffe)
+    const mon2 = dex.createShlagemon(salamiches)
+    dex.setActiveShlagemon(mon1)
+    const wrapper = mount(BattleMain, {
+      global: {
+        plugins: [pinia],
+        stubs: ['ProgressBar', 'ImageByBackground'],
+      },
+    })
+    await nextTick()
+    let hpDisplay = wrapper.findAll('.hp').at(0)!.text()
+    expect(hpDisplay).toContain(String(mon1.hp))
+    dex.setActiveShlagemon(mon2)
+    await nextTick()
+    hpDisplay = wrapper.findAll('.hp').at(0)!.text()
+    expect(hpDisplay).toContain(String(mon2.hp))
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- ensure the battle panel tracks current HP when switching active Pokémon
- add regression test for switching active Pokémon during battle

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6863bcc45bb8832a9485672a17ac8031