### PR TITLE
Update zone actions location

### DIFF
--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import type { Zone } from '~/type'
 import { computed } from 'vue'
-import Button from '~/components/ui/Button.vue'
 import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
 
@@ -13,15 +11,11 @@ const zone = useZoneStore()
 const dex = useShlagedexStore()
 const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
-const trainerBattle = useTrainerBattleStore()
 const dialog = useDialogStore()
 
 const zoneButtonsDisabled = computed(
   () => panel.current === 'trainerBattle' || dialog.isDialogVisible,
 )
-
-const currentKing = computed(() => zone.getKing(zone.current.id))
-const kingLabel = computed(() => currentKing.value.character.gender === 'female' ? 'reine' : 'roi')
 
 const xpZones = computed(() => zone.zones.filter(z => z.maxLevel > 0))
 
@@ -37,25 +31,11 @@ function canAccess(z: Zone) {
   return dex.highestLevel >= z.minLevel && progress.isKingDefeated(prev.id)
 }
 
-function onAction(id: string) {
-  if (id === 'shop')
-    panel.showShop()
-  else if (id === 'explore')
-    panel.showTrainerBattle()
-}
-
-function fightKing() {
-  const trainer = zone.getKing(zone.current.id)
-  trainerBattle.setQueue([trainer])
-  panel.showTrainerBattle()
-}
-
 function classes(z: Zone) {
-  const classes = []
+  const classes: string[] = []
   z.id === zone.current.id ? classes.push('bg-primary text-dark dark:bg-light') : classes.push('bg-gray-200 dark:bg-gray-700')
-  if (z.type === 'village') {
+  if (z.type === 'village')
     classes.push('bg-green-300 dark:bg-green-800')
-  }
   return classes.join(' ')
 }
 </script>
@@ -73,26 +53,6 @@ function classes(z: Zone) {
       >
         {{ z.name }}
       </button>
-    </div>
-    <div class="flex flex-col items-center gap-1" md="gap-2">
-      <Button
-        v-for="action in zone.current.actions"
-        :key="action.id"
-        class="text-xs"
-        @click="onAction(action.id)"
-      >
-        {{ action.label }}
-      </Button>
-      <Button
-        v-if="!progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
-        class="text-xs"
-        @click="fightKing"
-      >
-        Défier la {{ kingLabel }} de la zone
-      </Button>
-      <div v-else-if="progress.isKingDefeated(zone.current.id)" class="text-xs font-bold">
-        {{ kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1) }} vaincu{{ kingLabel === 'reine' ? 'e' : '' }} !
-      </div>
     </div>
   </div>
 </template>

--- a/src/components/village/VillagePanel.vue
+++ b/src/components/village/VillagePanel.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import { useZoneStore } from '~/stores/zone'
+import ZoneActions from './ZoneActions.vue'
 
 const zone = useZoneStore()
 </script>
 
 <template>
-  <ImageByBackground
-    v-if="zone.current.image"
-    :src="zone.current.image"
-    :alt="zone.current.name"
-    class="aspect-video h-full max-h-60 w-full object-contain md:max-h-80"
-  />
+  <div class="flex flex-col items-center gap-2">
+    <ImageByBackground
+      v-if="zone.current.image"
+      :src="zone.current.image"
+      :alt="zone.current.name"
+      class="aspect-video h-full max-h-60 w-full object-contain md:max-h-80"
+    />
+    <ZoneActions />
+  </div>
 </template>

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Button from '~/components/ui/Button.vue'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useTrainerBattleStore } from '~/stores/trainerBattle'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
+
+const zone = useZoneStore()
+const panel = useMainPanelStore()
+const progress = useZoneProgressStore()
+const trainerBattle = useTrainerBattleStore()
+
+const currentKing = computed(() => zone.getKing(zone.current.id))
+const kingLabel = computed(() =>
+  currentKing.value.character.gender === 'female' ? 'reine' : 'roi',
+)
+
+function onAction(id: string) {
+  if (id === 'shop')
+    panel.showShop()
+  else if (id === 'explore')
+    panel.showTrainerBattle()
+}
+
+function fightKing() {
+  const trainer = zone.getKing(zone.current.id)
+  trainerBattle.setQueue([trainer])
+  panel.showTrainerBattle()
+}
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-1" md="gap-2">
+    <Button
+      v-for="action in zone.current.actions"
+      :key="action.id"
+      class="text-xs"
+      @click="onAction(action.id)"
+    >
+      {{ action.label }}
+    </Button>
+    <Button
+      v-if="!progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
+      class="text-xs"
+      @click="fightKing"
+    >
+      Défier la {{ kingLabel }} de la zone
+    </Button>
+    <div v-else-if="progress.isKingDefeated(zone.current.id)" class="text-xs font-bold">
+      {{ kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1) }} vaincu{{ kingLabel === 'reine' ? 'e' : '' }} !
+    </div>
+  </div>
+</template>

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import ZonePanel from '../src/components/panels/ZonePanel.vue'
+import ZoneActions from '../src/components/village/ZoneActions.vue'
 import { carapouffe } from '../src/data/shlagemons'
 import { useMainPanelStore } from '../src/stores/mainPanel'
 import { useShlagedexStore } from '../src/stores/shlagedex'
@@ -59,7 +60,7 @@ describe('zone panel', () => {
     setActivePinia(pinia)
     const progress = useZoneProgressStore()
     const zone = useZoneStore()
-    const wrapper = mount(ZonePanel, { global: { plugins: [pinia] } })
+    const wrapper = mount(ZoneActions, { global: { plugins: [pinia] } })
     zone.setZone('plaine-kekette')
     await wrapper.vm.$nextTick()
     expect(wrapper.text()).not.toContain('Défier le roi')


### PR DESCRIPTION
## Summary
- move zone-specific buttons and king challenge logic into a new `ZoneActions` component
- show `ZoneActions` within `VillagePanel`
- keep `ZonePanel` focused on zone selection only
- adjust unit test to use `ZoneActions`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6866cf00eb08832a8d01a8190706df3b