### PR TITLE
Add capture icon for wild battles

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -44,6 +44,9 @@ const winTooltip = computed(() =>
 const playerHp = ref(0)
 const enemyHp = ref(0)
 const enemy = ref<ReturnType<typeof createDexShlagemon> | null>(null)
+const enemyCaptured = computed(() =>
+  enemy.value ? dex.shlagemons.some(m => m.base.id === enemy.value.base.id) : false,
+)
 const battleActive = ref(false)
 const showCapture = ref(false)
 const captureBall = ref(balls[0])
@@ -280,7 +283,14 @@ onUnmounted(() => {
         </div>
         <div v-if="enemy" class="mon relative flex flex-1 flex-col select-none items-center" :class="{ flash: flashEnemy }" @click="attack">
           <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-          <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" />
+          <BattleShlagemon
+            :mon="enemy"
+            :hp="enemyHp"
+            :fainted="enemyFainted"
+            color="bg-red-500"
+            show-ball
+            :owned="enemyCaptured"
+          />
         </div>
       </div>
       <Button

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -10,6 +10,8 @@ interface Props {
   flipped?: boolean
   fainted?: boolean
   levelPosition?: 'top' | 'bottom'
+  showBall?: boolean
+  owned?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -17,6 +19,8 @@ const props = withDefaults(defineProps<Props>(), {
   flipped: false,
   fainted: false,
   levelPosition: 'bottom',
+  showBall: false,
+  owned: false,
 })
 
 const emit = defineEmits<{ (e: 'faintEnd'): void }>()
@@ -41,6 +45,13 @@ function onAnimationEnd() {
       lvl {{ props.mon.lvl }}
     </div>
     <div class="mt-1 flex items-center gap-1">
+      <img
+        v-if="props.showBall"
+        src="/items/shlageball/shlageball.png"
+        alt="ball"
+        class="h-4 w-4"
+        :class="{ 'opacity-50': !props.owned }"
+      >
       <span class="font-bold">{{ props.mon.base.name }}</span>
       <!-- <ShlagemonType v-for="t in props.mon.base.types" :key="t.id" :value="t" size="xs" /> -->
     </div>


### PR DESCRIPTION
## Summary
- show capture status icon in battle UI
- display capture status only in wild battles

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined, network issues fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6866cda1d6f4832aa08a6f86e8ecb568