### PR TITLE
Fix trainer battle start

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -103,6 +103,7 @@ watch(
 function startFight() {
   if (!trainer.value || !dex.activeShlagemon)
     return
+  enemyIndex.value = 0
   if (dex.activeShlagemon.hpCurrent <= 0)
     dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
   result.value = 'none'
@@ -117,6 +118,8 @@ function startBattle() {
     return
   stage.value = 'battle'
   const spec = t.shlagemons[enemyIndex.value]
+  if (!spec)
+    return
   const base = allShlagemons.find(b => b.id === spec.baseId)
   if (!base)
     return


### PR DESCRIPTION
## Summary
- reset `enemyIndex` when starting a trainer battle
- handle undefined enemy specs in `startBattle`

## Testing
- `pnpm -s test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68678770c28c832ab6bb49317dda6b4e