### PR TITLE
Add capture overlay animation

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import BattleToast from '~/components/battle/BattleToast.vue'
-import CaptureMenu from '~/components/battle/CaptureMenu.vue'
+import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
@@ -18,6 +18,7 @@ const playerHp = ref(0)
 const enemyHp = ref(0)
 const enemy = ref<ReturnType<typeof createDexShlagemon> | null>(null)
 const battleActive = ref(false)
+const showCapture = ref(false)
 const flashPlayer = ref(false)
 const flashEnemy = ref(false)
 const playerEffect = ref('')
@@ -38,15 +39,27 @@ function showEffect(target: 'player' | 'enemy', effect: 'super' | 'not' | 'norma
   }
 }
 
-function onCapture(success: boolean) {
-  if (!success)
+function openCapture() {
+  if (!enemy.value)
     return
   battleActive.value = false
   if (battleInterval)
     clearInterval(battleInterval)
   battleInterval = undefined
-  enemy.value = null
-  setTimeout(startBattle, 1000)
+  showCapture.value = true
+}
+
+function onCaptureEnd(success: boolean) {
+  showCapture.value = false
+  if (success && enemy.value) {
+    dex.captureShlagemon(enemy.value.base)
+    enemy.value = null
+    setTimeout(startBattle, 1000)
+  }
+  else {
+    battleActive.value = true
+    battleInterval = window.setInterval(tick, 1000)
+  }
 }
 
 function startBattle() {
@@ -211,7 +224,14 @@ onUnmounted(() => {
           </div>
         </div>
       </div>
-      <CaptureMenu :enemy="enemy" @capture="onCapture" />
+      <button
+        type="button"
+        class="absolute right-2 top-2 h-8 w-8"
+        @click="openCapture"
+      >
+        <img src="/items/shlageball/shlageball.png" alt="capture" class="h-full w-full">
+      </button>
+      <CaptureOverlay v-if="showCapture && enemy" :target="enemy" @finish="onCaptureEnd" />
     </div>
   </div>
 </template>

--- a/src/components/battle/CaptureOverlay.vue
+++ b/src/components/battle/CaptureOverlay.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+import { onMounted, ref } from 'vue'
+import { simpleCapture } from '~/utils/capture'
+
+const props = defineProps<{ target: DexShlagemon }>()
+const emit = defineEmits<{ (e: 'finish', success: boolean): void }>()
+
+const shake = ref(0)
+
+function attempt(step: number) {
+  shake.value = step
+  const success = simpleCapture(props.target)
+  if (success) {
+    setTimeout(() => emit('finish', true), 500)
+  }
+  else if (step >= 3) {
+    setTimeout(() => emit('finish', false), 500)
+  }
+  else {
+    setTimeout(() => attempt(step + 1), 700)
+  }
+}
+
+onMounted(() => {
+  setTimeout(() => attempt(1), 500)
+})
+</script>
+
+<template>
+  <div class="absolute inset-0 z-20 flex items-center justify-center bg-black/50">
+    <div class="relative">
+      <img
+        src="/items/shlageball/shlageball.png"
+        alt="ball"
+        class="h-16 w-16" :class="`shake-${shake}`"
+      >
+      <img
+        :src="`/shlagemons/${target.base.id}/${target.base.id}.png`"
+        :alt="target.base.name"
+        class="absolute left-1/2 top-1/2 h-12 w-12 object-contain -translate-x-1/2 -translate-y-1/2"
+        :class="{ 'to-ball': shake > 0 }"
+      >
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.to-ball {
+  animation: capture 0.5s forwards;
+}
+@keyframes capture {
+  to {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+  }
+}
+.shake-1 {
+  animation: shake 0.5s;
+}
+.shake-2 {
+  animation: shake 0.5s;
+}
+.shake-3 {
+  animation: shake 0.5s;
+}
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  50% {
+    transform: translateX(4px);
+  }
+  75% {
+    transform: translateX(-4px);
+  }
+}
+</style>

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -7,3 +7,17 @@ export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
   const chance = baseChance * ball.catchBonus * rarityMod
   return Math.random() * 100 < chance
 }
+
+export function captureChanceFromHp(ratio: number): number {
+  const r = Math.min(1, Math.max(0, ratio))
+  if (r <= 0.1)
+    return 90
+  if (r >= 1)
+    return 10
+  return 10 + (1 - r) / 0.9 * 80
+}
+
+export function simpleCapture(enemy: DexShlagemon): boolean {
+  const chance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
+  return Math.random() * 100 < chance
+}


### PR DESCRIPTION
## Summary
- add CaptureOverlay component for capture animation
- update BattleMain to use CaptureOverlay and add openCapture logic
- provide simpleCapture helper with HP-based formula

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6864e8e4e630832ab497a0ad71feedc9