### PR TITLE
Update menu icons and layout

### DIFF
--- a/src/components/inventory/InventoryModal.vue
+++ b/src/components/inventory/InventoryModal.vue
@@ -10,6 +10,9 @@ const inventoryModal = useInventoryModalStore()
 <template>
   <Modal v-model="inventoryModal.isVisible" footer-close>
     <PanelWrapper title="Inventaire">
+      <template #icon>
+        <div class="i-carbon-inventory-management" />
+      </template>
       <InventoryPanel />
     </PanelWrapper>
   </Modal>

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -2,6 +2,7 @@
 import { useMediaQuery } from '@vueuse/core'
 import { computed, watch } from 'vue'
 import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
+import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import InventoryModal from '~/components/inventory/InventoryModal.vue'
 import InventoryPanel from '~/components/panels/InventoryPanel.vue'
 import MainPanel from '~/components/panels/MainPanel.vue'
@@ -95,6 +96,9 @@ watch(
       <div v-if="displayZonePanel" class="zone h-[33vh]" md="col-span-6 row-span-5  col-start-4 row-start-8">
         <!-- middle C zone -->
         <PanelWrapper title="Zones">
+          <template #icon>
+            <div class="i-carbon-map" />
+          </template>
           <ZonePanel />
         </PanelWrapper>
       </div>
@@ -106,15 +110,24 @@ watch(
       <div v-if="displayInventory || displayAchievements" class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1 flex flex-col gap-2">
         <!-- left zone -->
         <PanelWrapper v-if="displayInventory" title="Inventaire">
+          <template #icon>
+            <div class="i-carbon-inventory-management" />
+          </template>
           <InventoryPanel />
         </PanelWrapper>
         <PanelWrapper v-if="displayAchievements" title="Succès">
+          <template #icon>
+            <div class="i-carbon-trophy" />
+          </template>
           <AchievementsPanel />
         </PanelWrapper>
       </div>
       <div v-if="displayDex" class="zone tiny-scrollbar" md="col-span-3 row-span-12 col-start-10 row-start-1  overflow-auto">
         <!-- right zone -->
         <PanelWrapper title="Shlagédex">
+          <template #icon>
+            <SchlagedexIcon class="h-4 w-4" />
+          </template>
           <Shlagedex />
         </PanelWrapper>
       </div>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import Button from '~/components/ui/Button.vue'
 import { useInventoryModalStore } from '~/stores/inventoryModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
@@ -15,22 +16,38 @@ function toggleInventory() {
 </script>
 
 <template>
-  <nav class="h-12 flex items-center justify-between bg-gray-100 px-2 md:hidden dark:bg-gray-800">
-    <div class="flex gap-2">
-      <Button type="icon" :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('dex')">
-        <div class="i-carbon-list" />
-      </Button>
-      <Button type="icon" :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('achievements')">
-        <div class="i-carbon-trophy" />
-      </Button>
-    </div>
-    <Button type="icon" class="h-14 w-14 text-2xl -my-4" :class="mobile.current === 'game' ? 'text-teal-600 dark:text-teal-400' : ''" @click="mobile.set('game')">
+  <nav class="h-12 flex items-center justify-between gap-2 bg-gray-100 px-2 md:hidden dark:bg-gray-800">
+    <Button
+      type="menu"
+      class="aspect-square"
+      :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''"
+      @click="mobile.set('dex')"
+    >
+      <SchlagedexIcon class="h-5 w-5" />
+    </Button>
+    <Button
+      type="menu"
+      class="aspect-square"
+      :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''"
+      @click="mobile.set('achievements')"
+    >
+      <div class="i-carbon-trophy" />
+    </Button>
+    <Button
+      type="icon"
+      class="h-14 w-14 text-2xl -my-4"
+      :class="mobile.current === 'game' ? 'text-teal-600 dark:text-teal-400' : ''"
+      @click="mobile.set('game')"
+    >
       <div class="i-carbon-game-console" />
     </Button>
-    <div class="flex gap-2">
-      <Button type="icon" :class="inventoryModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''" @click="toggleInventory">
-        <div class="i-carbon-inventory-management" />
-      </Button>
-    </div>
+    <Button
+      type="menu"
+      class="aspect-square"
+      :class="inventoryModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''"
+      @click="toggleInventory"
+    >
+      <div class="i-carbon-inventory-management" />
+    </Button>
   </nav>
 </template>

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -14,6 +14,8 @@ const variantClass = computed(() => {
       return 'rounded px-2 py-1 text-white bg-red-600 dark:bg-red-700 hover:bg-red-700 dark:hover:bg-red-800'
     case 'icon':
       return 'rounded-full p-2 bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
+    case 'menu':
+      return 'flex-1 p-2 rounded bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
     case 'primary':
       return 'rounded px-2 py-1 text-white bg-blue-600 dark:bg-blue-700'
     default:

--- a/src/components/ui/PanelWrapper.vue
+++ b/src/components/ui/PanelWrapper.vue
@@ -10,7 +10,10 @@ function toggle() {
 <template>
   <div class="panel-wrapper" v-bind="$attrs" :class="isInline ? '' : 'overflow-hidden'" md="h-full">
     <div v-if="props.title" class="mb-1 flex cursor-pointer items-center justify-between" @click="toggle">
-      <span class="font-bold">{{ props.title }}</span>
+      <div class="flex items-center gap-1">
+        <slot name="icon" />
+        <span class="font-bold">{{ props.title }}</span>
+      </div>
       <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
     </div>
     <div v-show="opened" class="tiny-scrollbar flex flex-1 flex-col" :class="isInline ? ' flex items-center justify-center' : 'overflow-auto'">

--- a/src/components/zones/ZoneMapModal.vue
+++ b/src/components/zones/ZoneMapModal.vue
@@ -10,6 +10,9 @@ const mapModal = useMapModalStore()
 <template>
   <Modal v-model="mapModal.isVisible" footer-close>
     <PanelWrapper title="Zones">
+      <template #icon>
+        <div class="i-carbon-map" />
+      </template>
       <ZonePanel />
     </PanelWrapper>
   </Modal>

--- a/src/type/button.ts
+++ b/src/type/button.ts
@@ -1,1 +1,7 @@
-export type ButtonType = 'primary' | 'valid' | 'danger' | 'icon' | 'default'
+export type ButtonType =
+  | 'primary'
+  | 'valid'
+  | 'danger'
+  | 'icon'
+  | 'menu'
+  | 'default'


### PR DESCRIPTION
## Summary
- allow new `menu` button type
- adjust `MobileMenu` to use square flex buttons and new Schlagedex icon
- show icons next to panel titles via `PanelWrapper`

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch errors prevent web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686922a11d70832a9fe9f37393dafc60