### PR TITLE
Fix zone persistence causing wrong levels

### DIFF
--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -1,23 +1,25 @@
 import type { Zone } from '~/type/zone'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { zonesData } from '~/data/zones'
 
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
-  const current = ref<Zone>(zones.value[0])
+  const currentId = ref<string>(zones.value[0].id)
+  const current = computed(() => zones.value.find(z => z.id === currentId.value)!)
 
   function setZone(id: string) {
-    const zone = zones.value.find(z => z.id === id)
-    if (zone)
-      current.value = zone
+    if (zones.value.some(z => z.id === id))
+      currentId.value = id
   }
 
   function reset() {
-    current.value = zones.value[0]
+    currentId.value = zones.value[0].id
   }
 
   return { zones, current, setZone, reset }
 }, {
-  persist: true,
+  persist: {
+    paths: ['currentId'],
+  },
 })


### PR DESCRIPTION
## Summary
- store only the active zone id rather than the whole zone objects
- derive the current zone from that id

This avoids persisting outdated zone definitions and keeps enemy levels consistent.

## Testing
- `pnpm test:unit`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6863d8189b84832aa9ddf4274ee8f034