### PR TITLE
feat: capture enemy level and rarity

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -82,7 +82,7 @@ function openCapture() {
 function onCaptureEnd(success: boolean) {
   showCapture.value = false
   if (success && enemy.value) {
-    dex.captureShlagemon(enemy.value.base, enemy.value.isShiny)
+    dex.captureEnemy(enemy.value)
     enemy.value = null
     setTimeout(startBattle, 1000)
   }

--- a/src/components/battle/CaptureMenu.vue
+++ b/src/components/battle/CaptureMenu.vue
@@ -28,7 +28,7 @@ function useBall(ball: Ball) {
   inventory.remove(ball.id)
   setTimeout(() => (animBall.value = null), 500)
   if (success) {
-    dex.captureShlagemon(props.enemy.base, props.enemy.isShiny)
+    dex.captureEnemy(props.enemy)
     emit('capture', true)
     toast(`Vous avez capturé ${props.enemy.base.name} !`)
   }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -134,13 +134,19 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   function captureEnemy(enemy: DexShlagemon) {
     const existing = shlagemons.value.find(mon => mon.base.id === enemy.base.id)
     if (existing) {
-      existing.lvl = enemy.lvl
-      existing.xp = enemy.xp
-      existing.rarity = enemy.rarity
-      existing.baseStats = { ...enemy.baseStats }
-      existing.sex = enemy.sex
-      if (enemy.isShiny)
-        existing.isShiny = true
+      if (existing.rarity < 100) {
+        existing.rarity += 1
+        toast(`${existing.base.name} atteint la rareté ${existing.rarity} !`)
+      }
+      existing.isShiny ||= enemy.isShiny
+      existing.lvl = 1
+      existing.xp = 0
+      existing.baseStats = {
+        hp: statWithRarityAndCoefficient(baseStats.hp, existing.base.coefficient, existing.rarity),
+        attack: statWithRarityAndCoefficient(baseStats.attack, existing.base.coefficient, existing.rarity),
+        defense: statWithRarityAndCoefficient(baseStats.defense, existing.base.coefficient, existing.rarity),
+        smelling: statWithRarityAndCoefficient(baseStats.smelling, existing.base.coefficient, existing.rarity),
+      }
       applyStats(existing)
       existing.hpCurrent = existing.hp
       updateHighestLevel(existing)

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -131,7 +131,33 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return created
   }
 
-  return { shlagemons, activeShlagemon, highestLevel, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, gainXp, healActive, boostDefense }
+  function captureEnemy(enemy: DexShlagemon) {
+    const existing = shlagemons.value.find(mon => mon.base.id === enemy.base.id)
+    if (existing) {
+      existing.lvl = enemy.lvl
+      existing.xp = enemy.xp
+      existing.rarity = enemy.rarity
+      existing.baseStats = { ...enemy.baseStats }
+      existing.sex = enemy.sex
+      if (enemy.isShiny)
+        existing.isShiny = true
+      applyStats(existing)
+      existing.hpCurrent = existing.hp
+      updateHighestLevel(existing)
+      return existing
+    }
+    const captured: DexShlagemon = {
+      ...enemy,
+      id: crypto.randomUUID(),
+      hpCurrent: enemy.hp,
+    }
+    addShlagemon(captured)
+    updateHighestLevel(captured)
+    toast(`Tu as obtenu ${captured.base.name} !`)
+    return captured
+  }
+
+  return { shlagemons, activeShlagemon, highestLevel, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, captureEnemy, gainXp, healActive, boostDefense }
 }, {
   persist: {
     debug: true,

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { toast } from 'vue3-toastify'
 import { carapouffe } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
-import { applyStats, xpForLevel } from '../src/utils/dexFactory'
+import { applyStats, createDexShlagemon, xpForLevel } from '../src/utils/dexFactory'
 
 vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
 
@@ -33,16 +33,33 @@ describe('shlagedex capture', () => {
     expect(mon.isShiny).toBe(true)
   })
 
-  it('captures enemy with same level and rarity', () => {
+  it('captures new enemy with same level and rarity', () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
-    const enemy = dex.createShlagemon(carapouffe)
+    const enemy = createDexShlagemon(carapouffe)
     enemy.lvl = 17
     enemy.rarity = 42
     applyStats(enemy)
     const captured = dex.captureEnemy(enemy)
     expect(captured.lvl).toBe(17)
     expect(captured.rarity).toBe(42)
+  })
+
+  it('increases rarity and resets level when capturing duplicate enemy', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const existing = dex.createShlagemon(carapouffe)
+    existing.rarity = 1
+    applyStats(existing)
+    const enemy = createDexShlagemon(carapouffe)
+    enemy.isShiny = true
+    enemy.lvl = 10
+    applyStats(enemy)
+    const captured = dex.captureEnemy(enemy)
+    expect(captured.id).toBe(existing.id)
+    expect(existing.rarity).toBe(2)
+    expect(existing.lvl).toBe(1)
+    expect(existing.isShiny).toBe(true)
   })
 })
 

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { toast } from 'vue3-toastify'
 import { carapouffe } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
-import { xpForLevel } from '../src/utils/dexFactory'
+import { applyStats, xpForLevel } from '../src/utils/dexFactory'
 
 vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
 
@@ -31,6 +31,18 @@ describe('shlagedex capture', () => {
     expect(mon.isShiny).toBe(false)
     dex.captureShlagemon(carapouffe, true)
     expect(mon.isShiny).toBe(true)
+  })
+
+  it('captures enemy with same level and rarity', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const enemy = dex.createShlagemon(carapouffe)
+    enemy.lvl = 17
+    enemy.rarity = 42
+    applyStats(enemy)
+    const captured = dex.captureEnemy(enemy)
+    expect(captured.lvl).toBe(17)
+    expect(captured.rarity).toBe(42)
   })
 })
 


### PR DESCRIPTION
## Summary
- keep enemy stats when capturing during battle
- adjust capture components to use the new method
- add regression test for capturing enemies with same level and rarity

## Testing
- `pnpm lint`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_686523adda74832aad4fb4652b881676