### PR TITLE
Add held item support for Schlagemon

### DIFF
--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -74,7 +74,12 @@ const captureInfo = computed(() => {
     <h2 class="mb-2 flex items-center justify-between text-lg font-bold">
       <div class="flex items-center gap-1">
         <span :class="mon.isShiny ? 'shiny-text' : ''">{{ mon.base.name }}</span>  - lvl {{ mon.lvl }}
-        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="h-4 w-4" />
+        <template v-if="multiExpStore.holderId === mon.id">
+          <MultiExpIcon class="h-4 w-4" />
+          <Button type="icon" class="ml-1" @click="multiExpStore.removeHolder()">
+            <div i-carbon-trash-can />
+          </Button>
+        </template>
       </div>
       <Tooltip text="Plus un Pokémon est rare, plus son potentiel de puissance est élevé.">
         <ShlagemonRarity :rarity="mon.rarity" class="rounded-tr-0 -m-r-4 -m-t-4" />

--- a/src/stores/multiExp.ts
+++ b/src/stores/multiExp.ts
@@ -1,11 +1,13 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { useInventoryStore } from './inventory'
 import { useShlagedexStore } from './shlagedex'
 
 export const useMultiExpStore = defineStore('multiExp', () => {
   const holderId = ref<string | null>(null)
   const isVisible = ref(false)
   const dex = useShlagedexStore()
+  const inventory = useInventoryStore()
 
   const holder = computed(() =>
     holderId.value ? dex.shlagemons.find(m => m.id === holderId.value) || null : null,
@@ -20,11 +22,29 @@ export const useMultiExpStore = defineStore('multiExp', () => {
   }
 
   function setHolder(monId: string) {
+    const previous = holder.value
+    if (previous) {
+      previous.heldItemId = null
+    }
+    const mon = dex.shlagemons.find(m => m.id === monId)
+    if (mon) {
+      mon.heldItemId = 'multi-exp'
+      inventory.remove('multi-exp')
+    }
     holderId.value = monId
     close()
   }
 
-  return { holderId, holder, isVisible, open, close, setHolder }
+  function removeHolder() {
+    const mon = holder.value
+    if (!mon)
+      return
+    mon.heldItemId = null
+    inventory.add('multi-exp')
+    holderId.value = null
+  }
+
+  return { holderId, holder, isVisible, open, close, setHolder, removeHolder }
 }, {
   persist: true,
 })

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -39,4 +39,8 @@ export interface DexShlagemon extends Stats {
    * When true, this Shlagémon will evolve automatically without asking.
    */
   allowEvolution: boolean
+  /**
+   * ID of the item currently held by the Shlagémon, if any.
+   */
+  heldItemId?: string | null
 }

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -65,6 +65,7 @@ export function createDexShlagemon(
     isShiny: shiny || Math.random() < 0.01,
     hpCurrent: 0,
     allowEvolution: true,
+    heldItemId: null,
   }
   applyStats(mon)
   return mon

--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -16,12 +16,14 @@ export const shlagedexSerializer = {
         ...mon,
         baseId: mon.base?.id ?? mon.baseId,
         base: undefined, // on supprime la boucle
+        heldItemId: mon.heldItemId ?? null,
       })),
       activeShlagemon: data.activeShlagemon
         ? {
             ...data.activeShlagemon,
             baseId: data.activeShlagemon.base?.id ?? data.activeShlagemon.baseId,
             base: undefined,
+            heldItemId: data.activeShlagemon.heldItemId ?? null,
           }
         : null,
     })
@@ -50,6 +52,7 @@ export const shlagedexSerializer = {
           allowEvolution: mon.allowEvolution ?? true,
           captureDate: mon.captureDate ?? new Date().toISOString(),
           captureCount: mon.captureCount ?? 1,
+          heldItemId: mon.heldItemId ?? null,
         }
       })
       .filter(Boolean)
@@ -72,6 +75,7 @@ export const shlagedexSerializer = {
           allowEvolution: active.allowEvolution ?? true,
           captureDate: active.captureDate ?? new Date().toISOString(),
           captureCount: active.captureCount ?? 1,
+          heldItemId: active.heldItemId ?? null,
         }
       }
       else {


### PR DESCRIPTION
## Summary
- allow each Schlagemon to store a held item
- equip and unequip Multi‑EXP through MultiExp store
- show a remove button in the detail view when the Multi‑EXP is held
- persist held item in save data

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68693c26a920832ab4100423b658aa17