### PR TITLE
Disable zone changes during trainer battles or dialogs

### DIFF
--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -2,6 +2,7 @@
 import type { Zone } from '~/type'
 import { computed } from 'vue'
 import Button from '~/components/ui/Button.vue'
+import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
@@ -13,6 +14,11 @@ const dex = useShlagedexStore()
 const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
+const dialog = useDialogStore()
+
+const zoneButtonsDisabled = computed(
+  () => panel.current === 'trainerBattle' || dialog.isDialogVisible,
+)
 
 const currentKing = computed(() => zone.getKing(zone.current.id))
 const kingLabel = computed(() => currentKing.value.character.gender === 'female' ? 'reine' : 'roi')
@@ -61,8 +67,9 @@ function classes(z: Zone) {
         v-for="z in accessibleZones"
         :key="z.id"
         class="rounded px-2 py-1 text-xs"
-        :class="classes(z)"
-        @click="zone.setZone(z.id)"
+        :class="`${classes(z)} ${zoneButtonsDisabled ? 'opacity-50 cursor-not-allowed' : ''}`"
+        :disabled="zoneButtonsDisabled"
+        @click="!zoneButtonsDisabled && zone.setZone(z.id)"
       >
         {{ z.name }}
       </button>

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import ZonePanel from '../src/components/panels/ZonePanel.vue'
 import { carapouffe } from '../src/data/shlagemons'
+import { useMainPanelStore } from '../src/stores/mainPanel'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useZoneStore } from '../src/stores/zone'
 import { useZoneProgressStore } from '../src/stores/zoneProgress'
@@ -66,5 +67,29 @@ describe('zone panel', () => {
       progress.addWin('plaine-kekette')
     await wrapper.vm.$nextTick()
     expect(wrapper.text()).toContain('Défier le roi de la zone')
+  })
+
+  it('disables zone buttons during trainer battle', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    dex.createShlagemon(carapouffe)
+    const panel = useMainPanelStore()
+    const wrapper = mount(ZonePanel, { global: { plugins: [pinia] } })
+    panel.showTrainerBattle()
+    await wrapper.vm.$nextTick()
+    const buttons = wrapper.findAll('div.flex-wrap button')
+    expect(buttons.length).toBeGreaterThan(0)
+    expect(buttons.every(b => b.attributes('disabled') !== undefined)).toBe(true)
+  })
+
+  it('disables zone buttons when dialog is visible', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const wrapper = mount(ZonePanel, { global: { plugins: [pinia] } })
+    await wrapper.vm.$nextTick()
+    const buttons = wrapper.findAll('div.flex-wrap button')
+    expect(buttons.length).toBeGreaterThan(0)
+    expect(buttons.every(b => b.attributes('disabled') !== undefined)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- disable zone buttons when a trainer battle is active or a dialog is open
- test that zone buttons are disabled during trainer battles or dialogs

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686657fe6f68832ab626f8f839d98768