### PR TITLE
Add critical hit visuals

### DIFF
--- a/src/components/battle/BattleToast.vue
+++ b/src/components/battle/BattleToast.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
-const { message } = defineProps<{ message: string }>()
+import { computed } from 'vue'
+
+const { message, variant } = defineProps<{ message: string, variant?: 'high' | 'low' | 'normal' }>()
+const variantClasses = computed(() => {
+  switch (variant) {
+    case 'high':
+      return 'bg-red-500 text-white border-yellow-300 shadow-lg dark:bg-red-600'
+    case 'low':
+      return 'bg-blue-200 text-blue-800 border-blue-300 shadow-inner dark:bg-blue-900/80 dark:text-blue-200'
+    default:
+      return 'bg-white/90 dark:bg-gray-800/90'
+  }
+})
 const rotation = (Math.random() * 5 + 15) * (Math.random() > 0.5 ? 1 : -1)
 </script>
 
@@ -8,7 +20,7 @@ const rotation = (Math.random() * 5 + 15) * (Math.random() > 0.5 ? 1 : -1)
     class="battle-toast pointer-events-none absolute left-1/2 -top-6 -translate-x-1/2"
     :style="{ transform: `translateX(-50%) rotate(${rotation}deg)` }"
   >
-    <div class="rounded bg-white/90 px-2 py-1 text-xs font-bold shadow dark:bg-gray-800/90">
+    <div class="border rounded px-2 py-1 text-xs font-bold" :class="variantClasses">
       {{ message }}
     </div>
   </div>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -30,18 +30,42 @@ const flashPlayer = ref(false)
 const flashEnemy = ref(false)
 const playerEffect = ref('')
 const enemyEffect = ref('')
+const playerVariant = ref<'normal' | 'high' | 'low'>('normal')
+const enemyVariant = ref<'normal' | 'high' | 'low'>('normal')
 
-function showEffect(target: 'player' | 'enemy', effect: 'super' | 'not' | 'normal') {
-  if (effect === 'normal')
+function showEffect(target: 'player' | 'enemy', effect: 'super' | 'not' | 'normal', crit: 'critical' | 'weak' | 'normal') {
+  if (effect === 'normal' && crit === 'normal')
     return
-  const text = effect === 'super' ? 'C\u2019est super efficace !' : 'Pas tr\u00E8s efficace...'
+  const messages: string[] = []
+  if (crit === 'critical')
+    messages.push('Coup critique !')
+  else if (crit === 'weak')
+    messages.push('Coup mou...')
+  if (effect === 'super')
+    messages.push('C\u2019est super efficace !')
+  else if (effect === 'not')
+    messages.push('Pas tr\u00E8s efficace...')
+  const text = messages.join(' ')
+  const variant = effect === 'super' || crit === 'critical'
+    ? 'high'
+    : effect === 'not' || crit === 'weak'
+      ? 'low'
+      : 'normal'
   if (target === 'enemy') {
     enemyEffect.value = text
-    setTimeout(() => (enemyEffect.value = ''), 500)
+    enemyVariant.value = variant
+    setTimeout(() => {
+      enemyEffect.value = ''
+      enemyVariant.value = 'normal'
+    }, 500)
   }
   else {
     playerEffect.value = text
-    setTimeout(() => (playerEffect.value = ''), 500)
+    playerVariant.value = variant
+    setTimeout(() => {
+      playerEffect.value = ''
+      playerVariant.value = 'normal'
+    }, 500)
   }
 }
 
@@ -85,8 +109,8 @@ function startBattle() {
 function attack() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
-  const { effect } = battle.attack(dex.activeShlagemon, enemy.value)
-  showEffect('enemy', effect)
+  const { effect, crit } = battle.attack(dex.activeShlagemon, enemy.value)
+  showEffect('enemy', effect, crit)
   enemyHp.value = enemy.value.hpCurrent
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
@@ -97,12 +121,12 @@ function tick() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
   const { player: resPlayer, enemy: resEnemy } = battle.duel(dex.activeShlagemon, enemy.value)
-  showEffect('enemy', resPlayer.effect)
+  showEffect('enemy', resPlayer.effect, resPlayer.crit)
   enemyHp.value = enemy.value.hpCurrent
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
   if (resEnemy) {
-    showEffect('player', resEnemy.effect)
+    showEffect('player', resEnemy.effect, resEnemy.crit)
     playerHp.value = dex.activeShlagemon.hpCurrent
     flashPlayer.value = true
     setTimeout(() => (flashPlayer.value = false), 100)
@@ -169,7 +193,7 @@ onUnmounted(() => {
     <div v-else-if="stage === 'battle'" class="w-full text-center" @click="attack">
       <div class="flex flex-1 items-center justify-center gap-4">
         <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
-          <BattleToast v-if="playerEffect" :message="playerEffect" />
+          <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
           <ShlagemonImage
             :id="dex.activeShlagemon.base.id"
             :alt="dex.activeShlagemon.base.name"
@@ -188,7 +212,7 @@ onUnmounted(() => {
           VS
         </div>
         <div v-if="enemy" class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
-          <BattleToast v-if="enemyEffect" :message="enemyEffect" />
+          <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
           <ShlagemonImage
             :id="enemy.base.id"
             :alt="enemy.base.name"

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -5,6 +5,7 @@ import { computeDamage } from '~/utils/combat'
 export interface AttackResult {
   damage: number
   effect: 'super' | 'not' | 'normal'
+  crit: 'critical' | 'weak' | 'normal'
 }
 
 export const useBattleStore = defineStore('battle', () => {

--- a/src/utils/combat.ts
+++ b/src/utils/combat.ts
@@ -32,8 +32,14 @@ export function computeDamage(
   base: number,
   attackType: ShlagemonType,
   targetType: ShlagemonType,
-): { damage: number, effect: 'super' | 'not' | 'normal' } {
-  const { multiplier, effect } = getTypeMultiplier(attackType, targetType)
-  const damage = Math.round(base * multiplier)
-  return { damage, effect }
+): { damage: number, effect: 'super' | 'not' | 'normal', crit: 'critical' | 'weak' | 'normal' } {
+  const { multiplier: typeMultiplier, effect } = getTypeMultiplier(attackType, targetType)
+  const variance = 0.8 + Math.random() * 0.4 // entre x0.8 et x1.2
+  let crit: 'critical' | 'weak' | 'normal' = 'normal'
+  if (variance > 1.15)
+    crit = 'critical'
+  else if (variance < 0.85)
+    crit = 'weak'
+  const damage = Math.round(base * typeMultiplier * variance)
+  return { damage, effect, crit }
 }


### PR DESCRIPTION
## Summary
- compute critical and weak hits in combat utils
- extend battle store results to include crit property
- display crit text and color-coded BattleToast
- style BattleToast variants for high and low damage
- show colored toasts in BattleMain and TrainerBattle

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6864fb9f1894832a8c1f1fdbd6b557e5