### PR TITLE
Update battle layout

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -251,14 +251,16 @@ onUnmounted(() => {
             :shiny="dex.activeShlagemon.isShiny"
             class="max-h-32 object-contain -scale-x-100"
           />
-          <div class="name">
-            {{ dex.activeShlagemon.base.name }}
+          <div class="absolute left-0 top-0 text-sm font-bold">
+            lvl {{ dex.activeShlagemon.lvl }}
           </div>
-          <div class="mt-1 flex gap-1">
+          <div class="mt-1 flex items-center gap-1">
+            <span class="font-bold">{{ dex.activeShlagemon.base.name }}</span>
             <ShlagemonType
               v-for="t in dex.activeShlagemon.base.types"
               :key="t.id"
               :value="t"
+              size="xs"
             />
           </div>
           <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
@@ -277,14 +279,16 @@ onUnmounted(() => {
             :shiny="enemy.isShiny"
             class="max-h-32 object-contain"
           />
-          <div class="name">
-            {{ enemy.base.name }} - lvl {{ enemy.lvl }}
+          <div class="absolute left-0 top-0 text-sm font-bold">
+            lvl {{ enemy.lvl }}
           </div>
-          <div class="mt-1 flex gap-1">
+          <div class="mt-1 flex items-center gap-1">
+            <span class="font-bold">{{ enemy.base.name }}</span>
             <ShlagemonType
               v-for="t in enemy.base.types"
               :key="t.id"
               :value="t"
+              size="xs"
             />
           </div>
           <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -253,8 +253,12 @@ onUnmounted(() => {
             :shiny="dex.activeShlagemon.isShiny"
             class="max-h-32 object-contain"
           />
-          <div class="mt-1 flex gap-1">
-            <ShlagemonType v-for="t in dex.activeShlagemon.base.types" :key="t.id" :value="t" />
+          <div class="absolute left-0 top-0 text-sm font-bold">
+            lvl {{ dex.activeShlagemon.lvl }}
+          </div>
+          <div class="mt-1 flex items-center gap-1">
+            <span class="font-bold">{{ dex.activeShlagemon.base.name }}</span>
+            <ShlagemonType v-for="t in dex.activeShlagemon.base.types" :key="t.id" :value="t" size="xs" />
           </div>
           <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
           <div class="hp text-sm">
@@ -272,10 +276,13 @@ onUnmounted(() => {
             :shiny="enemy.isShiny"
             class="max-h-32 object-contain"
           />
-          <div class="mt-1 flex gap-1">
-            <ShlagemonType v-for="t in enemy.base.types" :key="t.id" :value="t" />
+          <div class="absolute left-0 top-0 text-sm font-bold">
+            lvl {{ enemy.lvl }}
           </div>
-          <div>{{ enemy.base.name }} - lvl {{ enemy.lvl }}</div>
+          <div class="mt-1 flex items-center gap-1">
+            <span class="font-bold">{{ enemy.base.name }}</span>
+            <ShlagemonType v-for="t in enemy.base.types" :key="t.id" :value="t" size="xs" />
+          </div>
           <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
           <div class="hp text-sm">
             {{ enemyHp }} / {{ enemy.hp }}

--- a/src/components/panels/ActiveShlagemon.vue
+++ b/src/components/panels/ActiveShlagemon.vue
@@ -27,6 +27,7 @@ const dex = useShlagedexStore()
         v-for="t in dex.activeShlagemon.base.types"
         :key="t.id"
         :value="t"
+        size="xs"
       />
     </div>
   </div>

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -92,7 +92,7 @@ function isActive(mon: DexShlagemon) {
                 v-for="t in mon.base.types"
                 :key="t.id"
                 :value="t"
-                class="text-0.75rem"
+                size="xs"
               />
             </div>
           </div>

--- a/src/components/shlagemon/ShlagemonType.vue
+++ b/src/components/shlagemon/ShlagemonType.vue
@@ -1,7 +1,25 @@
 <script setup lang="ts">
 import type { ShlagemonType } from '~/type'
 
-const { value } = defineProps<{ value: ShlagemonType }>()
+interface Props {
+  value: ShlagemonType
+  size?: 'xs' | 'sm' | 'base' | 'lg'
+}
+
+const { value, size } = withDefaults(defineProps<Props>(), { size: 'xs' })
+
+const sizeClass = computed(() => {
+  switch (size) {
+    case 'sm':
+      return 'text-sm'
+    case 'base':
+      return 'text-base'
+    case 'lg':
+      return 'text-lg'
+    default:
+      return 'text-xs'
+  }
+})
 
 const textColor = computed(() => getAdjustedTextColor())
 
@@ -21,7 +39,11 @@ function getAdjustedTextColor(amount = 60) {
 </script>
 
 <template>
-  <span class="type rounded px-2 py-1 text-center text-xs" :style="{ backgroundColor: value.color, color: textColor }">
+  <span
+    class="type rounded px-2 py-1 text-center"
+    :class="sizeClass"
+    :style="{ backgroundColor: value.color, color: textColor }"
+  >
     {{ value.name }}
   </span>
 </template>


### PR DESCRIPTION
## Summary
- allow specifying size on `ShlagemonType`
- show level and inline name/type for player and enemy in battles
- adapt ActiveShlagemon and Shlagedex to use the new size prop

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68666cbe8d00832aacd383f0cb8a28ef