### PR TITLE
Add recursive evolutions to Schlagedex potential

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -34,10 +34,20 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
 
   const accessibleZones = computed(() => zonesData.filter(z => canAccess(z)))
 
+  function collectEvolutionIds(base: BaseShlagemon, ids: Set<string>, visited: Set<string>) {
+    if (visited.has(base.id))
+      return
+    visited.add(base.id)
+    ids.add(base.id)
+    if (base.evolution)
+      collectEvolutionIds(base.evolution.base, ids, visited)
+  }
+
   const completableIds = computed(() => {
     const ids = new Set<string>()
+    const visited = new Set<string>()
     for (const z of accessibleZones.value)
-      z.shlagemons?.forEach(m => ids.add(m.id))
+      z.shlagemons?.forEach(m => collectEvolutionIds(m, ids, visited))
     return ids
   })
 

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { toast } from 'vue3-toastify'
 import { carapouffe } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useZoneProgressStore } from '../src/stores/zoneProgress'
 import { applyStats, createDexShlagemon, xpForLevel } from '../src/utils/dexFactory'
 
 vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
@@ -73,5 +74,19 @@ describe('shlagedex highest level', () => {
       await dex.gainXp(mon, xpForLevel(mon.lvl))
     expect(mon.lvl).toBe(10)
     expect(dex.highestLevel).toBe(10)
+  })
+})
+
+describe('completable ids', () => {
+  it('includes evolutions recursively', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const progress = useZoneProgressStore()
+    dex.highestLevel.value = 30
+    progress.defeatKing('grotte-nanard')
+    const ids = (dex as any).completableIds as Set<string>
+    expect(ids.has('salamiches')).toBe(true)
+    expect(ids.has('raptorincel')).toBe(true)
+    expect(ids.has('draco-con')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- include evolutions when computing potential Schlagedex entries
- test that evolved forms appear in the potential list

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetching google fonts and other TypeError due to dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686701d3bbe0832a96b11a3aca42c0af