### PR TITLE
Fix click damage consistency

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -138,7 +138,7 @@ function startBattle() {
 function attack() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
-  const { effect, crit } = battle.attack(dex.activeShlagemon, enemy.value, false, false, true)
+  const { effect, crit } = battle.clickAttack(dex.activeShlagemon, enemy.value)
   showEffect('enemy', effect, crit)
   enemyHp.value = enemy.value.hpCurrent
   flashEnemy.value = true

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -129,7 +129,7 @@ function startBattle() {
 function attack() {
   if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
     return
-  const { effect, crit } = battle.attack(dex.activeShlagemon, enemy.value)
+  const { effect, crit } = battle.clickAttack(dex.activeShlagemon, enemy.value)
   showEffect('enemy', effect, crit)
   enemyHp.value = enemy.value.hpCurrent
   flashEnemy.value = true

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -29,6 +29,10 @@ export const useBattleStore = defineStore('battle', () => {
     return { ...result, damage: finalDamage }
   }
 
+  function clickAttack(attacker: DexShlagemon, defender: DexShlagemon) {
+    return attack(attacker, defender, false, false, true)
+  }
+
   function duel(player: DexShlagemon, enemy: DexShlagemon) {
     const playerResult = attack(player, enemy, true, false)
     let enemyResult: AttackResult | null = null
@@ -37,5 +41,5 @@ export const useBattleStore = defineStore('battle', () => {
     return { player: playerResult, enemy: enemyResult }
   }
 
-  return { attack, duel }
+  return { attack, clickAttack, duel }
 })


### PR DESCRIPTION
## Summary
- tweak battle store with `clickAttack`
- use `clickAttack` for player hits in TrainerBattle and BattleMain

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68667368707c832abeb16e6bc3c5e407