### PR TITLE
Factorize battle slugemon display

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
+    BattleShlagemon: typeof import('./components/battle/BattleShlagemon.vue')['default']
     BattleToast: typeof import('./components/battle/BattleToast.vue')['default']
     Bonus: typeof import('./components/icons/bonus.vue')['default']
     BonusDetails: typeof import('./components/panels/BonusDetails.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
+import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
-import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
-import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
@@ -248,56 +247,14 @@ onUnmounted(() => {
       <div class="w-full flex flex-1 items-center justify-center gap-4">
         <div class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-          <ShlagemonImage
-            :id="dex.activeShlagemon.base.id"
-            :alt="dex.activeShlagemon.base.name"
-            :shiny="dex.activeShlagemon.isShiny"
-            class="max-h-32 object-contain -scale-x-100"
-          />
-          <div class="absolute bottom-0 left-0 text-sm font-bold">
-            lvl {{ dex.activeShlagemon.lvl }}
-          </div>
-          <div class="mt-1 flex items-center gap-1">
-            <span class="font-bold">{{ dex.activeShlagemon.base.name }}</span>
-            <ShlagemonType
-              v-for="t in dex.activeShlagemon.base.types"
-              :key="t.id"
-              :value="t"
-              size="xs"
-            />
-          </div>
-          <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
-          <div class="hp w-full text-right text-sm">
-            {{ playerHp }} / {{ dex.activeShlagemon.hp }}
-          </div>
+          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" flipped />
         </div>
         <div class="vs font-bold">
           VS
         </div>
         <div v-if="enemy" class="mon relative flex flex-1 flex-col select-none items-center" :class="{ flash: flashEnemy }" @click="attack">
           <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-          <ShlagemonImage
-            :id="enemy.base.id"
-            :alt="enemy.base.name"
-            :shiny="enemy.isShiny"
-            class="max-h-32 object-contain"
-          />
-          <div class="absolute bottom-0 left-0 text-sm font-bold">
-            lvl {{ enemy.lvl }}
-          </div>
-          <div class="mt-1 flex items-center gap-1">
-            <span class="font-bold">{{ enemy.base.name }}</span>
-            <ShlagemonType
-              v-for="t in enemy.base.types"
-              :key="t.id"
-              :value="t"
-              size="xs"
-            />
-          </div>
-          <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
-          <div class="w-full text-right text-sm">
-            {{ enemyHp }} / {{ enemy.hp }}
-          </div>
+          <BattleShlagemon :mon="enemy" :hp="enemyHp" color="bg-red-500" />
         </div>
       </div>
       <Button

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
+import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
+import ProgressBar from '~/components/ui/ProgressBar.vue'
+
+interface Props {
+  mon: DexShlagemon
+  hp: number
+  color?: string
+  flipped?: boolean
+  levelPosition?: 'top' | 'bottom'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  color: undefined,
+  flipped: false,
+  levelPosition: 'bottom',
+})
+</script>
+
+<template>
+  <div class="relative flex flex-col items-center">
+    <ShlagemonImage
+      :id="props.mon.base.id"
+      :alt="props.mon.base.name"
+      :shiny="props.mon.isShiny"
+      class="max-h-32 object-contain"
+      :class="props.flipped ? '-scale-x-100' : ''"
+    />
+    <div class="absolute left-0 text-sm font-bold" :class="props.levelPosition === 'top' ? 'top-0' : 'bottom-0'">
+      lvl {{ props.mon.lvl }}
+    </div>
+    <div class="mt-1 flex items-center gap-1">
+      <span class="font-bold">{{ props.mon.base.name }}</span>
+      <ShlagemonType v-for="t in props.mon.base.types" :key="t.id" :value="t" size="xs" />
+    </div>
+    <ProgressBar :value="props.hp" :max="props.mon.hp" :color="props.color" class="mt-1 w-24" />
+    <div class="w-full text-right text-sm">
+      {{ props.hp }} / {{ props.mon.hp }}
+    </div>
+  </div>
+</template>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
+import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CharacterImage from '~/components/character/CharacterImage.vue'
-import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import Button from '~/components/ui/Button.vue'
-import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
@@ -247,46 +246,14 @@ onUnmounted(() => {
       <div class="flex flex-1 items-center justify-center gap-4">
         <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-          <ShlagemonImage
-            :id="dex.activeShlagemon.base.id"
-            :alt="dex.activeShlagemon.base.name"
-            :shiny="dex.activeShlagemon.isShiny"
-            class="max-h-32 object-contain"
-          />
-          <div class="absolute left-0 top-0 text-sm font-bold">
-            lvl {{ dex.activeShlagemon.lvl }}
-          </div>
-          <div class="mt-1 flex items-center gap-1">
-            <span class="font-bold">{{ dex.activeShlagemon.base.name }}</span>
-            <ShlagemonType v-for="t in dex.activeShlagemon.base.types" :key="t.id" :value="t" size="xs" />
-          </div>
-          <ProgressBar :value="playerHp" :max="dex.activeShlagemon.hp" class="mt-1 w-24" />
-          <div class="hp text-sm">
-            {{ playerHp }} / {{ dex.activeShlagemon.hp }}
-          </div>
+          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" level-position="top" />
         </div>
         <div class="vs font-bold">
           VS
         </div>
         <div v-if="enemy" class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
           <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-          <ShlagemonImage
-            :id="enemy.base.id"
-            :alt="enemy.base.name"
-            :shiny="enemy.isShiny"
-            class="max-h-32 object-contain"
-          />
-          <div class="absolute left-0 top-0 text-sm font-bold">
-            lvl {{ enemy.lvl }}
-          </div>
-          <div class="mt-1 flex items-center gap-1">
-            <span class="font-bold">{{ enemy.base.name }}</span>
-            <ShlagemonType v-for="t in enemy.base.types" :key="t.id" :value="t" size="xs" />
-          </div>
-          <ProgressBar :value="enemyHp" :max="enemy.hp" color="bg-red-500" class="mt-1 w-24" />
-          <div class="hp text-sm">
-            {{ enemyHp }} / {{ enemy.hp }}
-          </div>
+          <BattleShlagemon :mon="enemy" :hp="enemyHp" color="bg-red-500" level-position="top" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add reusable `BattleShlagemon` component to display a slugemon's battle info
- use new component in `BattleMain` and `TrainerBattle`
- register the new component in `components.d.ts`

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68667b68f770832aae4d0c5cfd78fc76