### PR TITLE
Fix battle level calculation and add regression test

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -24,8 +24,9 @@ function startBattle() {
     return
   const base = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
   enemy.value = createDexShlagemon(base)
-  const min = zone.current.minLevel
-  const max = Math.max(zone.current.maxLevel - 1, min)
+  const min = Number(zone.current.minLevel ?? 1)
+  const zoneMax = Number(zone.current.maxLevel ?? (min + 1))
+  const max = Math.max(zoneMax - 1, min)
   const lvl = Math.floor(Math.random() * (max - min + 1)) + min
   enemy.value.lvl = lvl
   applyStats(enemy.value)

--- a/test/battle-nan.test.ts
+++ b/test/battle-nan.test.ts
@@ -1,0 +1,28 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import BattleMain from '../src/components/battle/BattleMain.vue'
+import { carapouffe } from '../src/data/shlagemons'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useZoneStore } from '../src/stores/zone'
+
+describe('battle NaN bug', () => {
+  it('should not produce NaN hp or level', async () => {
+    vi.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const zone = useZoneStore()
+    dex.createShlagemon(carapouffe)
+    zone.setZone('plaine')
+    const wrapper = mount(BattleMain, {
+      global: { plugins: [pinia], stubs: ['ProgressBar', 'ImageByBackground'] },
+    })
+    await Promise.resolve()
+    vi.runOnlyPendingTimers()
+    const text = wrapper.text()
+    expect(text).not.toContain('NaN')
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- avoid NaN levels by guarding zone level values when starting a battle
- add test ensuring battle never renders NaN values

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6863d35526f8832a9efbb99199b829af