### PR TITLE
Add profile modal and header button

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -35,6 +35,7 @@ declare module 'vue' {
     Modal: typeof import('./components/modal/Modal.vue')['default']
     PanelWrapper: typeof import('./components/ui/PanelWrapper.vue')['default']
     PlayerInfos: typeof import('./components/panels/PlayerInfos.vue')['default']
+    Profile: typeof import('./components/profile/Profile.vue')['default']
     ProgressBar: typeof import('./components/ui/ProgressBar.vue')['default']
     README: typeof import('./components/README.md')['default']
     RouterLink: typeof import('vue-router')['RouterLink']

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import Profile from '~/components/profile/Profile.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
+import Button from '~/components/ui/Button.vue'
 import { useSaveStore } from '~/stores/save'
 
 const save = useSaveStore()
+
+const showProfile = ref(false)
 
 function reset() {
   save.reset()
@@ -14,9 +19,13 @@ function reset() {
     <img src="/logo.png" alt="Logo Shlagémon" class="h-20 -my-4">
     <div class="flex items-center gap-2">
       <ThemeToggle />
+      <Button type="icon" aria-label="Profil" @click="showProfile = true">
+        <div class="i-carbon-user" />
+      </Button>
       <button class="p-1" aria-label="Reset Save" @click="reset">
         <div class="i-carbon-trash-can text-red" />
       </button>
+      <Profile v-model="showProfile" />
     </div>
   </header>
 </template>

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import Button from '~/components/ui/Button.vue'
+import { useSaveStore } from '~/stores/save'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits(['update:modelValue'])
+
+const save = useSaveStore()
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function removeSave() {
+  save.reset()
+  close()
+}
+</script>
+
+<template>
+  <Modal
+    :model-value="props.modelValue"
+    @update:model-value="emit('update:modelValue', $event)"
+    @close="close"
+  >
+    <h2 class="mb-4 text-center text-lg font-bold">
+      Profil
+    </h2>
+    <Button type="danger" class="mx-auto flex items-center gap-1" @click="removeSave">
+      <div i-carbon-trash-can />
+      Supprimer
+    </Button>
+  </Modal>
+</template>

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -9,17 +9,19 @@ const props = withDefaults(defineProps<{ type?: ButtonType }>(), {
 const variantClass = computed(() => {
   switch (props.type) {
     case 'valid':
-      return 'bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-800'
+      return 'rounded px-2 py-1 text-white bg-green-600 dark:bg-green-700 hover:bg-green-700 dark:hover:bg-green-800'
     case 'danger':
-      return 'bg-red-600 dark:bg-red-700 hover:bg-red-700 dark:hover:bg-red-800'
+      return 'rounded px-2 py-1 text-white bg-red-600 dark:bg-red-700 hover:bg-red-700 dark:hover:bg-red-800'
+    case 'icon':
+      return 'rounded-full p-2 bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
     default:
-      return 'bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80'
+      return 'rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80'
   }
 })
 </script>
 
 <template>
-  <button class="rounded px-2 py-1 text-white" :class="variantClass">
+  <button class="inline-flex items-center justify-center" :class="variantClass">
     <slot />
   </button>
 </template>

--- a/src/type/button.ts
+++ b/src/type/button.ts
@@ -1,1 +1,1 @@
-export type ButtonType = 'primary' | 'valid' | 'danger'
+export type ButtonType = 'primary' | 'valid' | 'danger' | 'icon'


### PR DESCRIPTION
## Summary
- update `Button` component to support `icon` style
- add a `Profile` modal component
- display new profile icon button in header that opens the modal
- expose the new component type

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Snapshot mismatched and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686685eba868832aa611632186ed18da