### PR TITLE
Add Shlagémon capture system

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import CaptureMenu from '~/components/battle/CaptureMenu.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { useGameStore } from '~/stores/game'
@@ -17,6 +18,17 @@ const battleActive = ref(false)
 const flashPlayer = ref(false)
 const flashEnemy = ref(false)
 let battleInterval: number | undefined
+
+function onCapture(success: boolean) {
+  if (!success)
+    return
+  battleActive.value = false
+  if (battleInterval)
+    clearInterval(battleInterval)
+  battleInterval = undefined
+  enemy.value = null
+  setTimeout(startBattle, 1000)
+}
 
 function startBattle() {
   const active = dex.activeShlagemon
@@ -114,30 +126,33 @@ onUnmounted(() => {
     <div v-if="zone.current.maxLevel" class="mb-1 font-bold">
       {{ zone.current.name }} (lvl {{ zone.current.minLevel }} à {{ zone.current.maxLevel }})
     </div>
-    <div v-if="dex.activeShlagemon && enemy" class="flex flex-1 items-center justify-center gap-4">
-      <div class="mon flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
-        <img :src="`/shlagemons/${dex.activeShlagemon.base.id}/${dex.activeShlagemon.base.id}.png`" class="max-h-32 object-contain" :alt="dex.activeShlagemon.base.name">
-        <div class="name">
-          {{ dex.activeShlagemon.base.name }}
+    <div v-if="dex.activeShlagemon && enemy" class="flex flex-1 flex-col items-center gap-2">
+      <div class="w-full flex flex-1 items-center justify-center gap-4">
+        <div class="mon flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
+          <img :src="`/shlagemons/${dex.activeShlagemon.base.id}/${dex.activeShlagemon.base.id}.png`" class="max-h-32 object-contain" :alt="dex.activeShlagemon.base.name">
+          <div class="name">
+            {{ dex.activeShlagemon.base.name }}
+          </div>
+          <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
+          <div class="hp text-sm">
+            {{ playerHp }} / {{ dex.activeShlagemon.hp }}
+          </div>
         </div>
-        <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
-        <div class="hp text-sm">
-          {{ playerHp }} / {{ dex.activeShlagemon.hp }}
+        <div class="vs font-bold">
+          VS
+        </div>
+        <div v-if="enemy" class="mon flex flex-1 flex-col select-none items-center" :class="{ flash: flashEnemy }" @click="attack">
+          <img :src="`/shlagemons/${enemy.base.id}/${enemy.base.id}.png`" class="max-h-32 object-contain" :alt="enemy.base.name">
+          <div class="name">
+            {{ enemy.base.name }} - lvl {{ enemy.lvl }}
+          </div>
+          <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
+          <div class="hp text-sm">
+            {{ enemyHp }} / {{ enemy.hp }}
+          </div>
         </div>
       </div>
-      <div class="vs font-bold">
-        VS
-      </div>
-      <div v-if="enemy" class="mon flex flex-1 flex-col select-none items-center" :class="{ flash: flashEnemy }" @click="attack">
-        <img :src="`/shlagemons/${enemy.base.id}/${enemy.base.id}.png`" class="max-h-32 object-contain" :alt="enemy.base.name">
-        <div class="name">
-          {{ enemy.base.name }} - lvl {{ enemy.lvl }}
-        </div>
-        <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
-        <div class="hp text-sm">
-          {{ enemyHp }} / {{ enemy.hp }}
-        </div>
-      </div>
+      <CaptureMenu :enemy="enemy" @capture="onCapture" />
     </div>
   </div>
 </template>

--- a/src/components/battle/CaptureMenu.vue
+++ b/src/components/battle/CaptureMenu.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { Ball, DexShlagemon } from '~/type'
+import { computed, ref } from 'vue'
+import { toast } from 'vue3-toastify'
+import { balls as ballData } from '~/data/balls'
+import { useInventoryStore } from '~/stores/inventory'
+import { useShlagedexStore } from '~/stores/shlagedex'
+import { tryCapture } from '~/utils/capture'
+
+const props = defineProps<{ enemy: DexShlagemon | null }>()
+const emit = defineEmits<{ (e: 'capture', success: boolean): void }>()
+
+const inventory = useInventoryStore()
+const dex = useShlagedexStore()
+const animBall = ref<string | null>(null)
+
+const availableBalls = computed(() =>
+  ballData
+    .map(b => ({ ...b, quantity: inventory.items[b.id] || 0 }))
+    .filter(b => b.quantity > 0),
+)
+
+function useBall(ball: Ball) {
+  if (!props.enemy || inventory.items[ball.id] <= 0)
+    return
+  animBall.value = ball.animation
+  const success = tryCapture(props.enemy, ball)
+  inventory.remove(ball.id)
+  setTimeout(() => (animBall.value = null), 500)
+  if (success) {
+    dex.captureShlagemon(props.enemy.base)
+    emit('capture', true)
+    toast(`Vous avez capturé ${props.enemy.base.name} !`)
+  }
+  else {
+    emit('capture', false)
+    toast('Raté !')
+  }
+}
+</script>
+
+<template>
+  <div class="relative mt-2 flex justify-center gap-2">
+    <div
+      v-for="ball in availableBalls"
+      :key="ball.id"
+      class="flex flex-col items-center"
+    >
+      <img
+        :src="ball.animation"
+        :alt="ball.name"
+        class="h-8 w-8 cursor-pointer"
+        @click="useBall(ball)"
+      >
+      <span class="text-xs">x{{ ball.quantity }}</span>
+    </div>
+    <img
+      v-if="animBall"
+      :src="animBall"
+      alt=""
+      class="ball-anim absolute left-1/2 top-0 h-8 w-8 -translate-x-1/2"
+    >
+  </div>
+</template>
+
+<style scoped>
+.ball-anim {
+  animation: throw 0.5s ease;
+}
+@keyframes throw {
+  0% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  50% {
+    transform: translate(-50%, -1.5rem) scale(1.2);
+  }
+  100% {
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+</style>

--- a/src/data/balls.ts
+++ b/src/data/balls.ts
@@ -1,0 +1,11 @@
+import type { Ball } from '~/type'
+
+export const balls: Ball[] = [
+  {
+    id: 'shlageball',
+    name: 'Shlage Ball',
+    catchBonus: 1,
+    animation: '/items/shlageball/shlageball.png',
+    quantity: 0,
+  },
+]

--- a/src/type/ball.ts
+++ b/src/type/ball.ts
@@ -1,0 +1,7 @@
+export interface Ball {
+  id: string
+  name: string
+  catchBonus: number
+  animation: string
+  quantity: number
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,3 +1,4 @@
+export * from './ball'
 export * from './button'
 export * from './dialog'
 export * from './item'

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -1,0 +1,9 @@
+import type { Ball, DexShlagemon } from '~/type'
+
+export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
+  const hpRatio = enemy.hpCurrent / enemy.hp
+  const baseChance = (1 - hpRatio) * 100
+  const rarityMod = 1 / (enemy.rarity / 100)
+  const chance = baseChance * ball.catchBonus * rarityMod
+  return Math.random() * 100 < chance
+}

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { balls } from '../src/data/balls'
+import { carapouffe } from '../src/data/shlagemons'
+import { tryCapture } from '../src/utils/capture'
+import { createDexShlagemon } from '../src/utils/dexFactory'
+
+describe('capture mechanics', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('succeeds when random is low', () => {
+    const mon = createDexShlagemon(carapouffe)
+    mon.hpCurrent = 0
+    mon.rarity = 50
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    expect(tryCapture(mon, balls[0])).toBe(true)
+  })
+
+  it('fails when random is high', () => {
+    const mon = createDexShlagemon(carapouffe)
+    mon.hpCurrent = mon.hp
+    mon.rarity = 100
+    vi.spyOn(Math, 'random').mockReturnValue(0.99)
+    expect(tryCapture(mon, balls[0])).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add `Ball` type and capture data
- implement `tryCapture` helper
- create `CaptureMenu` component with throw animation
- integrate capture menu into battles
- add unit tests for capture odds

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: exit code 130 after success)*

------
https://chatgpt.com/codex/tasks/task_e_68645581e6e0832a916295f6d485e7cc