### PR TITLE
Add half-dex dialog

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -33,6 +33,7 @@ declare module 'vue' {
     EvolutionModal: typeof import('./components/shlagemon/EvolutionModal.vue')['default']
     FightKingButton: typeof import('./components/battle/FightKingButton.vue')['default']
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
+    HalfDexDialog: typeof import('./components/dialog/HalfDexDialog.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
     ImageByBackground: typeof import('./components/ui/ImageByBackground.vue')['default']
     InventoryItemCard: typeof import('./components/inventory/InventoryItemCard.vue')['default']

--- a/src/components/dialog/HalfDexDialog.vue
+++ b/src/components/dialog/HalfDexDialog.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import DialogBox from '~/components/dialog/DialogBox.vue'
+import { profSchlag } from '~/data/characters/prof-schlag'
+import { useGameStore } from '~/stores/game'
+
+const emit = defineEmits(['done'])
+const game = useGameStore()
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'step1',
+    text: `Oh ! Salut dresseur ! Je suis ${profSchlag.name}. Tu as rempli 50% du Schlagedex !`,
+    responses: [
+      { label: 'Continuer', nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: 'Je dois avouer que je ne m\'attendais pas à sentir ta persévérance aussi longtemps.',
+    responses: [
+      { label: 'Retour', nextId: 'step1', type: 'danger' },
+      { label: 'Continuer', nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: 'Pour célébrer, je t\'offre 10 Schlagediamonds. Ils brillent presque autant que toi.',
+    responses: [
+      { label: 'Retour', nextId: 'step2', type: 'danger' },
+      { label: 'Continuer', nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: 'Ne les dépense pas tous au même endroit... sauf si c\'est pour m\'acheter des parfums.',
+    responses: [
+      { label: 'Retour', nextId: 'step3', type: 'danger' },
+      { label: 'Continuer', nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: 'Allez, file. Le Schlagedex n\'attend que toi pour être complété.',
+    responses: [
+      { label: 'Retour', nextId: 'step4', type: 'danger' },
+      {
+        label: 'Merci, Professeur !',
+        type: 'valid',
+        action: () => {
+          game.addShlagidiamond(10)
+          emit('done', 'halfDex')
+        },
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :speaker="profSchlag.name"
+    avatar-url="/characters/prof-merdant/prof-merdant.png"
+    :dialog-tree="dialogTree"
+  />
+</template>

--- a/src/data/characters/prof-schlag.ts
+++ b/src/data/characters/prof-schlag.ts
@@ -1,0 +1,7 @@
+import type { Character } from '~/type/character'
+
+export const profSchlag: Character = {
+  id: 'prof-schlag',
+  name: 'Professeur Schlag',
+  gender: 'male',
+}

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { markRaw } from 'vue'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
 import DialogStarter from '~/components/dialog/DialogStarter.vue'
+import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
 import ReleaseSchlagemonDialog from '~/components/dialog/ReleaseSchlagemonDialog.vue'
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
@@ -32,6 +33,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'richReward',
       component: markRaw(AnotherShlagemonDialog),
       condition: () => game.shlagidolar >= 10,
+    },
+    {
+      id: 'halfDex',
+      component: markRaw(HalfDexDialog),
+      condition: () => dex.completionPercent >= 50,
     },
     {
       id: 'release',


### PR DESCRIPTION
## Summary
- celebrate 50% dex completion with a new professor dialog
- register the new character and dialog component
- expose the dialog in the dialog store

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6868e0c35ec0832a8aaee2ab4433813d