### PR TITLE
Add evolution system

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -178,6 +178,7 @@ declare global {
   const useEventBus: typeof import('@vueuse/core')['useEventBus']
   const useEventListener: typeof import('@vueuse/core')['useEventListener']
   const useEventSource: typeof import('@vueuse/core')['useEventSource']
+  const useEvolutionStore: typeof import('./stores/evolution')['useEvolutionStore']
   const useEyeDropper: typeof import('@vueuse/core')['useEyeDropper']
   const useFavicon: typeof import('@vueuse/core')['useFavicon']
   const useFetch: typeof import('@vueuse/core')['useFetch']
@@ -516,6 +517,7 @@ declare module 'vue' {
     readonly useEventBus: UnwrapRef<typeof import('@vueuse/core')['useEventBus']>
     readonly useEventListener: UnwrapRef<typeof import('@vueuse/core')['useEventListener']>
     readonly useEventSource: UnwrapRef<typeof import('@vueuse/core')['useEventSource']>
+    readonly useEvolutionStore: UnwrapRef<typeof import('./stores/evolution')['useEvolutionStore']>
     readonly useEyeDropper: UnwrapRef<typeof import('@vueuse/core')['useEyeDropper']>
     readonly useFavicon: UnwrapRef<typeof import('@vueuse/core')['useFavicon']>
     readonly useFetch: UnwrapRef<typeof import('@vueuse/core')['useFetch']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -25,6 +25,7 @@ declare module 'vue' {
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
     DialogPanel: typeof import('./components/panels/DialogPanel.vue')['default']
     DialogStarter: typeof import('./components/dialog/DialogStarter.vue')['default']
+    EvolutionModal: typeof import('./components/shlagemon/EvolutionModal.vue')['default']
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
     ImageByBackground: typeof import('./components/ui/ImageByBackground.vue')['default']

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -3,6 +3,7 @@ import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
 import InventoryPanel from '~/components/panels/InventoryPanel.vue'
 import MainPanel from '~/components/panels/MainPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
+import EvolutionModal from '~/components/shlagemon/EvolutionModal.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import PanelWrapper from '~/components/ui/PanelWrapper.vue'
 import { useAchievementsStore } from '~/stores/achievements'
@@ -74,6 +75,7 @@ const isAchievementVisible = computed(() => achievements.hasAny)
           <Shlagedex />
         </PanelWrapper>
       </div>
+      <EvolutionModal />
     </div>
   </div>
 </template>

--- a/src/components/shlagemon/EvolutionModal.vue
+++ b/src/components/shlagemon/EvolutionModal.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import Button from '~/components/ui/Button.vue'
+import { useEvolutionStore } from '~/stores/evolution'
+
+const store = useEvolutionStore()
+</script>
+
+<template>
+  <Modal v-model="store.isVisible" :close-on-outside-click="false">
+    <div class="flex flex-col items-center gap-4">
+      <h3 class="text-center text-lg font-bold">
+        {{ store.pending?.mon.base.name }} veut évoluer en {{ store.pending?.to.name }}
+      </h3>
+      <div class="flex gap-2">
+        <Button type="valid" @click="store.accept">
+          Oui
+        </Button>
+        <Button type="danger" @click="store.reject">
+          Non
+        </Button>
+      </div>
+    </div>
+  </Modal>
+</template>

--- a/src/stores/evolution.ts
+++ b/src/stores/evolution.ts
@@ -1,0 +1,36 @@
+import type { BaseShlagemon, DexShlagemon } from '~/type'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+interface EvolutionRequest {
+  mon: DexShlagemon
+  to: BaseShlagemon
+  resolve: (v: boolean) => void
+}
+
+export const useEvolutionStore = defineStore('evolution', () => {
+  const pending = ref<EvolutionRequest | null>(null)
+  const isVisible = computed(() => pending.value !== null)
+
+  function requestEvolution(mon: DexShlagemon, to: BaseShlagemon) {
+    return new Promise<boolean>((resolve) => {
+      pending.value = { mon, to, resolve }
+    })
+  }
+
+  function accept() {
+    if (pending.value) {
+      pending.value.resolve(true)
+      pending.value = null
+    }
+  }
+
+  function reject() {
+    if (pending.value) {
+      pending.value.resolve(false)
+      pending.value = null
+    }
+  }
+
+  return { pending, isVisible, requestEvolution, accept, reject }
+})

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -1,0 +1,20 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import abraquemar from '../src/data/shlagemons/abraquemar'
+import alakalbar from '../src/data/shlagemons/alakalbar'
+import { useEvolutionStore } from '../src/stores/evolution'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { xpForLevel } from '../src/utils/dexFactory'
+
+describe('evolution', () => {
+  it('evolves when reaching level condition', async () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const evo = useEvolutionStore()
+    vi.spyOn(evo, 'requestEvolution').mockResolvedValue(true)
+    const mon = dex.createShlagemon(abraquemar)
+    await dex.gainXp(mon, xpForLevel(1) + xpForLevel(2))
+    expect(mon.base.id).toBe(alakalbar.id)
+    expect(mon.lvl).toBe(3)
+  })
+})

--- a/test/gainxp-heal.test.ts
+++ b/test/gainxp-heal.test.ts
@@ -5,13 +5,13 @@ import { useShlagedexStore } from '../src/stores/shlagedex'
 import { xpForLevel } from '../src/utils/dexFactory'
 
 describe('gainXp heal percent', () => {
-  it('heals only a portion of hp on level up', () => {
+  it('heals only a portion of hp on level up', async () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
     const mon = dex.createShlagemon(carapouffe)
     mon.hpCurrent = Math.floor(mon.hp / 2)
     const prevHp = mon.hpCurrent
-    dex.gainXp(mon, xpForLevel(mon.lvl), undefined, 15)
+    await dex.gainXp(mon, xpForLevel(mon.lvl), undefined, 15)
     const expected = Math.min(mon.hp, prevHp + Math.round(mon.hp * 15 / 100))
     expect(mon.hpCurrent).toBe(expected)
     expect(mon.lvl).toBe(2)

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -64,13 +64,13 @@ describe('shlagedex capture', () => {
 })
 
 describe('shlagedex highest level', () => {
-  it('updates when a mon levels up', () => {
+  it('updates when a mon levels up', async () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
     const mon = dex.createShlagemon(carapouffe)
     expect(dex.highestLevel).toBe(1)
     for (let i = 0; i < 9; i++)
-      dex.gainXp(mon, xpForLevel(mon.lvl))
+      await dex.gainXp(mon, xpForLevel(mon.lvl))
     expect(mon.lvl).toBe(10)
     expect(dex.highestLevel).toBe(10)
   })

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -48,7 +48,7 @@ describe('zone panel', () => {
     progress.defeatKing('plaine-kekette')
     progress.defeatKing('bois-de-bouffon')
     for (let i = 0; i < 9; i++)
-      dex.gainXp(mon, xpForLevel(mon.lvl))
+      await dex.gainXp(mon, xpForLevel(mon.lvl))
     await wrapper.vm.$nextTick()
     btn = wrapper.findAll('button').find(b => b.text().includes('Grotte du Slip'))
     expect(btn).toBeDefined()


### PR DESCRIPTION
## Summary
- add EvolutionModal component and evolution store
- handle evolution logic inside shlagedex store
- display evolution modal in main layout
- adapt existing unit tests and add a new one for evolutions

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined and fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68669c7089c8832aa0166edfe2e1ef9d