### PR TITLE
Fix Tooltip cleanup

### DIFF
--- a/src/components/ui/Tooltip.vue
+++ b/src/components/ui/Tooltip.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom'
-import { ref } from 'vue'
+import { onUnmounted, ref } from 'vue'
 
 const props = defineProps<{ text: string }>()
 
@@ -33,6 +33,8 @@ function hide() {
     cleanup = undefined
   }
 }
+
+onUnmounted(hide)
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- prevent tooltip from calling Floating UI on missing elements by cleaning up on unmount

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*
- `pnpm test:e2e` *(fails: dependency Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_686913a93448832ab76803bfdcf3f45b