### PR TITLE
Fix zone progress persistence

### DIFF
--- a/src/stores/zoneProgress.ts
+++ b/src/stores/zoneProgress.ts
@@ -33,6 +33,7 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
 
   return {
     wins,
+    kingsDefeated,
     addWin,
     getWins,
     canFightKing,


### PR DESCRIPTION
## Summary
- ensure defeated kings are persisted by returning `kingsDefeated`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected 'La Chambre du Noobi' to contain 'Entrer le Shop')*

------
https://chatgpt.com/codex/tasks/task_e_68659dee84d8832aa0a255754b564e13