### PR TITLE
Fix tooltip after capture

### DIFF
--- a/src/components/ui/Tooltip.vue
+++ b/src/components/ui/Tooltip.vue
@@ -11,13 +11,17 @@ let cleanup: (() => void) | undefined
 
 function show() {
   visible.value = true
-  if (wrapper.value && tooltip.value) {
-    cleanup = autoUpdate(wrapper.value, tooltip.value, () => {
-      computePosition(wrapper.value!, tooltip.value!, {
+  const wrapperEl = wrapper.value
+  const tooltipEl = tooltip.value
+  if (wrapperEl && tooltipEl) {
+    cleanup = autoUpdate(wrapperEl, tooltipEl, () => {
+      if (!wrapperEl || !tooltipEl)
+        return
+      computePosition(wrapperEl, tooltipEl, {
         placement: 'top',
         middleware: [offset(6), flip(), shift({ padding: 4 })],
       }).then(({ x, y }) => {
-        Object.assign(tooltip.value!.style, {
+        Object.assign(tooltipEl.style, {
           left: `${x}px`,
           top: `${y}px`,
         })


### PR DESCRIPTION
## Summary
- ensure autoUpdate uses stable elements to avoid `getComputedStyle` errors

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, etc)*

------
https://chatgpt.com/codex/tasks/task_e_686921b5cf4c832a822e4d2cbe008701