### PR TITLE
Improve achievements display and add thresholds

### DIFF
--- a/src/components/achievements/AchievementItem.vue
+++ b/src/components/achievements/AchievementItem.vue
@@ -12,7 +12,7 @@ function toggle() {
   <div
     class="flex flex-col border rounded p-1 text-xs transition-colors"
     :class="props.achievement.achieved
-      ? 'bg-blue-50 border-blue-300 text-blue-800 dark:bg-blue-900/40 dark:border-blue-700'
+      ? 'bg-blue-600 border-blue-500 text-white dark:bg-blue-700'
       : 'bg-gray-50 border-gray-300 text-gray-500 dark:bg-gray-800 dark:border-gray-700'"
   >
     <div class="flex cursor-pointer items-center justify-between" @click="toggle">

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Button from '~/components/ui/Button.vue'
+import CheckBox from '~/components/ui/CheckBox.vue'
 import { useAchievementsStore } from '~/stores/achievements'
 import AchievementItem from './AchievementItem.vue'
 
@@ -10,8 +11,9 @@ const list = computed(() => showLocked.value ? store.list : store.unlockedList)
 
 <template>
   <div class="flex flex-col gap-1">
-    <Button class="self-end text-xs" @click="showLocked = !showLocked">
-      {{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés
+    <Button class="w-full flex items-center justify-between text-xs" @click="showLocked = !showLocked">
+      <span>{{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés</span>
+      <CheckBox :model-value="showLocked" @update:model-value="showLocked = $event" @click.stop />
     </Button>
     <AchievementItem
       v-for="a in list"

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -77,7 +77,7 @@ export const useAchievementsStore = defineStore('achievements', () => {
       icon: 'carbon:chart-line',
     })
   })
-  const winThresholds = [1, 10, 100, 1000]
+  const winThresholds = [1, 10, 100, 1000, 10000]
   winThresholds.forEach((n) => {
     defs.push({
       id: `win-${n}`,
@@ -92,25 +92,37 @@ export const useAchievementsStore = defineStore('achievements', () => {
       icon: 'carbon:fire',
     })
   })
+  const shinyThresholds = [1, 10, 100, 1000]
+  shinyThresholds.forEach((n) => {
+    defs.push({
+      id: `shiny-${n}`,
+      title: n === 1 ? 'Shiny!' : `${n.toLocaleString()} shiny`,
+      description: `Capturer ${n.toLocaleString()} Shlagémon shiny extrêmement rares.`,
+      icon: 'carbon:star',
+    })
+  })
+
+  const itemThresholds = [1, 10, 100, 1000, 10000]
+  itemThresholds.forEach((n) => {
+    defs.push({
+      id: `item-${n}`,
+      title: 'Dépensier',
+      description: `Utiliser ${n.toLocaleString()} objet${n > 1 ? 's' : ''} pendant vos combats ou explorations.`,
+      icon: 'carbon:shopping-bag',
+    })
+  })
+
+  const kingThresholds = [1, 2, 3, 4, 5, 6, 7]
+  kingThresholds.forEach((n) => {
+    defs.push({
+      id: `king-${n}`,
+      title: n === 1 ? 'Premier roi' : `${n} rois vaincus`,
+      description: `Terrasser ${n} roi${n > 1 ? 's' : ''} de zone pour restaurer la paix.`,
+      icon: 'mdi:crown',
+    })
+  })
+
   // extra achievements
-  defs.push({
-    id: 'king-1',
-    title: 'Premier roi',
-    description: 'Terrasser votre premier roi de zone pour restaurer la paix.',
-    icon: 'mdi:crown',
-  })
-  defs.push({
-    id: 'shiny-1',
-    title: 'Shiny!',
-    description: 'Capturer un Shlagémon shiny extrêmement rare.',
-    icon: 'carbon:star',
-  })
-  defs.push({
-    id: 'item-10',
-    title: 'Dépensier',
-    description: 'Utiliser 10 objets pendant vos combats ou explorations.',
-    icon: 'carbon:shopping-bag',
-  })
   defs.push({
     id: 'team-6',
     title: 'Équipe complète',
@@ -157,18 +169,9 @@ export const useAchievementsStore = defineStore('achievements', () => {
   watch(() => dex.averageLevel, v => checkThresholds(v, 'avg', levelThresholds), { immediate: true })
   watch(() => counters.wins, v => checkThresholds(v, 'win', winThresholds))
   watch(() => counters.winsStronger, v => checkThresholds(v, 'stronger', winThresholds))
-  watch(() => counters.itemsUsed, (v) => {
-    if (v >= 10)
-      unlock('item-10')
-  })
-  watch(() => counters.kings, (v) => {
-    if (v >= 1)
-      unlock('king-1')
-  })
-  watch(() => counters.shiny, (v) => {
-    if (v >= 1)
-      unlock('shiny-1')
-  })
+  watch(() => counters.itemsUsed, v => checkThresholds(v, 'item', itemThresholds))
+  watch(() => counters.kings, v => checkThresholds(v, 'king', kingThresholds))
+  watch(() => counters.shiny, v => checkThresholds(v, 'shiny', shinyThresholds))
 
   watch(() => dex.shlagemons.length, (v) => {
     if (v >= 6)


### PR DESCRIPTION
## Summary
- add checkbox to toggle locked achievements and make button full width
- use a darker blue with white text for unlocked achievements
- expand achievements thresholds for shinies, items used, kings and tough wins

## Testing
- `pnpm run lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686645cbc834832ab512f282c167ab82