### PR TITLE
Add reusable XP bar component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -46,6 +46,7 @@ declare module 'vue' {
     ShlagemonImage: typeof import('./components/shlagemon/ShlagemonImage.vue')['default']
     ShlagemonRarity: typeof import('./components/shlagemon/ShlagemonRarity.vue')['default']
     ShlagemonType: typeof import('./components/shlagemon/ShlagemonType.vue')['default']
+    ShlagemonXpBar: typeof import('./components/shlagemon/ShlagemonXpBar.vue')['default']
     Shlagidolar: typeof import('./components/icons/shlagidolar.vue')['default']
     ShopPanel: typeof import('./components/panels/ShopPanel.vue')['default']
     ThemeToggle: typeof import('./components/ThemeToggle.vue')['default']

--- a/src/components/panels/ActiveShlagemon.vue
+++ b/src/components/panels/ActiveShlagemon.vue
@@ -8,27 +8,29 @@ const dex = useShlagedexStore()
 <template>
   <div
     v-if="dex.activeShlagemon"
-    class="h-full w-full flex items-center justify-between gap-2 rounded bg-white dark:bg-gray-900"
+    class="h-full w-full flex flex-col gap-1 rounded bg-white p-2 dark:bg-gray-900"
   >
-    <ShlagemonImage
-      v-if="dex.activeShlagemon"
-      :id="dex.activeShlagemon.base.id"
-      :alt="dex.activeShlagemon.base.name"
-      :shiny="dex.activeShlagemon.isShiny"
-      class="aspect-square h-full max-h-20"
-      md="w-8"
-    />
-    <span class="font-bold">{{ dex.activeShlagemon.base.name }}</span> -
-    <span class="text-sm">lvl {{ dex.activeShlagemon.lvl }}</span>
-
-    <div class="flex-1" />
-    <div class="flex gap-1">
-      <ShlagemonType
-        v-for="t in dex.activeShlagemon.base.types"
-        :key="t.id"
-        :value="t"
-        size="xs"
+    <div class="flex items-center justify-between gap-2">
+      <ShlagemonImage
+        :id="dex.activeShlagemon.base.id"
+        :alt="dex.activeShlagemon.base.name"
+        :shiny="dex.activeShlagemon.isShiny"
+        class="aspect-square h-full max-h-20"
+        md="w-8"
       />
+      <span class="font-bold">{{ dex.activeShlagemon.base.name }}</span> -
+      <span class="text-sm">lvl {{ dex.activeShlagemon.lvl }}</span>
+
+      <div class="flex-1" />
+      <div class="flex gap-1">
+        <ShlagemonType
+          v-for="t in dex.activeShlagemon.base.types"
+          :key="t.id"
+          :value="t"
+          size="xs"
+        />
+      </div>
     </div>
+    <ShlagemonXpBar :mon="dex.activeShlagemon" />
   </div>
 </template>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import ProgressBar from '~/components/ui/ProgressBar.vue'
-import { xpForLevel } from '~/utils/dexFactory'
 
 const props = defineProps<{ mon: DexShlagemon | null }>()
 
@@ -24,9 +22,6 @@ const stats = computed(() => {
     { label: 'Puanteur', value: props.mon.smelling },
   ]
 })
-
-const maxXp = computed(() => props.mon ? xpForLevel(props.mon.lvl) : 0)
-// const xpLeft = computed(() => props.mon ? maxXp.value - props.mon.xp : 0)
 </script>
 
 <template>
@@ -61,12 +56,7 @@ const maxXp = computed(() => props.mon ? xpForLevel(props.mon.lvl) : 0)
         <span class="text-base">{{ stat.value.toLocaleString() }}</span>
       </div>
     </div>
-    <div class="mt-4">
-      <div class="mb-1 text-center text-sm">
-        Expérience : {{ mon.xp.toLocaleString() }} / {{ maxXp.toLocaleString() }}
-      </div>
-      <ProgressBar :value="mon.xp" :max="maxXp" class="w-full" />
-    </div>
+    <ShlagemonXpBar :mon="mon" class="mt-4" />
   </div>
 </template>
 

--- a/src/components/shlagemon/ShlagemonXpBar.vue
+++ b/src/components/shlagemon/ShlagemonXpBar.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+import ProgressBar from '~/components/ui/ProgressBar.vue'
+import { xpForLevel } from '~/utils/dexFactory'
+
+const props = defineProps<{ mon: DexShlagemon }>()
+
+const maxXp = computed(() => xpForLevel(props.mon.lvl))
+</script>
+
+<template>
+  <div>
+    <div class="mb-1 text-center text-xs sm:text-sm">
+      Expérience : {{ props.mon.xp.toLocaleString() }} / {{ maxXp.toLocaleString() }}
+    </div>
+    <ProgressBar :value="props.mon.xp" :max="maxXp" class="w-full" />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- extract XP bar into `ShlagemonXpBar` component
- reuse XP bar in shlagemon detail and active shlagemon panels

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686672f12d08832a8e89504af66ba52b