### PR TITLE
Add zone king defeat gating

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -9,6 +9,8 @@ import { useGameStore } from '~/stores/game'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
 import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
@@ -16,6 +18,8 @@ const game = useGameStore()
 const trainerStore = useTrainerBattleStore()
 const battle = useBattleStore()
 const panel = useMainPanelStore()
+const zone = useZoneStore()
+const progress = useZoneProgressStore()
 
 const trainer = computed(() => trainerStore.current)
 const vigor = computed(() => trainerStore.vigor)
@@ -178,6 +182,8 @@ function checkEnd() {
 }
 
 function finish() {
+  if (trainer.value?.id.startsWith('king-'))
+    progress.defeatKing(zone.current.id)
   trainerStore.next()
   panel.showBattle()
 }

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -1,12 +1,43 @@
+import type { Trainer } from '~/type/trainer'
 import type { Zone } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { allShlagemons } from '~/data/shlagemons'
 import { zonesData } from '~/data/zones'
 
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
   const currentId = ref<string>(zones.value[0].id)
   const current = computed(() => zones.value.find(z => z.id === currentId.value)!)
+
+  const kings = ref<Record<string, Trainer>>({})
+
+  function getKing(id: string): Trainer {
+    if (!kings.value[id]) {
+      const z = zones.value.find(z => z.id === id)
+      if (!z)
+        throw new Error('Zone not found')
+      const level = z.maxLevel + 1
+      const trainer: Trainer = {
+        id: `king-${z.id}`,
+        name: `Roi de ${z.name}`,
+        image: '/characters/professor/professor.png',
+        dialogBefore: 'Prépare-toi à perdre !',
+        dialogAfter: 'Tu as gagné... pour cette fois.',
+        reward: 5,
+        shlagemons: Array.from({ length: 6 }, () => {
+          const list = z.shlagemons?.length ? z.shlagemons! : allShlagemons
+          const base = list[Math.floor(Math.random() * list.length)]
+          return {
+            baseId: base.id,
+            level,
+          }
+        }),
+      }
+      kings.value[id] = trainer
+    }
+    return kings.value[id]
+  }
 
   const rewardMultiplier = computed(() => {
     const zone = current.value
@@ -25,7 +56,7 @@ export const useZoneStore = defineStore('zone', () => {
     currentId.value = zones.value[0].id
   }
 
-  return { zones, current, rewardMultiplier, setZone, reset }
+  return { zones, current, rewardMultiplier, setZone, getKing, reset }
 }, {
   persist: {
     pick: ['currentId'],

--- a/src/stores/zoneProgress.ts
+++ b/src/stores/zoneProgress.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 
 export const useZoneProgressStore = defineStore('zoneProgress', () => {
   const wins = ref<Record<string, number>>({})
+  const kingsDefeated = ref<Record<string, boolean>>({})
 
   function addWin(id: string) {
     wins.value[id] = (wins.value[id] || 0) + 1
@@ -16,11 +17,28 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
     return getWins(id) >= 20
   }
 
-  function reset() {
-    wins.value = {}
+  function defeatKing(id: string) {
+    kingsDefeated.value[id] = true
   }
 
-  return { wins, addWin, getWins, canFightKing, reset }
+  function isKingDefeated(id: string) {
+    return !!kingsDefeated.value[id]
+  }
+
+  function reset() {
+    wins.value = {}
+    kingsDefeated.value = {}
+  }
+
+  return {
+    wins,
+    addWin,
+    getWins,
+    canFightKing,
+    defeatKing,
+    isKingDefeated,
+    reset,
+  }
 }, {
   persist: true,
 })

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -37,15 +37,19 @@ describe('zone panel', () => {
     const wrapper = mount(ZonePanel, {
       global: { plugins: [pinia] },
     })
-    expect(wrapper.text()).not.toContain('Grotte du Slip')
+    let btn = wrapper.findAll('button').find(b => b.text().includes('Grotte du Slip'))
+    expect(btn?.attributes('disabled')).toBeDefined()
     for (let i = 0; i < 20; i++)
       progress.addWin('plaine-kekette')
     for (let i = 0; i < 20; i++)
       progress.addWin('bois-de-bouffon')
+    progress.defeatKing('plaine-kekette')
+    progress.defeatKing('bois-de-bouffon')
     for (let i = 0; i < 9; i++)
       dex.gainXp(mon, xpForLevel(mon.lvl))
     await wrapper.vm.$nextTick()
-    expect(wrapper.text()).toContain('Grotte du Slip')
+    btn = wrapper.findAll('button').find(b => b.text().includes('Grotte du Slip'))
+    expect(btn?.attributes('disabled')).toBeUndefined()
   })
 
   it('shows king button after 20 wins', async () => {


### PR DESCRIPTION
## Summary
- store zone kings in the zone store
- track defeated kings in zoneProgress store
- block access to next zone until the current king is defeated
- display king status and disable buttons accordingly
- update tests for new king defeat logic

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68651a3a5dec832ab87e3c2eb1ba7922