### PR TITLE
Improve achievement card design

### DIFF
--- a/src/components/achievements/AchievementItem.vue
+++ b/src/components/achievements/AchievementItem.vue
@@ -10,19 +10,19 @@ function toggle() {
 
 <template>
   <div
-    class="flex flex-col border rounded p-1 text-xs transition-colors"
+    class="flex flex-col border rounded-lg p-2 text-sm shadow-sm transition-colors"
     :class="props.achievement.achieved
-      ? 'bg-blue-600 border-blue-500 text-white dark:bg-blue-700'
-      : 'bg-gray-50 border-gray-300 text-gray-500 dark:bg-gray-800 dark:border-gray-700'"
+      ? 'border-cyan-600 bg-cyan-50 text-gray-900 dark:border-cyan-500 dark:bg-cyan-950/40 dark:text-gray-100'
+      : 'border-gray-300 bg-white text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400'"
   >
     <div class="flex cursor-pointer items-center justify-between" @click="toggle">
       <div class="flex items-center gap-2">
-        <div :class="props.achievement.icon" class="inline-block" />
-        <span>{{ props.achievement.title }}</span>
+        <div :class="props.achievement.icon" class="inline-block text-lg" />
+        <span class="font-bold">{{ props.achievement.title }}</span>
       </div>
       <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
     </div>
-    <div v-show="opened" class="mt-1">
+    <div v-show="opened" class="mt-1 text-xs">
       <p>{{ props.achievement.description }}</p>
     </div>
   </div>

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -10,8 +10,8 @@ const list = computed(() => showLocked.value ? store.list : store.unlockedList)
 </script>
 
 <template>
-  <div class="flex flex-col gap-1">
-    <Button class="w-full flex items-center justify-between text-xs" @click="showLocked = !showLocked">
+  <div class="flex flex-col gap-2">
+    <Button class="w-full flex items-center justify-between text-sm" @click="showLocked = !showLocked">
       <span>{{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés</span>
       <CheckBox :model-value="showLocked" @update:model-value="showLocked = $event" @click.stop />
     </Button>


### PR DESCRIPTION
## Summary
- refresh achievement item to use a lighter card style
- enlarge spacing and font sizes in achievements panel

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68664cd920f0832a8b0283d754ba819b