### PR TITLE
Fix rounding of shlagidolars

### DIFF
--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -5,7 +5,7 @@ export const useGameStore = defineStore('game', () => {
   const shlagidiamond = ref(0)
 
   function addShlagidolar(amount: number) {
-    shlagidolar.value += amount
+    shlagidolar.value = Math.ceil(shlagidolar.value + amount)
   }
 
   function addShlagidiamond(amount: number) {


### PR DESCRIPTION
## Summary
- ensure shlagidolar amount stays an integer by rounding up on each update

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68650107ba08832aa7e0578c3d161f11