### PR TITLE
Fix zone fallback for invalid persistence

### DIFF
--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -15,7 +15,10 @@ import { useShlagedexStore } from './shlagedex'
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
   const currentId = ref<string>(zones.value[0].id)
-  const current = computed(() => zones.value.find(z => z.id === currentId.value)!)
+  const current = computed(() => {
+    const zone = zones.value.find(z => z.id === currentId.value)
+    return zone ?? zones.value[0]
+  })
   const xpZones = computed(() => zones.value.filter(z => z.maxLevel > 0))
 
   const kings = ref<Record<string, Trainer>>({})


### PR DESCRIPTION
## Summary
- ensure `current` zone always falls back to valid zone

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6868e387cec0832abc1ba0244cd726b1