### PR TITLE
Include chosen starter in Shlagedex potential

### DIFF
--- a/src/components/dialog/DialogStarter.vue
+++ b/src/components/dialog/DialogStarter.vue
@@ -62,6 +62,7 @@ const dialogTree = [
         label: s.id === 'bulgrosboule' ? 'Je l\'aime pas trop mais ok' : `Merci ${profMerdant.name}`,
         type: 'valid',
         action: () => {
+          gameState.setStarterId(s.id)
           dex.createShlagemon(s)
           gameState.setHasPokemon(true)
           emit('done', 'starter')

--- a/src/stores/gameState.ts
+++ b/src/stores/gameState.ts
@@ -7,6 +7,7 @@ export const useGameStateStore = defineStore('gameState', () => {
   const dex = useShlagedexStore()
   const hasPokemon = ref(false)
   const dialogStep = ref(0)
+  const starterId = ref<string | null>(null)
   const activeShlagemon = computed<DexShlagemon | null>(() => dex.activeShlagemon)
 
   function setHasPokemon(v: boolean) {
@@ -15,6 +16,9 @@ export const useGameStateStore = defineStore('gameState', () => {
   function setDialogStep(step: number) {
     dialogStep.value = step
   }
+  function setStarterId(id: string) {
+    starterId.value = id
+  }
   function setActiveShlagemon(mon: DexShlagemon | null) {
     if (mon)
       dex.setActiveShlagemon(mon)
@@ -22,9 +26,10 @@ export const useGameStateStore = defineStore('gameState', () => {
   function reset() {
     hasPokemon.value = false
     dialogStep.value = 0
+    starterId.value = null
   }
 
-  return { hasPokemon, dialogStep, activeShlagemon, setHasPokemon, setDialogStep, setActiveShlagemon, reset }
+  return { hasPokemon, dialogStep, activeShlagemon, starterId, setHasPokemon, setDialogStep, setStarterId, setActiveShlagemon, reset }
 }, {
   persist: true,
 })

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -4,6 +4,7 @@ import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import type { Zone } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { toast } from 'vue3-toastify'
+import { allShlagemons } from '~/data/shlagemons'
 import { zonesData } from '~/data/zones'
 import {
   applyStats,
@@ -14,6 +15,7 @@ import {
 } from '~/utils/dexFactory'
 import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
 import { useEvolutionStore } from './evolution'
+import { useGameStateStore } from './gameState'
 import { useZoneProgressStore } from './zoneProgress'
 
 export const useShlagedexStore = defineStore('shlagedex', () => {
@@ -22,6 +24,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const highestLevel = ref(0)
   const effects = ref<ActiveEffect[]>([])
   const progress = useZoneProgressStore()
+  const gameState = useGameStateStore()
+  const baseMap = Object.fromEntries(allShlagemons.map(b => [b.id, b]))
   cleanupEffects()
   watchEffect(cleanupEffects)
 
@@ -51,6 +55,11 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const completableIds = computed(() => {
     const ids = new Set<string>()
     const visited = new Set<string>()
+    if (gameState.starterId) {
+      const base = baseMap[gameState.starterId]
+      if (base)
+        collectEvolutionIds(base, ids, visited)
+    }
     for (const z of accessibleZones.value)
       z.shlagemons?.forEach(m => collectEvolutionIds(m, ids, visited))
     return ids


### PR DESCRIPTION
## Summary
- track selected starter in `gameState` store
- remember chosen starter when picking it in the dialog
- account for starter and its evolutions when computing Shlagedex potential

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot mismatch and zone heal test)*

------
https://chatgpt.com/codex/tasks/task_e_6867e8b004ec832ab3b0b6f645e5527d