### PR TITLE
Fix illness damage for click attack

### DIFF
--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -32,8 +32,8 @@ export const useBattleStore = defineStore('battle', () => {
     const result = computeDamage(baseAttack, atkType, defType)
     const roundedDamage = Math.max(1, Math.round(result.damage / defBonus))
     let finalDamage = reduced ? Math.round(roundedDamage / 5) : roundedDamage // reduced (case by clicking)
-    if (isPlayerAttacker && disease.active)
-      finalDamage = 1
+    if (disease.active && attacker.id === dex.activeShlagemon?.id)
+      finalDamage = 10
     defender.hpCurrent = Math.max(0, defender.hpCurrent - finalDamage)
     return { ...result, damage: finalDamage }
   }

--- a/test/disease-damage.test.ts
+++ b/test/disease-damage.test.ts
@@ -1,0 +1,23 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons'
+import { useBattleStore } from '../src/stores/battle'
+import { useDiseaseStore } from '../src/stores/disease'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('disease damage', () => {
+  it('deals 10 damage on click attack when sick', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const battle = useBattleStore()
+    const disease = useDiseaseStore()
+    const player = dex.createShlagemon(carapouffe)
+    const enemy = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(player)
+    disease.active.value = true
+    const initialHp = enemy.hpCurrent
+    const result = battle.clickAttack(player, enemy)
+    expect(result.damage).toBe(10)
+    expect(enemy.hpCurrent).toBe(initialHp - 10)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure illness reduces click attack damage to a constant value
- add unit test for disease damage

## Testing
- `pnpm lint`
- `pnpm test -t 'disease damage'` *(fails: ENETUNREACH while fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68694cb492e8832a99d2be6c3353bf99