### PR TITLE
Heal active Shlagémon on zone change

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -214,6 +214,8 @@ watch(
 watch(
   () => zone.current.id,
   () => {
+    if (dex.activeShlagemon)
+      dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
     if (battleInterval)
       clearInterval(battleInterval)
     battleInterval = undefined

--- a/test/zone-heal.test.ts
+++ b/test/zone-heal.test.ts
@@ -1,0 +1,45 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import BattleMain from '../src/components/battle/BattleMain.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useZoneStore } from '../src/stores/zone'
+
+// Ensure selected Shlagémon heals when zone changes and battle restarts
+
+describe('zone change healing', () => {
+  it('heals active shlagemon on zone change', async () => {
+    vi.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const zone = useZoneStore()
+
+    const mon = dex.createShlagemon(carapouffe)
+    zone.setZone('plaine-kekette')
+
+    const wrapper = mount(BattleMain, {
+      global: {
+        plugins: [pinia],
+        stubs: ['ProgressBar', 'ImageByBackground'],
+      },
+    })
+
+    // let initial battle start
+    await Promise.resolve()
+    vi.runOnlyPendingTimers()
+
+    // injure the mon
+    mon.hpCurrent = Math.floor(mon.hp / 2)
+
+    // change zone, triggering new battle
+    zone.setZone('bois-de-bouffon')
+    await Promise.resolve()
+    vi.runOnlyPendingTimers()
+
+    expect(mon.hpCurrent).toBe(mon.hp)
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- restore HP when switching zones
- test zone healing on zone switch

## Testing
- `pnpm test` *(fails: cannot read properties of undefined 'coefficient')*

------
https://chatgpt.com/codex/tasks/task_e_68666d25a9f0832a8364580ebac3c858