### PR TITLE
Implement profile improvements and clear achievements on reset

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -3,15 +3,8 @@ import { ref } from 'vue'
 import Profile from '~/components/profile/Profile.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
 import Button from '~/components/ui/Button.vue'
-import { useSaveStore } from '~/stores/save'
-
-const save = useSaveStore()
 
 const showProfile = ref(false)
-
-function reset() {
-  save.reset()
-}
 </script>
 
 <template>
@@ -22,9 +15,6 @@ function reset() {
       <Button type="icon" aria-label="Profil" @click="showProfile = true">
         <div class="i-carbon-user" />
       </Button>
-      <button class="p-1" aria-label="Reset Save" @click="reset">
-        <div class="i-carbon-trash-can text-red" />
-      </button>
       <Profile v-model="showProfile" />
     </div>
   </header>

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -27,6 +27,9 @@ function removeSave() {
     <h2 class="mb-4 text-center text-lg font-bold">
       Profil
     </h2>
+    <p class="mb-4 text-center">
+      Voulez-vous supprimer toutes vos progressions et votre sauvegarde ?
+    </p>
     <Button type="danger" class="mx-auto flex items-center gap-1" @click="removeSave">
       <div i-carbon-trash-can />
       Supprimer

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -32,20 +32,20 @@ export const useAchievementsStore = defineStore('achievements', () => {
     shiny: 0,
   })
 
-  function reset() {
-    // counters.captures = 0
-    // counters.wins = 0
-    // counters.winsStronger = 0
-    // counters.itemsUsed = 0
-    // counters.kings = 0
-    // counters.shiny = 0
-    // unlocked.value = {}
-  }
-
   const unlocked = useLocalStorage<Record<string, boolean>>(
     'shlagemon_achievements',
     {},
   )
+
+  function reset() {
+    counters.captures = 0
+    counters.wins = 0
+    counters.winsStronger = 0
+    counters.itemsUsed = 0
+    counters.kings = 0
+    counters.shiny = 0
+    unlocked.value = {}
+  }
 
   function unlock(id: string) {
     if (!unlocked.value[id]) {


### PR DESCRIPTION
## Summary
- reset achievements store when clearing save
- remove reset button from header
- show confirmation in profile modal before deleting progress

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH during unocss fetch, many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68678c08fb70832aadfc1ba1f57c80de