### PR TITLE
Fix ball item inheritance

### DIFF
--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -1,13 +1,8 @@
 import type { Item } from '~/type/item'
+import { balls } from './shlageball'
 
 export const shopItems: Item[] = [
-  {
-    id: 'shlageball',
-    name: 'Shlage Ball',
-    description: 'Permet de capturer des Shlagémons sauvages.',
-    price: 10,
-    image: '/items/shlageball/shlageball.png',
-  },
+  ...balls,
   {
     id: 'potion',
     name: 'Potion Dégueulasse',

--- a/src/data/items/shlageball.ts
+++ b/src/data/items/shlageball.ts
@@ -4,8 +4,10 @@ export const balls: Ball[] = [
   {
     id: 'shlageball',
     name: 'Shlagéball',
+    description: 'Permet de capturer des Shlagémons sauvages.',
+    price: 10,
+    image: '/items/shlageball/shlageball.png',
     catchBonus: 1,
     animation: '/items/shlageball/shlageball.png',
-    quantity: 0,
   },
 ]

--- a/src/type/ball.ts
+++ b/src/type/ball.ts
@@ -1,7 +1,7 @@
-export interface Ball {
-  id: string
-  name: string
+import type { Item } from './item'
+
+export interface Ball extends Item {
   catchBonus: number
   animation: string
-  quantity: number
+  quantity?: number
 }


### PR DESCRIPTION
## Summary
- extend `Ball` interface from `Item`
- store Shlage Ball data once and reuse it in shop items

## Testing
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6864e368d364832a85d5e456d3cd54a3