### PR TITLE
Move audio settings button

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import AudioSettingsModal from '~/components/audio/AudioSettingsModal.vue'
 import Profile from '~/components/profile/Profile.vue'
 import ThemeToggle from '~/components/ThemeToggle.vue'
 import Button from '~/components/ui/Button.vue'
 
 const showProfile = ref(false)
+const showAudio = ref(false)
 </script>
 
 <template>
@@ -12,6 +14,10 @@ const showProfile = ref(false)
     <img src="/logo.png" alt="Logo Shlagémon" class="h-20 -my-4">
     <div class="flex items-center gap-2">
       <ThemeToggle />
+      <Button type="icon" aria-label="Audio" @click="showAudio = true">
+        <div class="i-carbon-volume-up" />
+      </Button>
+      <AudioSettingsModal v-model="showAudio" />
       <Button type="icon" aria-label="Profil" @click="showProfile = true">
         <div class="i-carbon-user" />
       </Button>

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import AudioSettingsModal from '~/components/audio/AudioSettingsModal.vue'
 import BallSelectionModal from '~/components/ball/BallSelectionModal.vue'
 import BonusIcon from '~/components/icons/bonus.vue'
 import SchlagedexIcon from '~/components/icons/schlagedex.vue'
@@ -19,7 +18,6 @@ const inventory = useInventoryStore()
 const ballStore = useBallStore()
 
 const showBonus = ref(false)
-const showAudio = ref(false)
 
 const totalInDex = allShlagemons.length
 </script>
@@ -70,11 +68,5 @@ const totalInDex = allShlagemons.length
       </div>
     </Tooltip>
     <BallSelectionModal />
-    <Tooltip text="Audio">
-      <div class="min-w-0 flex cursor-pointer items-center gap-1" @click="showAudio = true">
-        <div class="h-4 w-4" i-carbon-volume-up />
-      </div>
-    </Tooltip>
-    <AudioSettingsModal v-model="showAudio" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show audio settings in app header
- clean up PlayerInfos panel

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch errors for google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6867ccdcb460832aa343dba8d2f79570