### PR TITLE
Fix evolution modal trigger logic

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -89,9 +89,9 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       return
     if (evo.condition.type !== 'lvl' || mon.lvl < evo.condition.value)
       return
-    let accepted = true
     if (!mon.allowEvolution)
-      accepted = await evolutionStore.requestEvolution(mon, evo.base)
+      return
+    const accepted = await evolutionStore.requestEvolution(mon, evo.base)
     if (!accepted)
       return
     mon.base = evo.base

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -7,7 +7,7 @@ import { useShlagedexStore } from '../src/stores/shlagedex'
 import { xpForLevel } from '../src/utils/dexFactory'
 
 describe('evolution', () => {
-  it('auto evolves without prompt when allowed', async () => {
+  it('prompts before evolution when allowed', async () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
     const evo = useEvolutionStore()
@@ -16,10 +16,10 @@ describe('evolution', () => {
     await dex.gainXp(mon, xpForLevel(1) + xpForLevel(2))
     expect(mon.base.id).toBe(alakalbar.id)
     expect(mon.lvl).toBe(3)
-    expect(spy).not.toHaveBeenCalled()
+    expect(spy).toHaveBeenCalled()
   })
 
-  it('asks for evolution when not allowed automatically', async () => {
+  it('skips evolution when not allowed', async () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
     const evo = useEvolutionStore()
@@ -27,8 +27,8 @@ describe('evolution', () => {
     const mon = dex.createShlagemon(abraquemar)
     mon.allowEvolution = false
     await dex.gainXp(mon, xpForLevel(1) + xpForLevel(2))
-    expect(spy).toHaveBeenCalled()
-    expect(mon.base.id).toBe(alakalbar.id)
+    expect(spy).not.toHaveBeenCalled()
+    expect(mon.base.id).toBe(abraquemar.id)
     expect(mon.lvl).toBe(3)
   })
 })


### PR DESCRIPTION
## Summary
- ask player before evolving when evolution is allowed
- skip evolution and modal if it's disabled
- adjust unit tests for new behavior

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient') etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866f8a97b84832a982011f11e12be8e