### PR TITLE
Adjust shiny spawn rate

### DIFF
--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -62,7 +62,7 @@ export function createDexShlagemon(
     defense: 0,
     smelling: 0,
     sex: Math.random() < 0.5 ? 'male' : 'female',
-    isShiny: shiny || Math.random() < 0.0001,
+    isShiny: shiny || Math.random() < 0.01,
     hpCurrent: 0,
     allowEvolution: true,
   }


### PR DESCRIPTION
## Summary
- increase shiny spawn rate to 1%

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined, snapshot mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_6867b03e7bb8832a87065990f15454bb