### PR TITLE
Fix dedup logic to keep active Shlagemon

### DIFF
--- a/src/utils/saveFix.ts
+++ b/src/utils/saveFix.ts
@@ -4,7 +4,7 @@ import type { DexShlagemon } from '~/type'
  * Supprime les doublons dans le Schlagedex en choisissant le meilleur
  * Schlagémon de chaque base.
  */
-export function deduplicateDex(mons: DexShlagemon[]): DexShlagemon[] {
+export function deduplicateDex(mons: DexShlagemon[], activeId?: string): DexShlagemon[] {
   const groups = new Map<string, DexShlagemon[]>()
   for (const mon of mons) {
     const baseId = mon.base.id
@@ -22,7 +22,12 @@ export function deduplicateDex(mons: DexShlagemon[]): DexShlagemon[] {
       if (isBetter(mon, best))
         best = mon
     }
-    result.push(best)
+
+    const keep = arr.find(m => m.id === activeId) ?? best
+    if (keep !== best)
+      Object.assign(keep, { ...best, id: keep.id })
+
+    result.push(keep)
   }
   return result
 }

--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -54,16 +54,12 @@ export const shlagedexSerializer = {
       })
       .filter(Boolean)
 
-    shlagemons = deduplicateDex(shlagemons)
-
+    // build active before deduplication so that deduplication can keep its id
     let active = parsed.activeShlagemon
     if (active) {
       const base = active.base ?? baseMap[active.baseId]
       if (base) {
-        const found
-          = shlagemons.find((m: any) => m.id === active.id)
-            || shlagemons.find((m: any) => m.base.id === base.id)
-        active = found || {
+        active = {
           ...active,
           base,
           baseId: active.baseId ?? base.id,
@@ -81,6 +77,15 @@ export const shlagedexSerializer = {
       else {
         active = null
       }
+    }
+
+    shlagemons = deduplicateDex(shlagemons, active?.id)
+
+    if (active) {
+      const found = shlagemons.find((m: any) => m.id === active!.id)
+        || shlagemons.find((m: any) => m.base.id === active!.base.id)
+      if (found)
+        active = found
     }
 
     return {


### PR DESCRIPTION
## Summary
- preserve the active Shlagemon's id during Schlagedex deduplication
- update serializer to build the active mon before deduping and retain it afterwards

## Testing
- `npm test` *(fails: Failed to fetch web fonts)*
- `npm run lint`
- `npm run typecheck` *(fails: various TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868e3791a9c832a9f4f7c7519905760