### PR TITLE
Fix potion timer display and level position

### DIFF
--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -5,6 +5,7 @@ import { onUnmounted, ref } from 'vue'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import Tooltip from '~/components/ui/Tooltip.vue'
+import { formatDuration } from '~/utils/formatDuration'
 
 interface Props {
   mon: DexShlagemon
@@ -40,6 +41,10 @@ function onAnimationEnd() {
   if (props.fainted)
     emit('faintEnd')
 }
+
+function remainingTime(effect: ActiveEffect) {
+  return formatDuration(effect.expiresAt - now.value)
+}
 </script>
 
 <template>
@@ -53,7 +58,7 @@ function onAnimationEnd() {
         <div class="relative h-5 w-5">
           <div class="h-5 w-5" :class="[`i-${e.icon}`, e.iconClass]" />
           <span class="absolute rounded-full bg-white px-0.5 text-[10px] font-bold -right-1 -top-1 dark:bg-gray-800">
-            {{ Math.ceil((e.expiresAt - now.value) / 1000) }}
+            {{ remainingTime(e) }}
           </span>
         </div>
       </Tooltip>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -263,14 +263,14 @@ onUnmounted(() => {
       <div class="flex flex-1 items-center justify-center gap-4">
         <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" level-position="top" :effects="dex.effects" />
+          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" :effects="dex.effects" />
         </div>
         <div class="vs font-bold">
           VS
         </div>
         <div v-if="enemy" class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
           <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-          <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" level-position="top" />
+          <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" />
         </div>
         <AttackCursor v-if="showAttackCursor" :x="cursorX" :y="cursorY" :clicked="cursorClicked" />
       </div>

--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,0 +1,14 @@
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms))
+    return '∞'
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  if (hours >= 100)
+    return '∞'
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  const pad = (n: number) => String(n).padStart(2, '0')
+  if (hours > 0)
+    return `${hours}:${pad(minutes)}:${pad(seconds)}`
+  return `${minutes}:${pad(seconds)}`
+}


### PR DESCRIPTION
## Summary
- display potion effect countdown using formatted duration
- keep level text at bottom in trainer battles

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_6867b327f570832a802315ceff2b6f18