### PR TITLE
Add currency tooltip component and disable shop buy

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -24,6 +24,7 @@ declare module 'vue' {
     CaptureOverlay: typeof import('./components/battle/CaptureOverlay.vue')['default']
     CharacterImage: typeof import('./components/character/CharacterImage.vue')['default']
     CheckBox: typeof import('./components/ui/CheckBox.vue')['default']
+    CurrencyAmount: typeof import('./components/ui/CurrencyAmount.vue')['default']
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
     DialogPanel: typeof import('./components/panels/DialogPanel.vue')['default']
     DialogStarter: typeof import('./components/dialog/DialogStarter.vue')['default']

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -2,11 +2,10 @@
 import BallSelectionModal from '~/components/ball/BallSelectionModal.vue'
 import BonusIcon from '~/components/icons/bonus.vue'
 import SchlagedexIcon from '~/components/icons/schlagedex.vue'
-import ShlagediamondIcon from '~/components/icons/shlagediamond.vue'
-import ShlagidolarIcon from '~/components/icons/shlagidolar.vue'
 import XpIcon from '~/components/icons/xp.vue'
 import Modal from '~/components/modal/Modal.vue'
 import BonusDetails from '~/components/panels/BonusDetails.vue'
+import CurrencyAmount from '~/components/ui/CurrencyAmount.vue'
 import Tooltip from '~/components/ui/Tooltip.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { useBallStore } from '~/stores/ball'
@@ -28,18 +27,8 @@ const totalInDex = allShlagemons.length
     class="w-full inline-flex items-center justify-around gap-3 rounded bg-white text-xs dark:bg-gray-900"
     sm="text-sm"
   >
-    <Tooltip text="Shlagidolars">
-      <div class="min-w-0 flex items-center gap-1">
-        <ShlagidolarIcon class="h-4 w-4" />
-        <span class="shrink-0 font-bold">{{ game.shlagidolar.toLocaleString() }}</span>
-      </div>
-    </Tooltip>
-    <Tooltip text="Shlagidiamond">
-      <div class="min-w-0 flex items-center gap-1">
-        <ShlagediamondIcon class="h-4 w-4" />
-        <span class="shrink-0 font-bold">{{ game.shlagidiamond?.toLocaleString() }}</span>
-      </div>
-    </Tooltip>
+    <CurrencyAmount :amount="game.shlagidolar" currency="shlagidolar" />
+    <CurrencyAmount :amount="game.shlagidiamond" currency="shlagidiamond" />
     <Tooltip text="SchlagéDex">
       <div class="min-w-0 flex items-center gap-1">
         <SchlagedexIcon class="h-4 w-4" />

--- a/src/components/panels/ShopPanel.vue
+++ b/src/components/panels/ShopPanel.vue
@@ -1,14 +1,23 @@
 <script setup lang="ts">
+import type { Item } from '~/type/item'
 import { computed } from 'vue'
 import ItemCard from '~/components/shop/ItemCard.vue'
 import Button from '~/components/ui/Button.vue'
 import { getShop } from '~/data/shops'
+import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
 import { useZoneStore } from '~/stores/zone'
 
 const inventory = useInventoryStore()
+const game = useGameStore()
 const zone = useZoneStore()
 const shopItems = computed(() => getShop(zone.current.id)?.items || [])
+
+function canBuy(item: Item) {
+  if (item.currency === 'shlagidiamond')
+    return game.shlagidiamond >= item.price
+  return game.shlagidolar >= item.price
+}
 </script>
 
 <template>
@@ -18,7 +27,7 @@ const shopItems = computed(() => getShop(zone.current.id)?.items || [])
     </h2>
     <div class="flex flex-col gap-2 overflow-auto">
       <ItemCard v-for="item in shopItems" :key="item.id" :item="item">
-        <Button class="ml-2" @click="inventory.buy(item.id)">
+        <Button class="ml-2" :disabled="!canBuy(item)" @click="inventory.buy(item.id)">
           Acheter
         </Button>
       </ItemCard>

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
-import ShlagediamondIcon from '~/components/icons/shlagediamond.vue'
-import ShlagidolarIcon from '~/components/icons/shlagidolar.vue'
+import CurrencyAmount from '~/components/ui/CurrencyAmount.vue'
 
 const props = defineProps<{ item: Item }>()
 </script>
@@ -18,10 +17,7 @@ const props = defineProps<{ item: Item }>()
       <span class="font-bold">{{ props.item.name }}</span>
       <span class="text-xs">{{ props.item.description }}</span>
     </div>
-    <span class="flex items-center gap-1 font-bold">
-      <component :is="props.item.currency === 'shlagidiamond' ? ShlagediamondIcon : ShlagidolarIcon" class="h-4 w-4" />
-      {{ props.item.price }}
-    </span>
+    <CurrencyAmount :amount="props.item.price" :currency="props.item.currency" />
     <slot />
   </div>
 </template>

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -23,7 +23,7 @@ const variantClass = computed(() => {
 </script>
 
 <template>
-  <button class="inline-flex items-center justify-center" :class="variantClass">
+  <button class="inline-flex items-center justify-center disabled:cursor-not-allowed disabled:opacity-50" :class="variantClass">
     <slot />
   </button>
 </template>

--- a/src/components/ui/CurrencyAmount.vue
+++ b/src/components/ui/CurrencyAmount.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import ShlagediamondIcon from '~/components/icons/shlagediamond.vue'
+import ShlagidolarIcon from '~/components/icons/shlagidolar.vue'
+import Tooltip from '~/components/ui/Tooltip.vue'
+
+const props = defineProps<{
+  amount: number
+  currency: 'shlagidolar' | 'shlagidiamond'
+}>()
+
+const currencyName = computed(() => props.currency === 'shlagidiamond' ? 'Shlagidiamond' : 'Shlagidolar')
+const icon = computed(() => props.currency === 'shlagidiamond' ? ShlagediamondIcon : ShlagidolarIcon)
+</script>
+
+<template>
+  <Tooltip :text="currencyName">
+    <span class="inline-flex items-center gap-1">
+      <component :is="icon" class="h-4 w-4" />
+      <span class="font-bold">{{ amount.toLocaleString() }}</span>
+    </span>
+  </Tooltip>
+</template>


### PR DESCRIPTION
## Summary
- add CurrencyAmount component
- show player's currencies with CurrencyAmount
- use CurrencyAmount for item price
- disable shop buy button if currency is insufficient
- allow Button to show disabled style

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, Snapshot mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_6867aa90b638832a8fc354aee9b8a55a