### PR TITLE
Update battle healing logic

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -168,8 +168,10 @@ function checkEnd() {
     if (battleInterval)
       clearInterval(battleInterval)
     battleInterval = undefined
-    if (dex.activeShlagemon)
-      dex.activeShlagemon.hpCurrent = playerHp.value
+    if (dex.activeShlagemon) {
+      dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
+      playerHp.value = dex.activeShlagemon.hpCurrent
+    }
     if (enemyHp.value <= 0 && playerHp.value > 0) {
       const stronger = enemy.value && dex.activeShlagemon
         ? enemy.value.lvl > dex.activeShlagemon.lvl

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -164,8 +164,14 @@ function checkEnd() {
       dex.activeShlagemon.hpCurrent = playerHp.value
 
     if (enemyHp.value <= 0 && playerHp.value > 0) {
-      if (dex.activeShlagemon && enemy.value)
-        dex.gainXp(dex.activeShlagemon, xpRewardForLevel(enemy.value.lvl))
+      if (dex.activeShlagemon && enemy.value) {
+        dex.gainXp(
+          dex.activeShlagemon,
+          xpRewardForLevel(enemy.value.lvl),
+          undefined,
+          trainerStore.levelUpHealPercent,
+        )
+      }
       enemyIndex.value += 1
       if (enemyIndex.value < (trainer.value?.shlagemons.length || 0)) {
         setTimeout(startBattle, 500)

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -72,15 +72,22 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     }, duration)
   }
 
-  function gainXp(mon: DexShlagemon, amount: number, maxLevel = 100) {
+  function gainXp(
+    mon: DexShlagemon,
+    amount: number,
+    maxLevel = 100,
+    healPercent = 100,
+  ) {
     if (mon.lvl >= maxLevel)
       return
     mon.xp += amount
     while (mon.lvl < maxLevel && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)
       mon.lvl += 1
+      const prevHp = mon.hpCurrent
       applyStats(mon)
-      mon.hpCurrent = mon.hp
+      const healAmount = Math.round((mon.hp * healPercent) / 100)
+      mon.hpCurrent = Math.min(mon.hp, prevHp + healAmount)
       updateHighestLevel(mon)
     }
     if (mon.lvl >= maxLevel)

--- a/src/stores/trainerBattle.ts
+++ b/src/stores/trainerBattle.ts
@@ -6,6 +6,7 @@ import { trainers as trainersData } from '~/data/trainers'
 export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   const queue = ref<Trainer[]>([])
   const currentIndex = ref(0)
+  const levelUpHealPercent = ref(15)
 
   function setQueue(list: Trainer[]) {
     queue.value = list
@@ -30,5 +31,5 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   // init with default trainers
   setQueue(trainersData)
 
-  return { queue, current, next, add, setQueue, reset }
+  return { queue, current, next, add, setQueue, reset, levelUpHealPercent }
 })

--- a/test/gainxp-heal.test.ts
+++ b/test/gainxp-heal.test.ts
@@ -1,0 +1,19 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { xpForLevel } from '../src/utils/dexFactory'
+
+describe('gainXp heal percent', () => {
+  it('heals only a portion of hp on level up', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.hpCurrent = Math.floor(mon.hp / 2)
+    const prevHp = mon.hpCurrent
+    dex.gainXp(mon, xpForLevel(mon.lvl), undefined, 15)
+    const expected = Math.min(mon.hp, prevHp + Math.round(mon.hp * 15 / 100))
+    expect(mon.hpCurrent).toBe(expected)
+    expect(mon.lvl).toBe(2)
+  })
+})

--- a/test/trainer-store.test.ts
+++ b/test/trainer-store.test.ts
@@ -1,0 +1,11 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useTrainerBattleStore } from '../src/stores/trainerBattle'
+
+describe('trainer battle store', () => {
+  it('exposes level up heal percent', () => {
+    setActivePinia(createPinia())
+    const store = useTrainerBattleStore()
+    expect(store.levelUpHealPercent).toBe(15)
+  })
+})


### PR DESCRIPTION
## Summary
- update health restoration after wild fights
- expose heal percentage for trainer battles
- allow custom heal percentage in `gainXp`
- heal partially on level up during trainer fights
- add unit tests

## Testing
- `pnpm test` *(fails: Failed to fetch web fonts; TypeError in test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68665f2973e0832a915dba2eee5dd162