### PR TITLE
Add attack cursor on battle hover

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,7 @@ declare module 'vue' {
     AchievementsPanel: typeof import('./components/achievements/AchievementsPanel.vue')['default']
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
+    AttackCursor: typeof import('./components/battle/AttackCursor.vue')['default']
     BallSelectionModal: typeof import('./components/ball/BallSelectionModal.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
     BattleShlagemon: typeof import('./components/battle/BattleShlagemon.vue')['default']

--- a/src/components/battle/AttackCursor.vue
+++ b/src/components/battle/AttackCursor.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const props = defineProps<{ x: number, y: number, clicked: boolean }>()
+</script>
+
+<template>
+  <div
+    class="i-mdi:sword pointer-events-none fixed z-100 transition-all"
+    :class="props.clicked ? 'text-red-600 dark:text-red-400 scale-125' : 'text-white dark:text-gray-300 scale-100'"
+    :style="{ left: `${props.x + 8}px`, top: `${props.y + 8}px` }"
+  />
+</template>

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
@@ -64,6 +65,10 @@ const flashPlayer = ref(false)
 const flashEnemy = ref(false)
 const playerFainted = ref(false)
 const enemyFainted = ref(false)
+const showAttackCursor = ref(false)
+const cursorX = ref(0)
+const cursorY = ref(0)
+const cursorClicked = ref(false)
 const { playerEffect, enemyEffect, playerVariant, enemyVariant, showEffect } = useBattleEffects()
 const { start: startInterval, clear: stopInterval } = useSingleInterval(() => tick(), 1000)
 
@@ -126,6 +131,25 @@ function attack() {
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
   checkEnd()
+}
+
+function onMouseMove(e: MouseEvent) {
+  cursorX.value = e.clientX
+  cursorY.value = e.clientY
+}
+
+function onMouseEnter() {
+  showAttackCursor.value = true
+}
+
+function onMouseLeave() {
+  showAttackCursor.value = false
+}
+
+function onClick(_e: MouseEvent) {
+  cursorClicked.value = true
+  setTimeout(() => (cursorClicked.value = false), 150)
+  attack()
 }
 
 function tick() {
@@ -246,7 +270,15 @@ onUnmounted(() => {
         <div class="vs font-bold">
           VS
         </div>
-        <div v-if="enemy" class="mon relative flex flex-1 flex-col select-none items-center" :class="{ flash: flashEnemy }" @click="attack">
+        <div
+          v-if="enemy"
+          class="mon relative flex flex-1 flex-col select-none items-center"
+          :class="{ flash: flashEnemy }"
+          @click="onClick"
+          @mousemove="onMouseMove"
+          @mouseenter="onMouseEnter"
+          @mouseleave="onMouseLeave"
+        >
           <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
           <BattleShlagemon
             :mon="enemy"
@@ -257,6 +289,7 @@ onUnmounted(() => {
             :owned="enemyCaptured"
           />
         </div>
+        <AttackCursor v-if="showAttackCursor" :x="cursorX" :y="cursorY" :clicked="cursorClicked" />
       </div>
       <Button
         class="absolute right-50% top-8 aspect-square h-12 w-12 flex flex-col translate-x-1/2 cursor-pointer items-center gap-2 rounded-full text-xs"

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CharacterImage from '~/components/character/CharacterImage.vue'
@@ -41,6 +42,10 @@ const flashPlayer = ref(false)
 const flashEnemy = ref(false)
 const playerFainted = ref(false)
 const enemyFainted = ref(false)
+const showAttackCursor = ref(false)
+const cursorX = ref(0)
+const cursorY = ref(0)
+const cursorClicked = ref(false)
 const { playerEffect, enemyEffect, playerVariant, enemyVariant, showEffect } = useBattleEffects()
 const { start: startInterval, clear: stopInterval } = useSingleInterval(() => tick(), 1000)
 watch(trainer, (t) => {
@@ -102,6 +107,25 @@ function attack() {
   flashEnemy.value = true
   setTimeout(() => (flashEnemy.value = false), 100)
   checkEnd()
+}
+
+function onMouseMove(e: MouseEvent) {
+  cursorX.value = e.clientX
+  cursorY.value = e.clientY
+}
+
+function onMouseEnter() {
+  showAttackCursor.value = true
+}
+
+function onMouseLeave() {
+  showAttackCursor.value = false
+}
+
+function onClickArea(_e: MouseEvent) {
+  cursorClicked.value = true
+  setTimeout(() => (cursorClicked.value = false), 150)
+  attack()
 }
 
 function tick() {
@@ -219,7 +243,14 @@ onUnmounted(() => {
         </Button>
       </div>
     </div>
-    <div v-else-if="stage === 'battle'" class="w-full text-center" @click="attack">
+    <div
+      v-else-if="stage === 'battle'"
+      class="w-full text-center"
+      @click="onClickArea"
+      @mousemove="onMouseMove"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+    >
       <div class="mb-1 h-12 flex items-center justify-end gap-2 overflow-hidden font-bold">
         <div class="h-full flex flex-col">
           <div>{{ trainer.character.name }}</div>
@@ -241,6 +272,7 @@ onUnmounted(() => {
           <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
           <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" level-position="top" />
         </div>
+        <AttackCursor v-if="showAttackCursor" :x="cursorX" :y="cursorY" :clicked="cursorClicked" />
       </div>
     </div>
     <div v-else class="flex flex-col items-center gap-2 text-center">


### PR DESCRIPTION
## Summary
- show sword icon cursor during battle hover
- animate red sword on click

## Testing
- `pnpm test` *(fails: FetchError for webfonts, many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867a071c18c832ab103003addc524ca