### PR TITLE
Add mobile navigation

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
 import { computed, watch } from 'vue'
 import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
 import InventoryPanel from '~/components/panels/InventoryPanel.vue'
@@ -14,6 +15,7 @@ import { useDialogStore } from '~/stores/dialog'
 import { useGameStateStore } from '~/stores/gameState'
 import { useInventoryStore } from '~/stores/inventory'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
@@ -27,6 +29,8 @@ const achievements = useAchievementsStore()
 const mainPanel = useMainPanelStore()
 const audio = useAudioStore()
 const trainerBattle = useTrainerBattleStore()
+const mobileTab = useMobileTabStore()
+const isMobile = useMediaQuery('(max-width: 767px)')
 
 const showXpBar = computed(() =>
   ['battle', 'trainerBattle'].includes(mainPanel.current),
@@ -40,6 +44,13 @@ const showMainPanel = computed(() =>
 const isInventoryVisible = computed(() => inventory.list.length > 0)
 const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
 const isAchievementVisible = computed(() => achievements.hasAny)
+
+const displayZonePanel = computed(() => isShlagedexVisible.value && (!isMobile.value || mobileTab.current === 'zones'))
+const displayPlayerInfo = computed(() => !isMobile.value || mobileTab.current === 'game')
+const displayMainPanel = computed(() => showMainPanel.value && (!isMobile.value || mobileTab.current === 'game'))
+const displayInventory = computed(() => isInventoryVisible.value && (!isMobile.value || mobileTab.current === 'game'))
+const displayAchievements = computed(() => isAchievementVisible.value && (!isMobile.value || mobileTab.current === 'achievements'))
+const displayDex = computed(() => isShlagedexVisible.value && (!isMobile.value || mobileTab.current === 'dex'))
 
 watch(
   () => [mainPanel.current, zone.current.id, trainerBattle.current?.id],
@@ -61,19 +72,19 @@ watch(
       class="game flex flex-col gap-1 p-1"
       md="grid grid-cols-12 grid-rows-12 w-full h-full gap-2"
     >
-      <div v-if="isShlagedexVisible" class="zone zone-big" md="col-span-6 row-span-5  col-start-4 row-start-8">
+      <div v-if="displayZonePanel" class="zone zone-big" md="col-span-6 row-span-5  col-start-4 row-start-8">
         <!-- middle C zone -->
         <PanelWrapper title="Zones">
           <ZonePanel />
         </PanelWrapper>
       </div>
-      <div class="zone overflow-visible!" md="col-span-6 row-span-1 col-start-4 row-start-1">
+      <div v-if="displayPlayerInfo" class="zone overflow-visible!" md="col-span-6 row-span-1 col-start-4 row-start-1">
         <!-- top zone -->
         <PanelWrapper is-inline>
           <PlayerInfos />
         </PanelWrapper>
       </div>
-      <div v-if="showMainPanel" class="zone" md="col-span-6 row-span-6 col-start-4 row-start-2">
+      <div v-if="displayMainPanel" class="zone" md="col-span-6 row-span-6 col-start-4 row-start-2">
         <!-- middle A zone -->
         <PanelWrapper>
           <MainPanel class="flex-1" />
@@ -88,16 +99,16 @@ watch(
           <ActiveShlagemon />
         </PanelWrapper>
       </div> -->
-      <div v-if="isInventoryVisible || isAchievementVisible" class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1 flex flex-col gap-2">
+      <div v-if="displayInventory || displayAchievements" class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1 flex flex-col gap-2">
         <!-- left zone -->
-        <PanelWrapper v-if="isInventoryVisible" title="Inventaire">
+        <PanelWrapper v-if="displayInventory" title="Inventaire">
           <InventoryPanel />
         </PanelWrapper>
-        <PanelWrapper v-if="isAchievementVisible" title="Succès">
+        <PanelWrapper v-if="displayAchievements" title="Succès">
           <AchievementsPanel />
         </PanelWrapper>
       </div>
-      <div v-if="isShlagedexVisible" class="zone tiny-scrollbar" md="col-span-3 row-span-12 col-start-10 row-start-1  overflow-auto">
+      <div v-if="displayDex" class="zone tiny-scrollbar" md="col-span-3 row-span-12 col-start-10 row-start-1  overflow-auto">
         <!-- right zone -->
         <PanelWrapper title="Shlagédex">
           <Shlagedex />

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import Button from '~/components/ui/Button.vue'
+import { useMobileTabStore } from '~/stores/mobileTab'
+
+const mobile = useMobileTabStore()
+</script>
+
+<template>
+  <nav class="h-12 flex items-center justify-around bg-gray-100 md:hidden dark:bg-gray-800">
+    <Button type="icon" :class="mobile.current === 'game' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('game')">
+      <div class="i-carbon-game-console" />
+    </Button>
+    <Button type="icon" :class="mobile.current === 'zones' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('zones')">
+      <div class="i-carbon-map" />
+    </Button>
+    <Button type="icon" :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('dex')">
+      <div class="i-carbon-list" />
+    </Button>
+    <Button type="icon" :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('achievements')">
+      <div class="i-carbon-trophy" />
+    </Button>
+  </nav>
+</template>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import MobileMenu from '~/components/layout/MobileMenu.vue'
 </script>
 
 <template>
   <div class="h-full flex flex-col overflow-hidden">
     <Header />
     <GameGrid class="flex-1" />
+    <MobileMenu />
   </div>
 </template>

--- a/src/stores/mobileTab.ts
+++ b/src/stores/mobileTab.ts
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type MobileTab = 'game' | 'zones' | 'dex' | 'achievements'
+
+export const useMobileTabStore = defineStore('mobileTab', () => {
+  const current = ref<MobileTab>('game')
+  function set(tab: MobileTab) {
+    current.value = tab
+  }
+  return { current, set }
+})


### PR DESCRIPTION
## Summary
- add store for mobile tabs
- add bottom MobileMenu
- conditionally display panels in GameGrid
- show MobileMenu in default layout

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch fonts and snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_686856632600832a96dc08120fcabc06