### PR TITLE
Add mobile map modal

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -215,10 +215,12 @@ declare global {
   const useMagicKeys: typeof import('@vueuse/core')['useMagicKeys']
   const useMainPanelStore: typeof import('./stores/mainPanel')['useMainPanelStore']
   const useManualRefHistory: typeof import('@vueuse/core')['useManualRefHistory']
+  const useMapModalStore: typeof import('./stores/mapModal')['useMapModalStore']
   const useMediaControls: typeof import('@vueuse/core')['useMediaControls']
   const useMediaQuery: typeof import('@vueuse/core')['useMediaQuery']
   const useMemoize: typeof import('@vueuse/core')['useMemoize']
   const useMemory: typeof import('@vueuse/core')['useMemory']
+  const useMobileTabStore: typeof import('./stores/mobileTab')['useMobileTabStore']
   const useModel: typeof import('vue')['useModel']
   const useMounted: typeof import('@vueuse/core')['useMounted']
   const useMouse: typeof import('@vueuse/core')['useMouse']
@@ -355,6 +357,9 @@ declare global {
   // @ts-ignore
   export type { MainPanel } from './stores/mainPanel'
   import('./stores/mainPanel')
+  // @ts-ignore
+  export type { MobileTab } from './stores/mobileTab'
+  import('./stores/mobileTab')
 }
 
 // for vue template auto import
@@ -568,10 +573,12 @@ declare module 'vue' {
     readonly useMagicKeys: UnwrapRef<typeof import('@vueuse/core')['useMagicKeys']>
     readonly useMainPanelStore: UnwrapRef<typeof import('./stores/mainPanel')['useMainPanelStore']>
     readonly useManualRefHistory: UnwrapRef<typeof import('@vueuse/core')['useManualRefHistory']>
+    readonly useMapModalStore: UnwrapRef<typeof import('./stores/mapModal')['useMapModalStore']>
     readonly useMediaControls: UnwrapRef<typeof import('@vueuse/core')['useMediaControls']>
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>
     readonly useMemoize: UnwrapRef<typeof import('@vueuse/core')['useMemoize']>
     readonly useMemory: UnwrapRef<typeof import('@vueuse/core')['useMemory']>
+    readonly useMobileTabStore: UnwrapRef<typeof import('./stores/mobileTab')['useMobileTabStore']>
     readonly useModel: UnwrapRef<typeof import('vue')['useModel']>
     readonly useMounted: UnwrapRef<typeof import('@vueuse/core')['useMounted']>
     readonly useMouse: UnwrapRef<typeof import('@vueuse/core')['useMouse']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -39,6 +39,7 @@ declare module 'vue' {
     InventoryPanel: typeof import('./components/panels/InventoryPanel.vue')['default']
     ItemCard: typeof import('./components/shop/ItemCard.vue')['default']
     MainPanel: typeof import('./components/panels/MainPanel.vue')['default']
+    MobileMenu: typeof import('./components/layout/MobileMenu.vue')['default']
     Modal: typeof import('./components/modal/Modal.vue')['default']
     MultiExp: typeof import('./components/icons/multi-exp.vue')['default']
     MultiExpModal: typeof import('./components/inventory/MultiExpModal.vue')['default']
@@ -68,6 +69,7 @@ declare module 'vue' {
     VillagePanel: typeof import('./components/village/VillagePanel.vue')['default']
     Xp: typeof import('./components/icons/xp.vue')['default']
     ZoneActions: typeof import('./components/village/ZoneActions.vue')['default']
+    ZoneMapModal: typeof import('./components/zones/ZoneMapModal.vue')['default']
     ZonePanel: typeof import('./components/panels/ZonePanel.vue')['default']
   }
 }

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -8,6 +8,7 @@ import ZonePanel from '~/components/panels/ZonePanel.vue'
 import EvolutionModal from '~/components/shlagemon/EvolutionModal.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import PanelWrapper from '~/components/ui/PanelWrapper.vue'
+import ZoneMapModal from '~/components/zones/ZoneMapModal.vue'
 import { trainerTracks, zoneBattleTracks, zoneTracks } from '~/data/music'
 import { useAchievementsStore } from '~/stores/achievements'
 import { useAudioStore } from '~/stores/audio'
@@ -45,7 +46,7 @@ const isInventoryVisible = computed(() => inventory.list.length > 0)
 const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
 const isAchievementVisible = computed(() => achievements.hasAny)
 
-const displayZonePanel = computed(() => isShlagedexVisible.value && (!isMobile.value || mobileTab.current === 'zones'))
+const displayZonePanel = computed(() => isShlagedexVisible.value && !isMobile.value)
 const displayPlayerInfo = computed(() => !isMobile.value || mobileTab.current === 'game')
 const displayMainPanel = computed(() => showMainPanel.value && (!isMobile.value || mobileTab.current === 'game'))
 const displayInventory = computed(() => isInventoryVisible.value && (!isMobile.value || mobileTab.current === 'game'))
@@ -84,7 +85,7 @@ watch(
           <PlayerInfos />
         </PanelWrapper>
       </div>
-      <div v-if="displayMainPanel" class="zone" md="col-span-6 row-span-6 col-start-4 row-start-2">
+      <div v-if="displayMainPanel" class="zone h-[50vh]" md="col-span-6 row-span-6 col-start-4 row-start-2">
         <!-- middle A zone -->
         <PanelWrapper>
           <MainPanel class="flex-1" />
@@ -115,6 +116,7 @@ watch(
         </PanelWrapper>
       </div>
       <EvolutionModal />
+      <ZoneMapModal />
     </div>
   </div>
 </template>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,23 +1,25 @@
 <script setup lang="ts">
 import Button from '~/components/ui/Button.vue'
+import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
 
 const mobile = useMobileTabStore()
+const mapModal = useMapModalStore()
 </script>
 
 <template>
   <nav class="h-12 flex items-center justify-around bg-gray-100 md:hidden dark:bg-gray-800">
-    <Button type="icon" :class="mobile.current === 'game' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('game')">
-      <div class="i-carbon-game-console" />
-    </Button>
-    <Button type="icon" :class="mobile.current === 'zones' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('zones')">
-      <div class="i-carbon-map" />
+    <Button type="icon" :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('achievements')">
+      <div class="i-carbon-trophy" />
     </Button>
     <Button type="icon" :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('dex')">
       <div class="i-carbon-list" />
     </Button>
-    <Button type="icon" :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('achievements')">
-      <div class="i-carbon-trophy" />
+    <Button type="icon" :class="mapModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''" @click="mapModal.open()">
+      <div class="i-carbon-map" />
+    </Button>
+    <Button type="icon" :class="mobile.current === 'game' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('game')">
+      <div class="i-carbon-game-console" />
     </Button>
   </nav>
 </template>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -3,6 +3,7 @@ import type { Zone } from '~/type'
 import { computed } from 'vue'
 import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMapModalStore } from '~/stores/mapModal'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
@@ -11,6 +12,7 @@ const zone = useZoneStore()
 const dex = useShlagedexStore()
 const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
+const mapModal = useMapModalStore()
 const dialog = useDialogStore()
 
 const zoneButtonsDisabled = computed(
@@ -29,6 +31,13 @@ function canAccess(z: Zone) {
     return dex.highestLevel >= z.minLevel
   const prev = xpZones.value[idx - 1]
   return dex.highestLevel >= z.minLevel && progress.isKingDefeated(prev.id)
+}
+
+function selectZone(id: string) {
+  if (zoneButtonsDisabled.value)
+    return
+  zone.setZone(id)
+  mapModal.close()
 }
 
 function classes(z: Zone) {
@@ -65,7 +74,7 @@ function classes(z: Zone) {
         class="rounded px-2 py-1 text-xs"
         :class="`${classes(z)} ${zoneButtonsDisabled ? 'opacity-50 cursor-not-allowed' : ''}`"
         :disabled="zoneButtonsDisabled"
-        @click="!zoneButtonsDisabled && zone.setZone(z.id)"
+        @click="selectZone(z.id)"
       >
         {{ z.name }}
       </button>

--- a/src/components/zones/ZoneMapModal.vue
+++ b/src/components/zones/ZoneMapModal.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import ZonePanel from '~/components/panels/ZonePanel.vue'
+import PanelWrapper from '~/components/ui/PanelWrapper.vue'
+import { useMapModalStore } from '~/stores/mapModal'
+
+const mapModal = useMapModalStore()
+</script>
+
+<template>
+  <Modal v-model="mapModal.isVisible" footer-close>
+    <PanelWrapper title="Zones">
+      <ZonePanel />
+    </PanelWrapper>
+  </Modal>
+</template>

--- a/src/stores/mapModal.ts
+++ b/src/stores/mapModal.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useMapModalStore = defineStore('mapModal', () => {
+  const isVisible = ref(false)
+
+  function open() {
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+  }
+
+  return { isVisible, open, close }
+})

--- a/src/stores/mobileTab.ts
+++ b/src/stores/mobileTab.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-export type MobileTab = 'game' | 'zones' | 'dex' | 'achievements'
+export type MobileTab = 'game' | 'dex' | 'achievements'
 
 export const useMobileTabStore = defineStore('mobileTab', () => {
   const current = ref<MobileTab>('game')


### PR DESCRIPTION
## Summary
- convert the zone list to a modal for mobile
- reorder bottom navigation for easier right-thumb access
- keep half of the screen for the main panel

## Testing
- `pnpm test:unit` *(fails: FetchError, snapshot mismatches, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68685b27b614832a9fe69eef481003f4