### PR TITLE
Add richer achievements list

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AchievementItem: typeof import('./components/achievements/AchievementItem.vue')['default']
     AchievementsPanel: typeof import('./components/achievements/AchievementsPanel.vue')['default']
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']

--- a/src/components/achievements/AchievementItem.vue
+++ b/src/components/achievements/AchievementItem.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { Achievement } from '~/stores/achievements'
+
+const props = defineProps<{ achievement: Achievement & { achieved: boolean } }>()
+const opened = ref(false)
+function toggle() {
+  opened.value = !opened.value
+}
+</script>
+
+<template>
+  <div
+    class="flex flex-col border rounded p-1 text-xs transition-colors"
+    :class="props.achievement.achieved
+      ? 'bg-blue-50 border-blue-300 text-blue-800 dark:bg-blue-900/40 dark:border-blue-700'
+      : 'bg-gray-50 border-gray-300 text-gray-500 dark:bg-gray-800 dark:border-gray-700'"
+  >
+    <div class="flex cursor-pointer items-center justify-between" @click="toggle">
+      <div class="flex items-center gap-2">
+        <div :class="props.achievement.icon" class="inline-block" />
+        <span>{{ props.achievement.title }}</span>
+      </div>
+      <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
+    </div>
+    <div v-show="opened" class="mt-1">
+      <p>{{ props.achievement.description }}</p>
+    </div>
+  </div>
+</template>

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -1,19 +1,22 @@
 <script setup lang="ts">
+import Button from '~/components/ui/Button.vue'
 import { useAchievementsStore } from '~/stores/achievements'
+import AchievementItem from './AchievementItem.vue'
 
 const store = useAchievementsStore()
-const list = computed(() => store.unlockedList)
+const showLocked = ref(false)
+const list = computed(() => showLocked.value ? store.list : store.unlockedList)
 </script>
 
 <template>
   <div class="flex flex-col gap-1">
-    <div
+    <Button class="self-end text-xs" @click="showLocked = !showLocked">
+      {{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés
+    </Button>
+    <AchievementItem
       v-for="a in list"
       :key="a.id"
-      class="flex items-center gap-2 border border-gray-300 rounded bg-gray-50 p-1 text-xs dark:border-gray-700 dark:bg-gray-800"
-    >
-      <div class="i-carbon-award inline-block text-green-600" />
-      <span>{{ a.title }}</span>
-    </div>
+      :achievement="a"
+    />
   </div>
 </template>

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -7,6 +7,7 @@ export interface Achievement {
   id: string
   title: string
   description: string
+  icon: string
 }
 
 export type AchievementEvent =
@@ -48,28 +49,75 @@ export const useAchievementsStore = defineStore('achievements', () => {
   const defs: Achievement[] = []
   const moneyThresholds = [100, 1000, 10000, 100000, 1000000]
   moneyThresholds.forEach((n) => {
-    defs.push({ id: `money-${n}`, title: `${n} Shlagidolars`, description: `Atteindre ${n} Shlagidolars` })
+    defs.push({
+      id: `money-${n}`,
+      title: `${n} Shlagidolars`,
+      description: `Accumuler au moins ${n} Shlagidolars pour montrer votre richesse.`,
+      icon: 'carbon:money',
+    })
   })
   const captureThresholds = [1, 10, 100, 1000]
   captureThresholds.forEach((n) => {
-    defs.push({ id: `capture-${n}`, title: `${n} captures`, description: `Capturer ${n} Shlagémon` })
+    defs.push({
+      id: `capture-${n}`,
+      title: `${n} captures`,
+      description: `Attraper ${n} Shlagémon différents durant vos aventures.`,
+      icon: 'mdi:pokeball',
+    })
   })
   const levelThresholds = Array.from({ length: 10 }, (_, i) => (i + 1) * 10)
   levelThresholds.forEach((lvl) => {
-    defs.push({ id: `avg-${lvl}`, title: `Niveau moyen ${lvl}`, description: `Atteindre un niveau moyen de ${lvl}` })
+    defs.push({
+      id: `avg-${lvl}`,
+      title: `Niveau moyen ${lvl}`,
+      description: `Atteindre un niveau moyen de ${lvl} pour votre équipe.`,
+      icon: 'carbon:chart-line',
+    })
   })
   const winThresholds = [1, 10, 100, 1000]
   winThresholds.forEach((n) => {
-    defs.push({ id: `win-${n}`, title: `${n} victoires`, description: `Gagner ${n} combats` })
-    defs.push({ id: `stronger-${n}`, title: `${n} victoires difficiles`, description: `Vaincre ${n} ennemis plus forts` })
+    defs.push({
+      id: `win-${n}`,
+      title: `${n} victoires`,
+      description: `Remporter ${n} combats contre vos adversaires.`,
+      icon: 'carbon:trophy',
+    })
+    defs.push({
+      id: `stronger-${n}`,
+      title: `${n} victoires difficiles`,
+      description: `Vaincre ${n} adversaires plus puissants que vous.`,
+      icon: 'carbon:fire',
+    })
   })
   // extra achievements
-  defs.push({ id: 'king-1', title: 'Premier roi', description: 'Vaincre un roi de zone' })
-  defs.push({ id: 'shiny-1', title: 'Shiny!', description: 'Capturer un Shlagémon shiny' })
-  defs.push({ id: 'item-10', title: 'Dépensier', description: 'Utiliser 10 objets' })
-  defs.push({ id: 'team-6', title: 'Équipe complète', description: 'Posséder 6 Shlagémon' })
+  defs.push({
+    id: 'king-1',
+    title: 'Premier roi',
+    description: 'Terrasser votre premier roi de zone pour restaurer la paix.',
+    icon: 'mdi:crown',
+  })
+  defs.push({
+    id: 'shiny-1',
+    title: 'Shiny!',
+    description: 'Capturer un Shlagémon shiny extrêmement rare.',
+    icon: 'carbon:star',
+  })
+  defs.push({
+    id: 'item-10',
+    title: 'Dépensier',
+    description: 'Utiliser 10 objets pendant vos combats ou explorations.',
+    icon: 'carbon:shopping-bag',
+  })
+  defs.push({
+    id: 'team-6',
+    title: 'Équipe complète',
+    description: 'Former une équipe composée de 6 Shlagémon.',
+    icon: 'carbon:user-multiple',
+  })
 
-  const list = computed(() => defs.map(d => ({ ...d, achieved: !!unlocked.value[d.id] })))
+  const list = computed(() =>
+    defs.map(d => ({ ...d, achieved: !!unlocked.value[d.id] })),
+  )
   const unlockedList = computed(() => list.value.filter(a => a.achieved))
   const hasAny = computed(() => unlockedList.value.length > 0)
 


### PR DESCRIPTION
## Summary
- add icons and longer descriptions to the achievements store
- show a button to toggle locked achievements
- add an AchievementItem component with collapsible description
- generate typings for the new component

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68663a687854832aa6c34169304691a0