### PR TITLE
Persist filter and reset ball

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -168,6 +168,7 @@ declare global {
   const useDeviceOrientation: typeof import('@vueuse/core')['useDeviceOrientation']
   const useDevicePixelRatio: typeof import('@vueuse/core')['useDevicePixelRatio']
   const useDevicesList: typeof import('@vueuse/core')['useDevicesList']
+  const useDexFilterStore: typeof import('./stores/dexFilter')['useDexFilterStore']
   const useDialogStore: typeof import('./stores/dialog')['useDialogStore']
   const useDisplayMedia: typeof import('@vueuse/core')['useDisplayMedia']
   const useDocumentVisibility: typeof import('@vueuse/core')['useDocumentVisibility']
@@ -344,6 +345,9 @@ declare global {
   export type { AttackResult } from './stores/battle'
   import('./stores/battle')
   // @ts-ignore
+  export type { DexSort } from './stores/dexFilter'
+  import('./stores/dexFilter')
+  // @ts-ignore
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
   // @ts-ignore
@@ -515,6 +519,7 @@ declare module 'vue' {
     readonly useDeviceOrientation: UnwrapRef<typeof import('@vueuse/core')['useDeviceOrientation']>
     readonly useDevicePixelRatio: UnwrapRef<typeof import('@vueuse/core')['useDevicePixelRatio']>
     readonly useDevicesList: UnwrapRef<typeof import('@vueuse/core')['useDevicesList']>
+    readonly useDexFilterStore: UnwrapRef<typeof import('./stores/dexFilter')['useDexFilterStore']>
     readonly useDialogStore: UnwrapRef<typeof import('./stores/dialog')['useDialogStore']>
     readonly useDisplayMedia: UnwrapRef<typeof import('@vueuse/core')['useDisplayMedia']>
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -3,17 +3,16 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import Modal from '~/components/modal/Modal.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
+import { useDexFilterStore } from '~/stores/dexFilter'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonType from './ShlagemonType.vue'
 
 const dex = useShlagedexStore()
 const panel = useMainPanelStore()
+const filter = useDexFilterStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
-const search = ref('')
-const sortBy = ref<'level' | 'rarity' | 'name' | 'type' | 'attack' | 'defense' | 'count' | 'date'>('level')
-const sortAsc = ref(false)
 const isTrainerBattle = computed(() => panel.current === 'trainerBattle')
 const sortOptions = [
   { label: 'Niveau', value: 'level' },
@@ -26,17 +25,13 @@ const sortOptions = [
   { label: 'Première capture', value: 'date' },
 ]
 
-watch(sortBy, (val) => {
-  sortAsc.value = val === 'name' || val === 'type' || val === 'date'
-}, { immediate: true })
-
 const displayedMons = computed(() => {
   let mons = dex.shlagemons.slice()
-  if (search.value.trim()) {
-    const q = search.value.toLowerCase()
+  if (filter.search.trim()) {
+    const q = filter.search.toLowerCase()
     mons = mons.filter(m => m.base.name.toLowerCase().includes(q))
   }
-  switch (sortBy.value) {
+  switch (filter.sortBy) {
     case 'level':
       mons.sort((a, b) => a.lvl - b.lvl)
       break
@@ -62,7 +57,7 @@ const displayedMons = computed(() => {
       mons.sort((a, b) => (a.base.types[0]?.name || '').localeCompare(b.base.types[0]?.name || ''))
       break
   }
-  if (!sortAsc.value)
+  if (!filter.sortAsc)
     mons.reverse()
   return mons
 })
@@ -102,19 +97,19 @@ function isActive(mon: DexShlagemon) {
     <div class="mb-2 flex flex-wrap gap-2">
       <div class="min-w-36 flex flex-1 items-center">
         <SelectOption
-          v-model="sortBy"
+          v-model="filter.sortBy"
           class="min-w-24 flex-1"
           :options="sortOptions"
         />
         <button
           class="ml-1 text-lg icon-btn"
-          :aria-label="sortAsc ? 'Tri ascendant' : 'Tri descendant'"
-          @click="sortAsc = !sortAsc"
+          :aria-label="filter.sortAsc ? 'Tri ascendant' : 'Tri descendant'"
+          @click="filter.sortAsc = !filter.sortAsc"
         >
-          <div :class="sortAsc ? 'i-carbon-sort-ascending' : 'i-carbon-sort-descending'" />
+          <div :class="filter.sortAsc ? 'i-carbon-sort-ascending' : 'i-carbon-sort-descending'" />
         </button>
       </div>
-      <SearchInput v-model="search" />
+      <SearchInput v-model="filter.search" />
     </div>
     <div class="flex flex-col gap-2">
       <div

--- a/src/stores/ball.ts
+++ b/src/stores/ball.ts
@@ -25,7 +25,11 @@ export const useBallStore = defineStore('ball', () => {
     close()
   }
 
-  return { current, currentBall, isVisible, open, close, setBall }
+  function reset() {
+    current.value = 'shlageball'
+  }
+
+  return { current, currentBall, isVisible, open, close, setBall, reset }
 }, {
   persist: true,
 })

--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -1,0 +1,35 @@
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+
+export type DexSort =
+  | 'level'
+  | 'rarity'
+  | 'name'
+  | 'type'
+  | 'attack'
+  | 'defense'
+  | 'count'
+  | 'date'
+
+export const useDexFilterStore = defineStore('dexFilter', () => {
+  const search = ref('')
+  const sortBy = ref<DexSort>('level')
+  const sortAsc = ref(false)
+
+  watch(sortBy, (val) => {
+    if (val === 'name' || val === 'type' || val === 'date')
+      sortAsc.value = true
+    else
+      sortAsc.value = false
+  })
+
+  function reset() {
+    search.value = ''
+    sortBy.value = 'level'
+    sortAsc.value = false
+  }
+
+  return { search, sortBy, sortAsc, reset }
+}, {
+  persist: true,
+})

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -1,5 +1,7 @@
 import { defineStore } from 'pinia'
 import { useAchievementsStore } from './achievements'
+import { useBallStore } from './ball'
+import { useDexFilterStore } from './dexFilter'
 import { useDialogStore } from './dialog'
 import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
@@ -17,6 +19,8 @@ export const useSaveStore = defineStore('save', () => {
   const zone = useZoneStore()
   const zoneProgress = useZoneProgressStore()
   const achievements = useAchievementsStore()
+  const ball = useBallStore()
+  const dexFilter = useDexFilterStore()
 
   function reset() {
     dex.reset()
@@ -27,6 +31,8 @@ export const useSaveStore = defineStore('save', () => {
     zone.reset()
     zoneProgress.reset()
     achievements.reset()
+    ball.reset()
+    dexFilter.reset()
   }
 
   return { reset }


### PR DESCRIPTION
## Summary
- add dex filter store to persist dex sorting & search
- reset active ball and search filter in save store
- expose reset() in ball store
- use filter store in Schlagedex component

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot fetch Google Fonts; snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6867cdb428a0832aa4da5d6e1d5eef09