### PR TITLE
Add disease system

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -170,6 +170,7 @@ declare global {
   const useDevicesList: typeof import('@vueuse/core')['useDevicesList']
   const useDexFilterStore: typeof import('./stores/dexFilter')['useDexFilterStore']
   const useDialogStore: typeof import('./stores/dialog')['useDialogStore']
+  const useDiseaseStore: typeof import('./stores/disease')['useDiseaseStore']
   const useDisplayMedia: typeof import('@vueuse/core')['useDisplayMedia']
   const useDocumentVisibility: typeof import('@vueuse/core')['useDocumentVisibility']
   const useDraggable: typeof import('@vueuse/core')['useDraggable']
@@ -182,6 +183,7 @@ declare global {
   const useEventBus: typeof import('@vueuse/core')['useEventBus']
   const useEventListener: typeof import('@vueuse/core')['useEventListener']
   const useEventSource: typeof import('@vueuse/core')['useEventSource']
+  const useEventStore: typeof import('./stores/event')['useEventStore']
   const useEvolutionItemStore: typeof import('./stores/evolutionItem')['useEvolutionItemStore']
   const useEvolutionStore: typeof import('./stores/evolution')['useEvolutionStore']
   const useEyeDropper: typeof import('@vueuse/core')['useEyeDropper']
@@ -356,6 +358,9 @@ declare global {
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
   // @ts-ignore
+  export type { EventCallback } from './stores/event'
+  import('./stores/event')
+  // @ts-ignore
   export type { MainPanel } from './stores/mainPanel'
   import('./stores/mainPanel')
   // @ts-ignore
@@ -529,6 +534,7 @@ declare module 'vue' {
     readonly useDevicesList: UnwrapRef<typeof import('@vueuse/core')['useDevicesList']>
     readonly useDexFilterStore: UnwrapRef<typeof import('./stores/dexFilter')['useDexFilterStore']>
     readonly useDialogStore: UnwrapRef<typeof import('./stores/dialog')['useDialogStore']>
+    readonly useDiseaseStore: UnwrapRef<typeof import('./stores/disease')['useDiseaseStore']>
     readonly useDisplayMedia: UnwrapRef<typeof import('@vueuse/core')['useDisplayMedia']>
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>
@@ -541,6 +547,7 @@ declare module 'vue' {
     readonly useEventBus: UnwrapRef<typeof import('@vueuse/core')['useEventBus']>
     readonly useEventListener: UnwrapRef<typeof import('@vueuse/core')['useEventListener']>
     readonly useEventSource: UnwrapRef<typeof import('@vueuse/core')['useEventSource']>
+    readonly useEventStore: UnwrapRef<typeof import('./stores/event')['useEventStore']>
     readonly useEvolutionItemStore: UnwrapRef<typeof import('./stores/evolutionItem')['useEvolutionItemStore']>
     readonly useEvolutionStore: UnwrapRef<typeof import('./stores/evolution')['useEvolutionStore']>
     readonly useEyeDropper: UnwrapRef<typeof import('@vueuse/core')['useEyeDropper']>

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -11,6 +11,7 @@ import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBallStore } from '~/stores/ball'
 import { useBattleStore } from '~/stores/battle'
+import { useEventStore } from '~/stores/event'
 import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
 import { useMultiExpStore } from '~/stores/multiExp'
@@ -28,6 +29,7 @@ const battle = useBattleStore()
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
 const multiExpStore = useMultiExpStore()
+const events = useEventStore()
 const equilibrerank = 2
 
 const wins = computed(() => progress.getWins(zone.current.id))
@@ -189,6 +191,7 @@ function checkEnd() {
     playerFainted.value = playerHp.value <= 0
     enemyFainted.value = enemyHp.value <= 0
     setTimeout(async () => {
+      events.emit('battle:end')
       if (dex.activeShlagemon) {
         dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
         playerHp.value = dex.activeShlagemon.hpCurrent

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -8,6 +8,7 @@ import { useBattleEffects, useSingleInterval } from '~/composables/battleEngine'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
+import { useEventStore } from '~/stores/event'
 import { useGameStore } from '~/stores/game'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMultiExpStore } from '~/stores/multiExp'
@@ -25,6 +26,7 @@ const panel = useMainPanelStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
 const multiExpStore = useMultiExpStore()
+const events = useEventStore()
 const equilibrerank = 2
 
 const trainer = computed(() => trainerStore.current)
@@ -156,6 +158,7 @@ function checkEnd() {
     playerFainted.value = playerHp.value <= 0
     enemyFainted.value = enemyHp.value <= 0
     setTimeout(async () => {
+      events.emit('battle:end')
       if (enemyHp.value <= 0 && playerHp.value > 0) {
         if (dex.activeShlagemon && enemy.value) {
           const xp = xpRewardForLevel(enemy.value.lvl)

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -9,13 +9,17 @@ import CurrencyAmount from '~/components/ui/CurrencyAmount.vue'
 import Tooltip from '~/components/ui/Tooltip.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { useBallStore } from '~/stores/ball'
+import { useDiseaseStore } from '~/stores/disease'
 import { useInventoryStore } from '~/stores/inventory'
+import { usePlayerStore } from '~/stores/player'
 import { ballHues } from '~/utils/ball'
 
 const game = useGameStore()
 const dex = useShlagedexStore()
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
+const player = usePlayerStore()
+const disease = useDiseaseStore()
 
 const showBonus = ref(false)
 
@@ -27,6 +31,15 @@ const totalInDex = allShlagemons.length
     class="w-full inline-flex items-center justify-around gap-3 rounded bg-white text-xs dark:bg-gray-900"
     sm="text-sm"
   >
+    <span v-if="player.pseudo" class="min-w-0 flex items-center gap-1 font-bold">
+      {{ player.pseudo }}
+      <Tooltip
+        v-if="disease.active"
+        :text="`Malade : ${disease.remaining} combats restants`"
+      >
+        <div class="i-mdi:emoticon-sick text-red-500" />
+      </Tooltip>
+    </span>
     <CurrencyAmount :amount="game.shlagidolar" currency="shlagidolar" />
     <CurrencyAmount :amount="game.shlagidiamond" currency="shlagidiamond" />
     <Tooltip text="SchlagéDex">

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -2,6 +2,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
 import { computeDamage } from '~/utils/combat'
 import { useAudioStore } from './audio'
+import { useDiseaseStore } from './disease'
 import { useShlagedexStore } from './shlagedex'
 
 export interface AttackResult {
@@ -13,6 +14,7 @@ export interface AttackResult {
 export const useBattleStore = defineStore('battle', () => {
   const dex = useShlagedexStore()
   const audio = useAudioStore()
+  const disease = useDiseaseStore()
   function attack(
     attacker: DexShlagemon,
     defender: DexShlagemon,
@@ -29,7 +31,9 @@ export const useBattleStore = defineStore('battle', () => {
     const baseAttack = Math.round(attacker.attack * atkBonus * musicBonus * shinyBonus)
     const result = computeDamage(baseAttack, atkType, defType)
     const roundedDamage = Math.max(1, Math.round(result.damage / defBonus))
-    const finalDamage = reduced ? Math.round(roundedDamage / 5) : roundedDamage // reduced (case by clicking)
+    let finalDamage = reduced ? Math.round(roundedDamage / 5) : roundedDamage // reduced (case by clicking)
+    if (isPlayerAttacker && disease.active)
+      finalDamage = 1
     defender.hpCurrent = Math.max(0, defender.hpCurrent - finalDamage)
     return { ...result, damage: finalDamage }
   }

--- a/src/stores/disease.ts
+++ b/src/stores/disease.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { toast } from 'vue3-toastify'
+import { useEventStore } from './event'
+
+export const useDiseaseStore = defineStore('disease', () => {
+  const active = ref(false)
+  const remaining = ref(0)
+  const events = useEventStore()
+
+  function start() {
+    active.value = true
+    remaining.value = 100
+    toast('Votre Schlagémon est malade !')
+  }
+
+  function clear() {
+    active.value = false
+    remaining.value = 0
+  }
+
+  function onBattleEnd() {
+    if (active.value) {
+      remaining.value -= 1
+      if (remaining.value <= 0)
+        clear()
+    }
+    else if (Math.random() < 0.00001) {
+      start()
+    }
+  }
+
+  events.on('battle:end', onBattleEnd)
+
+  return { active, remaining, start }
+}, {
+  persist: true,
+})

--- a/src/stores/event.ts
+++ b/src/stores/event.ts
@@ -1,0 +1,23 @@
+import { defineStore } from 'pinia'
+
+export type EventCallback<T = any> = (payload: T) => void
+
+export const useEventStore = defineStore('event', () => {
+  const listeners = new Map<string, Set<EventCallback>>()
+
+  function on<T = any>(event: string, cb: EventCallback<T>) {
+    if (!listeners.has(event))
+      listeners.set(event, new Set())
+    listeners.get(event)!.add(cb as EventCallback)
+  }
+
+  function off<T = any>(event: string, cb: EventCallback<T>) {
+    listeners.get(event)?.delete(cb as EventCallback)
+  }
+
+  function emit<T = any>(event: string, payload: T) {
+    listeners.get(event)?.forEach(cb => cb(payload))
+  }
+
+  return { on, off, emit }
+})

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -15,6 +15,7 @@ import {
   xpForLevel,
 } from '~/utils/dexFactory'
 import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
+import { useDiseaseStore } from './disease'
 import { useEvolutionStore } from './evolution'
 import { useZoneProgressStore } from './zoneProgress'
 
@@ -24,6 +25,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const highestLevel = ref(0)
   const effects = ref<ActiveEffect[]>([])
   const progress = useZoneProgressStore()
+  const disease = useDiseaseStore()
   const baseMap = Object.fromEntries(allShlagemons.map(b => [b.id, b]))
   cleanupEffects()
   watchEffect(cleanupEffects)
@@ -97,6 +99,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   }
 
   function setActiveShlagemon(mon: DexShlagemon) {
+    if (disease.active)
+      return
     activeShlagemon.value = mon
   }
 


### PR DESCRIPTION
## Summary
- implement a generic event store
- add disease store to handle random sickness after battles
- prevent switching schlagemon when diseased and reduce damage
- show disease status in PlayerInfos panel
- emit events after battles

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError when retrieving web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686937cebf54832ab5dbecd8de840352