### PR TITLE
Reduce manual battle damage

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -40,7 +40,7 @@ function startBattle() {
 function attack() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
-  enemyHp.value = Math.max(0, enemyHp.value - dex.activeShlagemon.attack)
+  enemyHp.value = Math.max(0, enemyHp.value - 1)
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
   checkEnd()


### PR DESCRIPTION
## Summary
- tweak manual attack damage to subtract just 1 HP

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6863d5d42978832a9a19c35c0afd6404