### PR TITLE
Fix EvolutionModal visibility binding

### DIFF
--- a/src/components/shlagemon/EvolutionModal.vue
+++ b/src/components/shlagemon/EvolutionModal.vue
@@ -7,7 +7,10 @@ const store = useEvolutionStore()
 </script>
 
 <template>
-  <Modal v-model="store.isVisible" :close-on-outside-click="false">
+  <!-- We only bind the visibility as a prop because `isVisible` is a
+       computed value without a setter. Using `v-model` would attempt to
+       write to it and trigger an error. -->
+  <Modal :model-value="store.isVisible" :close-on-outside-click="false">
     <div class="flex flex-col items-center gap-4">
       <h3 class="text-center text-lg font-bold">
         {{ store.pending?.mon.base.name }} veut évoluer en {{ store.pending?.to.name }}


### PR DESCRIPTION
## Summary
- prevent Modal from trying to write to computed `isVisible`

## Testing
- `pnpm test` *(fails: FetchError on fonts and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6866c26929dc832a87471780a746f698