### PR TITLE
Implement shiny upgrade on duplicate capture

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -80,7 +80,7 @@ function openCapture() {
 function onCaptureEnd(success: boolean) {
   showCapture.value = false
   if (success && enemy.value) {
-    dex.captureShlagemon(enemy.value.base)
+    dex.captureShlagemon(enemy.value.base, enemy.value.isShiny)
     enemy.value = null
     setTimeout(startBattle, 1000)
   }

--- a/src/components/battle/CaptureMenu.vue
+++ b/src/components/battle/CaptureMenu.vue
@@ -28,7 +28,7 @@ function useBall(ball: Ball) {
   inventory.remove(ball.id)
   setTimeout(() => (animBall.value = null), 500)
   if (success) {
-    dex.captureShlagemon(props.enemy.base)
+    dex.captureShlagemon(props.enemy.base, props.enemy.isShiny)
     emit('capture', true)
     toast(`Vous avez capturé ${props.enemy.base.name} !`)
   }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -80,21 +80,23 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       mon.xp = 0
   }
 
-  function createShlagemon(base: BaseShlagemon) {
-    const mon = createDexShlagemon(base)
+  function createShlagemon(base: BaseShlagemon, shiny = false) {
+    const mon = createDexShlagemon(base, shiny)
     addShlagemon(mon)
     updateHighestLevel(mon)
     toast(`Tu as obtenu ${base.name} !`)
     return mon
   }
 
-  function captureShlagemon(base: BaseShlagemon) {
+  function captureShlagemon(base: BaseShlagemon, shiny = false) {
     const existing = shlagemons.value.find(mon => mon.base.id === base.id)
     if (existing) {
       if (existing.rarity < 100) {
         existing.rarity += 1
         toast(`${existing.base.name} atteint la rareté ${existing.rarity} !`)
       }
+      if (shiny)
+        existing.isShiny = true
       existing.lvl = 1
       existing.xp = 0
       existing.baseStats = {
@@ -124,7 +126,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       updateHighestLevel(existing)
       return existing
     }
-    const created = createShlagemon(base)
+    const created = createShlagemon(base, shiny)
     updateHighestLevel(created)
     return created
   }

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -33,7 +33,7 @@ export function applyStats(mon: DexShlagemon) {
   mon.hpCurrent = mon.hp
 }
 
-export function createDexShlagemon(base: BaseShlagemon): DexShlagemon {
+export function createDexShlagemon(base: BaseShlagemon, shiny = false): DexShlagemon {
   const rarity = generateRarity()
   const mon: DexShlagemon = {
     id: crypto.randomUUID(),
@@ -52,7 +52,7 @@ export function createDexShlagemon(base: BaseShlagemon): DexShlagemon {
     defense: 0,
     smelling: 0,
     sex: Math.random() < 0.5 ? 'male' : 'female',
-    isShiny: Math.random() < 0.0001,
+    isShiny: shiny || Math.random() < 0.0001,
     hpCurrent: 0,
   }
   applyStats(mon)

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -22,6 +22,16 @@ describe('shlagedex capture', () => {
       `${mon.base.name} atteint la rareté ${mon.rarity} !`,
     )
   })
+
+  it('turns existing mon shiny if duplicate is shiny', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.isShiny = false
+    expect(mon.isShiny).toBe(false)
+    dex.captureShlagemon(carapouffe, true)
+    expect(mon.isShiny).toBe(true)
+  })
 })
 
 describe('shlagedex highest level', () => {


### PR DESCRIPTION
## Summary
- preserve shiny when capturing duplicates
- forward shiny state through capture menu and battle flow
- allow specifying shiny when creating new shlagemon
- test shiny upgrade

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68650028e36c832a92280cdff4c2fa2f