### PR TITLE
Fix active Schlagemon not linked after loading

### DIFF
--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -47,19 +47,23 @@ export const shlagedexSerializer = {
     let active = parsed.activeShlagemon
     if (active) {
       const base = active.base ?? baseMap[active.baseId]
-      active = base
-        ? {
-            ...active,
-            base,
-            baseId: active.baseId ?? base.id,
-            baseStats: active.baseStats ?? {
-              hp: statWithRarityAndCoefficient(baseStats.hp, base.coefficient, active.rarity ?? 1),
-              attack: statWithRarityAndCoefficient(baseStats.attack, base.coefficient, active.rarity ?? 1),
-              defense: statWithRarityAndCoefficient(baseStats.defense, base.coefficient, active.rarity ?? 1),
-              smelling: statWithRarityAndCoefficient(baseStats.smelling, base.coefficient, active.rarity ?? 1),
-            },
-          }
-        : null
+      if (base) {
+        const found = shlagemons.find((m: any) => m.id === active.id)
+        active = found || {
+          ...active,
+          base,
+          baseId: active.baseId ?? base.id,
+          baseStats: active.baseStats ?? {
+            hp: statWithRarityAndCoefficient(baseStats.hp, base.coefficient, active.rarity ?? 1),
+            attack: statWithRarityAndCoefficient(baseStats.attack, base.coefficient, active.rarity ?? 1),
+            defense: statWithRarityAndCoefficient(baseStats.defense, base.coefficient, active.rarity ?? 1),
+            smelling: statWithRarityAndCoefficient(baseStats.smelling, base.coefficient, active.rarity ?? 1),
+          },
+        }
+      }
+      else {
+        active = null
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary
- ensure the active Schlagemon references the same object from the Dex when loading saved data

## Testing
- `pnpm lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6864eace9754832a92d1588c44fde7fa