### PR TITLE
Fix capture item usage

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -45,6 +45,7 @@ function showEffect(target: 'player' | 'enemy', effect: 'super' | 'not' | 'norma
 function openCapture() {
   if (!enemy.value || (inventory.items.shlageball || 0) <= 0)
     return
+  inventory.remove('shlageball')
   battleActive.value = false
   if (battleInterval)
     clearInterval(battleInterval)

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -26,7 +26,10 @@ const zoneDescriptions: ZoneDescription[] = [
 
 // Génération automatique des paliers 1 → 79
 const generatedZones: Zone[] = zoneDescriptions.map((desc, index) => ({
-  ...desc,
+  id: desc.id,
+  name: desc.name,
+  type: desc.type,
+  actions: desc.actions ?? [],
   minLevel: index * 5 || 1,
   maxLevel: index * 5 + 5,
 }))


### PR DESCRIPTION
## Summary
- consume a shlageball when attempting a capture
- ensure generated zones always include an `actions` array so typecheck passes

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6864fb7466c8832a8951528f31b52e6b