### PR TITLE
Add item details modal

### DIFF
--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import Modal from '~/components/modal/Modal.vue'
 import Button from '~/components/ui/Button.vue'
 
 const props = defineProps<{ item: Item, qty: number }>()
@@ -10,10 +11,12 @@ const emit = defineEmits<{
 }>()
 
 const isBall = computed(() => 'catchBonus' in props.item)
+const showInfo = ref(false)
+const details = computed(() => props.item.details || props.item.description)
 </script>
 
 <template>
-  <div class="flex flex-col gap-1 border rounded bg-white p-2 dark:bg-gray-900">
+  <div class="relative flex flex-col gap-1 border rounded bg-white p-2 dark:bg-gray-900">
     <div class="flex items-center gap-2">
       <img
         v-if="props.item.image"
@@ -40,5 +43,27 @@ const isBall = computed(() => 'catchBonus' in props.item)
       </Button>
       -->
     </div>
+    <button
+      class="absolute bottom-1 left-1 h-4 w-4 flex items-center justify-center rounded-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+      @click.stop="showInfo = true"
+    >
+      <div i-carbon-help class="text-xs" />
+    </button>
+    <Modal v-model="showInfo" footer-close>
+      <div class="flex flex-col items-center gap-2">
+        <img
+          v-if="props.item.image"
+          :src="props.item.image"
+          :alt="props.item.name"
+          class="h-16 w-16 object-contain"
+        >
+        <h3 class="text-lg font-bold">
+          {{ props.item.name }}
+        </h3>
+        <p class="text-center text-sm">
+          {{ details }}
+        </p>
+      </div>
+    </Modal>
   </div>
 </template>

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -7,12 +7,14 @@ export const shopItems: Item[] = [
     id: 'potion',
     name: 'Potion Dégueulasse',
     description: 'Soigne 50 HP de votre Shlagémon.',
+    details: 'Redonne 50 points de vie à votre Shlagémon actif pendant le combat.',
     price: 5,
   },
   {
     id: 'spray',
     name: 'Spray Anti-Odeur',
     description: 'Augmente temporairement la défense.',
+    details: 'Un aérosol étrange qui renforce brièvement la défense de votre Shlagémon actif.',
     price: 7,
   },
 ]

--- a/src/data/items/shlageball.ts
+++ b/src/data/items/shlageball.ts
@@ -5,6 +5,7 @@ export const balls: Ball[] = [
     id: 'shlageball',
     name: 'Shlagéball',
     description: 'Permet de capturer des Shlagémons sauvages.',
+    details: 'Permet de capturer le Shlagémon actuellement en combat. Moins il a de points de vie, plus la chance de capture augmente.',
     price: 10,
     image: '/items/shlageball/shlageball.png',
     catchBonus: 1,

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -2,6 +2,11 @@ export interface Item {
   id: string
   name: string
   description: string
+  /**
+   * Detailed explanation of how the item works.
+   * When not provided, `description` will be used instead.
+   */
+  details?: string
   price: number
   image?: string
 }


### PR DESCRIPTION
## Summary
- add `details` field to Item type for longer explanations
- add question mark icon on each inventory item card to open a modal
- add detailed descriptions for existing shop items

## Testing
- `pnpm test --silent` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6866854e5748832aa4a7ee9af180e5db