### PR TITLE
Add evolution stone item and modal

### DIFF
--- a/public/items/pierre-foudre/pierre-foudre.svg
+++ b/public/items/pierre-foudre/pierre-foudre.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="24,0 0,36 20,36 16,64 40,28 20,28" fill="#FDEE00" stroke="#FBC600" stroke-width="2"/>
+</svg>

--- a/src/components/inventory/EvolutionItemModal.vue
+++ b/src/components/inventory/EvolutionItemModal.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
+import Button from '~/components/ui/Button.vue'
+import { useEvolutionItemStore } from '~/stores/evolutionItem'
+
+const store = useEvolutionItemStore()
+</script>
+
+<template>
+  <Modal v-model="store.isVisible" footer-close>
+    <div class="flex flex-col gap-2">
+      <h3 class="text-center text-lg font-bold">
+        Utiliser {{ store.current?.name }}
+      </h3>
+      <div v-if="store.availableMons.length" class="flex flex-col gap-2">
+        <div
+          v-for="mon in store.availableMons"
+          :key="mon.id"
+          class="flex items-center justify-between border rounded p-2"
+        >
+          <div class="flex items-center gap-2">
+            <ShlagemonImage :id="mon.base.id" :alt="mon.base.name" class="h-6 w-6" />
+            <span>{{ mon.base.name }} (lvl {{ mon.lvl }})</span>
+          </div>
+          <Button class="text-xs" @click="store.useOn(mon)">
+            Évoluer
+          </Button>
+        </div>
+      </div>
+      <p v-else class="text-center text-sm">
+        Aucun Shlagémon compatible.
+      </p>
+    </div>
+  </Modal>
+</template>

--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -5,7 +5,7 @@ import Modal from '~/components/modal/Modal.vue'
 import Button from '~/components/ui/Button.vue'
 import { ballHues } from '~/utils/ball'
 
