### PR TITLE
Add mobile map and inventory modals

### DIFF
--- a/src/components/inventory/InventoryModal.vue
+++ b/src/components/inventory/InventoryModal.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import InventoryPanel from '~/components/panels/InventoryPanel.vue'
+import PanelWrapper from '~/components/ui/PanelWrapper.vue'
+import { useInventoryModalStore } from '~/stores/inventoryModal'
+
+const inventoryModal = useInventoryModalStore()
+</script>
+
+<template>
+  <Modal v-model="inventoryModal.isVisible" footer-close>
+    <PanelWrapper title="Inventaire">
+      <InventoryPanel />
+    </PanelWrapper>
+  </Modal>
+</template>

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -2,6 +2,7 @@
 import { useMediaQuery } from '@vueuse/core'
 import { computed, watch } from 'vue'
 import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
+import InventoryModal from '~/components/inventory/InventoryModal.vue'
 import InventoryPanel from '~/components/panels/InventoryPanel.vue'
 import MainPanel from '~/components/panels/MainPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
@@ -49,7 +50,7 @@ const isAchievementVisible = computed(() => achievements.hasAny)
 const displayZonePanel = computed(() => isShlagedexVisible.value && !isMobile.value)
 const displayPlayerInfo = computed(() => !isMobile.value || mobileTab.current === 'game')
 const displayMainPanel = computed(() => showMainPanel.value && (!isMobile.value || mobileTab.current === 'game'))
-const displayInventory = computed(() => isInventoryVisible.value && (!isMobile.value || mobileTab.current === 'game'))
+const displayInventory = computed(() => isInventoryVisible.value && !isMobile.value)
 const displayAchievements = computed(() => isAchievementVisible.value && (!isMobile.value || mobileTab.current === 'achievements'))
 const displayDex = computed(() => isShlagedexVisible.value && (!isMobile.value || mobileTab.current === 'dex'))
 
@@ -117,6 +118,7 @@ watch(
       </div>
       <EvolutionModal />
       <ZoneMapModal />
+      <InventoryModal />
     </div>
   </div>
 </template>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,25 +1,48 @@
 <script setup lang="ts">
 import Button from '~/components/ui/Button.vue'
+import { useInventoryModalStore } from '~/stores/inventoryModal'
 import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
 
 const mobile = useMobileTabStore()
 const mapModal = useMapModalStore()
+const inventoryModal = useInventoryModalStore()
+
+function toggleMap() {
+  if (mapModal.isVisible)
+    mapModal.close()
+  else
+    mapModal.open()
+}
+
+function toggleInventory() {
+  if (inventoryModal.isVisible)
+    inventoryModal.close()
+  else
+    inventoryModal.open()
+}
 </script>
 
 <template>
-  <nav class="h-12 flex items-center justify-around bg-gray-100 md:hidden dark:bg-gray-800">
-    <Button type="icon" :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('achievements')">
-      <div class="i-carbon-trophy" />
-    </Button>
-    <Button type="icon" :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('dex')">
-      <div class="i-carbon-list" />
-    </Button>
-    <Button type="icon" :class="mapModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''" @click="mapModal.open()">
-      <div class="i-carbon-map" />
-    </Button>
-    <Button type="icon" :class="mobile.current === 'game' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('game')">
+  <nav class="h-12 flex items-center justify-between bg-gray-100 px-2 md:hidden dark:bg-gray-800">
+    <div class="flex gap-2">
+      <Button type="icon" :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('dex')">
+        <div class="i-carbon-list" />
+      </Button>
+      <Button type="icon" :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('achievements')">
+        <div class="i-carbon-trophy" />
+      </Button>
+    </div>
+    <Button type="icon" class="h-14 w-14 text-2xl -my-4" :class="mobile.current === 'game' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('game')">
       <div class="i-carbon-game-console" />
     </Button>
+    <div class="flex gap-2">
+      <Button type="icon" :class="mapModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''" @click="toggleMap">
+        <div class="i-carbon-map" />
+      </Button>
+      <Button type="icon" :class="inventoryModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''" @click="toggleInventory">
+        <div class="i-carbon-inventory-management" />
+      </Button>
+    </div>
   </nav>
 </template>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue'
 import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMapModalStore } from '~/stores/mapModal'
+import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
@@ -14,6 +15,7 @@ const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
 const mapModal = useMapModalStore()
 const dialog = useDialogStore()
+const mobile = useMobileTabStore()
 
 const zoneButtonsDisabled = computed(
   () => panel.current === 'trainerBattle' || dialog.isDialogVisible,
@@ -38,6 +40,7 @@ function selectZone(id: string) {
     return
   zone.setZone(id)
   mapModal.close()
+  mobile.set('game')
 }
 
 function classes(z: Zone) {

--- a/src/stores/inventoryModal.ts
+++ b/src/stores/inventoryModal.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useMobileTabStore } from './mobileTab'
 
-export const useMapModalStore = defineStore('mapModal', () => {
+export const useInventoryModalStore = defineStore('inventoryModal', () => {
   const isVisible = ref(false)
   const mobile = useMobileTabStore()
 


### PR DESCRIPTION
## Summary
- introduce inventory modal store and component
- center the game button in the mobile menu and add inventory button
- ensure map and inventory modals switch back to the main panel
- hide inventory panel on mobile and use modal instead

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetching fonts and multiple unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68685e7e586c832a9acc14f9b3f19635