### PR TITLE
Update evolution pop-up

### DIFF
--- a/src/components/shlagemon/EvolutionModal.vue
+++ b/src/components/shlagemon/EvolutionModal.vue
@@ -10,13 +10,18 @@ const store = useEvolutionStore()
   <Modal v-model="store.isVisible" :close-on-outside-click="false">
     <div class="flex flex-col items-center gap-4">
       <h3 class="text-center text-lg font-bold">
-        {{ store.pending?.mon.base.name }} veut évoluer en {{ store.pending?.to.name }}
+        {{ store.pending?.mon.base.name }} évolue
       </h3>
+      <p class="text-center">
+        « {{ store.pending?.mon.base.name }} » veut évoluer en « {{ store.pending?.to.name }} », voulez-vous le laisser faire ou l'empêcher de répandre sa... sa schlaguitude ?
+      </p>
       <div class="flex gap-2">
-        <Button type="valid" @click="store.accept">
+        <Button type="valid" class="flex items-center gap-1" @click="store.accept">
+          <div i-carbon-checkmark />
           Oui
         </Button>
-        <Button type="danger" @click="store.reject">
+        <Button type="danger" class="flex items-center gap-1" @click="store.reject">
+          <div i-carbon-close />
           Non
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- improve wording and style for the evolution confirmation modal

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6866c194baf4832a876784a18c821103