### PR TITLE
feat: shiny sort option

### DIFF
--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -24,6 +24,7 @@ const isMobile = useMediaQuery('(max-width: 767px)')
 const sortOptions = [
   { label: 'Niveau', value: 'level' },
   { label: 'Rareté', value: 'rarity' },
+  { label: 'Shiny', value: 'shiny' },
   { label: 'Nom', value: 'name' },
   { label: 'Type', value: 'type' },
   { label: 'Attaque', value: 'attack' },
@@ -44,6 +45,9 @@ const displayedMons = computed(() => {
       break
     case 'rarity':
       mons.sort((a, b) => a.rarity - b.rarity)
+      break
+    case 'shiny':
+      mons.sort((a, b) => Number(a.isShiny) - Number(b.isShiny))
       break
     case 'attack':
       mons.sort((a, b) => a.attack - b.attack)

--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -6,6 +6,7 @@ export type DexSort =
   | 'rarity'
   | 'name'
   | 'type'
+  | 'shiny'
   | 'attack'
   | 'defense'
   | 'count'

--- a/test/sort-shiny.test.ts
+++ b/test/sort-shiny.test.ts
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import Shlagedex from '../src/components/shlagemon/Shlagedex.vue'
+import { carapouffe, sacdepates } from '../src/data/shlagemons'
+import { useDexFilterStore } from '../src/stores/dexFilter'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('shlagedex sort', () => {
+  it('displays shiny shlagemons first', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const filter = useDexFilterStore()
+    dex.createShlagemon(carapouffe, false)
+    dex.createShlagemon(sacdepates, true)
+    filter.sortBy = 'shiny'
+    const wrapper = mount(Shlagedex, {
+      global: {
+        plugins: [pinia],
+        stubs: [
+          'ShlagemonImage',
+          'ShlagemonType',
+          'Modal',
+          'SearchInput',
+          'SelectOption',
+          'CheckBox',
+          'MultiExpIcon',
+        ],
+      },
+    })
+
+    const items = wrapper.findAll('div.relative')
+    expect(items.length).toBe(2)
+    expect(items[0].text()).toContain('Sac de Pâtes')
+  })
+})


### PR DESCRIPTION
## Summary
- allow sorting the Schlagedex by shiny status
- update dex filter store for shiny sorting
- test shiny sorting in the Schlagedex

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient') and snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68691f6cd0dc832a9d6be7ad916b7d0a