### PR TITLE
Integrate character objects

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -18,6 +18,7 @@ declare module 'vue' {
     Button: typeof import('./components/ui/Button.vue')['default']
     CaptureMenu: typeof import('./components/battle/CaptureMenu.vue')['default']
     CaptureOverlay: typeof import('./components/battle/CaptureOverlay.vue')['default']
+    CharacterImage: typeof import('./components/character/CharacterImage.vue')['default']
     CheckBox: typeof import('./components/ui/CheckBox.vue')['default']
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
     DialogPanel: typeof import('./components/panels/DialogPanel.vue')['default']

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import BattleToast from '~/components/battle/BattleToast.vue'
+import CharacterImage from '~/components/character/CharacterImage.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import Button from '~/components/ui/Button.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
@@ -209,7 +210,7 @@ onUnmounted(() => {
 <template>
   <div v-if="trainer" class="flex flex-col items-center gap-2">
     <div v-if="stage === 'before'" class="flex flex-col items-center gap-2 text-center">
-      <img :src="trainer.image" alt="trainer" class="h-24 object-contain">
+      <CharacterImage :id="trainer.character.id" :alt="trainer.character.name" class="h-24" />
       <div>{{ trainer.dialogBefore }}</div>
       <Button @click="startFight">
         Démarrer le combat
@@ -218,12 +219,12 @@ onUnmounted(() => {
     <div v-else-if="stage === 'battle'" class="w-full text-center" @click="attack">
       <div class="mb-1 h-12 flex items-center justify-end gap-2 overflow-hidden font-bold">
         <div class="h-full flex flex-col">
-          <div>{{ trainer.name }}</div>
+          <div>{{ trainer.character.name }}</div>
           <div class="flex gap-2">
             <ImageByBackground v-for="i in trainer.shlagemons.length" :key="i" src="/items/shlageball/shlageball.png" class="h-4 w-4" :class="i <= enemyIndex ? 'saturate-0' : ''" />
           </div>
         </div>
-        <img :src="trainer.image" alt="" class="h-full">
+        <CharacterImage :id="trainer.character.id" :alt="trainer.character.name" class="h-full" />
       </div>
       <div class="flex flex-1 items-center justify-center gap-4">
         <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
@@ -265,7 +266,7 @@ onUnmounted(() => {
       </div>
     </div>
     <div v-else class="flex flex-col items-center gap-2 text-center">
-      <img :src="trainer.image" alt="trainer" class="h-24 object-contain">
+      <CharacterImage :id="trainer.character.id" :alt="trainer.character.name" class="h-24" />
       <div v-if="result === 'win'">
         {{ trainer.dialogAfter }}
       </div>

--- a/src/components/character/CharacterImage.vue
+++ b/src/components/character/CharacterImage.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+const props = defineProps<{
+  id: string
+  alt: string
+}>()
+</script>
+
+<template>
+  <img :src="`/characters/${props.id}/${props.id}.png`" :alt="props.alt" class="object-contain" v-bind="$attrs">
+</template>

--- a/src/components/dialog/AnotherShlagemonDialog.vue
+++ b/src/components/dialog/AnotherShlagemonDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
+import { profMerdant } from '~/data/characters/prof-merdant'
 import { pikachiant } from '~/data/shlagemons/pikachiant'
 import { useShlagedexStore } from '~/stores/shlagedex'
 
@@ -33,8 +34,8 @@ const dialogTree = [
 
 <template>
   <DialogBox
-    speaker="Professeur Merdant"
-    avatar-url="/characters/professor/professor.png"
+    :speaker="profMerdant.name"
+    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/DialogStarter.vue
+++ b/src/components/dialog/DialogStarter.vue
@@ -2,6 +2,7 @@
 import type { BaseShlagemon } from '~/type'
 import type { DialogNode } from '~/type/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
+import { profMerdant } from '~/data/characters/prof-merdant'
 import bulgrosboule from '~/data/shlagemons/bulgrosboule'
 import carapouffe from '~/data/shlagemons/carapouffe'
 import salamiches from '~/data/shlagemons/salamiches'
@@ -25,7 +26,7 @@ function imageUrl(id: string) {
 const dialogTree = [
   {
     id: 'start',
-    text: 'Salut, je suis le Professeur Merdant, mes amis disent que je sent bon.',
+    text: `Salut, je suis ${profMerdant.name}, mes amis disent que je sent bon.`,
     responses: [
       { label: 'Tu n\'as pas l\'air très intelligent.', nextId: '2', type: 'primary' },
     ],
@@ -58,7 +59,7 @@ const dialogTree = [
     responses: [
       { label: 'T\'as pas mieux que cette merde ?', nextId: 'choice', type: 'danger' },
       {
-        label: s.id === 'bulgrosboule' ? 'Je l\'aime pas trop mais ok' : 'Merci professeur Merdant',
+        label: s.id === 'bulgrosboule' ? 'Je l\'aime pas trop mais ok' : `Merci ${profMerdant.name}`,
         type: 'valid',
         action: () => {
           dex.createShlagemon(s)
@@ -72,5 +73,9 @@ const dialogTree = [
 </script>
 
 <template>
-  <DialogBox speaker="Professeur Merdant" avatar-url="/characters/professor/professor.png" :dialog-tree="dialogTree" />
+  <DialogBox
+    :speaker="profMerdant.name"
+    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :dialog-tree="dialogTree"
+  />
 </template>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -14,6 +14,9 @@ const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
 
+const currentKing = computed(() => zone.getKing(zone.current.id))
+const kingLabel = computed(() => currentKing.value.character.gender === 'female' ? 'reine' : 'roi')
+
 const xpZones = computed(() => zone.zones.filter(z => z.maxLevel > 0))
 
 const accessibleZones = computed(() => zone.zones.filter(z => canAccess(z)))
@@ -78,10 +81,10 @@ function classes(z: Zone) {
         class="text-xs"
         @click="fightKing"
       >
-        Défier le roi de la zone
+        Défier la {{ kingLabel }} de la zone
       </Button>
       <div v-else-if="progress.isKingDefeated(zone.current.id)" class="text-xs font-bold">
-        Roi vaincu !
+        {{ kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1) }} vaincu{{ kingLabel === 'reine' ? 'e' : '' }} !
       </div>
     </div>
   </div>

--- a/src/data/trainers.ts
+++ b/src/data/trainers.ts
@@ -1,12 +1,18 @@
+import type { Character } from '~/type/character'
 import type { Trainer } from '~/types'
 import { carapouffe } from './shlagemons/carapouffe'
 import { salamiches } from './shlagemons/salamiches'
 
+const bobCharacter: Character = {
+  id: 'prof-merdant',
+  name: 'Bob le Déglingué',
+  gender: 'male',
+}
+
 export const trainers: Trainer[] = [
   {
     id: 'bob',
-    name: 'Bob le Déglingué',
-    image: '/characters/professor/professor.png',
+    character: bobCharacter,
     dialogBefore: 'Prépare-toi à manger la poussière !',
     dialogAfter: 'Pas possible... tu m\'as battu !',
     reward: 3,

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -2,6 +2,9 @@ import type { Trainer } from '~/type/trainer'
 import type { Zone } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { caillou } from '~/data/characters/caillou'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { sachatte } from '~/data/characters/sachatte'
 import { allShlagemons } from '~/data/shlagemons'
 import { zonesData } from '~/data/zones'
 
@@ -18,10 +21,16 @@ export const useZoneStore = defineStore('zone', () => {
       if (!z)
         throw new Error('Zone not found')
       const level = z.maxLevel + 1
+
+      let character = profMerdant
+      if (id === 'plaine-kekette')
+        character = caillou
+      else if (id === 'bois-de-bouffon')
+        character = sachatte
+
       const trainer: Trainer = {
         id: `king-${z.id}`,
-        name: `Roi de ${z.name}`,
-        image: '/characters/professor/professor.png',
+        character,
         dialogBefore: 'Prépare-toi à perdre !',
         dialogAfter: 'Tu as gagné... pour cette fois.',
         reward: 5,

--- a/src/type/trainer.ts
+++ b/src/type/trainer.ts
@@ -1,3 +1,5 @@
+import type { Character } from './character'
+
 export interface TrainerShlagemon {
   baseId: string
   level: number
@@ -5,8 +7,7 @@ export interface TrainerShlagemon {
 
 export interface Trainer {
   id: string
-  name: string
-  image: string
+  character: Character
   dialogBefore: string
   dialogAfter: string
   reward: number


### PR DESCRIPTION
## Summary
- add `CharacterImage` component to display avatars by character id
- update trainer type to store character info
- load Professor Merdant from data in dialogs
- adjust zone boss generation to use Caillou and Sachatte
- make zone panel text gender aware

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68664f6d6bf4832a93afbb1823522823