### PR TITLE
Fix reactive component warning

### DIFF
--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { markRaw } from 'vue'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
 import DialogStarter from '~/components/dialog/DialogStarter.vue'
 import { useGameStore } from '~/stores/game'
@@ -21,12 +22,12 @@ export const useDialogStore = defineStore('dialog', () => {
   const dialogs: DialogItem[] = [
     {
       id: 'starter',
-      component: DialogStarter,
+      component: markRaw(DialogStarter),
       condition: () => !gameState.hasPokemon,
     },
     {
       id: 'richReward',
-      component: AnotherShlagemonDialog,
+      component: markRaw(AnotherShlagemonDialog),
       condition: () => game.shlagidolar >= 100,
     },
   ]


### PR DESCRIPTION
## Summary
- mark dialog components as `markRaw` to avoid Vue making them reactive

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6866398903c0832a897dd2216b1daebd