### PR TITLE
Add player creation form and store

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -235,6 +235,7 @@ declare global {
   const useParentElement: typeof import('@vueuse/core')['useParentElement']
   const usePerformanceObserver: typeof import('@vueuse/core')['usePerformanceObserver']
   const usePermission: typeof import('@vueuse/core')['usePermission']
+  const usePlayerStore: typeof import('./stores/player')['usePlayerStore']
   const usePointer: typeof import('@vueuse/core')['usePointer']
   const usePointerLock: typeof import('@vueuse/core')['usePointerLock']
   const usePointerSwipe: typeof import('@vueuse/core')['usePointerSwipe']
@@ -582,6 +583,7 @@ declare module 'vue' {
     readonly useParentElement: UnwrapRef<typeof import('@vueuse/core')['useParentElement']>
     readonly usePerformanceObserver: UnwrapRef<typeof import('@vueuse/core')['usePerformanceObserver']>
     readonly usePermission: UnwrapRef<typeof import('@vueuse/core')['usePermission']>
+    readonly usePlayerStore: UnwrapRef<typeof import('./stores/player')['usePlayerStore']>
     readonly usePointer: UnwrapRef<typeof import('@vueuse/core')['usePointer']>
     readonly usePointerLock: UnwrapRef<typeof import('@vueuse/core')['usePointerLock']>
     readonly usePointerSwipe: UnwrapRef<typeof import('@vueuse/core')['usePointerSwipe']>

--- a/src/pages/player.vue
+++ b/src/pages/player.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import Button from '~/components/ui/Button.vue'
+import SearchInput from '~/components/ui/SearchInput.vue'
+import SelectOption from '~/components/ui/SelectOption.vue'
+import { usePlayerStore } from '~/stores/player'
+
+const store = usePlayerStore()
+
+const pseudo = ref(store.pseudo)
+const realName = ref(store.realName)
+const gender = ref(store.gender)
+
+function submit() {
+  store.setPlayer({ pseudo: pseudo.value, realName: realName.value, gender: gender.value })
+}
+</script>
+
+<route lang="yaml">
+head:
+  title: Profil Joueur
+</route>
+
+<template>
+  <form class="m-auto max-w-96 flex flex-col gap-4 p-4" @submit.prevent="submit">
+    <label class="flex flex-col gap-1">
+      <span>Pseudo</span>
+      <SearchInput v-model="pseudo" placeholder="Votre pseudo" />
+    </label>
+    <label class="flex flex-col gap-1">
+      <span>Nom</span>
+      <SearchInput v-model="realName" placeholder="Votre nom" />
+    </label>
+    <label class="flex flex-col gap-1">
+      <span>Genre</span>
+      <SelectOption
+        v-model="gender"
+        :options="[
+          { label: 'Homme', value: 'male' },
+          { label: 'Femme', value: 'female' },
+          { label: 'Autre', value: 'unknown' },
+        ]"
+      />
+    </label>
+    <Button type="primary" class="mt-2">
+      Valider
+    </Button>
+  </form>
+</template>

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -1,0 +1,35 @@
+import type { Character } from '~/type/character'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export const usePlayerStore = defineStore('player', () => {
+  const pseudo = ref('')
+  const realName = ref('')
+  const gender = ref<Character['gender']>('unknown')
+
+  const character = computed<Character>(() => ({
+    id: 'player',
+    name: pseudo.value,
+    gender: gender.value,
+  }))
+
+  function setPlayer(data: {
+    pseudo: string
+    realName: string
+    gender: Character['gender']
+  }) {
+    pseudo.value = data.pseudo
+    realName.value = data.realName
+    gender.value = data.gender
+  }
+
+  function reset() {
+    pseudo.value = ''
+    realName.value = ''
+    gender.value = 'unknown'
+  }
+
+  return { pseudo, realName, gender, character, setPlayer, reset }
+}, {
+  persist: true,
+})

--- a/src/typed-router.d.ts
+++ b/src/typed-router.d.ts
@@ -19,6 +19,7 @@ declare module 'vue-router/auto-routes' {
    */
   export interface RouteNamedMap {
     '/': RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>,
+    '/player': RouteRecordInfo<'/player', '/player', Record<never, never>, Record<never, never>>,
     '/README': RouteRecordInfo<'/README', '/README', Record<never, never>, Record<never, never>>,
   }
 }


### PR DESCRIPTION
## Summary
- create Pinia store for player data
- add a new page with a form to set pseudo, name and gender
- auto generate route and imports

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Could not find a declaration file for module 'howler', and other TypeScript errors)*
- `pnpm test` *(fails: multiple failing tests due to existing code issues)*

------
https://chatgpt.com/codex/tasks/task_e_6867cd14285c832a8af4be3fc149cd4c