### PR TITLE
Implement duplicate capture rules

### DIFF
--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -62,7 +62,7 @@ export const useInventoryStore = defineStore('inventory', () => {
     if (id === 'shlageball') {
       // simple capture of random shlagemon
       const base = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
-      dex.createShlagemon(base)
+      dex.captureShlagemon(base)
       remove(id)
       return true
     }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -1,6 +1,12 @@
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
-import { applyStats, createDexShlagemon, xpForLevel } from '~/utils/dexFactory'
+import {
+  applyStats,
+  baseStats,
+  createDexShlagemon,
+  statWithRarityAndCoefficient,
+  xpForLevel,
+} from '~/utils/dexFactory'
 import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
 
 export const useShlagedexStore = defineStore('shlagedex', () => {
@@ -61,7 +67,41 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return mon
   }
 
-  return { shlagemons, activeShlagemon, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, gainXp, healActive, boostDefense }
+  function captureShlagemon(base: BaseShlagemon) {
+    const existing = shlagemons.value.find(mon => mon.base.id === base.id)
+    if (existing) {
+      if (existing.rarity < 100)
+        existing.rarity += 1
+      existing.lvl = 1
+      existing.xp = 0
+      existing.hp = statWithRarityAndCoefficient(
+        baseStats.hp,
+        existing.base.coefficient,
+        existing.rarity,
+      )
+      existing.attack = statWithRarityAndCoefficient(
+        baseStats.attack,
+        existing.base.coefficient,
+        existing.rarity,
+      )
+      existing.defense = statWithRarityAndCoefficient(
+        baseStats.defense,
+        existing.base.coefficient,
+        existing.rarity,
+      )
+      existing.smelling = statWithRarityAndCoefficient(
+        baseStats.smelling,
+        existing.base.coefficient,
+        existing.rarity,
+      )
+      applyStats(existing)
+      existing.hpCurrent = existing.hp
+      return existing
+    }
+    return createShlagemon(base)
+  }
+
+  return { shlagemons, activeShlagemon, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, gainXp, healActive, boostDefense }
 }, {
   persist: {
     debug: true,

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -1,7 +1,7 @@
 import type { Stats } from '~/type'
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 
-const baseStats: Stats = {
+export const baseStats: Stats = {
   hp: 250,
   attack: 15,
   defense: 10,
@@ -46,7 +46,7 @@ function generateRarity(): number {
   return Math.floor(1 + skewed * 99)
 }
 
-function statWithRarityAndCoefficient(base: number, coefficient: number, rarity: number): number {
+export function statWithRarityAndCoefficient(base: number, coefficient: number, rarity: number): number {
   const coefficientBoost = 1 + 2.5 * (coefficient - 1) / 999 // 1.0 → 3.5
   const rarityBoost = 1 + 0.25 * (rarity - 1) / 99 // 1.0 → 1.25
   const randomFactor = 0.95 + Math.random() * 0.1 // ±5%


### PR DESCRIPTION
## Summary
- export helper functions from `dexFactory`
- add `captureShlagemon` method to handle duplicate captures
- use new capture logic when using a Shlagéball

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch fonts blocked but tests pass before cancellation)*

------
https://chatgpt.com/codex/tasks/task_e_6863bd72569c832a985565d292402535