### PR TITLE
Add shiny encounter alert

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { toast } from 'vue3-toastify'
 import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
@@ -114,6 +115,8 @@ function startBattle() {
   created.lvl = lvl
   applyStats(created)
   enemy.value = created
+  if (created.isShiny)
+    toast('Vous avez rencontré un Shiny !')
   if (active.hpCurrent <= 0)
     active.hpCurrent = active.hp
   playerHp.value = active.hpCurrent

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { toast } from 'vue3-toastify'
 import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
@@ -94,6 +95,8 @@ function startBattle() {
   created.lvl = spec.level
   applyStats(created)
   enemy.value = created
+  if (created.isShiny)
+    toast('Vous avez rencontré un Shiny !')
   enemyHp.value = enemy.value.hp
   battleActive.value = true
   startInterval()


### PR DESCRIPTION
## Summary
- show toast alert when a shiny appears in wild battles
- notify the player for shiny in trainer battles

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined, snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6867aff8e3e0832aa729b8acf7c0762f