### PR TITLE
Limit kings to wild zones

### DIFF
--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -11,9 +11,14 @@ const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
 
-const currentKing = computed(() => zone.getKing(zone.current.id))
+const hasKing = computed(() =>
+  zone.current.hasKing ?? zone.current.type === 'sauvage',
+)
+const currentKing = computed(() =>
+  hasKing.value ? zone.getKing(zone.current.id) : undefined,
+)
 const kingLabel = computed(() =>
-  currentKing.value.character.gender === 'female' ? 'reine' : 'roi',
+  currentKing.value?.character.gender === 'female' ? 'reine' : 'roi',
 )
 
 function onAction(id: string) {
@@ -24,7 +29,9 @@ function onAction(id: string) {
 }
 
 function fightKing() {
-  const trainer = zone.getKing(zone.current.id)
+  const trainer = currentKing.value
+  if (!trainer)
+    return
   trainerBattle.setQueue([trainer])
   panel.showTrainerBattle()
 }
@@ -41,14 +48,18 @@ function fightKing() {
       {{ action.label }}
     </Button>
     <Button
-      v-if="!progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
+      v-if="hasKing && !progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
       class="text-xs"
       @click="fightKing"
     >
       Défier la {{ kingLabel }} de la zone
     </Button>
-    <div v-else-if="progress.isKingDefeated(zone.current.id)" class="text-xs font-bold">
-      {{ kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1) }} vaincu{{ kingLabel === 'reine' ? 'e' : '' }} !
+    <div
+      v-else-if="hasKing && progress.isKingDefeated(zone.current.id)"
+      class="text-xs font-bold"
+    >
+      {{ kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1) }}
+      vaincu{{ kingLabel === 'reine' ? 'e' : '' }} !
     </div>
   </div>
 </template>

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -19,11 +19,14 @@ export const useZoneStore = defineStore('zone', () => {
 
   const kings = ref<Record<string, Trainer>>({})
 
-  function getKing(id: string): Trainer {
+  function getKing(id: string): Trainer | undefined {
+    const z = zones.value.find(z => z.id === id)
+    if (!z)
+      throw new Error('Zone not found')
+    const hasKing = z.hasKing ?? z.type === 'sauvage'
+    if (!hasKing)
+      return undefined
     if (!kings.value[id]) {
-      const z = zones.value.find(z => z.id === id)
-      if (!z)
-        throw new Error('Zone not found')
       const level = z.maxLevel + 1
 
       let character = profMerdant

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -18,6 +18,8 @@ export interface Zone {
   maxLevel: number
   shlagemons?: BaseShlagemon[]
   image?: string
+  /** Whether this zone features a king to challenge */
+  hasKing?: boolean
 }
 
 export type ZoneId = FightZoneId | VillageZoneId


### PR DESCRIPTION
## Summary
- add `hasKing` flag to zone type
- prevent king generation in non-wild zones
- hide king button if zone has no king

## Testing
- `pnpm test` *(fails: FetchError from unocss fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68670704487c832aa07937ad567eb3e8