### PR TITLE
Show map under main panel on mobile

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -358,6 +358,9 @@ declare global {
   // @ts-ignore
   export type { MainPanel } from './stores/mainPanel'
   import('./stores/mainPanel')
+  // @ts-ignore
+  export type { MobileTab } from './stores/mobileTab'
+  import('./stores/mobileTab')
 }
 
 // for vue template auto import
@@ -563,6 +566,7 @@ declare module 'vue' {
     readonly useIntersectionObserver: UnwrapRef<typeof import('@vueuse/core')['useIntersectionObserver']>
     readonly useInterval: UnwrapRef<typeof import('@vueuse/core')['useInterval']>
     readonly useIntervalFn: UnwrapRef<typeof import('@vueuse/core')['useIntervalFn']>
+    readonly useInventoryModalStore: UnwrapRef<typeof import('./stores/inventoryModal')['useInventoryModalStore']>
     readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>
@@ -571,10 +575,12 @@ declare module 'vue' {
     readonly useMagicKeys: UnwrapRef<typeof import('@vueuse/core')['useMagicKeys']>
     readonly useMainPanelStore: UnwrapRef<typeof import('./stores/mainPanel')['useMainPanelStore']>
     readonly useManualRefHistory: UnwrapRef<typeof import('@vueuse/core')['useManualRefHistory']>
+    readonly useMapModalStore: UnwrapRef<typeof import('./stores/mapModal')['useMapModalStore']>
     readonly useMediaControls: UnwrapRef<typeof import('@vueuse/core')['useMediaControls']>
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>
     readonly useMemoize: UnwrapRef<typeof import('@vueuse/core')['useMemoize']>
     readonly useMemory: UnwrapRef<typeof import('@vueuse/core')['useMemory']>
+    readonly useMobileTabStore: UnwrapRef<typeof import('./stores/mobileTab')['useMobileTabStore']>
     readonly useModel: UnwrapRef<typeof import('vue')['useModel']>
     readonly useMounted: UnwrapRef<typeof import('@vueuse/core')['useMounted']>
     readonly useMouse: UnwrapRef<typeof import('@vueuse/core')['useMouse']>

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -47,7 +47,9 @@ const isInventoryVisible = computed(() => inventory.list.length > 0)
 const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
 const isAchievementVisible = computed(() => achievements.hasAny)
 
-const displayZonePanel = computed(() => isShlagedexVisible.value && !isMobile.value)
+const displayZonePanel = computed(() =>
+  isShlagedexVisible.value && (!isMobile.value || mobileTab.current === 'game'),
+)
 const displayPlayerInfo = computed(() => !isMobile.value || mobileTab.current === 'game')
 const displayMainPanel = computed(() => showMainPanel.value && (!isMobile.value || mobileTab.current === 'game'))
 const displayInventory = computed(() => isInventoryVisible.value && !isMobile.value)
@@ -74,19 +76,13 @@ watch(
       class="game flex flex-col gap-1 p-1"
       md="grid grid-cols-12 grid-rows-12 w-full h-full gap-2"
     >
-      <div v-if="displayZonePanel" class="zone zone-big" md="col-span-6 row-span-5  col-start-4 row-start-8">
-        <!-- middle C zone -->
-        <PanelWrapper title="Zones">
-          <ZonePanel />
-        </PanelWrapper>
-      </div>
       <div v-if="displayPlayerInfo" class="zone overflow-visible!" md="col-span-6 row-span-1 col-start-4 row-start-1">
         <!-- top zone -->
         <PanelWrapper is-inline>
           <PlayerInfos />
         </PanelWrapper>
       </div>
-      <div v-if="displayMainPanel" class="zone h-[50vh]" md="col-span-6 row-span-6 col-start-4 row-start-2">
+      <div v-if="displayMainPanel" class="zone h-[66vh]" md="col-span-6 row-span-6 col-start-4 row-start-2">
         <!-- middle A zone -->
         <PanelWrapper>
           <MainPanel class="flex-1" />
@@ -94,6 +90,12 @@ watch(
             v-if="showXpBar && shlagedex.activeShlagemon"
             :mon="shlagedex.activeShlagemon"
           />
+        </PanelWrapper>
+      </div>
+      <div v-if="displayZonePanel" class="zone h-[33vh]" md="col-span-6 row-span-5  col-start-4 row-start-8">
+        <!-- middle C zone -->
+        <PanelWrapper title="Zones">
+          <ZonePanel />
         </PanelWrapper>
       </div>
       <!-- <div v-if="shlagedex.activeShlagemon" class="zone" md="col-span-6 row-span-1 col-start-4 row-start-7">

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,19 +1,10 @@
 <script setup lang="ts">
 import Button from '~/components/ui/Button.vue'
 import { useInventoryModalStore } from '~/stores/inventoryModal'
-import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
 
 const mobile = useMobileTabStore()
-const mapModal = useMapModalStore()
 const inventoryModal = useInventoryModalStore()
-
-function toggleMap() {
-  if (mapModal.isVisible)
-    mapModal.close()
-  else
-    mapModal.open()
-}
 
 function toggleInventory() {
   if (inventoryModal.isVisible)
@@ -37,9 +28,6 @@ function toggleInventory() {
       <div class="i-carbon-game-console" />
     </Button>
     <div class="flex gap-2">
-      <Button type="icon" :class="mapModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''" @click="toggleMap">
-        <div class="i-carbon-map" />
-      </Button>
       <Button type="icon" :class="inventoryModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''" @click="toggleInventory">
         <div class="i-carbon-inventory-management" />
       </Button>

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import { useMediaQuery } from '@vueuse/core'
 import MultiExpIcon from '~/components/icons/multi-exp.vue'
 import Modal from '~/components/modal/Modal.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMobileTabStore } from '~/stores/mobileTab'
 import { useMultiExpStore } from '~/stores/multiExp'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonType from './ShlagemonType.vue'
@@ -17,6 +19,8 @@ const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 const isTrainerBattle = computed(() => panel.current === 'trainerBattle')
 const multiExpStore = useMultiExpStore()
+const mobile = useMobileTabStore()
+const isMobile = useMediaQuery('(max-width: 767px)')
 const sortOptions = [
   { label: 'Niveau', value: 'level' },
   { label: 'Rareté', value: 'rarity' },
@@ -88,6 +92,8 @@ function changeActive(mon: DexShlagemon) {
   if (isTrainerBattle.value)
     return
   dex.setActiveShlagemon(mon)
+  if (isMobile.value)
+    mobile.set('game')
 }
 
 function isActive(mon: DexShlagemon) {


### PR DESCRIPTION
## Summary
- display ZonePanel under battle on mobile
- remove map button from mobile menu
- switch to gameplay tab when changing active Schlagémon

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686914d0f694832ab59f541d70e5885b