### PR TITLE
Implement attack/defense potions with active effects

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -265,7 +265,7 @@ onUnmounted(() => {
       <div class="w-full flex flex-1 items-center justify-center gap-4">
         <div class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" flipped />
+          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" flipped :effects="dex.effects" />
         </div>
         <div class="vs font-bold">
           VS

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+import type { ActiveEffect } from '~/type/effect'
 import type { DexShlagemon } from '~/type/shlagemon'
+import { onUnmounted, ref } from 'vue'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
+import Tooltip from '~/components/ui/Tooltip.vue'
 
 interface Props {
   mon: DexShlagemon
@@ -12,6 +15,7 @@ interface Props {
   levelPosition?: 'top' | 'bottom'
   showBall?: boolean
   owned?: boolean
+  effects?: ActiveEffect[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -21,9 +25,16 @@ const props = withDefaults(defineProps<Props>(), {
   levelPosition: 'bottom',
   showBall: false,
   owned: false,
+  effects: () => [],
 })
 
 const emit = defineEmits<{ (e: 'faintEnd'): void }>()
+
+const now = ref(Date.now())
+const timer = window.setInterval(() => {
+  now.value = Date.now()
+}, 1000)
+onUnmounted(() => window.clearInterval(timer))
 
 function onAnimationEnd() {
   if (props.fainted)
@@ -33,6 +44,20 @@ function onAnimationEnd() {
 
 <template>
   <div class="relative w-full flex flex-col items-center">
+    <div class="absolute left-0 top-0 flex gap-1">
+      <Tooltip
+        v-for="e in props.effects"
+        :key="e.id"
+        :text="e.type === 'attack' ? `Attaque +${e.percent}%` : `Défense +${e.percent}%`"
+      >
+        <div class="relative h-5 w-5">
+          <div class="h-5 w-5" :class="[`i-${e.icon}`, e.iconClass]" />
+          <span class="absolute rounded-full bg-white px-0.5 text-[10px] font-bold -right-1 -top-1 dark:bg-gray-800">
+            {{ Math.ceil((e.expiresAt - now.value) / 1000) }}
+          </span>
+        </div>
+      </Tooltip>
+    </div>
     <ShlagemonImage
       :id="props.mon.base.id"
       :alt="props.mon.base.name"

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -263,7 +263,7 @@ onUnmounted(() => {
       <div class="flex flex-1 items-center justify-center gap-4">
         <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" level-position="top" />
+          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" level-position="top" :effects="dex.effects" />
         </div>
         <div class="vs font-bold">
           VS

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -74,32 +74,32 @@ export const useInventoryStore = defineStore('inventory', () => {
       return true
     }
     if (id === 'defense-potion') {
-      dex.boostDefense(5)
+      dex.boostDefense(10, allItems.find(i => i.id === id)?.icon, allItems.find(i => i.id === id)?.iconClass)
       remove(id)
       return true
     }
     if (id === 'super-defense-potion') {
-      dex.boostDefense(10)
+      dex.boostDefense(25, allItems.find(i => i.id === id)?.icon, allItems.find(i => i.id === id)?.iconClass)
       remove(id)
       return true
     }
     if (id === 'hyper-defense-potion') {
-      dex.boostDefense(20)
+      dex.boostDefense(50, allItems.find(i => i.id === id)?.icon, allItems.find(i => i.id === id)?.iconClass)
       remove(id)
       return true
     }
     if (id === 'attack-potion') {
-      dex.boostAttack(5)
+      dex.boostAttack(10, allItems.find(i => i.id === id)?.icon, allItems.find(i => i.id === id)?.iconClass)
       remove(id)
       return true
     }
     if (id === 'super-attack-potion') {
-      dex.boostAttack(10)
+      dex.boostAttack(25, allItems.find(i => i.id === id)?.icon, allItems.find(i => i.id === id)?.iconClass)
       remove(id)
       return true
     }
     if (id === 'hyper-attack-potion') {
-      dex.boostAttack(20)
+      dex.boostAttack(50, allItems.find(i => i.id === id)?.icon, allItems.find(i => i.id === id)?.iconClass)
       remove(id)
       return true
     }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -1,3 +1,4 @@
+import type { ActiveEffect } from '~/type/effect'
 import type { Item } from '~/type/item'
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import type { Zone } from '~/type/zone'
@@ -19,6 +20,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const shlagemons = ref<DexShlagemon[]>([])
   const activeShlagemon = ref<DexShlagemon | null>(null)
   const highestLevel = ref(0)
+  const effects = ref<ActiveEffect[]>([])
   const progress = useZoneProgressStore()
 
   const xpZones = computed(() => zonesData.filter(z => z.maxLevel > 0))
@@ -108,21 +110,59 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     )
   }
 
-  function boostDefense(amount: number, duration = 10000) {
+  function boostDefense(
+    percent: number,
+    icon?: string,
+    iconClass?: string,
+    duration = 600000,
+  ) {
     if (!activeShlagemon.value)
       return
+    const amount = Math.floor(activeShlagemon.value.defense * percent / 100)
     activeShlagemon.value.defense += amount
+    const effect: ActiveEffect = {
+      id: Date.now() + Math.random(),
+      type: 'defense',
+      percent,
+      icon,
+      iconClass,
+      expiresAt: Date.now() + duration,
+      amount,
+    }
+    effects.value.push(effect)
     setTimeout(() => {
+      const idx = effects.value.findIndex(e => e.id === effect.id)
+      if (idx >= 0)
+        effects.value.splice(idx, 1)
       if (activeShlagemon.value)
         activeShlagemon.value.defense -= amount
     }, duration)
   }
 
-  function boostAttack(amount: number, duration = 10000) {
+  function boostAttack(
+    percent: number,
+    icon?: string,
+    iconClass?: string,
+    duration = 600000,
+  ) {
     if (!activeShlagemon.value)
       return
+    const amount = Math.floor(activeShlagemon.value.attack * percent / 100)
     activeShlagemon.value.attack += amount
+    const effect: ActiveEffect = {
+      id: Date.now() + Math.random(),
+      type: 'attack',
+      percent,
+      icon,
+      iconClass,
+      expiresAt: Date.now() + duration,
+      amount,
+    }
+    effects.value.push(effect)
     setTimeout(() => {
+      const idx = effects.value.findIndex(e => e.id === effect.id)
+      if (idx >= 0)
+        effects.value.splice(idx, 1)
       if (activeShlagemon.value)
         activeShlagemon.value.attack -= amount
     }, duration)
@@ -340,6 +380,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     healActive,
     boostDefense,
     boostAttack,
+    effects,
     evolveWithItem,
   }
 }, {

--- a/src/type/effect.ts
+++ b/src/type/effect.ts
@@ -1,0 +1,9 @@
+export interface ActiveEffect {
+  id: number
+  type: 'attack' | 'defense'
+  percent: number
+  icon?: string
+  iconClass?: string
+  expiresAt: number
+  amount: number
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,6 +1,7 @@
 export * from './ball'
 export * from './button'
 export * from './dialog'
+export * from './effect'
 export * from './item'
 export * from './shlagemon'
 export * from './shlagemonEvolution'


### PR DESCRIPTION
## Summary
- add `ActiveEffect` type for temporary boosts
- track active attack/defense boosts in `shlagedex` store
- apply percentage-based boosts when using potions
- display active boost icons with countdown in battle UI

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6867acb4da00832a95b21ffcb2e03fce