### PR TITLE
Implement trainer battle panel

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -327,6 +327,9 @@ declare global {
   // @ts-ignore
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
+  // @ts-ignore
+  export type { MainPanel } from './stores/mainPanel'
+  import('./stores/mainPanel')
 }
 
 // for vue template auto import
@@ -529,6 +532,7 @@ declare module 'vue' {
     readonly useLink: UnwrapRef<typeof import('vue-router/auto')['useLink']>
     readonly useLocalStorage: UnwrapRef<typeof import('@vueuse/core')['useLocalStorage']>
     readonly useMagicKeys: UnwrapRef<typeof import('@vueuse/core')['useMagicKeys']>
+    readonly useMainPanelStore: UnwrapRef<typeof import('./stores/mainPanel')['useMainPanelStore']>
     readonly useManualRefHistory: UnwrapRef<typeof import('@vueuse/core')['useManualRefHistory']>
     readonly useMediaControls: UnwrapRef<typeof import('@vueuse/core')['useMediaControls']>
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>

--- a/src/components/panels/MainPanel.vue
+++ b/src/components/panels/MainPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import BattleMain from '~/components/battle/BattleMain.vue'
+import TrainerBattle from '~/components/battle/TrainerBattle.vue'
 import DialogPanel from '~/components/panels/DialogPanel.vue'
 import ShopPanel from '~/components/panels/ShopPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
@@ -15,6 +16,8 @@ const currentComponent = computed(() => {
       return ShopPanel
     case 'battle':
       return BattleMain
+    case 'trainerBattle':
+      return TrainerBattle
     default:
       return ZonePanel
   }

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -17,6 +17,8 @@ const availableZones = computed(() =>
 function onAction(id: string) {
   if (id === 'shop')
     panel.showShop()
+  else if (id === 'explore')
+    panel.showTrainerBattle()
 }
 
 function classes(z: Zone) {

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 import { useZoneStore } from './zone'
 
-export type MainPanel = 'village' | 'battle' | 'shop'
+export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop'
 
 export const useMainPanelStore = defineStore('mainPanel', () => {
   const zone = useZoneStore()
@@ -28,9 +28,13 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     current.value = 'battle'
   }
 
+  function showTrainerBattle() {
+    current.value = 'trainerBattle'
+  }
+
   function showVillage() {
     current.value = 'village'
   }
 
-  return { current, showShop, showBattle, showVillage }
+  return { current, showShop, showBattle, showTrainerBattle, showVillage }
 })


### PR DESCRIPTION
## Summary
- add new `trainerBattle` state in `mainPanel` store
- switch to `TrainerBattle` component from main panel
- trigger trainer battles when clicking `explore` actions in zone panel

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6864e4e437d4832a9e30edc1ed54298b