### PR TITLE
Add toast notification on rarity upgrade

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -72,8 +72,10 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   function captureShlagemon(base: BaseShlagemon) {
     const existing = shlagemons.value.find(mon => mon.base.id === base.id)
     if (existing) {
-      if (existing.rarity < 100)
+      if (existing.rarity < 100) {
         existing.rarity += 1
+        toast(`${existing.base.name} atteint la rareté ${existing.rarity} !`)
+      }
       existing.lvl = 1
       existing.xp = 0
       existing.hp = statWithRarityAndCoefficient(

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -1,0 +1,24 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { toast } from 'vue3-toastify'
+import { carapouffe } from '../src/data/shlagemons'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
+
+const toastMock = vi.mocked(toast)
+
+describe('shlagedex capture', () => {
+  it('notifies when rarity increases', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.rarity = 1
+    toastMock.mockClear()
+    dex.captureShlagemon(carapouffe)
+    expect(mon.rarity).toBe(2)
+    expect(toastMock).toHaveBeenCalledWith(
+      `${mon.base.name} atteint la rareté ${mon.rarity} !`,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- notify rarity level upgrades for a shlagémon when capturing duplicates
- add test for rarity upgrade toast

## Testing
- `pnpm exec vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_6863cea839dc832abeb2b30da659b25e