### PR TITLE
Add tooltip component to player panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bd": "pnpm run build && pnpm run deploy"
   },
   "dependencies": {
+    "@floating-ui/dom": "catalog:frontend",
     "@unhead/vue": "catalog:frontend",
     "@unocss/reset": "catalog:frontend",
     "@vueuse/core": "catalog:frontend",
@@ -29,7 +30,6 @@
     "vue-i18n": "catalog:frontend",
     "vue-router": "catalog:frontend",
     "vue3-toastify": "catalog:frontend"
-
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ catalogs:
       specifier: ^2.2.8
       version: 2.2.8
   frontend:
+    '@floating-ui/dom':
+      specifier: ^1.7.2
+      version: 1.7.2
     '@unhead/vue':
       specifier: ^2.0.2
       version: 2.0.2
@@ -143,6 +146,9 @@ catalogs:
     vue-router:
       specifier: ^4.5.0
       version: 4.5.0
+    vue3-toastify:
+      specifier: ^0.2.8
+      version: 0.2.8
   types:
     '@types/markdown-it-link-attributes':
       specifier: ^3.0.5
@@ -160,6 +166,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/dom':
+        specifier: catalog:frontend
+        version: 1.7.2
       '@unhead/vue':
         specifier: catalog:frontend
         version: 2.0.2(vue@3.5.13(typescript@5.8.2))
@@ -188,7 +197,7 @@ importers:
         specifier: catalog:frontend
         version: 4.5.0(vue@3.5.13(typescript@5.8.2))
       vue3-toastify:
-        specifier: ^0.2.8
+        specifier: catalog:frontend
         version: 0.2.8(vue@3.5.13(typescript@5.8.2))
     devDependencies:
       '@antfu/eslint-config':
@@ -1405,6 +1414,15 @@ packages:
   '@eslint/plugin-kit@0.2.7':
     resolution: {integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.7.2':
+    resolution: {integrity: sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==}
+
+  '@floating-ui/dom@1.7.2':
+    resolution: {integrity: sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -7354,6 +7372,17 @@ snapshots:
     dependencies:
       '@eslint/core': 0.12.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.7.2':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.2':
+    dependencies:
+      '@floating-ui/core': 1.7.2
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/utils@0.2.10': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalogs:
     vue-tsc: ^2.2.8
 
   frontend:
+    '@floating-ui/dom': ^1.7.2
     '@unhead/vue': ^2.0.2
     '@unocss/reset': ^66.1.0-beta.7
     '@vueuse/core': ^13.0.0

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -1,4 +1,10 @@
 <script setup lang="ts">
+import BonusIcon from '~/components/icons/bonus.vue'
+import SchlagedexIcon from '~/components/icons/schlagedex.vue'
+import ShlagediamondIcon from '~/components/icons/shlagediamond.vue'
+import ShlagidolarIcon from '~/components/icons/shlagidolar.vue'
+import XpIcon from '~/components/icons/xp.vue'
+import Tooltip from '~/components/ui/Tooltip.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { useInventoryStore } from '~/stores/inventory'
 
@@ -14,29 +20,41 @@ const totalInDex = allShlagemons.length
     class="w-full inline-flex items-center justify-around gap-3 rounded bg-white text-xs dark:bg-gray-900"
     sm="text-sm"
   >
-    <div class="min-w-0 flex items-center gap-2">
-      <span class="truncate">Shlagidolars</span>
-      <span class="shrink-0 font-bold">{{ game.shlagidolar }}</span>
-    </div>
-    <div class="min-w-0 flex items-center gap-2">
-      <span class="truncate">Shlagédiamonds</span>
-      <span class="shrink-0 font-bold">{{ game.shlagidiamond }}</span>
-    </div>
-    <div class="min-w-0 flex items-center gap-2">
-      <span class="truncate">Shlagédex</span>
-      <span class="shrink-0 font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
-    </div>
-    <div class="min-w-0 flex items-center gap-2">
-      <span class="truncate">Niv. moyen</span>
-      <span class="shrink-0 font-bold">{{ dex.averageLevel.toFixed(1) }}</span>
-    </div>
-    <div class="min-w-0 flex items-center gap-2">
-      <span class="truncate">Bonus</span>
-      <span class="shrink-0 font-bold">+{{ Math.round(dex.bonusPercent) }}%</span>
-    </div>
-    <div class="min-w-0 flex items-center gap-2">
-      <img src="/items/shlageball/shlageball.png" alt="ball" class="h-4 w-4">
-      <span class="shrink-0 font-bold">{{ inventory.items.shlageball || 0 }}</span>
-    </div>
+    <Tooltip text="Schlage Dolar">
+      <div class="min-w-0 flex items-center gap-1">
+        <ShlagidolarIcon class="h-4 w-4" />
+        <span class="shrink-0 font-bold">{{ game.shlagidolar }}</span>
+      </div>
+    </Tooltip>
+    <Tooltip text="Schlage Diamant">
+      <div class="min-w-0 flex items-center gap-1">
+        <ShlagediamondIcon class="h-4 w-4" />
+        <span class="shrink-0 font-bold">{{ game.shlagidiamond }}</span>
+      </div>
+    </Tooltip>
+    <Tooltip text="Schlage Dex">
+      <div class="min-w-0 flex items-center gap-1">
+        <SchlagedexIcon class="h-4 w-4" />
+        <span class="shrink-0 font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
+      </div>
+    </Tooltip>
+    <Tooltip text="Niveau moyen">
+      <div class="min-w-0 flex items-center gap-1">
+        <XpIcon class="h-4 w-4" />
+        <span class="shrink-0 font-bold">{{ dex.averageLevel.toFixed(1) }}</span>
+      </div>
+    </Tooltip>
+    <Tooltip text="Bonus">
+      <div class="min-w-0 flex items-center gap-1">
+        <BonusIcon class="h-4 w-4" />
+        <span class="shrink-0 font-bold">+{{ Math.round(dex.bonusPercent) }}%</span>
+      </div>
+    </Tooltip>
+    <Tooltip text="Schlage Ball">
+      <div class="min-w-0 flex items-center gap-1">
+        <img src="/items/shlageball/shlageball.png" alt="ball" class="h-4 w-4">
+        <span class="shrink-0 font-bold">{{ inventory.items.shlageball || 0 }}</span>
+      </div>
+    </Tooltip>
   </div>
 </template>

--- a/src/components/ui/Tooltip.vue
+++ b/src/components/ui/Tooltip.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom'
+import { ref } from 'vue'
+
+const props = defineProps<{ text: string }>()
+
+const wrapper = ref<HTMLElement | null>(null)
+const tooltip = ref<HTMLElement | null>(null)
+const visible = ref(false)
+let cleanup: (() => void) | undefined
+
+function show() {
+  visible.value = true
+  if (wrapper.value && tooltip.value) {
+    cleanup = autoUpdate(wrapper.value, tooltip.value, () => {
+      computePosition(wrapper.value!, tooltip.value!, {
+        placement: 'top',
+        middleware: [offset(6), flip(), shift({ padding: 4 })],
+      }).then(({ x, y }) => {
+        Object.assign(tooltip.value!.style, {
+          left: `${x}px`,
+          top: `${y}px`,
+        })
+      })
+    })
+  }
+}
+
+function hide() {
+  visible.value = false
+  if (cleanup) {
+    cleanup()
+    cleanup = undefined
+  }
+}
+</script>
+
+<template>
+  <span
+    ref="wrapper"
+    class="relative inline-flex items-center"
+    @mouseenter="show"
+    @mouseleave="hide"
+    @focusin="show"
+    @focusout="hide"
+  >
+    <slot />
+    <span
+      v-show="visible"
+      ref="tooltip"
+      class="pointer-events-none absolute z-50 whitespace-nowrap rounded bg-gray-700 px-2 py-1 text-xs text-white dark:bg-gray-200 dark:text-gray-800"
+    >{{ props.text }}</span>
+  </span>
+</template>


### PR DESCRIPTION
## Summary
- create reusable `Tooltip` component using Floating UI
- update player panel to use icons with tooltips
- keep package versions in catalog and lockfiles

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: zone panel > renders actions)*

------
https://chatgpt.com/codex/tasks/task_e_68659d1763fc832ab4103e59519e01ba