### PR TITLE
Fix healing bug in wild battles

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -127,7 +127,8 @@ function startBattle() {
   const lvl = Math.floor(Math.random() * (max - min + 1)) + min
   enemy.value.lvl = lvl
   applyStats(enemy.value)
-  active.hpCurrent = active.hp
+  if (active.hpCurrent <= 0)
+    active.hpCurrent = active.hp
   playerHp.value = active.hpCurrent
   enemyHp.value = enemy.value.hp
   battleActive.value = true


### PR DESCRIPTION
## Summary
- ensure the active Schlagemon only heals at the start of a battle if it had fainted previously

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68665187d8e4832a80956203378295b5