### PR TITLE
Add shlagemon release feature

### DIFF
--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -132,7 +132,7 @@ function isActive(mon: DexShlagemon) {
       </div>
     </div>
     <Modal v-model="showDetail" footer-close @close="showDetail = false">
-      <ShlagemonDetail :mon="detailMon" />
+      <ShlagemonDetail :mon="detailMon" @release="showDetail = false" />
     </Modal>
   </section>
 </template>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import { computed, ref } from 'vue'
+import Modal from '~/components/modal/Modal.vue'
+import Button from '~/components/ui/Button.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
+import { useShlagedexStore } from '~/stores/shlagedex'
 
 const props = defineProps<{ mon: DexShlagemon | null }>()
+const emit = defineEmits<{
+  (e: 'release'): void
+}>()
 
 const statColors = [
   'bg-red-200 dark:bg-red-700',
@@ -32,6 +39,24 @@ const allowEvolution = computed({
       (props.mon.allowEvolution = val)
   },
 })
+
+const store = useShlagedexStore()
+const showConfirm = ref(false)
+
+function requestRelease() {
+  showConfirm.value = true
+}
+
+function confirmRelease() {
+  if (props.mon)
+    store.releaseShlagemon(props.mon)
+  emit('release')
+  showConfirm.value = false
+}
+
+function cancelRelease() {
+  showConfirm.value = false
+}
 </script>
 
 <template>
@@ -71,6 +96,32 @@ const allowEvolution = computed({
       </div>
     </div>
     <ShlagemonXpBar :mon="mon" class="mt-4" />
+    <div class="mt-4 flex justify-end">
+      <Button type="danger" class="flex items-center gap-1" @click="requestRelease">
+        <div i-carbon-trash-can />
+        Relâcher
+      </Button>
+    </div>
+    <Modal v-model="showConfirm" :close-on-outside-click="false">
+      <div class="flex flex-col items-center gap-4">
+        <h3 class="text-lg font-bold">
+          Relâcher un Schlagemon ?
+        </h3>
+        <p class="text-center text-sm">
+          Attention, si vous le relâchez, il ira schlagiser tout le territoire.
+        </p>
+        <div class="flex gap-2">
+          <Button type="valid" class="flex items-center gap-1" @click="confirmRelease">
+            <div i-carbon-checkmark />
+            Oui
+          </Button>
+          <Button type="danger" class="flex items-center gap-1" @click="cancelRelease">
+            <div i-carbon-close />
+            Non
+          </Button>
+        </div>
+      </div>
+    </Modal>
   </div>
 </template>
 

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -273,7 +273,18 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return captured
   }
 
-  return { shlagemons, activeShlagemon, highestLevel, averageLevel, completionPercent, bonusPercent, bonusMultiplier, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, captureEnemy, gainXp, healActive, boostDefense }
+  function releaseShlagemon(mon: DexShlagemon) {
+    const index = shlagemons.value.findIndex(m => m.id === mon.id)
+    if (index === -1)
+      return
+    shlagemons.value.splice(index, 1)
+    if (activeShlagemon.value?.id === mon.id)
+      activeShlagemon.value = shlagemons.value[0] || null
+    recomputeHighestLevel()
+    toast(`${mon.base.name} a été relâché !`)
+  }
+
+  return { shlagemons, activeShlagemon, highestLevel, averageLevel, completionPercent, bonusPercent, bonusMultiplier, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, captureEnemy, releaseShlagemon, gainXp, healActive, boostDefense }
 }, {
   persist: {
     debug: true,


### PR DESCRIPTION
## Summary
- allow removing a schlagemon from the dex
- add release confirmation modal in the schlagemon detail
- close detail modal after releasing

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: FetchError to fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_68679a0fe014832a9ea6506f9a7dda5e