### PR TITLE
Add cancel option before trainer battle

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -211,6 +211,10 @@ function finish() {
   }
 }
 
+function cancelFight() {
+  panel.showBattle()
+}
+
 onUnmounted(() => {
   if (battleInterval)
     clearInterval(battleInterval)
@@ -232,6 +236,9 @@ onUnmounted(() => {
       <div>{{ trainer.dialogBefore }}</div>
       <Button @click="startFight">
         Démarrer le combat
+      </Button>
+      <Button type="danger" @click="cancelFight">
+        Abandonner
       </Button>
     </div>
     <div v-else-if="stage === 'battle'" class="w-full text-center" @click="attack">


### PR DESCRIPTION
## Summary
- add `cancelFight` method in TrainerBattle component
- show "Abandonner" button before starting trainer battle

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*
- `pnpm test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68667b930ab4832ab991e05ee89fbc4d