### PR TITLE
Handle shlageball quantity

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -6,6 +6,7 @@ import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { useBattleStore } from '~/stores/battle'
 import { useGameStore } from '~/stores/game'
+import { useInventoryStore } from '~/stores/inventory'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
@@ -14,6 +15,7 @@ const dex = useShlagedexStore()
 const game = useGameStore()
 const zone = useZoneStore()
 const battle = useBattleStore()
+const inventory = useInventoryStore()
 
 const playerHp = ref(0)
 const enemyHp = ref(0)
@@ -41,7 +43,7 @@ function showEffect(target: 'player' | 'enemy', effect: 'super' | 'not' | 'norma
 }
 
 function openCapture() {
-  if (!enemy.value)
+  if (!enemy.value || (inventory.items.shlageball || 0) <= 0)
     return
   battleActive.value = false
   if (battleInterval)
@@ -220,6 +222,8 @@ onUnmounted(() => {
       <button
         type="button"
         class="absolute right-2 top-2 h-8 w-8"
+        :class="{ 'opacity-50 cursor-not-allowed': (inventory.items.shlageball || 0) <= 0 }"
+        :disabled="(inventory.items.shlageball || 0) <= 0"
         @click="openCapture"
       >
         <img src="/items/shlageball/shlageball.png" alt="capture" class="h-full w-full">

--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
+import { computed } from 'vue'
 import Button from '~/components/ui/Button.vue'
 
 const props = defineProps<{ item: Item, qty: number }>()
@@ -7,6 +8,8 @@ const emit = defineEmits<{
   (e: 'use'): void
   (e: 'sell'): void
 }>()
+
+const isBall = computed(() => 'catchBonus' in props.item)
 </script>
 
 <template>
@@ -23,7 +26,11 @@ const emit = defineEmits<{
     <span class="text-xs">{{ props.item.description }}</span>
     <div class="mt-1 flex items-center justify-end gap-1">
       <span class="font-bold">x{{ props.qty }}</span>
-      <Button class="flex items-center gap-1 text-xs" @click="emit('use')">
+      <Button
+        v-if="!isBall"
+        class="flex items-center gap-1 text-xs"
+        @click="emit('use')"
+      >
         <div i-carbon-play inline-block />
         Utiliser
       </Button>

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { allShlagemons } from '~/data/shlagemons'
+import { useInventoryStore } from '~/stores/inventory'
 
 const game = useGameStore()
 const dex = useShlagedexStore()
+const inventory = useInventoryStore()
 
 const totalInDex = allShlagemons.length
 </script>
@@ -23,6 +25,10 @@ const totalInDex = allShlagemons.length
     <div class="flex items-center gap-2">
       <span>Shlagédex</span>
       <span class="font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <img src="/items/shlageball/shlageball.png" alt="ball" class="h-4 w-4">
+      <span class="font-bold">{{ inventory.items.shlageball || 0 }}</span>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- hide use button for shlageballs in inventory
- show shlageball count in player info panel
- disable capture button when out of balls

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6864f56a8578832ab4169b1c542da5bb