### PR TITLE
Disable mobile menu when dialog open

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,11 +1,28 @@
 <script setup lang="ts">
+import { computed, watch } from 'vue'
 import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import Button from '~/components/ui/Button.vue'
+import { useAchievementsStore } from '~/stores/achievements'
+import { useDialogStore } from '~/stores/dialog'
+import { useInventoryStore } from '~/stores/inventory'
 import { useInventoryModalStore } from '~/stores/inventoryModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
 
 const mobile = useMobileTabStore()
 const inventoryModal = useInventoryModalStore()
+const dialog = useDialogStore()
+const inventory = useInventoryStore()
+const achievements = useAchievementsStore()
+
+const menuDisabled = computed(() => dialog.isDialogVisible)
+const dexDisabled = menuDisabled
+const achievementsDisabled = computed(() => menuDisabled.value || !achievements.hasAny)
+const inventoryDisabled = computed(() => menuDisabled.value || inventory.list.length === 0)
+
+watch(dialog.isDialogVisible, (val) => {
+  if (val)
+    mobile.set('game')
+})
 
 function toggleInventory() {
   if (inventoryModal.isVisible)
@@ -21,6 +38,7 @@ function toggleInventory() {
       type="menu"
       class="aspect-square"
       :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''"
+      :disabled="dexDisabled"
       @click="mobile.set('dex')"
     >
       <SchlagedexIcon class="h-5 w-5" />
@@ -29,6 +47,7 @@ function toggleInventory() {
       type="menu"
       class="aspect-square"
       :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''"
+      :disabled="achievementsDisabled"
       @click="mobile.set('achievements')"
     >
       <div class="i-carbon-trophy" />
@@ -45,6 +64,7 @@ function toggleInventory() {
       type="menu"
       class="aspect-square"
       :class="inventoryModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''"
+      :disabled="inventoryDisabled"
       @click="toggleInventory"
     >
       <div class="i-carbon-inventory-management" />


### PR DESCRIPTION
## Summary
- disable mobile menu buttons while a dialog is visible
- disable inventory button when empty
- disable achievement button when none unlocked
- auto focus game tab when dialog opens

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6869653784e0832aafa05edc003acd5a