### PR TITLE
Fix serializer initialization

### DIFF
--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -1,7 +1,11 @@
 import { allShlagemons } from '~/data/shlagemons'
 import { baseStats, statWithRarityAndCoefficient } from './dexFactory'
 
-const baseMap = Object.fromEntries(allShlagemons.map(b => [b.id, b]))
+function getBaseMap() {
+  return Object.fromEntries(
+    (allShlagemons || []).filter(Boolean).map(b => [b.id, b]),
+  )
+}
 
 export const shlagedexSerializer = {
   serialize(data: any): string {
@@ -24,6 +28,8 @@ export const shlagedexSerializer = {
 
   deserialize(raw: string): any {
     const parsed = JSON.parse(raw)
+
+    const baseMap = getBaseMap()
 
     const shlagemons = (parsed.shlagemons || [])
       .map((mon: any) => {


### PR DESCRIPTION
## Summary
- safely build shlagemon map when (de)serializing state

## Testing
- `npm run test` *(fails: Snapshot mismatch & unable to access fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6866febc1adc832abfe0ba729e69c5be