### PR TITLE
Ajout de la HEO Rotate et explications des Schlagebols

### DIFF
--- a/src/components/ball/BallSelectionModal.vue
+++ b/src/components/ball/BallSelectionModal.vue
@@ -21,6 +21,13 @@ function choose(id: string) {
 <template>
   <Modal v-model="ballStore.isVisible" footer-close>
     <div class="flex flex-col items-center gap-2">
+      <h3 class="text-lg font-bold">
+        Choix de la Schlagéball
+      </h3>
+      <p class="text-center text-sm">
+        La Super et l'Hyper Schlagéball améliorent vos chances de capture
+        (x1.5 et x2).
+      </p>
       <Button
         v-for="ball in options"
         :key="ball.id"

--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -3,6 +3,7 @@ import type { Item } from '~/type/item'
 import { computed, ref } from 'vue'
 import Modal from '~/components/modal/Modal.vue'
 import Button from '~/components/ui/Button.vue'
+import { ballHues } from '~/utils/ball'
 
 const props = defineProps<{ item: Item, qty: number }>()
 const emit = defineEmits<{
@@ -12,6 +13,9 @@ const emit = defineEmits<{
 
 const showInfo = ref(false)
 const details = computed(() => props.item.details || props.item.description)
+const ballFilter = computed(() =>
+  'catchBonus' in props.item ? { filter: `hue-rotate(${ballHues[props.item.id]})` } : {},
+)
 </script>
 
 <template>
@@ -22,6 +26,7 @@ const details = computed(() => props.item.details || props.item.description)
         :src="props.item.image"
         :alt="props.item.name"
         class="h-8 w-8 object-contain"
+        :style="ballFilter"
       >
       <span class="font-bold">{{ props.item.name }}</span>
     </div>
@@ -54,6 +59,7 @@ const details = computed(() => props.item.details || props.item.description)
           :src="props.item.image"
           :alt="props.item.name"
           class="h-16 w-16 object-contain"
+          :style="ballFilter"
         >
         <h3 class="text-lg font-bold">
           {{ props.item.name }}


### PR DESCRIPTION
## Summary
- colorie les Schlagebols dans l'inventaire grâce au hue-rotate
- ajoute un titre et des explications dans la modale de sélection

## Testing
- `pnpm lint`
- `pnpm test` *(échoue : Snapshots et données manquantes)*

------
https://chatgpt.com/codex/tasks/task_e_6866c786819c832a83d12022e5fd974a