### PR TITLE
Add vigor and switching phase to trainer battles

### DIFF
--- a/src/stores/trainerBattle.ts
+++ b/src/stores/trainerBattle.ts
@@ -6,6 +6,15 @@ import { trainers as trainersData } from '~/data/trainers'
 export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   const queue = ref<Trainer[]>([])
   const currentIndex = ref(0)
+  const vigor = ref(100)
+
+  function resetVigor(value = 100) {
+    vigor.value = value
+  }
+
+  function decreaseVigor(amount = 10) {
+    vigor.value = Math.max(0, vigor.value - amount)
+  }
 
   function setQueue(list: Trainer[]) {
     queue.value = list
@@ -30,5 +39,5 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   // init with default trainers
   setQueue(trainersData)
 
-  return { queue, current, next, add, setQueue, reset }
+  return { queue, current, next, add, setQueue, reset, vigor, resetVigor, decreaseVigor }
 })


### PR DESCRIPTION
## Summary
- extend trainer battle store with vigor tracking
- support switching Shlagemon between enemies and show vigor bar

## Testing
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68646034dd8c832aa5a13f41aea71ad2