### PR TITLE
Fix battle pause during evolution

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -150,7 +150,7 @@ function checkEnd() {
     stopInterval()
     playerFainted.value = playerHp.value <= 0
     enemyFainted.value = enemyHp.value <= 0
-    setTimeout(() => {
+    setTimeout(async () => {
       if (dex.activeShlagemon) {
         dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
         playerHp.value = dex.activeShlagemon.hpCurrent
@@ -163,7 +163,7 @@ function checkEnd() {
         game.addShlagidolar(zone.rewardMultiplier)
         notifyAchievement({ type: 'battle-win', stronger })
         if (dex.activeShlagemon && enemy.value) {
-          dex.gainXp(
+          await dex.gainXp(
             dex.activeShlagemon,
             xpRewardForLevel(enemy.value.lvl),
             zone.current.maxLevel,

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -129,10 +129,10 @@ function checkEnd() {
       dex.activeShlagemon.hpCurrent = playerHp.value
     playerFainted.value = playerHp.value <= 0
     enemyFainted.value = enemyHp.value <= 0
-    setTimeout(() => {
+    setTimeout(async () => {
       if (enemyHp.value <= 0 && playerHp.value > 0) {
         if (dex.activeShlagemon && enemy.value) {
-          dex.gainXp(
+          await dex.gainXp(
             dex.activeShlagemon,
             xpRewardForLevel(enemy.value.lvl),
             undefined,


### PR DESCRIPTION
## Summary
- wait for XP gain to resolve before starting the next fight
- do this for wild battles and trainer battles

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6867989c6228832a8f1dff435a52a768