### PR TITLE
Add battle toast bubble effect

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,6 +11,7 @@ declare module 'vue' {
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
+    BattleToast: typeof import('./components/battle/BattleToast.vue')['default']
     Button: typeof import('./components/ui/Button.vue')['default']
     CaptureMenu: typeof import('./components/battle/CaptureMenu.vue')['default']
     CheckBox: typeof import('./components/ui/CheckBox.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { toast } from 'vue3-toastify'
+import BattleToast from '~/components/battle/BattleToast.vue'
 import CaptureMenu from '~/components/battle/CaptureMenu.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
@@ -20,7 +20,23 @@ const enemy = ref<ReturnType<typeof createDexShlagemon> | null>(null)
 const battleActive = ref(false)
 const flashPlayer = ref(false)
 const flashEnemy = ref(false)
+const playerEffect = ref('')
+const enemyEffect = ref('')
 let battleInterval: number | undefined
+
+function showEffect(target: 'player' | 'enemy', effect: 'super' | 'not' | 'normal') {
+  if (effect === 'normal')
+    return
+  const text = effect === 'super' ? 'C\u2019est super efficace !' : 'Pas tr\u00E8s efficace...'
+  if (target === 'enemy') {
+    enemyEffect.value = text
+    setTimeout(() => (enemyEffect.value = ''), 500)
+  }
+  else {
+    playerEffect.value = text
+    setTimeout(() => (playerEffect.value = ''), 500)
+  }
+}
 
 function onCapture(success: boolean) {
   if (!success)
@@ -62,10 +78,7 @@ function attack() {
     atkType,
     defType,
   )
-  if (effect === 'super')
-    toast('C’est super efficace !')
-  else if (effect === 'not')
-    toast('Pas très efficace...')
+  showEffect('enemy', effect)
   enemyHp.value = Math.max(0, enemyHp.value - damage)
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
@@ -82,10 +95,7 @@ function tick() {
     atkType,
     defType,
   )
-  if (eff1 === 'super')
-    toast('C’est super efficace !')
-  else if (eff1 === 'not')
-    toast('Pas très efficace...')
+  showEffect('enemy', eff1)
   enemyHp.value = Math.max(0, enemyHp.value - dmgToEnemy)
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
@@ -96,10 +106,7 @@ function tick() {
     atkType2,
     defType2,
   )
-  if (eff2 === 'super')
-    toast('C’est super efficace !')
-  else if (eff2 === 'not')
-    toast('Pas très efficace...')
+  showEffect('player', eff2)
   playerHp.value = Math.max(0, playerHp.value - dmgToPlayer)
   dex.activeShlagemon.hpCurrent = playerHp.value
   flashPlayer.value = true
@@ -164,7 +171,8 @@ onUnmounted(() => {
     </div>
     <div v-if="dex.activeShlagemon && enemy" class="flex flex-1 flex-col items-center gap-2">
       <div class="w-full flex flex-1 items-center justify-center gap-4">
-        <div class="mon flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
+        <div class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
+          <BattleToast v-if="playerEffect" :message="playerEffect" />
           <img :src="`/shlagemons/${dex.activeShlagemon.base.id}/${dex.activeShlagemon.base.id}.png`" class="max-h-32 object-contain" :alt="dex.activeShlagemon.base.name">
           <div class="name">
             {{ dex.activeShlagemon.base.name }}
@@ -184,7 +192,8 @@ onUnmounted(() => {
         <div class="vs font-bold">
           VS
         </div>
-        <div v-if="enemy" class="mon flex flex-1 flex-col select-none items-center" :class="{ flash: flashEnemy }" @click="attack">
+        <div v-if="enemy" class="mon relative flex flex-1 flex-col select-none items-center" :class="{ flash: flashEnemy }" @click="attack">
+          <BattleToast v-if="enemyEffect" :message="enemyEffect" />
           <img :src="`/shlagemons/${enemy.base.id}/${enemy.base.id}.png`" class="max-h-32 object-contain" :alt="enemy.base.name">
           <div class="name">
             {{ enemy.base.name }} - lvl {{ enemy.lvl }}

--- a/src/components/battle/BattleToast.vue
+++ b/src/components/battle/BattleToast.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const { message } = defineProps<{ message: string }>()
+const rotation = (Math.random() * 5 + 15) * (Math.random() > 0.5 ? 1 : -1)
+</script>
+
+<template>
+  <div
+    class="battle-toast pointer-events-none absolute left-1/2 -top-6 -translate-x-1/2"
+    :style="{ transform: `translateX(-50%) rotate(${rotation}deg)` }"
+  >
+    <div class="rounded bg-white/90 px-2 py-1 text-xs font-bold shadow dark:bg-gray-800/90">
+      {{ message }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.battle-toast {
+  animation: toast-pop 0.3s ease;
+}
+@keyframes toast-pop {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -10px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+</style>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { toast } from 'vue3-toastify'
+import BattleToast from '~/components/battle/BattleToast.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import Button from '~/components/ui/Button.vue'
@@ -28,6 +28,22 @@ const battleActive = ref(false)
 let battleInterval: number | undefined
 const flashPlayer = ref(false)
 const flashEnemy = ref(false)
+const playerEffect = ref('')
+const enemyEffect = ref('')
+
+function showEffect(target: 'player' | 'enemy', effect: 'super' | 'not' | 'normal') {
+  if (effect === 'normal')
+    return
+  const text = effect === 'super' ? 'C\u2019est super efficace !' : 'Pas tr\u00E8s efficace...'
+  if (target === 'enemy') {
+    enemyEffect.value = text
+    setTimeout(() => (enemyEffect.value = ''), 500)
+  }
+  else {
+    playerEffect.value = text
+    setTimeout(() => (playerEffect.value = ''), 500)
+  }
+}
 
 watch(trainer, (t) => {
   if (t) {
@@ -77,10 +93,7 @@ function attack() {
     defType,
     typeEffectiveness,
   )
-  if (effect === 'super')
-    toast('C’est super efficace !')
-  else if (effect === 'not')
-    toast('Pas très efficace...')
+  showEffect('enemy', effect)
   enemyHp.value = Math.max(0, enemyHp.value - damage)
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
@@ -98,10 +111,7 @@ function tick() {
     defType,
     typeEffectiveness,
   )
-  if (eff1 === 'super')
-    toast('C’est super efficace !')
-  else if (eff1 === 'not')
-    toast('Pas très efficace...')
+  showEffect('enemy', eff1)
   enemyHp.value = Math.max(0, enemyHp.value - dmgToEnemy)
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
@@ -113,10 +123,7 @@ function tick() {
     defType2,
     typeEffectiveness,
   )
-  if (eff2 === 'super')
-    toast('C’est super efficace !')
-  else if (eff2 === 'not')
-    toast('Pas très efficace...')
+  showEffect('player', eff2)
   playerHp.value = Math.max(0, playerHp.value - dmgToPlayer)
   dex.activeShlagemon.hpCurrent = playerHp.value
   flashPlayer.value = true
@@ -182,7 +189,8 @@ onUnmounted(() => {
     </div>
     <div v-else-if="stage === 'battle'" class="w-full text-center" @click="attack">
       <div class="flex flex-1 items-center justify-center gap-4">
-        <div v-if="dex.activeShlagemon" class="mon flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
+        <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
+          <BattleToast v-if="playerEffect" :message="playerEffect" />
           <img :src="`/shlagemons/${dex.activeShlagemon.base.id}/${dex.activeShlagemon.base.id}.png`" class="max-h-32 object-contain" :alt="dex.activeShlagemon.base.name">
           <div class="mt-1 flex gap-1">
             <ShlagemonType v-for="t in dex.activeShlagemon.base.types" :key="t.id" :value="t" />
@@ -195,7 +203,8 @@ onUnmounted(() => {
         <div class="vs font-bold">
           VS
         </div>
-        <div v-if="enemy" class="mon flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
+        <div v-if="enemy" class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
+          <BattleToast v-if="enemyEffect" :message="enemyEffect" />
           <img :src="`/shlagemons/${enemy.base.id}/${enemy.base.id}.png`" class="max-h-32 object-contain" :alt="enemy.base.name">
           <div class="mt-1 flex gap-1">
             <ShlagemonType v-for="t in enemy.base.types" :key="t.id" :value="t" />


### PR DESCRIPTION
## Summary
- add `BattleToast` component for comic-style effect messages
- show battle toast above Pokémon when attacks are super or not very effective
- remove old toast usage in `BattleMain` and `TrainerBattle`
- update component auto imports

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: command terminated with exit code 130 but tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_6864dc4a8d78832abb8c9d83accc960f