### PR TITLE
Implement zone-specific enemy selection

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -96,7 +96,10 @@ function startBattle() {
   const active = dex.activeShlagemon
   if (!active)
     return
-  const base = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
+  const available = zone.current.shlagemons?.length
+    ? zone.current.shlagemons
+    : allShlagemons
+  const base = available[Math.floor(Math.random() * available.length)]
   enemy.value = createDexShlagemon(base)
   const min = Number(zone.current.minLevel ?? 1)
   const zoneMax = Number(zone.current.maxLevel ?? (min + 1))

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -46,10 +46,14 @@ function fightKing() {
     dialogBefore: 'Prépare-toi à perdre !',
     dialogAfter: 'Tu as gagné... pour cette fois.',
     reward: 5,
-    shlagemons: Array.from({ length: 6 }, () => ({
-      baseId: allShlagemons[Math.floor(Math.random() * allShlagemons.length)].id,
-      level,
-    })),
+    shlagemons: Array.from({ length: 6 }, () => {
+      const list = z.shlagemons?.length ? z.shlagemons! : allShlagemons
+      const base = list[Math.floor(Math.random() * list.length)]
+      return {
+        baseId: base.id,
+        level,
+      }
+    }),
   }
   trainerBattle.setQueue([trainer])
   panel.showTrainerBattle()

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -65,6 +65,7 @@ const generatedZones: Zone[] = zoneDescriptions.map((desc, index) => ({
   name: desc.name,
   type: desc.type,
   actions: desc.actions ?? [],
+  shlagemons: desc.shlagemons,
   minLevel: index * 5 || 1,
   maxLevel: index * 5 + 5,
 }))


### PR DESCRIPTION
## Summary
- include shlagemon list when building zones
- pick enemies from current zone's shlagemons in battle panel
- pick zone shlagemons for zone king fights

## Testing
- `pnpm lint`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_686517069214832aa45f02e958ef51d9