### PR TITLE
Fix save reset for zone progress

### DIFF
--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -5,6 +5,7 @@ import { useGameStateStore } from './gameState'
 import { useInventoryStore } from './inventory'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
+import { useZoneProgressStore } from './zoneProgress'
 
 export const useSaveStore = defineStore('save', () => {
   const dex = useShlagedexStore()
@@ -13,6 +14,7 @@ export const useSaveStore = defineStore('save', () => {
   const inventory = useInventoryStore()
   const dialog = useDialogStore()
   const zone = useZoneStore()
+  const zoneProgress = useZoneProgressStore()
 
   function reset() {
     dex.reset()
@@ -21,6 +23,7 @@ export const useSaveStore = defineStore('save', () => {
     dialog.reset()
     inventory.reset()
     zone.reset()
+    zoneProgress.reset()
   }
 
   return { reset }

--- a/test/save-reset.test.ts
+++ b/test/save-reset.test.ts
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import { useDialogStore } from '../src/stores/dialog'
 import { useSaveStore } from '../src/stores/save'
+import { useZoneProgressStore } from '../src/stores/zoneProgress'
 
 describe('useSaveStore.reset', () => {
   it('should reset dialog store', () => {
@@ -15,5 +16,18 @@ describe('useSaveStore.reset', () => {
     save.reset()
 
     expect(dialog.isDone('foo')).toBe(false)
+  })
+
+  it('should reset zone progress store', () => {
+    setActivePinia(createPinia())
+    const progress = useZoneProgressStore()
+    const save = useSaveStore()
+
+    progress.addWin('foo')
+    expect(progress.getWins('foo')).toBe(1)
+
+    save.reset()
+
+    expect(progress.getWins('foo')).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- clear zone progress when resetting a save
- verify in unit tests

## Testing
- `pnpm lint`
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686519d9ce44832aad978b207fbde885