### PR TITLE
Add faint animation

### DIFF
--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -8,14 +8,23 @@ interface Props {
   hp: number
   color?: string
   flipped?: boolean
+  fainted?: boolean
   levelPosition?: 'top' | 'bottom'
 }
 
 const props = withDefaults(defineProps<Props>(), {
   color: undefined,
   flipped: false,
+  fainted: false,
   levelPosition: 'bottom',
 })
+
+const emit = defineEmits<{ (e: 'faintEnd'): void }>()
+
+function onAnimationEnd() {
+  if (props.fainted)
+    emit('faintEnd')
+}
 </script>
 
 <template>
@@ -25,7 +34,8 @@ const props = withDefaults(defineProps<Props>(), {
       :alt="props.mon.base.name"
       :shiny="props.mon.isShiny"
       class="max-h-32 object-contain"
-      :class="props.flipped ? '-scale-x-100' : ''"
+      :class="[props.flipped ? '-scale-x-100' : '', { faint: props.fainted }]"
+      @animationend="onAnimationEnd"
     />
     <div class="absolute left-0 text-sm font-bold" :class="props.levelPosition === 'top' ? 'top-0' : 'bottom-0'">
       lvl {{ props.mon.lvl }}
@@ -40,3 +50,16 @@ const props = withDefaults(defineProps<Props>(), {
     </div>
   </div>
 </template>
+
+<style scoped>
+.faint {
+  animation: faint 0.5s forwards;
+}
+
+@keyframes faint {
+  to {
+    transform: scale(0);
+    opacity: 0;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- animate fainting Shlagemon on battle defeat
- heal player's Shlagemon only in normal battles
- chain trainer battles without healing

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6866870141b4832abc3d9c5a3d42fbf7