### PR TITLE
Fix healing after capture

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -94,6 +94,10 @@ function onCaptureEnd(success: boolean) {
   if (success && enemy.value) {
     dex.captureEnemy(enemy.value)
     notifyAchievement({ type: 'capture', shiny: enemy.value.isShiny })
+    if (dex.activeShlagemon) {
+      dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
+      playerHp.value = dex.activeShlagemon.hpCurrent
+    }
     enemy.value = null
     setTimeout(startBattle, 1000)
   }


### PR DESCRIPTION
## Summary
- ensure the active Shlagémon heals to full HP after a successful capture

## Testing
- `pnpm test` *(fails: ENETUNREACH while fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6867e907e550832a98b0a199ce86326e