### PR TITLE
Implement random battle and village music

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -41,12 +41,14 @@ const isAchievementVisible = computed(() => achievements.hasAny)
 watch(
   () => [mainPanel.current, zone.current.type],
   ([panel, type]) => {
-    if (['battle', 'trainerBattle'].includes(panel))
-      audio.fadeToMusic('/audio/battle.ogg')
+    if (panel === 'battle')
+      audio.fadeToRandomMusic('battle')
+    else if (panel === 'trainerBattle')
+      audio.fadeToRandomMusic('trainers')
     else if (type === 'village')
-      audio.fadeToMusic('/audio/ambient.ogg')
+      audio.fadeToRandomMusic('villages')
     else
-      audio.fadeToMusic('/audio/ambient.ogg')
+      audio.fadeToRandomMusic('villages')
   },
   { immediate: true },
 )

--- a/src/modules/audio.ts
+++ b/src/modules/audio.ts
@@ -6,5 +6,5 @@ export const install: UserModule = ({ isClient }) => {
     return
   const audio = useAudioStore()
   if (audio.isMusicEnabled && !audio.currentMusic)
-    audio.playMusic('/audio/ambient.ogg')
+    audio.playRandomMusic('villages')
 }

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -9,6 +9,31 @@ export const useAudioStore = defineStore('audio', () => {
   const isSfxEnabled = ref(true)
   const currentMusic = ref<Howl | null>(null)
 
+  const tracks = {
+    battle: [
+      '/audio/musics/battle/battle-a.ogg',
+      '/audio/musics/battle/battle-b.ogg',
+      '/audio/musics/battle/battle-c.ogg',
+      '/audio/musics/battle/battle-d.ogg',
+    ],
+    trainers: [
+      '/audio/musics/trainers/trainer-a.ogg',
+      '/audio/musics/trainers/trainer-b.ogg',
+      '/audio/musics/trainers/trainer-c.ogg',
+      '/audio/musics/trainers/trainer-d.ogg',
+    ],
+    villages: [
+      '/audio/musics/villages/village-a.ogg',
+      '/audio/musics/villages/village-b.ogg',
+      '/audio/musics/villages/village-c.ogg',
+    ],
+  } as const
+
+  function randomTrack(category: keyof typeof tracks) {
+    const list = tracks[category]
+    return list[Math.floor(Math.random() * list.length)]
+  }
+
   function createMusic(src: string) {
     return new Howl({
       src: [src],
@@ -44,6 +69,14 @@ export const useAudioStore = defineStore('audio', () => {
     else {
       playMusic(track)
     }
+  }
+
+  function playRandomMusic(category: keyof typeof tracks) {
+    playMusic(randomTrack(category))
+  }
+
+  function fadeToRandomMusic(category: keyof typeof tracks) {
+    fadeToMusic(randomTrack(category))
   }
 
   function stopMusic() {
@@ -83,6 +116,8 @@ export const useAudioStore = defineStore('audio', () => {
     currentMusic,
     playMusic,
     fadeToMusic,
+    playRandomMusic,
+    fadeToRandomMusic,
     stopMusic,
     playSfx,
   }


### PR DESCRIPTION
## Summary
- preload new battle, trainer and village songs
- play random music when game loads or context changes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca1136ec832a8da5abfbd5143f17