### PR TITLE
Add timed potion stacking

### DIFF
--- a/src/type/effect.ts
+++ b/src/type/effect.ts
@@ -6,4 +6,5 @@ export interface ActiveEffect {
   iconClass?: string
   expiresAt: number
   amount: number
+  timeoutId?: number
 }

--- a/test/potion-timer.test.ts
+++ b/test/potion-timer.test.ts
@@ -1,0 +1,33 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('potion timer', () => {
+  it('extends and replaces potion effects', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(mon)
+
+    dex.boostDefense(10)
+    expect(dex.effects.length).toBe(1)
+    const firstExpire = dex.effects[0].expiresAt
+    vi.advanceTimersByTime(60_000)
+    dex.boostDefense(10)
+    expect(dex.effects[0].expiresAt).toBe(firstExpire + 600_000)
+
+    const baseDefense = mon.baseStats.defense
+    dex.boostDefense(25)
+    expect(dex.effects.length).toBe(1)
+    expect(dex.effects[0].percent).toBe(25)
+    expect(mon.defense).toBe(baseDefense + Math.floor(baseDefense * 25 / 100))
+
+    vi.advanceTimersByTime(600_000)
+    vi.runOnlyPendingTimers()
+    expect(dex.effects.length).toBe(0)
+    expect(mon.defense).toBe(baseDefense)
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- support timer checks for active attack/defense potions
- extend effect duration on repeated use
- replace weaker potion when a stronger one is used
- test behaviour of potion timers

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH while fetching google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6867b6ae1df4832aa6376d0e48b64f16