### PR TITLE
Limit zone list to player's level

### DIFF
--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import Modal from '~/components/modal/Modal.vue'
 import ShopPanel from '~/components/panels/ShopPanel.vue'
 import Button from '~/components/ui/Button.vue'
+import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 
 const zone = useZoneStore()
+const dex = useShlagedexStore()
 const showShop = ref(false)
+
+const availableZones = computed(() =>
+  zone.zones.filter(z => z.type === 'village' || dex.highestLevel >= z.minLevel),
+)
 
 function onAction(id: string) {
   if (id === 'shop') {
@@ -18,7 +25,7 @@ function onAction(id: string) {
   <div class="flex flex-col gap-2" md="gap-3">
     <div class="flex flex-wrap justify-center gap-1" md="gap-2">
       <button
-        v-for="z in zone.zones"
+        v-for="z in availableZones"
         :key="z.id"
         class="rounded px-2 py-1 text-xs"
         :class="z.id === zone.current.id ? 'bg-primary text-white' : 'bg-gray-200 dark:bg-gray-700'"

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -13,11 +13,22 @@ import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
 export const useShlagedexStore = defineStore('shlagedex', () => {
   const shlagemons = ref<DexShlagemon[]>([])
   const activeShlagemon = ref<DexShlagemon | null>(null)
+  const highestLevel = ref(0)
+
+  function updateHighestLevel(mon: DexShlagemon) {
+    if (mon.lvl > highestLevel.value)
+      highestLevel.value = mon.lvl
+  }
+
+  function recomputeHighestLevel() {
+    highestLevel.value = shlagemons.value.reduce((max, m) => Math.max(max, m.lvl), 0)
+  }
 
   function addShlagemon(mon: DexShlagemon) {
     shlagemons.value.push(mon)
     if (!activeShlagemon.value)
       activeShlagemon.value = mon
+    updateHighestLevel(mon)
   }
 
   function setActiveShlagemon(mon: DexShlagemon) {
@@ -26,11 +37,13 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
 
   function setShlagemons(mons: DexShlagemon[]) {
     shlagemons.value = [...mons]
+    recomputeHighestLevel()
   }
 
   function reset() {
     shlagemons.value = []
     activeShlagemon.value = null
+    highestLevel.value = 0
   }
 
   function healActive(amount: number) {
@@ -61,6 +74,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       mon.lvl += 1
       applyStats(mon)
       mon.hpCurrent = mon.hp
+      updateHighestLevel(mon)
     }
     if (mon.lvl >= maxLevel)
       mon.xp = 0
@@ -69,6 +83,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   function createShlagemon(base: BaseShlagemon) {
     const mon = createDexShlagemon(base)
     addShlagemon(mon)
+    updateHighestLevel(mon)
     toast(`Tu as obtenu ${base.name} !`)
     return mon
   }
@@ -104,12 +119,15 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       )
       applyStats(existing)
       existing.hpCurrent = existing.hp
+      updateHighestLevel(existing)
       return existing
     }
-    return createShlagemon(base)
+    const created = createShlagemon(base)
+    updateHighestLevel(created)
+    return created
   }
 
-  return { shlagemons, activeShlagemon, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, gainXp, healActive, boostDefense }
+  return { shlagemons, activeShlagemon, highestLevel, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, gainXp, healActive, boostDefense }
 }, {
   persist: {
     debug: true,

--- a/test/__snapshots__/zone.test.ts.snap
+++ b/test/__snapshots__/zone.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`zone panel > renders actions 1`] = `
 "<div class="flex flex-col gap-2" md="gap-3">
-  <div class="flex flex-wrap justify-center gap-1" md="gap-2"><button class="rounded px-2 py-1 text-xs bg-primary text-white">Village Paumé</button><button class="rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700">Grotte Sombre</button><button class="rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700">Plaine Verdoyante</button></div>
+  <div class="flex flex-wrap justify-center gap-1" md="gap-2"><button class="rounded px-2 py-1 text-xs bg-primary text-white">Village Paumé</button></div>
   <div class="flex flex-col items-center gap-1" md="gap-2"><span class="font-bold">Village Paumé</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs">Entrer le Shop</button></div>
 </div>
 <dialog data-v-b759700c="" class="modal">

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { toast } from 'vue3-toastify'
 import { carapouffe } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
+import { xpForLevel } from '../src/utils/dexFactory'
 
 vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
 
@@ -20,5 +21,18 @@ describe('shlagedex capture', () => {
     expect(toastMock).toHaveBeenCalledWith(
       `${mon.base.name} atteint la rareté ${mon.rarity} !`,
     )
+  })
+})
+
+describe('shlagedex highest level', () => {
+  it('updates when a mon levels up', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    expect(dex.highestLevel).toBe(1)
+    for (let i = 0; i < 9; i++)
+      dex.gainXp(mon, xpForLevel(mon.lvl))
+    expect(mon.lvl).toBe(10)
+    expect(dex.highestLevel).toBe(10)
   })
 })

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -2,7 +2,10 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import ZonePanel from '../src/components/panels/ZonePanel.vue'
+import { carapouffe } from '../src/data/shlagemons'
+import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useZoneStore } from '../src/stores/zone'
+import { xpForLevel } from '../src/utils/dexFactory'
 
 describe('zone store', () => {
   it('changes current zone', () => {
@@ -23,5 +26,20 @@ describe('zone panel', () => {
     })
     expect(wrapper.text()).toContain('Entrer le Shop')
     expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('filters zones by level', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    const wrapper = mount(ZonePanel, {
+      global: { plugins: [pinia] },
+    })
+    expect(wrapper.text()).not.toContain('Grotte Sombre')
+    for (let i = 0; i < 9; i++)
+      dex.gainXp(mon, xpForLevel(mon.lvl))
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Grotte Sombre')
   })
 })


### PR DESCRIPTION
## Summary
- track highest level reached in shlagédex store
- show only accessible zones based on highest level
- test highest level tracking and zone filtering

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6863de4ac6f8832a990bfe2af65886cb