### PR TITLE
Heal updates in battle

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -171,6 +171,14 @@ watch(
 )
 
 watch(
+  () => dex.activeShlagemon?.hpCurrent,
+  (value) => {
+    if (typeof value === 'number')
+      playerHp.value = value
+  },
+)
+
+watch(
   () => zone.current.id,
   () => {
     if (battleInterval)

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -79,6 +79,14 @@ watch(trainer, (t) => {
   }
 })
 
+watch(
+  () => dex.activeShlagemon?.hpCurrent,
+  (value) => {
+    if (typeof value === 'number')
+      playerHp.value = value
+  },
+)
+
 function startFight() {
   if (!trainer.value || !dex.activeShlagemon)
     return


### PR DESCRIPTION
## Summary
- keep HP display in sync with healing items
- sync TrainerBattle HP too

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6865012d6548832a88922ec56fc830e9