### PR TITLE
Add achievements system

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -53,6 +53,7 @@ declare global {
   const makeDestructurable: typeof import('@vueuse/core')['makeDestructurable']
   const markRaw: typeof import('vue')['markRaw']
   const nextTick: typeof import('vue')['nextTick']
+  const notifyAchievement: typeof import('./stores/achievements')['notifyAchievement']
   const onActivated: typeof import('vue')['onActivated']
   const onBeforeMount: typeof import('vue')['onBeforeMount']
   const onBeforeRouteLeave: typeof import('vue-router')['onBeforeRouteLeave']
@@ -117,6 +118,7 @@ declare global {
   const unref: typeof import('vue')['unref']
   const unrefElement: typeof import('@vueuse/core')['unrefElement']
   const until: typeof import('@vueuse/core')['until']
+  const useAchievementsStore: typeof import('./stores/achievements')['useAchievementsStore']
   const useActiveElement: typeof import('@vueuse/core')['useActiveElement']
   const useAnimate: typeof import('@vueuse/core')['useAnimate']
   const useArrayDifference: typeof import('@vueuse/core')['useArrayDifference']
@@ -327,6 +329,9 @@ declare global {
   export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
   // @ts-ignore
+  export type { Achievement, AchievementEvent } from './stores/achievements'
+  import('./stores/achievements')
+  // @ts-ignore
   export type { AttackResult } from './stores/battle'
   import('./stores/battle')
   // @ts-ignore
@@ -386,6 +391,7 @@ declare module 'vue' {
     readonly makeDestructurable: UnwrapRef<typeof import('@vueuse/core')['makeDestructurable']>
     readonly markRaw: UnwrapRef<typeof import('vue')['markRaw']>
     readonly nextTick: UnwrapRef<typeof import('vue')['nextTick']>
+    readonly notifyAchievement: UnwrapRef<typeof import('./stores/achievements')['notifyAchievement']>
     readonly onActivated: UnwrapRef<typeof import('vue')['onActivated']>
     readonly onBeforeMount: UnwrapRef<typeof import('vue')['onBeforeMount']>
     readonly onBeforeRouteLeave: UnwrapRef<typeof import('vue-router')['onBeforeRouteLeave']>
@@ -450,6 +456,7 @@ declare module 'vue' {
     readonly unref: UnwrapRef<typeof import('vue')['unref']>
     readonly unrefElement: UnwrapRef<typeof import('@vueuse/core')['unrefElement']>
     readonly until: UnwrapRef<typeof import('@vueuse/core')['until']>
+    readonly useAchievementsStore: UnwrapRef<typeof import('./stores/achievements')['useAchievementsStore']>
     readonly useActiveElement: UnwrapRef<typeof import('@vueuse/core')['useActiveElement']>
     readonly useAnimate: UnwrapRef<typeof import('@vueuse/core')['useAnimate']>
     readonly useArrayDifference: UnwrapRef<typeof import('@vueuse/core')['useArrayDifference']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AchievementsPanel: typeof import('./components/achievements/AchievementsPanel.vue')['default']
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { useAchievementsStore } from '~/stores/achievements'
+
+const store = useAchievementsStore()
+const list = computed(() => store.unlockedList)
+</script>
+
+<template>
+  <div class="flex flex-col gap-1">
+    <div
+      v-for="a in list"
+      :key="a.id"
+      class="flex items-center gap-2 border border-gray-300 rounded bg-gray-50 p-1 text-xs dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div class="i-carbon-award inline-block text-green-600" />
+      <span>{{ a.title }}</span>
+    </div>
+  </div>
+</template>

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -4,6 +4,7 @@ import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
+import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
 import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
@@ -83,6 +84,7 @@ function onCaptureEnd(success: boolean) {
   showCapture.value = false
   if (success && enemy.value) {
     dex.captureEnemy(enemy.value)
+    notifyAchievement({ type: 'capture', shiny: enemy.value.isShiny })
     enemy.value = null
     setTimeout(startBattle, 1000)
   }
@@ -150,8 +152,12 @@ function checkEnd() {
     if (dex.activeShlagemon)
       dex.activeShlagemon.hpCurrent = playerHp.value
     if (enemyHp.value <= 0 && playerHp.value > 0) {
+      const stronger = enemy.value && dex.activeShlagemon
+        ? enemy.value.lvl > dex.activeShlagemon.lvl
+        : false
       progress.addWin(zone.current.id)
       game.addShlagidolar(zone.rewardMultiplier)
+      notifyAchievement({ type: 'battle-win', stronger })
       if (dex.activeShlagemon && enemy.value) {
         dex.gainXp(
           dex.activeShlagemon,

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -4,6 +4,7 @@ import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import Button from '~/components/ui/Button.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
+import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
 import { useGameStore } from '~/stores/game'
 import { useMainPanelStore } from '~/stores/mainPanel'
@@ -188,8 +189,10 @@ function checkEnd() {
 
 function finish() {
   if (result.value === 'win') {
-    if (trainer.value?.id.startsWith('king-'))
+    if (trainer.value?.id.startsWith('king-')) {
       progress.defeatKing(zone.current.id)
+      notifyAchievement({ type: 'king-defeated' })
+    }
     trainerStore.next()
     panel.showBattle()
   }

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
 import ActiveShlagemon from '~/components/panels/ActiveShlagemon.vue'
 import InventoryPanel from '~/components/panels/InventoryPanel.vue'
 import MainPanel from '~/components/panels/MainPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import PanelWrapper from '~/components/ui/PanelWrapper.vue'
+import { useAchievementsStore } from '~/stores/achievements'
 import { useDialogStore } from '~/stores/dialog'
 import { useGameStateStore } from '~/stores/gameState'
 import { useInventoryStore } from '~/stores/inventory'
@@ -16,6 +18,7 @@ const zone = useZoneStore()
 const inventory = useInventoryStore()
 const shlagedex = useShlagedexStore()
 const dialogStore = useDialogStore()
+const achievements = useAchievementsStore()
 
 const showMainPanel = computed(() =>
   dialogStore.isDialogVisible
@@ -24,6 +27,7 @@ const showMainPanel = computed(() =>
 )
 const isInventoryVisible = computed(() => inventory.list.length > 0)
 const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
+const isAchievementVisible = computed(() => achievements.hasAny)
 </script>
 
 <template>
@@ -56,10 +60,13 @@ const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
           <ActiveShlagemon />
         </PanelWrapper>
       </div>
-      <div v-if="isInventoryVisible" class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1">
+      <div v-if="isInventoryVisible || isAchievementVisible" class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1">
         <!-- left zone -->
         <PanelWrapper v-if="isInventoryVisible" title="Inventaire">
           <InventoryPanel />
+        </PanelWrapper>
+        <PanelWrapper v-if="isAchievementVisible" title="Succès">
+          <AchievementsPanel />
         </PanelWrapper>
       </div>
       <div v-if="isShlagedexVisible" class="zone" md="col-span-3 row-span-12 col-start-10 row-start-1">

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -1,0 +1,123 @@
+import { defineStore } from 'pinia'
+import { computed, reactive, ref, watch } from 'vue'
+import { useGameStore } from './game'
+import { useShlagedexStore } from './shlagedex'
+
+export interface Achievement {
+  id: string
+  title: string
+  description: string
+}
+
+export type AchievementEvent =
+  | { type: 'capture', shiny?: boolean }
+  | { type: 'battle-win', stronger: boolean }
+  | { type: 'item-used' }
+  | { type: 'king-defeated' }
+
+export const useAchievementsStore = defineStore('achievements', () => {
+  const game = useGameStore()
+  const dex = useShlagedexStore()
+
+  const counters = reactive({
+    captures: 0,
+    wins: 0,
+    winsStronger: 0,
+    itemsUsed: 0,
+    kings: 0,
+    shiny: 0,
+  })
+
+  const unlocked = ref<Record<string, boolean>>({})
+
+  function unlock(id: string) {
+    if (!unlocked.value[id])
+      unlocked.value[id] = true
+  }
+
+  const defs: Achievement[] = []
+  const moneyThresholds = [100, 1000, 10000, 100000, 1000000]
+  moneyThresholds.forEach((n) => {
+    defs.push({ id: `money-${n}`, title: `${n} Shlagidolars`, description: `Atteindre ${n} Shlagidolars` })
+  })
+  const captureThresholds = [1, 10, 100, 1000]
+  captureThresholds.forEach((n) => {
+    defs.push({ id: `capture-${n}`, title: `${n} captures`, description: `Capturer ${n} Shlagémon` })
+  })
+  const levelThresholds = Array.from({ length: 10 }, (_, i) => (i + 1) * 10)
+  levelThresholds.forEach((lvl) => {
+    defs.push({ id: `avg-${lvl}`, title: `Niveau moyen ${lvl}`, description: `Atteindre un niveau moyen de ${lvl}` })
+  })
+  const winThresholds = [1, 10, 100, 1000]
+  winThresholds.forEach((n) => {
+    defs.push({ id: `win-${n}`, title: `${n} victoires`, description: `Gagner ${n} combats` })
+    defs.push({ id: `stronger-${n}`, title: `${n} victoires difficiles`, description: `Vaincre ${n} ennemis plus forts` })
+  })
+  // extra achievements
+  defs.push({ id: 'king-1', title: 'Premier roi', description: 'Vaincre un roi de zone' })
+  defs.push({ id: 'shiny-1', title: 'Shiny!', description: 'Capturer un Shlagémon shiny' })
+  defs.push({ id: 'item-10', title: 'Dépensier', description: 'Utiliser 10 objets' })
+  defs.push({ id: 'team-6', title: 'Équipe complète', description: 'Posséder 6 Shlagémon' })
+
+  const list = computed(() => defs.map(d => ({ ...d, achieved: !!unlocked.value[d.id] })))
+  const unlockedList = computed(() => list.value.filter(a => a.achieved))
+  const hasAny = computed(() => unlockedList.value.length > 0)
+
+  function handleEvent(e: AchievementEvent) {
+    switch (e.type) {
+      case 'capture':
+        counters.captures += 1
+        if (e.shiny)
+          counters.shiny += 1
+        break
+      case 'battle-win':
+        counters.wins += 1
+        if (e.stronger)
+          counters.winsStronger += 1
+        break
+      case 'item-used':
+        counters.itemsUsed += 1
+        break
+      case 'king-defeated':
+        counters.kings += 1
+        break
+    }
+  }
+
+  function checkThresholds(value: number, prefix: string, thresholds: number[]) {
+    thresholds.forEach((n) => {
+      if (value >= n)
+        unlock(`${prefix}-${n}`)
+    })
+  }
+
+  watch(() => game.shlagidolar, v => checkThresholds(v, 'money', moneyThresholds), { immediate: true })
+  watch(() => counters.captures, v => checkThresholds(v, 'capture', captureThresholds))
+  watch(() => dex.averageLevel, v => checkThresholds(v, 'avg', levelThresholds), { immediate: true })
+  watch(() => counters.wins, v => checkThresholds(v, 'win', winThresholds))
+  watch(() => counters.winsStronger, v => checkThresholds(v, 'stronger', winThresholds))
+  watch(() => counters.itemsUsed, (v) => {
+    if (v >= 10)
+      unlock('item-10')
+  })
+  watch(() => counters.kings, (v) => {
+    if (v >= 1)
+      unlock('king-1')
+  })
+  watch(() => counters.shiny, (v) => {
+    if (v >= 1)
+      unlock('shiny-1')
+  })
+
+  watch(() => dex.shlagemons.length, (v) => {
+    if (v >= 6)
+      unlock('team-6')
+  })
+
+  return { list, unlockedList, hasAny, handleEvent }
+}, { persist: true })
+
+export function notifyAchievement(event: AchievementEvent) {
+  const store = useAchievementsStore()
+  store.handleEvent(event)
+}

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { shopItems } from '~/data/items/items'
 import { allShlagemons } from '~/data/shlagemons'
+import { notifyAchievement } from './achievements'
 import { useGameStore } from './game'
 import { useShlagedexStore } from './shlagedex'
 
@@ -49,6 +50,7 @@ export const useInventoryStore = defineStore('inventory', () => {
   function useItem(id: string) {
     if (!items.value[id])
       return false
+    notifyAchievement({ type: 'item-used' })
     if (id === 'potion') {
       dex.healActive(50)
       remove(id)
@@ -62,7 +64,8 @@ export const useInventoryStore = defineStore('inventory', () => {
     if (id === 'shlageball') {
       // simple capture of random shlagemon
       const base = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
-      dex.captureShlagemon(base)
+      const mon = dex.captureShlagemon(base)
+      notifyAchievement({ type: 'capture', shiny: mon.isShiny })
       remove(id)
       return true
     }

--- a/test/achievements.test.ts
+++ b/test/achievements.test.ts
@@ -1,0 +1,18 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import { notifyAchievement, useAchievementsStore } from '../src/stores/achievements'
+import { useGameStore } from '../src/stores/game'
+
+describe('achievements', () => {
+  it('unlocks win and money achievements', async () => {
+    setActivePinia(createPinia())
+    const achievements = useAchievementsStore()
+    const game = useGameStore()
+    notifyAchievement({ type: 'battle-win', stronger: false })
+    game.addShlagidolar(200)
+    await nextTick()
+    expect(achievements.unlockedList.some(a => a.id === 'win-1')).toBe(true)
+    expect(achievements.unlockedList.some(a => a.id === 'money-100')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- implement generic achievement store with unlock conditions
- display unlocked achievements in new panel
- trigger events from battles and inventory usage
- show achievements panel below inventory
- cover basic behaviour with unit test

## Testing
- `pnpm lint`
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68658e03380c832a9989cedd82a0a4a7