### PR TITLE
Reset battle when switching active Shlagemon

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -193,10 +193,21 @@ function checkEnd() {
 
 watch(
   () => dex.activeShlagemon,
-  (mon) => {
+  (mon, prev) => {
     if (!mon)
       return
     playerHp.value = mon.hpCurrent
+    if (prev && prev.id !== mon.id) {
+      mon.hpCurrent = mon.hp
+      if (enemy.value)
+        enemy.value.hpCurrent = enemy.value.hp
+      enemyHp.value = enemy.value?.hp ?? 0
+      if (battleInterval)
+        clearInterval(battleInterval)
+      battleInterval = undefined
+      battleActive.value = false
+      playerHp.value = mon.hpCurrent
+    }
     if (!battleActive.value && battleInterval === undefined)
       startBattle()
   },

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -2,15 +2,18 @@
 import type { DexShlagemon } from '~/type/shlagemon'
 import Modal from '~/components/modal/Modal.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
+import { useMainPanelStore } from '~/stores/mainPanel'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonType from './ShlagemonType.vue'
 
 const dex = useShlagedexStore()
+const panel = useMainPanelStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 const search = ref('')
 const sortBy = ref<'level' | 'rarity' | 'name' | 'type'>('level')
 const sortAsc = ref(false)
+const isTrainerBattle = computed(() => panel.current === 'trainerBattle')
 const sortOptions = [
   { label: 'Niveau', value: 'level' },
   { label: 'Rareté', value: 'rarity' },
@@ -52,6 +55,12 @@ function open(mon: DexShlagemon | null) {
     detailMon.value = mon
     showDetail.value = true
   }
+}
+
+function changeActive(mon: DexShlagemon) {
+  if (isTrainerBattle.value)
+    return
+  dex.setActiveShlagemon(mon)
 }
 
 function isActive(mon: DexShlagemon) {
@@ -120,7 +129,8 @@ function isActive(mon: DexShlagemon) {
         <CheckBox
           class="ml-2"
           :model-value="isActive(mon)"
-          @update:model-value="() => dex.setActiveShlagemon(mon)"
+          :disabled="isTrainerBattle"
+          @update:model-value="() => changeActive(mon)"
           @click.stop
         />
       </div>

--- a/src/components/ui/CheckBox.vue
+++ b/src/components/ui/CheckBox.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const props = defineProps<{ modelValue: boolean }>()
+const props = defineProps<{ modelValue: boolean, disabled?: boolean }>()
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
 }>()
@@ -11,10 +11,14 @@ function onChange(event: Event) {
 </script>
 
 <template>
-  <label class="cursor-pointer text-white">
+  <label
+    class="text-white"
+    :class="props.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'"
+  >
     <input
       type="checkbox"
       :checked="props.modelValue"
+      :disabled="props.disabled"
       class="dark:border-white-400/20 h-4 w-4 transition-all duration-500 ease-in-out dark:scale-100 dark:checked:scale-100 dark:hover:scale-110"
       @change="onChange"
     >


### PR DESCRIPTION
## Summary
- disable active Shlagemon switch while in trainer battle
- reset wild battles when active Shlagemon changes
- add disabled state to CheckBox component

## Testing
- `pnpm test:unit` *(fails: FetchError ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686676581014832aa19008b8e76e9791