-const props = defineProps<{ item: Item, qty: number }>()
+const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
 const emit = defineEmits<{
   (e: 'use'): void
   (e: 'sell'): void
@@ -35,6 +35,7 @@ const ballFilter = computed(() =>
       <span class="font-bold">x{{ props.qty }}</span>
       <Button
         class="flex items-center gap-1 text-xs"
+        :disabled="props.disabled"
         @click="emit('use')"
       >
         <div i-carbon-play inline-block />

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
+import EvolutionItemModal from '~/components/inventory/EvolutionItemModal.vue'
 import InventoryItemCard from '~/components/inventory/InventoryItemCard.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import { useBallStore } from '~/stores/ball'
+import { useEvolutionItemStore } from '~/stores/evolutionItem'
 import { useInventoryStore } from '~/stores/inventory'
 
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
+const evoItemStore = useEvolutionItemStore()
 const search = ref('')
 const filteredList = computed(() => {
   const q = search.value.toLowerCase().trim()
@@ -15,9 +18,15 @@ const filteredList = computed(() => {
   return inventory.list.filter(entry => entry.item.name.toLowerCase().includes(q))
 })
 
+function isDisabled(item: Item) {
+  return item.type === 'evolution' && !evoItemStore.canUse(item)
+}
+
 function onUse(item: Item) {
   if ('catchBonus' in item)
     ballStore.setBall(item.id as any)
+  else if (item.type === 'evolution')
+    evoItemStore.open(item)
   else
     inventory.useItem(item.id)
 }
@@ -31,8 +40,10 @@ function onUse(item: Item) {
       :key="entry.item.id"
       :item="entry.item"
       :qty="entry.qty"
+      :disabled="isDisabled(entry.item)"
       @use="onUse(entry.item)"
       @sell="inventory.sell(entry.item.id)"
     />
   </section>
+  <EvolutionItemModal />
 </template>

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
+import ShlagediamondIcon from '~/components/icons/shlagediamond.vue'
+import ShlagidolarIcon from '~/components/icons/shlagidolar.vue'
 
 const props = defineProps<{ item: Item }>()
 </script>
@@ -11,7 +13,10 @@ const props = defineProps<{ item: Item }>()
       <span class="font-bold">{{ props.item.name }}</span>
       <span class="text-xs">{{ props.item.description }}</span>
     </div>
-    <span class="font-bold">{{ props.item.price }}$</span>
+    <span class="flex items-center gap-1 font-bold">
+      <component :is="props.item.currency === 'shlagidiamond' ? ShlagediamondIcon : ShlagidolarIcon" class="h-4 w-4" />
+      {{ props.item.price }}
+    </span>
     <slot />
   </div>
 </template>

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -7,6 +7,7 @@ export const potion: Item = {
   description: 'Soigne 50 HP de votre Shlagémon.',
   details: 'Redonne 50 points de vie à votre Shlagémon actif pendant le combat.',
   price: 5,
+  currency: 'shlagidolar',
 }
 
 export const defensePotion: Item = {
@@ -15,6 +16,7 @@ export const defensePotion: Item = {
   description: 'Augmente temporairement la défense.',
   details: 'Renforce brièvement la défense de votre Shlagémon actif.',
   price: 7,
+  currency: 'shlagidolar',
 }
 
 export const superPotion: Item = {
@@ -23,6 +25,7 @@ export const superPotion: Item = {
   description: 'Soigne 100 HP de votre Shlagémon.',
   details: 'Redonne 100 points de vie à votre Shlagémon actif pendant le combat.',
   price: 15,
+  currency: 'shlagidolar',
 }
 
 export const hyperPotion: Item = {
@@ -31,6 +34,18 @@ export const hyperPotion: Item = {
   description: 'Soigne 200 HP de votre Shlagémon.',
   details: 'Redonne 200 points de vie à votre Shlagémon actif pendant le combat.',
   price: 30,
+  currency: 'shlagidolar',
+}
+
+export const thunderStone: Item = {
+  id: 'pierre-foudre',
+  name: 'Pierre Foudre',
+  description: 'Permet certaines évolutions de type électrique.',
+  details: 'Fait évoluer Pikachiant en Raïchiotte.',
+  price: 10,
+  currency: 'shlagidiamond',
+  type: 'evolution',
+  image: '/items/pierre-foudre/pierre-foudre.svg',
 }
 
 export const allItems: Item[] = [
@@ -41,4 +56,5 @@ export const allItems: Item[] = [
   defensePotion,
   superPotion,
   hyperPotion,
+  thunderStone,
 ]

--- a/src/data/items/shlageball.ts
+++ b/src/data/items/shlageball.ts
@@ -7,6 +7,7 @@ export const shlageball: Ball = {
   details:
     'Permet de capturer le Shlagémon actuellement en combat. Moins il a de points de vie, plus la chance de capture augmente.',
   price: 10,
+  currency: 'shlagidolar',
   image: '/items/shlageball/shlageball.png',
   catchBonus: 1,
   animation: '/items/shlageball/shlageball.png',
@@ -19,6 +20,7 @@ export const superShlageball: Ball = {
   details:
     'Capture des Shlagémons plus récalcitrants avec un léger bonus de chance.',
   price: 25,
+  currency: 'shlagidolar',
   image: '/items/shlageball/shlageball.png',
   catchBonus: 1.5,
   animation: '/items/shlageball/shlageball.png',
@@ -31,6 +33,7 @@ export const hyperShlageball: Ball = {
   details:
     'Conçue pour capturer les Shlagémons coriaces, elle bénéficie d’un gros bonus.',
   price: 50,
+  currency: 'shlagidolar',
   image: '/items/shlageball/shlageball.png',
   catchBonus: 2,
   animation: '/items/shlageball/shlageball.png',

--- a/src/data/shlagemons/pikachiant.ts
+++ b/src/data/shlagemons/pikachiant.ts
@@ -1,4 +1,5 @@
 import type { BaseShlagemon } from '~/type'
+import { thunderStone } from '../items/items'
 import { shlagemonTypes } from '../shlagemons-type'
 import raichiotte from './raichiotte'
 
@@ -13,7 +14,7 @@ Il vit généralement dans des squats connectés où il recharge ses batteries a
     base: raichiotte,
     condition: {
       type: 'item',
-      value: '',
+      value: thunderStone,
     },
   },
 }

--- a/src/data/shops.ts
+++ b/src/data/shops.ts
@@ -4,6 +4,7 @@ import {
   hyperPotion,
   potion,
   superPotion,
+  thunderStone,
 } from './items/items'
 import { hyperShlageball, shlageball, superShlageball } from './items/shlageball'
 
@@ -16,7 +17,7 @@ export const shops: Shop[] = [
   {
     id: 'village-boule',
     level: 25,
-    items: [potion, superPotion, superShlageball, shlageball],
+    items: [potion, superPotion, superShlageball, shlageball, thunderStone],
   },
   {
     id: 'village-paume',

--- a/src/stores/evolutionItem.ts
+++ b/src/stores/evolutionItem.ts
@@ -1,0 +1,50 @@
+import type { Item } from '~/type/item'
+import type { DexShlagemon } from '~/type/shlagemon'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { useInventoryStore } from './inventory'
+import { useShlagedexStore } from './shlagedex'
+
+export const useEvolutionItemStore = defineStore('evolutionItem', () => {
+  const current = ref<Item | null>(null)
+  const dex = useShlagedexStore()
+  const inventory = useInventoryStore()
+
+  const isVisible = computed(() => current.value !== null)
+  const availableMons = computed(() => {
+    if (!current.value)
+      return []
+    return dex.shlagemons.filter((m) => {
+      const evo = m.base.evolution
+      return evo && evo.condition.type === 'item' && evo.condition.value.id === current.value!.id
+    })
+  })
+
+  function canUse(item: Item) {
+    return dex.shlagemons.some((m) => {
+      const evo = m.base.evolution
+      return evo && evo.condition.type === 'item' && evo.condition.value.id === item.id
+    })
+  }
+
+  function open(item: Item) {
+    current.value = item
+  }
+
+  function close() {
+    current.value = null
+  }
+
+  async function useOn(mon: DexShlagemon) {
+    if (!current.value)
+      return false
+    const success = await dex.evolveWithItem(mon, current.value)
+    if (success) {
+      inventory.remove(current.value.id)
+      close()
+    }
+    return success
+  }
+
+  return { current, isVisible, availableMons, open, close, useOn, canUse }
+})

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -40,9 +40,18 @@ export const useInventoryStore = defineStore('inventory', () => {
 
   function buy(id: string) {
     const item = allItems.find(i => i.id === id)
-    if (!item || game.shlagidolar < item.price)
+    if (!item)
       return false
-    game.addShlagidolar(-item.price)
+    if (item.currency === 'shlagidiamond') {
+      if (game.shlagidiamond < item.price)
+        return false
+      game.addShlagidiamond(-item.price)
+    }
+    else {
+      if (game.shlagidolar < item.price)
+        return false
+      game.addShlagidolar(-item.price)
+    }
     add(id)
     return true
   }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -1,3 +1,4 @@
+import type { Item } from '~/type/item'
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import type { Zone } from '~/type/zone'
 import { defineStore } from 'pinia'
@@ -119,18 +120,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
 
   const evolutionStore = useEvolutionStore()
 
-  async function checkEvolution(mon: DexShlagemon) {
-    const evo = mon.base.evolution
-    if (!evo)
-      return
-    if (evo.condition.type !== 'lvl' || mon.lvl < evo.condition.value)
-      return
-    if (!mon.allowEvolution)
-      return
-    const accepted = await evolutionStore.requestEvolution(mon, evo.base)
-    if (!accepted)
-      return
-    const existing = shlagemons.value.find(m => m.base.id === evo.base.id && m.id !== mon.id)
+  function applyEvolution(mon: DexShlagemon, to: BaseShlagemon) {
+    const existing = shlagemons.value.find(m => m.base.id === to.id && m.id !== mon.id)
     if (existing) {
       existing.captureCount += 1
       if (existing.rarity < 100) {
@@ -155,7 +146,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       recomputeHighestLevel()
     }
     else {
-      mon.base = evo.base
+      mon.base = to
       mon.baseStats = {
         hp: statWithRarityAndCoefficient(baseStats.hp, mon.base.coefficient, mon.rarity),
         attack: statWithRarityAndCoefficient(baseStats.attack, mon.base.coefficient, mon.rarity),
@@ -168,6 +159,33 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       mon.captureCount = 1
       toast(`${mon.base.name} a évolué !`)
     }
+  }
+
+  async function checkEvolution(mon: DexShlagemon) {
+    const evo = mon.base.evolution
+    if (!evo)
+      return
+    if (evo.condition.type !== 'lvl' || mon.lvl < evo.condition.value)
+      return
+    if (!mon.allowEvolution)
+      return
+    const accepted = await evolutionStore.requestEvolution(mon, evo.base)
+    if (!accepted)
+      return
+    applyEvolution(mon, evo.base)
+  }
+
+  async function evolveWithItem(mon: DexShlagemon, item: Item) {
+    const evo = mon.base.evolution
+    if (!evo || evo.condition.type !== 'item' || evo.condition.value.id !== item.id)
+      return false
+    if (!mon.allowEvolution)
+      return false
+    const accepted = await evolutionStore.requestEvolution(mon, evo.base)
+    if (!accepted)
+      return false
+    applyEvolution(mon, evo.base)
+    return true
   }
 
   async function gainXp(
@@ -281,7 +299,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return captured
   }
 
-  return { shlagemons, activeShlagemon, highestLevel, averageLevel, completionPercent, bonusPercent, bonusMultiplier, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, captureEnemy, gainXp, healActive, boostDefense }
+  return { shlagemons, activeShlagemon, highestLevel, averageLevel, completionPercent, bonusPercent, bonusMultiplier, addShlagemon, setActiveShlagemon, setShlagemons, reset, createShlagemon, captureShlagemon, captureEnemy, gainXp, healActive, boostDefense, evolveWithItem }
 }, {
   persist: {
     debug: true,

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -1,3 +1,5 @@
+export type ItemCurrency = 'shlagidolar' | 'shlagidiamond'
+
 export interface Item {
   id: string
   name: string
@@ -8,6 +10,10 @@ export interface Item {
    */
   details?: string
   price: number
+  /** Currency used to buy this item. Defaults to shlagidolar. */
+  currency?: ItemCurrency
+  /** Category of the item (consumable, ball, evolution...). */
+  type?: string
   image?: string
 }
 

--- a/src/type/shlagemonEvolution.ts
+++ b/src/type/shlagemonEvolution.ts
@@ -1,3 +1,4 @@
+import type { Item } from './item'
 import type { BaseShlagemon } from './shlagemon'
 
 export type ShlagemonEvolutionConditionType = 'lvl' | 'item'
@@ -8,7 +9,7 @@ export interface ShlagemonEvolutionConditionLevel {
 }
 export interface ShlagemonEvolutionConditionItem {
   type: 'item'
-  value: string
+  value: Item
 }
 
 export type ShlagemonEvolutionCondition = ShlagemonEvolutionConditionLevel | ShlagemonEvolutionConditionItem


### PR DESCRIPTION
## Summary
- introduce item currency and evolution type
- add `Pierre Foudre` evolution stone and use it for Pikachiant evolution
- display currency icon in Shop
- support evolution items in inventory with new modal
- handle item-based evolutions in store

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch errors while downloading fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68679f3f3ce8832a8df2134523040f6f