### PR TITLE
Update active Shlagemon style

### DIFF
--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -110,8 +110,7 @@ function isActive(mon: DexShlagemon) {
         :key="mon.id"
         class="relative flex cursor-pointer items-center justify-between border rounded p-2"
         hover="bg-gray-100 dark:bg-gray-800"
-        :class="{ 'bg-primary/20': isActive(mon) }"
-        :style="isActive(mon) ? { backgroundImage: `url(/shlagemons/${mon.base.id}/${mon.base.id}.png)`, backgroundRepeat: 'no-repeat', backgroundSize: 'cover', backgroundPosition: 'center' } : {}"
+        :class="isActive(mon) ? 'bg-blue-500/20 dark:bg-blue-500/20 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400' : ''"
         @click.stop="open(mon)"
       >
         <div class="absolute bottom-0 right-2 text-xs">


### PR DESCRIPTION
## Summary
- highlight active Shlagemon list entry with a blue ring and border

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshot mismatches and runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867b13438a0832a8fc8da7b752d861d