### PR TITLE
Add main panel component

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -204,6 +204,7 @@ declare global {
   const useLink: typeof import('vue-router/auto')['useLink']
   const useLocalStorage: typeof import('@vueuse/core')['useLocalStorage']
   const useMagicKeys: typeof import('@vueuse/core')['useMagicKeys']
+  const useMainPanelStore: typeof import('./stores/mainPanel')['useMainPanelStore']
   const useManualRefHistory: typeof import('@vueuse/core')['useManualRefHistory']
   const useMediaControls: typeof import('@vueuse/core')['useMediaControls']
   const useMediaQuery: typeof import('@vueuse/core')['useMediaQuery']
@@ -326,6 +327,9 @@ declare global {
   // @ts-ignore
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
+  // @ts-ignore
+  export type { MainPanel } from './stores/mainPanel'
+  import('./stores/mainPanel')
 }
 
 // for vue template auto import
@@ -528,6 +532,7 @@ declare module 'vue' {
     readonly useLink: UnwrapRef<typeof import('vue-router/auto')['useLink']>
     readonly useLocalStorage: UnwrapRef<typeof import('@vueuse/core')['useLocalStorage']>
     readonly useMagicKeys: UnwrapRef<typeof import('@vueuse/core')['useMagicKeys']>
+    readonly useMainPanelStore: UnwrapRef<typeof import('./stores/mainPanel')['useMainPanelStore']>
     readonly useManualRefHistory: UnwrapRef<typeof import('@vueuse/core')['useManualRefHistory']>
     readonly useMediaControls: UnwrapRef<typeof import('@vueuse/core')['useMediaControls']>
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -24,6 +24,7 @@ declare module 'vue' {
     InventoryItemCard: typeof import('./components/inventory/InventoryItemCard.vue')['default']
     InventoryPanel: typeof import('./components/panels/InventoryPanel.vue')['default']
     ItemCard: typeof import('./components/shop/ItemCard.vue')['default']
+    MainPanel: typeof import('./components/panels/MainPanel.vue')['default']
     Modal: typeof import('./components/modal/Modal.vue')['default']
     PanelWrapper: typeof import('./components/ui/PanelWrapper.vue')['default']
     PlayerInfos: typeof import('./components/panels/PlayerInfos.vue')['default']

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import BattleMain from '~/components/battle/BattleMain.vue'
 import ActiveShlagemon from '~/components/panels/ActiveShlagemon.vue'
 import InventoryPanel from '~/components/panels/InventoryPanel.vue'
+import MainPanel from '~/components/panels/MainPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import PanelWrapper from '~/components/ui/PanelWrapper.vue'
@@ -17,7 +17,11 @@ const inventory = useInventoryStore()
 const shlagedex = useShlagedexStore()
 const dialogStore = useDialogStore()
 
-const canFight = computed(() => gameState.hasPokemon && zone.current.type !== 'village')
+const showMainPanel = computed(() =>
+  dialogStore.isDialogVisible
+  || gameState.hasPokemon
+  || zone.current.type === 'village',
+)
 const isInventoryVisible = computed(() => inventory.list.length > 0)
 const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
 </script>
@@ -40,11 +44,10 @@ const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
           <PlayerInfos />
         </PanelWrapper>
       </div>
-      <div v-if="canFight || dialogStore.isDialogVisible" class="zone" md="col-span-6 row-span-5 col-start-4 row-start-2">
+      <div v-if="showMainPanel" class="zone" md="col-span-6 row-span-5 col-start-4 row-start-2">
         <!-- middle A zone -->
         <PanelWrapper>
-          <DialogPanel v-if="dialogStore.isDialogVisible" />
-          <BattleMain v-else />
+          <MainPanel />
         </PanelWrapper>
       </div>
       <div v-if="shlagedex.activeShlagemon" class="zone" md="col-span-6 row-span-1 col-start-4 row-start-7">

--- a/src/components/panels/MainPanel.vue
+++ b/src/components/panels/MainPanel.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import BattleMain from '~/components/battle/BattleMain.vue'
+import DialogPanel from '~/components/panels/DialogPanel.vue'
+import ShopPanel from '~/components/panels/ShopPanel.vue'
+import ZonePanel from '~/components/panels/ZonePanel.vue'
+import { useDialogStore } from '~/stores/dialog'
+import { useMainPanelStore } from '~/stores/mainPanel'
+
+const dialogStore = useDialogStore()
+const panelStore = useMainPanelStore()
+
+const currentComponent = computed(() => {
+  switch (panelStore.current) {
+    case 'shop':
+      return ShopPanel
+    case 'battle':
+      return BattleMain
+    default:
+      return ZonePanel
+  }
+})
+</script>
+
+<template>
+  <DialogPanel v-if="dialogStore.isDialogVisible" />
+  <component :is="currentComponent" v-else />
+</template>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -1,24 +1,22 @@
 <script setup lang="ts">
 import type { Zone } from '~/type'
 import { computed } from 'vue'
-import Modal from '~/components/modal/Modal.vue'
-import ShopPanel from '~/components/panels/ShopPanel.vue'
 import Button from '~/components/ui/Button.vue'
+import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 
 const zone = useZoneStore()
 const dex = useShlagedexStore()
-const showShop = ref(false)
+const panel = useMainPanelStore()
 
 const availableZones = computed(() =>
   zone.zones.filter(z => (z.type === 'village' && z.minLevel <= dex.highestLevel) || dex.highestLevel >= z.minLevel),
 )
 
 function onAction(id: string) {
-  if (id === 'shop') {
-    showShop.value = true
-  }
+  if (id === 'shop')
+    panel.showShop()
 }
 
 function classes(z: Zone) {
@@ -55,7 +53,4 @@ function classes(z: Zone) {
       </Button>
     </div>
   </div>
-  <Modal v-model="showShop" @close="showShop = false">
-    <ShopPanel />
-  </Modal>
 </template>

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+import { useZoneStore } from './zone'
+
+export type MainPanel = 'village' | 'battle' | 'shop'
+
+export const useMainPanelStore = defineStore('mainPanel', () => {
+  const zone = useZoneStore()
+  const current = ref<MainPanel>('village')
+
+  // Update the panel when the zone changes
+  watch(
+    () => zone.current.type,
+    (type) => {
+      if (type === 'village')
+        current.value = 'village'
+      else
+        current.value = 'battle'
+    },
+    { immediate: true },
+  )
+
+  function showShop() {
+    current.value = 'shop'
+  }
+
+  function showBattle() {
+    current.value = 'battle'
+  }
+
+  function showVillage() {
+    current.value = 'village'
+  }
+
+  return { current, showShop, showBattle, showVillage }
+})

--- a/test/__snapshots__/zone.test.ts.snap
+++ b/test/__snapshots__/zone.test.ts.snap
@@ -4,26 +4,5 @@ exports[`zone panel > renders actions 1`] = `
 "<div class="flex flex-col gap-2" md="gap-3">
   <div class="flex flex-wrap justify-center gap-1" md="gap-2"><button class="rounded px-2 py-1 text-xs bg-primary text-dark dark:bg-light bg-green-300 dark:bg-green-800">Village Paumé</button></div>
   <div class="flex flex-col items-center gap-1" md="gap-2"><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 text-xs">Entrer le Shop</button></div>
-</div>
-<dialog data-v-b759700c="" class="modal">
-  <div data-v-b759700c="" class="modal-content relative flex flex-col"><button data-v-b759700c="" type="button" class="absolute right-2 top-2 h-6 w-6 flex items-center justify-center rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"> × </button>
-    <div class="h-full flex flex-col">
-      <h2 class="mb-2 text-center font-bold"> Boutique </h2>
-      <div class="flex flex-col gap-2 overflow-auto">
-        <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900"><img src="/items/shlageball/shlageball.png" alt="Shlage Ball" class="h-8 w-8 object-contain">
-          <div class="flex flex-1 flex-col text-left"><span class="font-bold">Shlage Ball</span><span class="text-xs">Permet de capturer des Shlagémons sauvages.</span></div><span class="font-bold">10$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>
-        </div>
-        <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900">
-          <!--v-if-->
-          <div class="flex flex-1 flex-col text-left"><span class="font-bold">Potion Dégueulasse</span><span class="text-xs">Soigne 50 HP de votre Shlagémon.</span></div><span class="font-bold">5$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>
-        </div>
-        <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900">
-          <!--v-if-->
-          <div class="flex flex-1 flex-col text-left"><span class="font-bold">Spray Anti-Odeur</span><span class="text-xs">Augmente temporairement la défense.</span></div><span class="font-bold">7$</span><button class="rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80 ml-2"> Acheter </button>
-        </div>
-      </div>
-    </div>
-    <!--v-if-->
-  </div>
-</dialog>"
+</div>"
 `;


### PR DESCRIPTION
## Summary
- centralize screen switching with a new `MainPanel` component
- add `mainPanel` pinia store to choose which panel to display
- integrate `MainPanel` in `GameGrid`
- open the shop panel via the main panel instead of a modal
- update snapshot

## Testing
- `pnpm test:unit --run -u`
- `pnpm test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6864e058e938832a8a41ac59e2871e72