### PR TITLE
Add potion icons and new attack/defense items

### DIFF
--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -21,8 +21,13 @@ const ballFilter = computed(() =>
 <template>
   <div class="relative flex flex-col gap-1 border rounded bg-white p-2 dark:bg-gray-900">
     <div class="flex items-center gap-2">
+      <div
+        v-if="props.item.icon"
+        class="h-8 w-8"
+        :class="[props.item.iconClass, `i-${props.item.icon}`]"
+      />
       <img
-        v-if="props.item.image"
+        v-else-if="props.item.image"
         :src="props.item.image"
         :alt="props.item.name"
         class="h-8 w-8 object-contain"
@@ -55,8 +60,13 @@ const ballFilter = computed(() =>
     </button>
     <Modal v-model="showInfo" footer-close>
       <div class="flex flex-col items-center gap-2">
+        <div
+          v-if="props.item.icon"
+          class="h-16 w-16"
+          :class="[props.item.iconClass, `i-${props.item.icon}`]"
+        />
         <img
-          v-if="props.item.image"
+          v-else-if="props.item.image"
           :src="props.item.image"
           :alt="props.item.name"
           class="h-16 w-16 object-contain"

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -8,7 +8,12 @@ const props = defineProps<{ item: Item }>()
 
 <template>
   <div class="flex items-center gap-2 border rounded bg-white p-2 dark:bg-gray-900">
-    <img v-if="props.item.image" :src="props.item.image" :alt="props.item.name" class="h-8 w-8 object-contain">
+    <div
+      v-if="props.item.icon"
+      class="h-8 w-8"
+      :class="[props.item.iconClass, `i-${props.item.icon}`]"
+    />
+    <img v-else-if="props.item.image" :src="props.item.image" :alt="props.item.name" class="h-8 w-8 object-contain">
     <div class="flex flex-1 flex-col text-left">
       <span class="font-bold">{{ props.item.name }}</span>
       <span class="text-xs">{{ props.item.description }}</span>

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -8,6 +8,8 @@ export const potion: Item = {
   details: 'Redonne 50 points de vie à votre Shlagémon actif pendant le combat.',
   price: 5,
   currency: 'shlagidolar',
+  icon: 'game-icons:health-potion',
+  iconClass: 'text-red-600 dark:text-red-400',
 }
 
 export const defensePotion: Item = {
@@ -17,6 +19,63 @@ export const defensePotion: Item = {
   details: 'Renforce brièvement la défense de votre Shlagémon actif.',
   price: 7,
   currency: 'shlagidolar',
+  icon: 'game-icons:magic-potion',
+  iconClass: 'text-blue-500 dark:text-blue-400',
+}
+
+export const superDefensePotion: Item = {
+  id: 'super-defense-potion',
+  name: 'Super Potion de Défense',
+  description: 'Augmente beaucoup la défense.',
+  details: 'Renforce considérablement la défense de votre Shlagémon actif.',
+  price: 15,
+  currency: 'shlagidolar',
+  icon: 'game-icons:round-potion',
+  iconClass: 'text-blue-600 dark:text-blue-500',
+}
+
+export const hyperDefensePotion: Item = {
+  id: 'hyper-defense-potion',
+  name: 'Hyper Potion de Défense',
+  description: 'Maximise temporairement la défense.',
+  details: 'Booste énormément la défense de votre Shlagémon actif.',
+  price: 25,
+  currency: 'shlagidolar',
+  icon: 'game-icons:standing-potion',
+  iconClass: 'text-blue-700 dark:text-blue-600',
+}
+
+export const attackPotion: Item = {
+  id: 'attack-potion',
+  name: 'Potion d\'Attaque',
+  description: 'Augmente temporairement l\'attaque.',
+  details: 'Renforce brièvement l\'attaque de votre Shlagémon actif.',
+  price: 7,
+  currency: 'shlagidolar',
+  icon: 'game-icons:magic-potion',
+  iconClass: 'text-orange-500 dark:text-orange-400',
+}
+
+export const superAttackPotion: Item = {
+  id: 'super-attack-potion',
+  name: 'Super Potion d\'Attaque',
+  description: 'Augmente beaucoup l\'attaque.',
+  details: 'Renforce considérablement l\'attaque de votre Shlagémon actif.',
+  price: 15,
+  currency: 'shlagidolar',
+  icon: 'game-icons:round-potion',
+  iconClass: 'text-orange-600 dark:text-orange-500',
+}
+
+export const hyperAttackPotion: Item = {
+  id: 'hyper-attack-potion',
+  name: 'Hyper Potion d\'Attaque',
+  description: 'Maximise temporairement l\'attaque.',
+  details: 'Booste énormément l\'attaque de votre Shlagémon actif.',
+  price: 25,
+  currency: 'shlagidolar',
+  icon: 'game-icons:standing-potion',
+  iconClass: 'text-orange-700 dark:text-orange-600',
 }
 
 export const superPotion: Item = {
@@ -26,6 +85,8 @@ export const superPotion: Item = {
   details: 'Redonne 100 points de vie à votre Shlagémon actif pendant le combat.',
   price: 15,
   currency: 'shlagidolar',
+  icon: 'game-icons:health-potion',
+  iconClass: 'text-violet-600 dark:text-violet-400',
 }
 
 export const hyperPotion: Item = {
@@ -35,6 +96,8 @@ export const hyperPotion: Item = {
   details: 'Redonne 200 points de vie à votre Shlagémon actif pendant le combat.',
   price: 30,
   currency: 'shlagidolar',
+  icon: 'game-icons:health-potion',
+  iconClass: 'text-yellow-500 dark:text-yellow-300',
 }
 
 export const thunderStone: Item = {
@@ -54,6 +117,11 @@ export const allItems: Item[] = [
   hyperShlageball,
   potion,
   defensePotion,
+  superDefensePotion,
+  hyperDefensePotion,
+  attackPotion,
+  superAttackPotion,
+  hyperAttackPotion,
   superPotion,
   hyperPotion,
   thunderStone,

--- a/src/data/shops.ts
+++ b/src/data/shops.ts
@@ -1,8 +1,13 @@
 import type { Shop } from '~/type'
 import {
+  attackPotion,
   defensePotion,
+  hyperAttackPotion,
+  hyperDefensePotion,
   hyperPotion,
   potion,
+  superAttackPotion,
+  superDefensePotion,
   superPotion,
   thunderStone,
 } from './items/items'
@@ -12,17 +17,17 @@ export const shops: Shop[] = [
   {
     id: 'village-veaux-du-gland',
     level: 10,
-    items: [potion, defensePotion, shlageball],
+    items: [potion, defensePotion, attackPotion, shlageball],
   },
   {
     id: 'village-boule',
     level: 25,
-    items: [potion, superPotion, superShlageball, shlageball, thunderStone],
+    items: [potion, superPotion, superDefensePotion, superAttackPotion, superShlageball, shlageball, thunderStone],
   },
   {
     id: 'village-paume',
     level: 50,
-    items: [hyperPotion, hyperShlageball],
+    items: [hyperPotion, hyperDefensePotion, hyperAttackPotion, hyperShlageball],
   },
 ]
 

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -78,6 +78,31 @@ export const useInventoryStore = defineStore('inventory', () => {
       remove(id)
       return true
     }
+    if (id === 'super-defense-potion') {
+      dex.boostDefense(10)
+      remove(id)
+      return true
+    }
+    if (id === 'hyper-defense-potion') {
+      dex.boostDefense(20)
+      remove(id)
+      return true
+    }
+    if (id === 'attack-potion') {
+      dex.boostAttack(5)
+      remove(id)
+      return true
+    }
+    if (id === 'super-attack-potion') {
+      dex.boostAttack(10)
+      remove(id)
+      return true
+    }
+    if (id === 'hyper-attack-potion') {
+      dex.boostAttack(20)
+      remove(id)
+      return true
+    }
     if (id === 'super-potion') {
       dex.healActive(100)
       remove(id)

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -118,6 +118,16 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     }, duration)
   }
 
+  function boostAttack(amount: number, duration = 10000) {
+    if (!activeShlagemon.value)
+      return
+    activeShlagemon.value.attack += amount
+    setTimeout(() => {
+      if (activeShlagemon.value)
+        activeShlagemon.value.attack -= amount
+    }, duration)
+  }
+
   const evolutionStore = useEvolutionStore()
 
   function applyEvolution(mon: DexShlagemon, to: BaseShlagemon) {
@@ -299,39 +309,39 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return captured
   }
 
-function releaseShlagemon(mon: DexShlagemon) {
-  const index = shlagemons.value.findIndex(m => m.id === mon.id)
-  if (index === -1)
-    return
-  shlagemons.value.splice(index, 1)
-  if (activeShlagemon.value?.id === mon.id)
-    activeShlagemon.value = shlagemons.value[0] || null
-  recomputeHighestLevel()
-  toast(`${mon.base.name} a été relâché !`)
-}
+  function releaseShlagemon(mon: DexShlagemon) {
+    const index = shlagemons.value.findIndex(m => m.id === mon.id)
+    if (index === -1)
+      return
+    shlagemons.value.splice(index, 1)
+    if (activeShlagemon.value?.id === mon.id)
+      activeShlagemon.value = shlagemons.value[0] || null
+    recomputeHighestLevel()
+    toast(`${mon.base.name} a été relâché !`)
+  }
 
-return {
-  shlagemons,
-  activeShlagemon,
-  highestLevel,
-  averageLevel,
-  completionPercent,
-  bonusPercent,
-  bonusMultiplier,
-  addShlagemon,
-  setActiveShlagemon,
-  setShlagemons,
-  reset,
-  createShlagemon,
-  captureShlagemon,
-  captureEnemy,
-  releaseShlagemon,
-  gainXp,
-  healActive,
-  boostDefense,
-  evolveWithItem,
-}
-
+  return {
+    shlagemons,
+    activeShlagemon,
+    highestLevel,
+    averageLevel,
+    completionPercent,
+    bonusPercent,
+    bonusMultiplier,
+    addShlagemon,
+    setActiveShlagemon,
+    setShlagemons,
+    reset,
+    createShlagemon,
+    captureShlagemon,
+    captureEnemy,
+    releaseShlagemon,
+    gainXp,
+    healActive,
+    boostDefense,
+    boostAttack,
+    evolveWithItem,
+  }
 }, {
   persist: {
     debug: true,

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -14,6 +14,10 @@ export interface Item {
   currency?: ItemCurrency
   /** Category of the item (consumable, ball, evolution...). */
   type?: string
+  /** Iconify icon name */
+  icon?: string
+  /** UnoCSS classes applied to the icon */
+  iconClass?: string
   image?: string
 }
 


### PR DESCRIPTION
## Summary
- support icon-based items
- show item icons in inventory and shop
- add attack/defense potion tiers with icons
- implement `boostAttack` and update stores
- update shops with new items
- fix lint

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: Cannot read properties of undefined; ENETUNREACH for fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6867a6df4798832a9f0bc34b6906a332