### PR TITLE
Implement damage bonus from music and shiny status

### DIFF
--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -1,6 +1,7 @@
 import type { DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
 import { computeDamage } from '~/utils/combat'
+import { useAudioStore } from './audio'
 import { useShlagedexStore } from './shlagedex'
 
 export interface AttackResult {
@@ -11,6 +12,7 @@ export interface AttackResult {
 
 export const useBattleStore = defineStore('battle', () => {
   const dex = useShlagedexStore()
+  const audio = useAudioStore()
   function attack(
     attacker: DexShlagemon,
     defender: DexShlagemon,
@@ -21,8 +23,11 @@ export const useBattleStore = defineStore('battle', () => {
     const atkType = attacker.base.types[0]
     const defType = defender.base.types[0]
     const atkBonus = isPlayerAttacker ? 1 + dex.bonusPercent / 100 : 1
+    const musicBonus = audio.isMusicEnabled ? 1.1 : 1
+    const shinyBonus = attacker.isShiny ? 1.15 : 1
     const defBonus = isPlayerDefender ? 1 + dex.bonusPercent / 100 : 1
-    const result = computeDamage(Math.round(attacker.attack * atkBonus), atkType, defType)
+    const baseAttack = Math.round(attacker.attack * atkBonus * musicBonus * shinyBonus)
+    const result = computeDamage(baseAttack, atkType, defType)
     const roundedDamage = Math.max(1, Math.round(result.damage / defBonus))
     const finalDamage = reduced ? Math.round(roundedDamage / 5) : roundedDamage // reduced (case by clicking)
     defender.hpCurrent = Math.max(0, defender.hpCurrent - finalDamage)


### PR DESCRIPTION
## Summary
- give attack bonus when music is enabled
- give attack bonus when the attacking Shlagémon is shiny

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined & network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68691175d5dc832aa5a268cdab72863e