### PR TITLE
Add bonus details modal

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,6 +15,7 @@ declare module 'vue' {
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
     BattleToast: typeof import('./components/battle/BattleToast.vue')['default']
     Bonus: typeof import('./components/icons/bonus.vue')['default']
+    BonusDetails: typeof import('./components/panels/BonusDetails.vue')['default']
     Button: typeof import('./components/ui/Button.vue')['default']
     CaptureMenu: typeof import('./components/battle/CaptureMenu.vue')['default']
     CaptureOverlay: typeof import('./components/battle/CaptureOverlay.vue')['default']

--- a/src/components/panels/BonusDetails.vue
+++ b/src/components/panels/BonusDetails.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import BonusIcon from '~/components/icons/bonus.vue'
+import SchlagedexIcon from '~/components/icons/schlagedex.vue'
+import XpIcon from '~/components/icons/xp.vue'
+
+const dex = useShlagedexStore()
+</script>
+
+<template>
+  <div class="flex flex-col gap-2 text-sm">
+    <p>Le bonus augmente les dégâts infligés par vos Schlagemon.</p>
+    <p>
+      Il se base sur le pourcentage de complétion du Schlagedex et sur le niveau
+      moyen de votre équipe.
+    </p>
+    <p class="text-center text-xs font-mono">
+      Bonus = niveau moyen × 2 × (taux de complétion / 100)
+    </p>
+    <div class="mt-2 flex flex-col gap-1">
+      <div class="flex items-center gap-2">
+        <SchlagedexIcon class="h-5 w-5" />
+        <span>Complétion : {{ Math.round(dex.completionPercent) }}%</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <XpIcon class="h-5 w-5" />
+        <span>Niveau moyen : {{ dex.averageLevel.toFixed(1) }}</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <BonusIcon class="h-5 w-5" />
+        <span>Bonus actuel : +{{ Math.round(dex.bonusPercent) }}%</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -4,6 +4,8 @@ import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import ShlagediamondIcon from '~/components/icons/shlagediamond.vue'
 import ShlagidolarIcon from '~/components/icons/shlagidolar.vue'
 import XpIcon from '~/components/icons/xp.vue'
+import Modal from '~/components/modal/Modal.vue'
+import BonusDetails from '~/components/panels/BonusDetails.vue'
 import Tooltip from '~/components/ui/Tooltip.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { useInventoryStore } from '~/stores/inventory'
@@ -11,6 +13,8 @@ import { useInventoryStore } from '~/stores/inventory'
 const game = useGameStore()
 const dex = useShlagedexStore()
 const inventory = useInventoryStore()
+
+const showBonus = ref(false)
 
 const totalInDex = allShlagemons.length
 </script>
@@ -45,11 +49,17 @@ const totalInDex = allShlagemons.length
       </div>
     </Tooltip>
     <Tooltip text="Bonus">
-      <div class="min-w-0 flex items-center gap-1">
+      <div
+        class="min-w-0 flex cursor-pointer items-center gap-1"
+        @click="showBonus = true"
+      >
         <BonusIcon class="h-4 w-4" />
         <span class="shrink-0 font-bold">+{{ Math.round(dex.bonusPercent) }}%</span>
       </div>
     </Tooltip>
+    <Modal v-model="showBonus" footer-close>
+      <BonusDetails />
+    </Modal>
     <Tooltip text="SchlagéBalls">
       <div class="min-w-0 flex items-center gap-1">
         <img src="/items/shlageball/shlageball.png" alt="ball" class="h-4 w-4">


### PR DESCRIPTION
## Summary
- make Bonus field in player panel clickable
- show BonusDetails modal explaining formula
- declare BonusDetails in component types

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686673d2aa4c832abd1a60da4e7cc06c