### PR TITLE
Add double-click selection in Shlagedex

### DIFF
--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -74,6 +74,10 @@ function open(mon: DexShlagemon | null) {
   }
 }
 
+function onDoubleClick(mon: DexShlagemon) {
+  changeActive(mon)
+}
+
 function changeActive(mon: DexShlagemon) {
   if (isTrainerBattle.value)
     return
@@ -113,6 +117,7 @@ function isActive(mon: DexShlagemon) {
         :class="{ 'bg-primary/20': isActive(mon) }"
         :style="isActive(mon) ? { backgroundImage: `url(/shlagemons/${mon.base.id}/${mon.base.id}.png)`, backgroundRepeat: 'no-repeat', backgroundSize: 'cover', backgroundPosition: 'center' } : {}"
         @click.stop="open(mon)"
+        @dblclick.stop="onDoubleClick(mon)"
       >
         <div class="absolute bottom-0 right-2 text-xs">
           lvl {{ mon.lvl }}

--- a/test/double-click.test.ts
+++ b/test/double-click.test.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import Shlagedex from '../src/components/shlagemon/Shlagedex.vue'
+import { carapouffe } from '../src/data/shlagemons'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('shlagedex double click', () => {
+  it('activates shlagemon on double click', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    const wrapper = mount(Shlagedex, {
+      global: {
+        plugins: [pinia],
+        stubs: [
+          'ShlagemonImage',
+          'ShlagemonType',
+          'Modal',
+          'SearchInput',
+          'SelectOption',
+          'CheckBox',
+        ],
+      },
+    })
+    const item = wrapper.find('div.relative')
+    await item.trigger('dblclick')
+    expect(dex.activeShlagemon?.id).toBe(mon.id)
+  })
+})


### PR DESCRIPTION
## Summary
- support activating a shlagemon on double click via `@dblclick`
- test new behaviour without timers

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6867addac2f4832a8e322856d129d0b8