### PR TITLE
Improve effect timer bubbles

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -207,6 +207,7 @@ declare global {
   const useIntersectionObserver: typeof import('@vueuse/core')['useIntersectionObserver']
   const useInterval: typeof import('@vueuse/core')['useInterval']
   const useIntervalFn: typeof import('@vueuse/core')['useIntervalFn']
+  const useInventoryModalStore: typeof import('./stores/inventoryModal')['useInventoryModalStore']
   const useInventoryStore: typeof import('./stores/inventory')['useInventoryStore']
   const useKeyModifier: typeof import('@vueuse/core')['useKeyModifier']
   const useLastChanged: typeof import('@vueuse/core')['useLastChanged']
@@ -565,6 +566,7 @@ declare module 'vue' {
     readonly useIntersectionObserver: UnwrapRef<typeof import('@vueuse/core')['useIntersectionObserver']>
     readonly useInterval: UnwrapRef<typeof import('@vueuse/core')['useInterval']>
     readonly useIntervalFn: UnwrapRef<typeof import('@vueuse/core')['useIntervalFn']>
+    readonly useInventoryModalStore: UnwrapRef<typeof import('./stores/inventoryModal')['useInventoryModalStore']>
     readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -4,8 +4,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { onUnmounted, ref } from 'vue'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
-import Tooltip from '~/components/ui/Tooltip.vue'
-import { formatDuration } from '~/utils/formatDuration'
+import EffectBadge from './EffectBadge.vue'
 
 interface Props {
   mon: DexShlagemon
@@ -41,27 +40,17 @@ function onAnimationEnd() {
   if (props.fainted)
     emit('faintEnd')
 }
-
-function remainingTime(effect: ActiveEffect) {
-  return formatDuration(effect.expiresAt - now.value)
-}
 </script>
 
 <template>
   <div class="relative w-full flex flex-col items-center">
     <div class="absolute left-0 top-0 flex gap-1">
-      <Tooltip
+      <EffectBadge
         v-for="e in props.effects"
         :key="e.id"
-        :text="e.type === 'attack' ? `Attaque +${e.percent}%` : `Défense +${e.percent}%`"
-      >
-        <div class="relative h-5 w-5">
-          <div class="h-5 w-5" :class="[`i-${e.icon}`, e.iconClass]" />
-          <span class="absolute rounded-full bg-white px-0.5 text-[10px] font-bold -right-1 -top-1 dark:bg-gray-800">
-            {{ remainingTime(e) }}
-          </span>
-        </div>
-      </Tooltip>
+        :effect="e"
+        :now="now"
+      />
     </div>
     <ShlagemonImage
       :id="props.mon.base.id"

--- a/src/components/battle/EffectBadge.vue
+++ b/src/components/battle/EffectBadge.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { ActiveEffect } from '~/type/effect'
+import { computed } from 'vue'
+import Tooltip from '~/components/ui/Tooltip.vue'
+import { formatDuration } from '~/utils/formatDuration'
+
+const props = defineProps<{ effect: ActiveEffect, now: number }>()
+
+const remaining = computed(() => formatDuration(props.effect.expiresAt - props.now))
+
+const tooltipText = computed(() =>
+  props.effect.type === 'attack'
+    ? `Votre attaque est boostée pour encore ${remaining.value}`
+    : `Votre défense est boostée pour encore ${remaining.value}`,
+)
+
+function colorClasses(prefix: string) {
+  if (!props.effect.iconClass)
+    return ''
+  return props.effect.iconClass
+    .split(' ')
+    .filter(c => c.includes('text-'))
+    .map((c) => {
+      const dark = c.startsWith('dark:')
+      const cls = c.replace(/^(dark:)?text-/, '')
+      return `${dark ? 'dark:' : ''}${prefix}-${cls}`
+    })
+    .join(' ')
+}
+
+const border = computed(() => `${colorClasses('border')} border`)
+const bg = computed(() => `${colorClasses('bg')}/20`)
+</script>
+
+<template>
+  <Tooltip :text="tooltipText">
+    <div class="flex items-center gap-1 rounded px-1 text-xs font-mono" :class="[bg, border]">
+      <div class="h-4 w-4" :class="[`i-${props.effect.icon}`, props.effect.iconClass]" />
+      <span class="w-16 text-center">{{ remaining }}</span>
+    </div>
+  </Tooltip>
+</template>


### PR DESCRIPTION
## Summary
- show active battle effects with a new `EffectBadge` component
- use tooltip with remaining time and color-coded background
- clean up `BattleShlagemon` effect display

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Failed to fetch web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6868e4c1d884832ab2b2912df5fe6e1d