### PR TITLE
Add animated XP progress bar

### DIFF
--- a/src/components/shlagemon/ShlagemonXpBar.vue
+++ b/src/components/shlagemon/ShlagemonXpBar.vue
@@ -13,6 +13,27 @@ const maxXp = computed(() => xpForLevel(props.mon.lvl))
     <div class="mb-1 text-center text-xs sm:text-sm">
       Expérience : {{ props.mon.xp.toLocaleString() }} / {{ maxXp.toLocaleString() }}
     </div>
-    <ProgressBar :value="props.mon.xp" :max="maxXp" class="w-full" />
+    <ProgressBar :value="props.mon.xp" :max="maxXp" color="experience-bar" class="w-full" />
   </div>
 </template>
+
+<style scoped>
+.experience-bar {
+  background-image: linear-gradient(90deg, #4ade80, #67e8f9, #4ade80);
+  background-size: 200% 100%;
+  animation: xp-flow 4s linear infinite;
+}
+
+.dark .experience-bar {
+  background-image: linear-gradient(90deg, #166534, #0e7490, #166534);
+}
+
+@keyframes xp-flow {
+  from {
+    background-position: 0% 0%;
+  }
+  to {
+    background-position: -200% 0%;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- animate the XP bar with a moving gradient

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68668635cc74832ab96d6702b41fb189