### PR TITLE
Implement computePotentialIds logic

### DIFF
--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -78,6 +78,15 @@ describe('shlagedex highest level', () => {
 })
 
 describe('completable ids', () => {
+  it('always includes starter bases', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const ids = (dex as any).completableIds as Set<string>
+    expect(ids.has('carapouffe')).toBe(true)
+    expect(ids.has('salamiches')).toBe(true)
+    expect(ids.has('bulgrosboule')).toBe(true)
+  })
+
   it('includes evolutions recursively', () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
@@ -88,5 +97,21 @@ describe('completable ids', () => {
     expect(ids.has('salamiches')).toBe(true)
     expect(ids.has('raptorincel')).toBe(true)
     expect(ids.has('draco-con')).toBe(true)
+  })
+
+  it('adds evolutions only when level reached', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const progress = useZoneProgressStore()
+
+    dex.highestLevel.value = 10
+    let ids = (dex as any).completableIds as Set<string>
+    expect(ids.has('carabifle')).toBe(false)
+
+    dex.highestLevel.value = 20
+    progress.defeatKing('grotte-du-slip')
+    ids = (dex as any).completableIds as Set<string>
+    expect(ids.has('carabifle')).toBe(true)
+    expect(ids.has('tord-turc')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- expand Shlagedex completable ids with starter bases
- restrict evolutions to highest accessible level
- support Pikachiant reward and shop level check
- add unit tests for new behaviour

## Testing
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68685b605910832a94d5d2f32d7a0dcc