### PR TITLE
Add search input component across panels

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -43,6 +43,7 @@ declare module 'vue' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     Schlagedex: typeof import('./components/icons/schlagedex.vue')['default']
+    SearchInput: typeof import('./components/ui/SearchInput.vue')['default']
     SelectedShlagemon: typeof import('./components/panels/SelectedShlagemon.vue')['default']
     SelectOption: typeof import('./components/ui/SelectOption.vue')['default']
     Shlagedex: typeof import('./components/shlagemon/Shlagedex.vue')['default']

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -1,12 +1,20 @@
 <script setup lang="ts">
 import Button from '~/components/ui/Button.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
+import SearchInput from '~/components/ui/SearchInput.vue'
 import { useAchievementsStore } from '~/stores/achievements'
 import AchievementItem from './AchievementItem.vue'
 
 const store = useAchievementsStore()
 const showLocked = ref(false)
+const search = ref('')
 const list = computed(() => showLocked.value ? store.list : store.unlockedList)
+const filteredList = computed(() => {
+  if (!search.value.trim())
+    return list.value
+  const q = search.value.toLowerCase()
+  return list.value.filter(a => a.title.toLowerCase().includes(q))
+})
 </script>
 
 <template>
@@ -15,8 +23,9 @@ const list = computed(() => showLocked.value ? store.list : store.unlockedList)
       <span>{{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés</span>
       <CheckBox :model-value="showLocked" @update:model-value="showLocked = $event" @click.stop />
     </Button>
+    <SearchInput v-model="search" class="w-full" />
     <AchievementItem
-      v-for="a in list"
+      v-for="a in filteredList"
       :key="a.id"
       :achievement="a"
     />

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import InventoryItemCard from '~/components/inventory/InventoryItemCard.vue'
+import SearchInput from '~/components/ui/SearchInput.vue'
 import { useBallStore } from '~/stores/ball'
 import { useInventoryStore } from '~/stores/inventory'
 
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
+const search = ref('')
+const filteredList = computed(() => {
+  const q = search.value.toLowerCase().trim()
+  if (!q)
+    return inventory.list
+  return inventory.list.filter(entry => entry.item.name.toLowerCase().includes(q))
+})
 
 function onUse(item: Item) {
   if ('catchBonus' in item)
@@ -17,8 +25,9 @@ function onUse(item: Item) {
 
 <template>
   <section v-if="inventory.list.length" class="flex flex-col gap-2">
+    <SearchInput v-model="search" class="w-full" />
     <InventoryItemCard
-      v-for="entry in inventory.list"
+      v-for="entry in filteredList"
       :key="entry.item.id"
       :item="entry.item"
       :qty="entry.qty"

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
 import Modal from '~/components/modal/Modal.vue'
+import SearchInput from '~/components/ui/SearchInput.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import ShlagemonDetail from './ShlagemonDetail.vue'
@@ -85,12 +86,7 @@ function isActive(mon: DexShlagemon) {
           <div :class="sortAsc ? 'i-carbon-sort-ascending' : 'i-carbon-sort-descending'" />
         </button>
       </div>
-      <input
-        v-model="search"
-        type="text"
-        placeholder="Recherche"
-        class="focus:border-primary min-w-36 flex-1 border border-gray-300 rounded bg-white px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 focus:outline-none"
-      >
+      <SearchInput v-model="search" />
     </div>
     <div class="flex flex-col gap-2">
       <div

--- a/src/components/ui/SearchInput.vue
+++ b/src/components/ui/SearchInput.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ modelValue?: string, placeholder?: string }>(), {
+  placeholder: 'Recherche',
+})
+const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>()
+function onInput(e: Event) {
+  emit('update:modelValue', (e.target as HTMLInputElement).value)
+}
+</script>
+
+<template>
+  <input
+    :value="props.modelValue"
+    type="text"
+    :placeholder="props.placeholder"
+    class="focus:border-primary min-w-36 flex-1 border border-gray-300 rounded bg-white px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 focus:outline-none"
+    @input="onInput"
+  >
+</template>


### PR DESCRIPTION
## Summary
- create `SearchInput` component for consistent search fields
- use `SearchInput` in the Shlagédex search bar
- add searchable lists to Achievements and Inventory panels

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686702f339b4832a850262056116ec14