### PR TITLE
fix xp gain and high level stats

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -4,7 +4,7 @@ import { allShlagemons } from '~/data/shlagemons'
 import { useGameStore } from '~/stores/game'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
-import { applyStats, createDexShlagemon, xpForLevel } from '~/utils/dexFactory'
+import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
 const game = useGameStore()
@@ -68,8 +68,13 @@ function checkEnd() {
       dex.activeShlagemon.hpCurrent = playerHp.value
     if (enemyHp.value <= 0 && playerHp.value > 0) {
       game.addShlagidolar(1)
-      if (dex.activeShlagemon && enemy.value)
-        dex.gainXp(dex.activeShlagemon, xpForLevel(enemy.value.lvl), zone.current.maxLevel)
+      if (dex.activeShlagemon && enemy.value) {
+        dex.gainXp(
+          dex.activeShlagemon,
+          xpRewardForLevel(enemy.value.lvl),
+          zone.current.maxLevel,
+        )
+      }
     }
     setTimeout(startBattle, 1000)
   }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -97,26 +97,28 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       }
       existing.lvl = 1
       existing.xp = 0
-      existing.hp = statWithRarityAndCoefficient(
-        baseStats.hp,
-        existing.base.coefficient,
-        existing.rarity,
-      )
-      existing.attack = statWithRarityAndCoefficient(
-        baseStats.attack,
-        existing.base.coefficient,
-        existing.rarity,
-      )
-      existing.defense = statWithRarityAndCoefficient(
-        baseStats.defense,
-        existing.base.coefficient,
-        existing.rarity,
-      )
-      existing.smelling = statWithRarityAndCoefficient(
-        baseStats.smelling,
-        existing.base.coefficient,
-        existing.rarity,
-      )
+      existing.baseStats = {
+        hp: statWithRarityAndCoefficient(
+          baseStats.hp,
+          existing.base.coefficient,
+          existing.rarity,
+        ),
+        attack: statWithRarityAndCoefficient(
+          baseStats.attack,
+          existing.base.coefficient,
+          existing.rarity,
+        ),
+        defense: statWithRarityAndCoefficient(
+          baseStats.defense,
+          existing.base.coefficient,
+          existing.rarity,
+        ),
+        smelling: statWithRarityAndCoefficient(
+          baseStats.smelling,
+          existing.base.coefficient,
+          existing.rarity,
+        ),
+      }
       applyStats(existing)
       existing.hpCurrent = existing.hp
       updateHighestLevel(existing)

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -17,6 +17,7 @@ export interface BaseShlagemon {
 export interface DexShlagemon extends Stats {
   id: string
   base: BaseShlagemon
+  baseStats: Stats
   lvl: number
   xp: number
   rarity: number

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -9,14 +9,18 @@ export const baseStats: Stats = {
 }
 
 export function xpForLevel(level: number): number {
-  return Math.floor(100 * 1.1 ** (level - 1))
+  return Math.floor(150 * 1.2 ** (level - 1))
+}
+
+export function xpRewardForLevel(level: number): number {
+  return Math.floor(xpForLevel(level) / 3)
 }
 
 export function applyStats(mon: DexShlagemon) {
-  mon.hp = Math.floor(mon.hp + (mon.lvl - 1) * 5)
-  mon.attack = Math.floor(mon.attack + (mon.lvl - 1) * 2)
-  mon.defense = Math.floor(mon.defense + (mon.lvl - 1) * 2)
-  mon.smelling = Math.floor(mon.smelling + (mon.lvl - 1) * 0.5)
+  mon.hp = Math.floor(mon.baseStats.hp + (mon.lvl - 1) * 5)
+  mon.attack = Math.floor(mon.baseStats.attack + (mon.lvl - 1) * 2)
+  mon.defense = Math.floor(mon.baseStats.defense + (mon.lvl - 1) * 2)
+  mon.smelling = Math.floor(mon.baseStats.smelling + (mon.lvl - 1) * 0.5)
   mon.hpCurrent = mon.hp
 }
 
@@ -25,13 +29,19 @@ export function createDexShlagemon(base: BaseShlagemon): DexShlagemon {
   const mon: DexShlagemon = {
     id: crypto.randomUUID(),
     base,
+    baseStats: {
+      hp: statWithRarityAndCoefficient(baseStats.hp, base.coefficient, rarity),
+      attack: statWithRarityAndCoefficient(baseStats.attack, base.coefficient, rarity),
+      defense: statWithRarityAndCoefficient(baseStats.defense, base.coefficient, rarity),
+      smelling: statWithRarityAndCoefficient(baseStats.smelling, base.coefficient, rarity),
+    },
     lvl: 1,
     xp: 0,
     rarity,
-    hp: statWithRarityAndCoefficient(baseStats.hp, base.coefficient, rarity),
-    attack: statWithRarityAndCoefficient(baseStats.attack, base.coefficient, rarity),
-    defense: statWithRarityAndCoefficient(baseStats.defense, base.coefficient, rarity),
-    smelling: statWithRarityAndCoefficient(baseStats.smelling, base.coefficient, rarity),
+    hp: 0,
+    attack: 0,
+    defense: 0,
+    smelling: 0,
     sex: Math.random() < 0.5 ? 'male' : 'female',
     isShiny: Math.random() < 0.0001,
     hpCurrent: 0,


### PR DESCRIPTION
## Summary
- keep initial base stats in DexShlagemon so stat scaling is correct
- recompute stats from stored base values when levels change
- tweak xp curve and reduce xp gained per fight

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` *(fails: Snapshot `zone panel > renders actions 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8182e78832aa76018bfef776755