### PR TITLE
Add Multi-EXP item with XP sharing

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -224,6 +224,7 @@ declare global {
   const useMouse: typeof import('@vueuse/core')['useMouse']
   const useMouseInElement: typeof import('@vueuse/core')['useMouseInElement']
   const useMousePressed: typeof import('@vueuse/core')['useMousePressed']
+  const useMultiExpStore: typeof import('./stores/multiExp')['useMultiExpStore']
   const useMutationObserver: typeof import('@vueuse/core')['useMutationObserver']
   const useNavigatorLanguage: typeof import('@vueuse/core')['useNavigatorLanguage']
   const useNetwork: typeof import('@vueuse/core')['useNetwork']
@@ -345,6 +346,9 @@ declare global {
   // @ts-ignore
   export type { AttackResult } from './stores/battle'
   import('./stores/battle')
+  // @ts-ignore
+  export type { DexSort } from './stores/dexFilter'
+  import('./stores/dexFilter')
   // @ts-ignore
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
@@ -517,6 +521,7 @@ declare module 'vue' {
     readonly useDeviceOrientation: UnwrapRef<typeof import('@vueuse/core')['useDeviceOrientation']>
     readonly useDevicePixelRatio: UnwrapRef<typeof import('@vueuse/core')['useDevicePixelRatio']>
     readonly useDevicesList: UnwrapRef<typeof import('@vueuse/core')['useDevicesList']>
+    readonly useDexFilterStore: UnwrapRef<typeof import('./stores/dexFilter')['useDexFilterStore']>
     readonly useDialogStore: UnwrapRef<typeof import('./stores/dialog')['useDialogStore']>
     readonly useDisplayMedia: UnwrapRef<typeof import('@vueuse/core')['useDisplayMedia']>
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
@@ -572,6 +577,7 @@ declare module 'vue' {
     readonly useMouse: UnwrapRef<typeof import('@vueuse/core')['useMouse']>
     readonly useMouseInElement: UnwrapRef<typeof import('@vueuse/core')['useMouseInElement']>
     readonly useMousePressed: UnwrapRef<typeof import('@vueuse/core')['useMousePressed']>
+    readonly useMultiExpStore: UnwrapRef<typeof import('./stores/multiExp')['useMultiExpStore']>
     readonly useMutationObserver: UnwrapRef<typeof import('@vueuse/core')['useMutationObserver']>
     readonly useNavigatorLanguage: UnwrapRef<typeof import('@vueuse/core')['useNavigatorLanguage']>
     readonly useNetwork: UnwrapRef<typeof import('@vueuse/core')['useNetwork']>
@@ -584,6 +590,7 @@ declare module 'vue' {
     readonly useParentElement: UnwrapRef<typeof import('@vueuse/core')['useParentElement']>
     readonly usePerformanceObserver: UnwrapRef<typeof import('@vueuse/core')['usePerformanceObserver']>
     readonly usePermission: UnwrapRef<typeof import('@vueuse/core')['usePermission']>
+    readonly usePlayerStore: UnwrapRef<typeof import('./stores/player')['usePlayerStore']>
     readonly usePointer: UnwrapRef<typeof import('@vueuse/core')['usePointer']>
     readonly usePointerLock: UnwrapRef<typeof import('@vueuse/core')['usePointerLock']>
     readonly usePointerSwipe: UnwrapRef<typeof import('@vueuse/core')['usePointerSwipe']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -40,6 +40,8 @@ declare module 'vue' {
     ItemCard: typeof import('./components/shop/ItemCard.vue')['default']
     MainPanel: typeof import('./components/panels/MainPanel.vue')['default']
     Modal: typeof import('./components/modal/Modal.vue')['default']
+    MultiExp: typeof import('./components/icons/multi-exp.vue')['default']
+    MultiExpModal: typeof import('./components/inventory/MultiExpModal.vue')['default']
     PanelWrapper: typeof import('./components/ui/PanelWrapper.vue')['default']
     PlayerInfos: typeof import('./components/panels/PlayerInfos.vue')['default']
     Profile: typeof import('./components/profile/Profile.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -13,6 +13,7 @@ import { useBallStore } from '~/stores/ball'
 import { useBattleStore } from '~/stores/battle'
 import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
+import { useMultiExpStore } from '~/stores/multiExp'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
@@ -26,6 +27,7 @@ const progress = useZoneProgressStore()
 const battle = useBattleStore()
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
+const multiExpStore = useMultiExpStore()
 const equilibrerank = 2
 
 const wins = computed(() => progress.getWins(zone.current.id))
@@ -195,11 +197,17 @@ function checkEnd() {
         game.addShlagidolar(zone.rewardMultiplier)
         notifyAchievement({ type: 'battle-win', stronger })
         if (dex.activeShlagemon && enemy.value) {
+          const xp = xpRewardForLevel(enemy.value.lvl)
           await dex.gainXp(
             dex.activeShlagemon,
-            xpRewardForLevel(enemy.value.lvl),
+            xp,
             zone.current.maxLevel,
           )
+          const holder = multiExpStore.holder
+          if (holder) {
+            const share = Math.round(xp * 0.5)
+            await dex.gainXp(holder, share, zone.current.maxLevel)
+          }
         }
       }
       playerFainted.value = false

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -10,6 +10,7 @@ import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
 import { useGameStore } from '~/stores/game'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMultiExpStore } from '~/stores/multiExp'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
@@ -23,6 +24,7 @@ const battle = useBattleStore()
 const panel = useMainPanelStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
+const multiExpStore = useMultiExpStore()
 const equilibrerank = 2
 
 const trainer = computed(() => trainerStore.current)
@@ -156,12 +158,18 @@ function checkEnd() {
     setTimeout(async () => {
       if (enemyHp.value <= 0 && playerHp.value > 0) {
         if (dex.activeShlagemon && enemy.value) {
+          const xp = xpRewardForLevel(enemy.value.lvl)
           await dex.gainXp(
             dex.activeShlagemon,
-            xpRewardForLevel(enemy.value.lvl),
+            xp,
             undefined,
             trainerStore.levelUpHealPercent,
           )
+          const holder = multiExpStore.holder
+          if (holder) {
+            const share = Math.round(xp * 0.5)
+            await dex.gainXp(holder, share, undefined, trainerStore.levelUpHealPercent)
+          }
         }
         enemyIndex.value += 1
         if (enemyIndex.value < (trainer.value?.shlagemons.length || 0)) {

--- a/src/components/icons/multi-exp.vue
+++ b/src/components/icons/multi-exp.vue
@@ -1,0 +1,6 @@
+<template>
+  <svg viewBox="0 0 100 100" width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="50" cy="50" r="45" fill="#facc15" stroke="#b45309" stroke-width="5" />
+    <text x="50" y="55" text-anchor="middle" font-size="40" font-weight="bold" fill="#b45309">XP</text>
+  </svg>
+</template>

--- a/src/components/inventory/MultiExpModal.vue
+++ b/src/components/inventory/MultiExpModal.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
+import Button from '~/components/ui/Button.vue'
+import { useMultiExpStore } from '~/stores/multiExp'
+import { useShlagedexStore } from '~/stores/shlagedex'
+
+const store = useMultiExpStore()
+const dex = useShlagedexStore()
+
+function select(monId: string) {
+  store.setHolder(monId)
+}
+</script>
+
+<template>
+  <Modal v-model="store.isVisible" footer-close>
+    <div class="flex flex-col gap-2">
+      <h3 class="text-center text-lg font-bold">
+        Choisir le porteur du Multi-EXP
+      </h3>
+      <div v-if="dex.shlagemons.length" class="flex flex-col gap-2">
+        <div
+          v-for="mon in dex.shlagemons"
+          :key="mon.id"
+          class="flex items-center justify-between border rounded p-2"
+        >
+          <div class="flex items-center gap-2">
+            <ShlagemonImage :id="mon.base.id" :alt="mon.base.name" class="h-6 w-6" />
+            <span>{{ mon.base.name }} (lvl {{ mon.lvl }})</span>
+          </div>
+          <Button class="text-xs" @click="select(mon.id)">
+            <span v-if="store.holderId === mon.id">Équipé</span>
+            <span v-else>Choisir</span>
+          </Button>
+        </div>
+      </div>
+      <p v-else class="text-center text-sm">
+        Aucun Shlagémon disponible.
+      </p>
+    </div>
+  </Modal>
+</template>

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -2,14 +2,17 @@
 import type { Item } from '~/type/item'
 import EvolutionItemModal from '~/components/inventory/EvolutionItemModal.vue'
 import InventoryItemCard from '~/components/inventory/InventoryItemCard.vue'
+import MultiExpModal from '~/components/inventory/MultiExpModal.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import { useBallStore } from '~/stores/ball'
 import { useEvolutionItemStore } from '~/stores/evolutionItem'
 import { useInventoryStore } from '~/stores/inventory'
+import { useMultiExpStore } from '~/stores/multiExp'
 
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
 const evoItemStore = useEvolutionItemStore()
+const multiExpStore = useMultiExpStore()
 const search = ref('')
 const filteredList = computed(() => {
   const q = search.value.toLowerCase().trim()
@@ -27,6 +30,8 @@ function onUse(item: Item) {
     ballStore.setBall(item.id as any)
   else if (item.type === 'evolution')
     evoItemStore.open(item)
+  else if (item.id === 'multi-exp')
+    multiExpStore.open()
   else
     inventory.useItem(item.id)
 }
@@ -46,4 +51,5 @@ function onUse(item: Item) {
     />
   </section>
   <EvolutionItemModal />
+  <MultiExpModal />
 </template>

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import MultiExpIcon from '~/components/icons/multi-exp.vue'
 import Modal from '~/components/modal/Modal.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMultiExpStore } from '~/stores/multiExp'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonType from './ShlagemonType.vue'
 
@@ -14,6 +16,7 @@ const filter = useDexFilterStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 const isTrainerBattle = computed(() => panel.current === 'trainerBattle')
+const multiExpStore = useMultiExpStore()
 const sortOptions = [
   { label: 'Niveau', value: 'level' },
   { label: 'Rareté', value: 'rarity' },
@@ -121,6 +124,7 @@ function isActive(mon: DexShlagemon) {
         @click.stop="onClick(mon)"
         @dblclick.stop="onDoubleClick(mon)"
       >
+        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="absolute left-1 top-1 h-4 w-4" />
         <div class="absolute bottom-0 right-2 text-xs">
           lvl {{ mon.lvl }}
         </div>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
 import { computed, ref } from 'vue'
+import MultiExpIcon from '~/components/icons/multi-exp.vue'
 import Modal from '~/components/modal/Modal.vue'
 import Button from '~/components/ui/Button.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
 import Tooltip from '~/components/ui/Tooltip.vue'
+import { useMultiExpStore } from '~/stores/multiExp'
 import { useShlagedexStore } from '~/stores/shlagedex'
 
 const props = defineProps<{ mon: DexShlagemon | null }>()
@@ -42,6 +44,7 @@ const allowEvolution = computed({
 })
 
 const store = useShlagedexStore()
+const multiExpStore = useMultiExpStore()
 const showConfirm = ref(false)
 
 function requestRelease() {
@@ -69,8 +72,9 @@ const captureInfo = computed(() => {
 <template>
   <div v-if="mon" class="max-w-sm w-full rounded bg-white dark:bg-gray-900">
     <h2 class="mb-2 flex items-center justify-between text-lg font-bold">
-      <div>
+      <div class="flex items-center gap-1">
         <span :class="mon.isShiny ? 'shiny-text' : ''">{{ mon.base.name }}</span>  - lvl {{ mon.lvl }}
+        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="h-4 w-4" />
       </div>
       <Tooltip text="Plus un Pokémon est rare, plus son potentiel de puissance est élevé.">
         <ShlagemonRarity :rarity="mon.rarity" class="rounded-tr-0 -m-r-4 -m-t-4" />

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -101,6 +101,18 @@ export const hyperPotion: Item = {
   iconClass: 'text-yellow-500 dark:text-yellow-300',
 }
 
+export const multiExp: Item = {
+  id: 'multi-exp',
+  name: 'Multi-EXP',
+  description: 'Partage l\'XP avec un Shlagémon.',
+  details:
+    'Permet de partager 50% de l\'XP gagnée en combat avec le Shlagémon porteur.',
+  price: 20,
+  currency: 'shlagidiamond',
+  icon: 'carbon:chart-multitype',
+  iconClass: 'text-orange-500 dark:text-orange-300',
+}
+
 export const thunderStone: Item = {
   id: 'pierre-foudre',
   name: 'Pierre Foudre',
@@ -125,5 +137,6 @@ export const allItems: Item[] = [
   hyperAttackPotion,
   superPotion,
   hyperPotion,
+  multiExp,
   thunderStone,
 ]

--- a/src/data/shops.ts
+++ b/src/data/shops.ts
@@ -5,6 +5,7 @@ import {
   hyperAttackPotion,
   hyperDefensePotion,
   hyperPotion,
+  multiExp,
   potion,
   superAttackPotion,
   superDefensePotion,
@@ -27,7 +28,7 @@ export const shops: Shop[] = [
   {
     id: 'village-paume',
     level: 50,
-    items: [hyperPotion, hyperDefensePotion, hyperAttackPotion, hyperShlageball],
+    items: [hyperPotion, hyperDefensePotion, hyperAttackPotion, hyperShlageball, multiExp],
   },
 ]
 

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -5,6 +5,7 @@ import { allItems } from '~/data/items/items'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from './achievements'
 import { useGameStore } from './game'
+import { useMultiExpStore } from './multiExp'
 import { useShlagedexStore } from './shlagedex'
 
 export const useInventoryStore = defineStore('inventory', () => {
@@ -68,6 +69,11 @@ export const useInventoryStore = defineStore('inventory', () => {
     if (!items.value[id])
       return false
     notifyAchievement({ type: 'item-used' })
+    if (id === 'multi-exp') {
+      const me = useMultiExpStore()
+      me.open()
+      return true
+    }
     if (id === 'potion') {
       dex.healActive(50)
       remove(id)

--- a/src/stores/multiExp.ts
+++ b/src/stores/multiExp.ts
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { useShlagedexStore } from './shlagedex'
+
+export const useMultiExpStore = defineStore('multiExp', () => {
+  const holderId = ref<string | null>(null)
+  const isVisible = ref(false)
+  const dex = useShlagedexStore()
+
+  const holder = computed(() =>
+    holderId.value ? dex.shlagemons.find(m => m.id === holderId.value) || null : null,
+  )
+
+  function open() {
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+  }
+
+  function setHolder(monId: string) {
+    holderId.value = monId
+    close()
+  }
+
+  return { holderId, holder, isVisible, open, close, setHolder }
+}, {
+  persist: true,
+})


### PR DESCRIPTION
## Summary
- add `Multi-EXP` item and expose it in the third shop
- create store to manage which Shlagémon holds the item
- allow choosing the holder via a new modal
- show active holder icon in the Shlagedex and detail views
- share XP with the holder after battles
- update inventory logic for the new item

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch errors and unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb6f40f4832ab4216e0558e25557