### PR TITLE
Implement weakness/resistance and crit chance

### DIFF
--- a/src/utils/combat.ts
+++ b/src/utils/combat.ts
@@ -9,20 +9,15 @@ export function getTypeMultiplier(
 ): { multiplier: number, effect: 'super' | 'not' | 'normal' } {
   let base = 1
 
-  if (attackType.weakness.some(w => w.id === targetType.id)) {
-    base = 0.8 // L'attaque est faible contre le type ciblé
-  }
-  else if (attackType.resistance.some(r => r.id === targetType.id)) {
-    base = 1.2 // L'attaque est forte contre le type ciblé
-  }
-
-  const variance = 0.8 + Math.random() * 0.4 // entre x0.8 et x1.2
-  const multiplier = base * variance
+  if (targetType.weakness.some(w => w.id === attackType.id))
+    base = 1.2 // La cible est faible contre ce type
+  else if (targetType.resistance.some(r => r.id === attackType.id))
+    base = 0.8 // La cible résiste à ce type
 
   const effect: 'super' | 'not' | 'normal'
     = base > 1 ? 'super' : base < 1 ? 'not' : 'normal'
 
-  return { multiplier, effect }
+  return { multiplier: base, effect }
 }
 
 /**
@@ -35,11 +30,17 @@ export function computeDamage(
 ): { damage: number, effect: 'super' | 'not' | 'normal', crit: 'critical' | 'weak' | 'normal' } {
   const { multiplier: typeMultiplier, effect } = getTypeMultiplier(attackType, targetType)
   const variance = 0.8 + Math.random() * 0.4 // entre x0.8 et x1.2
+  let multiplier = typeMultiplier * variance
   let crit: 'critical' | 'weak' | 'normal' = 'normal'
-  if (variance > 1.15)
+
+  if (Math.random() < 1 / 50) {
+    multiplier *= 2
     crit = 'critical'
-  else if (variance < 0.85)
+  }
+  else if (variance < 0.85) {
     crit = 'weak'
-  const damage = Math.round(base * typeMultiplier * variance)
+  }
+
+  const damage = Math.round(base * multiplier)
   return { damage, effect, crit }
 }


### PR DESCRIPTION
## Summary
- fix damage multiplier logic for type weakness and resistance
- add 1/50 critical hit chance doubling damage
- update computeDamage implementation

## Testing
- `pnpm exec vitest run`
- `pnpm exec cypress run --headless` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686505073ffc832aa520ac6e908992e3