### PR TITLE
Implement type effectiveness in battles

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { toast } from 'vue3-toastify'
+import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
+import { typeEffectiveness } from '~/data/typeEffectiveness'
 import { useGameStore } from '~/stores/game'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
+import { computeDamage } from '~/utils/combat'
 import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
@@ -40,7 +44,19 @@ function startBattle() {
 function attack() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
-  enemyHp.value = Math.max(0, enemyHp.value - 1)
+  const atkType = dex.activeShlagemon.base.types[0]?.name
+  const defType = enemy.value.base.types[0]?.name
+  const { damage, effect } = computeDamage(
+    dex.activeShlagemon.attack,
+    atkType,
+    defType,
+    typeEffectiveness,
+  )
+  if (effect === 'super')
+    toast('C’est super efficace !')
+  else if (effect === 'not')
+    toast('Pas très efficace...')
+  enemyHp.value = Math.max(0, enemyHp.value - damage)
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
   checkEnd()
@@ -49,10 +65,34 @@ function attack() {
 function tick() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
-  enemyHp.value = Math.max(0, enemyHp.value - dex.activeShlagemon.attack)
+  const atkType = dex.activeShlagemon.base.types[0]?.name
+  const defType = enemy.value.base.types[0]?.name
+  const { damage: dmgToEnemy, effect: eff1 } = computeDamage(
+    dex.activeShlagemon.attack,
+    atkType,
+    defType,
+    typeEffectiveness,
+  )
+  if (eff1 === 'super')
+    toast('C’est super efficace !')
+  else if (eff1 === 'not')
+    toast('Pas très efficace...')
+  enemyHp.value = Math.max(0, enemyHp.value - dmgToEnemy)
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
-  playerHp.value = Math.max(0, playerHp.value - enemy.value.attack)
+  const atkType2 = enemy.value.base.types[0]?.name
+  const defType2 = dex.activeShlagemon.base.types[0]?.name
+  const { damage: dmgToPlayer, effect: eff2 } = computeDamage(
+    enemy.value.attack,
+    atkType2,
+    defType2,
+    typeEffectiveness,
+  )
+  if (eff2 === 'super')
+    toast('C’est super efficace !')
+  else if (eff2 === 'not')
+    toast('Pas très efficace...')
+  playerHp.value = Math.max(0, playerHp.value - dmgToPlayer)
   dex.activeShlagemon.hpCurrent = playerHp.value
   flashPlayer.value = true
   setTimeout(() => (flashPlayer.value = false), 100)
@@ -120,6 +160,13 @@ onUnmounted(() => {
         <div class="name">
           {{ dex.activeShlagemon.base.name }}
         </div>
+        <div class="mt-1 flex gap-1">
+          <ShlagemonType
+            v-for="t in dex.activeShlagemon.base.types"
+            :key="t.id"
+            :value="t"
+          />
+        </div>
         <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
         <div class="hp text-sm">
           {{ playerHp }} / {{ dex.activeShlagemon.hp }}
@@ -132,6 +179,13 @@ onUnmounted(() => {
         <img :src="`/shlagemons/${enemy.base.id}/${enemy.base.id}.png`" class="max-h-32 object-contain" :alt="enemy.base.name">
         <div class="name">
           {{ enemy.base.name }} - lvl {{ enemy.lvl }}
+        </div>
+        <div class="mt-1 flex gap-1">
+          <ShlagemonType
+            v-for="t in enemy.base.types"
+            :key="t.id"
+            :value="t"
+          />
         </div>
         <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
         <div class="hp text-sm">

--- a/src/utils/combat.ts
+++ b/src/utils/combat.ts
@@ -1,0 +1,13 @@
+export function getTypeMultiplier(attackType: string, targetType: string, table: Record<string, Record<string, number>>): { multiplier: number, effect: 'super' | 'not' | 'normal' } {
+  const base = table[attackType]?.[targetType] ?? 1
+  const variance = 0.8 + Math.random() * 0.4 // ±20%
+  const multiplier = base * variance
+  const effect = base > 1 ? 'super' : base < 1 ? 'not' : 'normal'
+  return { multiplier, effect }
+}
+
+export function computeDamage(base: number, attackType: string, targetType: string, table: Record<string, Record<string, number>>): { damage: number, effect: 'super' | 'not' | 'normal' } {
+  const { multiplier, effect } = getTypeMultiplier(attackType, targetType, table)
+  const damage = Math.round(base * multiplier)
+  return { damage, effect }
+}


### PR DESCRIPTION
## Summary
- add combat util with damage calculations and randomness
- display type badges in battles
- factor in resistances and weaknesses when dealing damage

## Testing
- `pnpm lint`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6864580deb6c832abbe2e50a4ebb15d2