### PR TITLE
Fix trainer battle failing due to undefined shlagemons

### DIFF
--- a/src/data/shlagemons/barbe-bizarre.ts
+++ b/src/data/shlagemons/barbe-bizarre.ts
@@ -13,3 +13,5 @@ Il parle en citations absurdes qu’il invente sur le moment (“si l’eau mont
   coefficient: 25,
   evolution: { base: floripute, condition: { type: 'lvl', value: 36 } },
 }
+
+export default barbeBizarre

--- a/src/data/shlagemons/floripute.ts
+++ b/src/data/shlagemons/floripute.ts
@@ -12,3 +12,5 @@ On raconte qu’elle peut invoquer des cercles de danse autour d’un feu sacré
   types: [shlagemonTypes.plante],
   coefficient: 50,
 }
+
+export default floripute


### PR DESCRIPTION
## Summary
- add missing default exports on `floripute` and `barbe-bizarre`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: network fetch of fonts, several unit tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68678aac2494832aa47b2e65bbb49dfe