### PR TITLE
Change tooltip for capture when no ball

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -53,6 +53,11 @@ const enemyCaptured = computed(() =>
 const battleActive = ref(false)
 const showCapture = ref(false)
 const captureBall = ref(balls[0])
+const captureButtonTooltip = computed(() =>
+  (inventory.items[ballStore.current] || 0) <= 0
+    ? 'Pas de Schlagéball, capture impossible'
+    : 'Capturer le Schlagémon',
+)
 const flashPlayer = ref(false)
 const flashEnemy = ref(false)
 const playerFainted = ref(false)
@@ -304,7 +309,7 @@ onUnmounted(() => {
         :disabled="(inventory.items[ballStore.current] || 0) <= 0"
         @click="openCapture"
       >
-        <Tooltip text="Capturer le Shlagémon">
+        <Tooltip :text="captureButtonTooltip">
           <ImageByBackground
             src="/items/shlageball/shlageball.png"
             alt="capture"


### PR DESCRIPTION
## Summary
- tweak tooltip of capture button

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched, plus multiple TypeErrors)*

------
https://chatgpt.com/codex/tasks/task_e_686709a7990c832ab5c275e1266f17ab