### PR TITLE
Add satirical high-level zones

### DIFF
--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -31,4 +31,74 @@ export const zonesData: Zone[] = [
     minLevel: 1,
     maxLevel: 10,
   },
+  {
+    id: 'ravin-rattatak',
+    name: 'Ravin Rattatak',
+    type: 'sauvage',
+    actions: [
+      { id: 'battle', label: 'Chercher un Shlagémon' },
+    ],
+    minLevel: 20,
+    maxLevel: 30,
+  },
+  {
+    id: 'marais-smogogo',
+    name: 'Marais Smogogo',
+    type: 'sauvage',
+    actions: [
+      { id: 'battle', label: 'Chercher un Shlagémon' },
+    ],
+    minLevel: 30,
+    maxLevel: 40,
+  },
+  {
+    id: 'forteresse-machoak',
+    name: 'Forteresse Machoak',
+    type: 'grotte',
+    actions: [
+      { id: 'explore', label: 'Explorer la Forteresse' },
+    ],
+    minLevel: 40,
+    maxLevel: 50,
+  },
+  {
+    id: 'mont-dracatombe',
+    name: 'Mont Dracatombe',
+    type: 'grotte',
+    actions: [
+      { id: 'explore', label: 'Gravir le Mont' },
+    ],
+    minLevel: 50,
+    maxLevel: 60,
+  },
+  {
+    id: 'catacombes-tenefrites',
+    name: 'Catacombes Ténéfrites',
+    type: 'grotte',
+    actions: [
+      { id: 'explore', label: 'Fouiller les Catacombes' },
+    ],
+    minLevel: 60,
+    maxLevel: 70,
+  },
+  {
+    id: 'zone-ultraflop',
+    name: 'Zone Ultra-Flop',
+    type: 'sauvage',
+    actions: [
+      { id: 'battle', label: 'Chercher un Shlagémon' },
+    ],
+    minLevel: 80,
+    maxLevel: 90,
+  },
+  {
+    id: 'dome-mewpocalypse',
+    name: 'Dôme Mewpocalypse',
+    type: 'grotte',
+    actions: [
+      { id: 'explore', label: 'Affronter la Fin' },
+    ],
+    minLevel: 90,
+    maxLevel: 100,
+  },
 ]


### PR DESCRIPTION
## Summary
- add seven high-level zones inspired by Pokémon with a satirical twist

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: exit code 130 after manual cancel but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6863e27e2b78832a8475b232c1ea4a03