### PR TITLE
Add fight king button in battle screen

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -27,6 +27,7 @@ declare module 'vue' {
     DialogPanel: typeof import('./components/panels/DialogPanel.vue')['default']
     DialogStarter: typeof import('./components/dialog/DialogStarter.vue')['default']
     EvolutionModal: typeof import('./components/shlagemon/EvolutionModal.vue')['default']
+    FightKingButton: typeof import('./components/battle/FightKingButton.vue')['default']
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
     ImageByBackground: typeof import('./components/ui/ImageByBackground.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -2,6 +2,7 @@
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
+import FightKingButton from '~/components/battle/FightKingButton.vue'
 import { balls } from '~/data/items/shlageball'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
@@ -265,6 +266,7 @@ onUnmounted(() => {
 
 <template>
   <div class="relative flex flex-col text-center">
+    <FightKingButton />
     <div v-if="zone.current.maxLevel" class="relative mb-1 flex items-center justify-center gap-1 font-bold">
       <div class="absolute left-0 flex gap-2">
         <Tooltip :text="captureTooltip">

--- a/src/components/battle/FightKingButton.vue
+++ b/src/components/battle/FightKingButton.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import Button from '~/components/ui/Button.vue'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useTrainerBattleStore } from '~/stores/trainerBattle'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
+
+const panel = useMainPanelStore()
+const trainerBattle = useTrainerBattleStore()
+const zone = useZoneStore()
+const progress = useZoneProgressStore()
+
+const currentKing = computed(() => zone.getKing(zone.current.id))
+const kingLabel = computed(() =>
+  currentKing.value.character.gender === 'female' ? 'reine' : 'roi',
+)
+
+const visible = computed(() =>
+  !progress.isKingDefeated(zone.current.id)
+  && progress.canFightKing(zone.current.id),
+)
+
+function fightKing() {
+  const trainer = zone.getKing(zone.current.id)
+  trainerBattle.setQueue([trainer])
+  panel.showTrainerBattle()
+}
+</script>
+
+<template>
+  <Button
+    v-if="visible"
+    class="absolute right-0 top-0 m-1 text-xs"
+    @click="fightKing"
+  >
+    Défier le {{ kingLabel }}
+  </Button>
+</template>


### PR DESCRIPTION
## Summary
- create `FightKingButton` component for challenging zone king
- show this new button in `BattleMain` panel

## Testing
- `pnpm run lint`
- `pnpm run test:unit` *(fails: FetchError: fetch failed, plus other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686709d90358832a8a25a2bd309a2cc6