### PR TITLE
Add battle illness indicator

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -29,6 +29,7 @@ declare module 'vue' {
     DialogBox: typeof import('./components/dialog/DialogBox.vue')['default']
     DialogPanel: typeof import('./components/panels/DialogPanel.vue')['default']
     DialogStarter: typeof import('./components/dialog/DialogStarter.vue')['default']
+    DiseaseBadge: typeof import('./components/battle/DiseaseBadge.vue')['default']
     EffectBadge: typeof import('./components/battle/EffectBadge.vue')['default']
     EvolutionItemModal: typeof import('./components/inventory/EvolutionItemModal.vue')['default']
     EvolutionModal: typeof import('./components/shlagemon/EvolutionModal.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -11,6 +11,7 @@ import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBallStore } from '~/stores/ball'
 import { useBattleStore } from '~/stores/battle'
+import { useDiseaseStore } from '~/stores/disease'
 import { useEventStore } from '~/stores/event'
 import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
@@ -26,6 +27,7 @@ const game = useGameStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
 const battle = useBattleStore()
+const disease = useDiseaseStore()
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
 const multiExpStore = useMultiExpStore()
@@ -288,7 +290,15 @@ onUnmounted(() => {
       <div class="w-full flex flex-1 items-center justify-center gap-4">
         <div class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" flipped :effects="dex.effects" />
+          <BattleShlagemon
+            :mon="dex.activeShlagemon"
+            :hp="playerHp"
+            :fainted="playerFainted"
+            flipped
+            :effects="dex.effects"
+            :disease="disease.active"
+            :disease-remaining="disease.remaining"
+          />
         </div>
         <div class="vs font-bold">
           VS

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -4,6 +4,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { onUnmounted, ref } from 'vue'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
+import DiseaseBadge from './DiseaseBadge.vue'
 import EffectBadge from './EffectBadge.vue'
 
 interface Props {
@@ -16,6 +17,8 @@ interface Props {
   showBall?: boolean
   owned?: boolean
   effects?: ActiveEffect[]
+  disease?: boolean
+  diseaseRemaining?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -26,6 +29,8 @@ const props = withDefaults(defineProps<Props>(), {
   showBall: false,
   owned: false,
   effects: () => [],
+  disease: false,
+  diseaseRemaining: 0,
 })
 
 const emit = defineEmits<{ (e: 'faintEnd'): void }>()
@@ -43,7 +48,7 @@ function onAnimationEnd() {
 </script>
 
 <template>
-  <div class="relative w-full flex flex-col items-center">
+  <div class="relative w-full flex flex-col items-center" :class="{ 'saturate-0': props.disease }">
     <div class="absolute left-0 top-0 flex gap-1">
       <EffectBadge
         v-for="e in props.effects"
@@ -51,6 +56,7 @@ function onAnimationEnd() {
         :effect="e"
         :now="now"
       />
+      <DiseaseBadge v-if="props.disease" :remaining="props.diseaseRemaining" />
     </div>
     <ShlagemonImage
       :id="props.mon.base.id"

--- a/src/components/battle/DiseaseBadge.vue
+++ b/src/components/battle/DiseaseBadge.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import Tooltip from '~/components/ui/Tooltip.vue'
+
+const props = defineProps<{ remaining: number }>()
+</script>
+
+<template>
+  <Tooltip :text="`Malade : ${props.remaining} combats restants`">
+    <div class="relative flex items-center gap-1 border border-red-500 rounded bg-red-500/20 px-1 text-xs text-red-500">
+      <span class="absolute left-1/2 font-bold -top-2 -translate-x-1/2">{{ props.remaining }}</span>
+      <div class="i-mdi:sword-cross h-4 w-4" />
+      <div class="i-mdi:shield h-4 w-4" />
+    </div>
+  </Tooltip>
+</template>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -8,6 +8,7 @@ import { useBattleEffects, useSingleInterval } from '~/composables/battleEngine'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
+import { useDiseaseStore } from '~/stores/disease'
 import { useEventStore } from '~/stores/event'
 import { useGameStore } from '~/stores/game'
 import { useMainPanelStore } from '~/stores/mainPanel'
@@ -26,6 +27,7 @@ const panel = useMainPanelStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
 const multiExpStore = useMultiExpStore()
+const disease = useDiseaseStore()
 const events = useEventStore()
 const equilibrerank = 2
 
@@ -274,7 +276,14 @@ onUnmounted(() => {
       <div class="flex flex-1 items-center justify-center gap-4">
         <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-          <BattleShlagemon :mon="dex.activeShlagemon" :hp="playerHp" :fainted="playerFainted" :effects="dex.effects" />
+          <BattleShlagemon
+            :mon="dex.activeShlagemon"
+            :hp="playerHp"
+            :fainted="playerFainted"
+            :effects="dex.effects"
+            :disease="disease.active"
+            :disease-remaining="disease.remaining"
+          />
         </div>
         <div class="vs font-bold">
           VS

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -6,6 +6,7 @@ import Modal from '~/components/modal/Modal.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
+import { useDiseaseStore } from '~/stores/disease'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useMultiExpStore } from '~/stores/multiExp'
@@ -14,10 +15,11 @@ import ShlagemonType from './ShlagemonType.vue'
 
 const dex = useShlagedexStore()
 const panel = useMainPanelStore()
+const disease = useDiseaseStore()
 const filter = useDexFilterStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
-const isTrainerBattle = computed(() => panel.current === 'trainerBattle')
+const isLocked = computed(() => panel.current === 'trainerBattle' || disease.active)
 const multiExpStore = useMultiExpStore()
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
@@ -93,7 +95,7 @@ function onDoubleClick(mon: DexShlagemon) {
 }
 
 function changeActive(mon: DexShlagemon) {
-  if (isTrainerBattle.value)
+  if (isLocked.value)
     return
   dex.setActiveShlagemon(mon)
   if (isMobile.value)
@@ -162,7 +164,7 @@ function isActive(mon: DexShlagemon) {
         <CheckBox
           class="ml-2"
           :model-value="isActive(mon)"
-          :disabled="isTrainerBattle"
+          :disabled="isLocked"
           @update:model-value="() => changeActive(mon)"
           @click.stop
         />

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -6,6 +6,7 @@ import Modal from '~/components/modal/Modal.vue'
 import Button from '~/components/ui/Button.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
 import Tooltip from '~/components/ui/Tooltip.vue'
+import { useDiseaseStore } from '~/stores/disease'
 import { useMultiExpStore } from '~/stores/multiExp'
 import { useShlagedexStore } from '~/stores/shlagedex'
 
@@ -45,7 +46,12 @@ const allowEvolution = computed({
 
 const store = useShlagedexStore()
 const multiExpStore = useMultiExpStore()
+const disease = useDiseaseStore()
 const showConfirm = ref(false)
+
+const isActiveAndSick = computed(() =>
+  disease.active && props.mon?.id === store.activeShlagemon?.id,
+)
 
 function requestRelease() {
   showConfirm.value = true
@@ -73,7 +79,8 @@ const captureInfo = computed(() => {
   <div v-if="mon" class="max-w-sm w-full rounded bg-white dark:bg-gray-900">
     <h2 class="mb-2 flex items-center justify-between text-lg font-bold">
       <div class="flex items-center gap-1">
-        <span :class="mon.isShiny ? 'shiny-text' : ''">{{ mon.base.name }}</span>  - lvl {{ mon.lvl }}
+        <span :class="mon.isShiny ? 'shiny-text' : ''">{{ mon.base.name }}</span>
+        - lvl {{ mon.lvl }}<span v-if="isActiveAndSick"> (malade)</span>
         <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="h-4 w-4" />
       </div>
       <Tooltip text="Plus un Pokémon est rare, plus son potentiel de puissance est élevé.">


### PR DESCRIPTION
## Summary
- show sickness status in battles with Defense/Attack icons and grayscale
- block mon switching when sick
- indicate illness in mon details

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch failed and tests reported multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_68693db40c78832ab304b91afa5e9248