### PR TITLE
Improve HP scaling

### DIFF
--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -25,7 +25,8 @@ export function applyStats(mon: DexShlagemon) {
       smelling: statWithRarityAndCoefficient(baseStats.smelling, mon.base.coefficient, mon.rarity),
     }
   }
-  mon.hp = Math.floor(mon.baseStats.hp + (mon.lvl - 1) * 5)
+  const levelBoost = 1 + (mon.lvl - 1) * 0.02
+  mon.hp = Math.floor((mon.baseStats.hp + (mon.lvl - 1) * 5) * levelBoost)
   mon.attack = Math.floor(mon.baseStats.attack + (mon.lvl - 1) * 2)
   mon.defense = Math.floor(mon.baseStats.defense + (mon.lvl - 1) * 2)
   mon.smelling = Math.floor(mon.baseStats.smelling + (mon.lvl - 1) * 0.5)

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -12,8 +12,8 @@ describe('zone store', () => {
     setActivePinia(createPinia())
     const store = useZoneStore()
     expect(store.current.id).toBe(store.zones[0].id)
-    store.setZone('grotte')
-    expect(store.current.id).toBe('grotte')
+    store.setZone('grotte-du-slip')
+    expect(store.current.id).toBe('grotte-du-slip')
   })
 })
 
@@ -36,10 +36,10 @@ describe('zone panel', () => {
     const wrapper = mount(ZonePanel, {
       global: { plugins: [pinia] },
     })
-    expect(wrapper.text()).not.toContain('Grotte Sombre')
+    expect(wrapper.text()).not.toContain('Grotte du Slip')
     for (let i = 0; i < 9; i++)
       dex.gainXp(mon, xpForLevel(mon.lvl))
     await wrapper.vm.$nextTick()
-    expect(wrapper.text()).toContain('Grotte Sombre')
+    expect(wrapper.text()).toContain('Grotte du Slip')
   })
 })


### PR DESCRIPTION
## Summary
- tweak HP scaling so high level battles last longer
- fix outdated zone tests for changed dataset

## Testing
- `npx vitest run test/zone.test.ts`
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_686425f69724832ab08691e8159981c8