### PR TITLE
Fix constant reassign in serializer

### DIFF
--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -32,7 +32,7 @@ export const shlagedexSerializer = {
 
     const baseMap = getBaseMap()
 
-    const shlagemons = (parsed.shlagemons || [])
+    let shlagemons = (parsed.shlagemons || [])
       .map((mon: any) => {
         const base = mon.base ?? baseMap[mon.baseId]
         if (!base)


### PR DESCRIPTION
## Summary
- make `shlagemons` variable mutable when deserializing the Schlagedex

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined and snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_686703c5a728832a8f31a664d8538ce0