### PR TITLE
Improve PlayerInfos overflow handling

### DIFF
--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -14,21 +14,21 @@ const totalInDex = allShlagemons.length
     class="w-full inline-flex items-center justify-around gap-3 rounded bg-white text-xs dark:bg-gray-900"
     sm="text-sm"
   >
-    <div class="flex items-center gap-2">
-      <span>Shlagidolars</span>
-      <span class="font-bold">{{ game.shlagidolar }}</span>
+    <div class="min-w-0 flex items-center gap-2">
+      <span class="truncate">Shlagidolars</span>
+      <span class="shrink-0 font-bold">{{ game.shlagidolar }}</span>
     </div>
-    <div class="flex items-center gap-2">
-      <span>Shlagédiamonds</span>
-      <span class="font-bold">{{ game.shlagidiamond }}</span>
+    <div class="min-w-0 flex items-center gap-2">
+      <span class="truncate">Shlagédiamonds</span>
+      <span class="shrink-0 font-bold">{{ game.shlagidiamond }}</span>
     </div>
-    <div class="flex items-center gap-2">
-      <span>Shlagédex</span>
-      <span class="font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
+    <div class="min-w-0 flex items-center gap-2">
+      <span class="truncate">Shlagédex</span>
+      <span class="shrink-0 font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
     </div>
-    <div class="flex items-center gap-2">
+    <div class="min-w-0 flex items-center gap-2">
       <img src="/items/shlageball/shlageball.png" alt="ball" class="h-4 w-4">
-      <span class="font-bold">{{ inventory.items.shlageball || 0 }}</span>
+      <span class="shrink-0 font-bold">{{ inventory.items.shlageball || 0 }}</span>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- prevent overflow of labels in `PlayerInfos.vue` by adding `truncate` styling

## Testing
- `pnpm lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68651869b348832abf200569014df008