### PR TITLE
Fix mobile menu buttons

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import SchlagedexIcon from '~/components/icons/schlagedex.vue'
-import Button from '~/components/ui/Button.vue'
 import { useAchievementsStore } from '~/stores/achievements'
 import { useDialogStore } from '~/stores/dialog'
 import { useInventoryStore } from '~/stores/inventory'
@@ -33,44 +32,35 @@ function toggleInventory() {
 </script>
 
 <template>
-  <nav class="h-12 flex items-center justify-between gap-2 bg-gray-100 px-2 md:hidden dark:bg-gray-800">
-    <Button
-      type="menu"
-      class="aspect-square"
-      :class="mobile.current === 'dex' ? 'text-teal-600 dark:text-teal-400' : ''"
-      :disabled="dexDisabled"
-      @click="mobile.set('dex')"
-    >
-      <SchlagedexIcon class="h-5 w-5" />
-    </Button>
-    <Button
-      type="menu"
-      class="aspect-square"
-      :class="mobile.current === 'achievements' ? 'text-teal-600 dark:text-teal-400' : ''"
+  <nav class="h-12 flex items-center justify-between gap-1px bg-gray-100 px-2 md:hidden dark:bg-gray-800">
+    <button
+      class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"
+      :class="mobile.current === 'achievements' ? 'active' : ''"
       :disabled="achievementsDisabled"
       @click="mobile.set('achievements')"
     >
       <div class="i-carbon-trophy" />
     </button>
     <button
-      class="button button-rectangle"
+      class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"
       :class="mobile.current === 'dex' ? 'active' : ''"
+      :disabled="dexDisabled"
       @click="mobile.set('dex')"
     >
-      <div class="i-carbon-game-console" />
-    </Button>
-    <Button
-      type="menu"
-      class="aspect-square"
-      :class="inventoryModal.isVisible ? 'text-teal-600 dark:text-teal-400' : ''"
+      <SchlagedexIcon class="h-5 w-5" />
+    </button>
+    <button
+      class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"
+      :class="inventoryModal.isVisible ? 'active' : ''"
       :disabled="inventoryDisabled"
       @click="toggleInventory"
     >
       <div class="i-carbon-inventory-management" />
     </button>
     <button
-      class="button button-circle"
+      class="button button-circle disabled:cursor-not-allowed disabled:opacity-50"
       :class="mobile.current === 'game' ? 'active' : ''"
+      :disabled="menuDisabled"
       @click="mobile.set('game')"
     >
       <div class="i-carbon-game-console" />


### PR DESCRIPTION
## Summary
- revert MobileMenu to plain `<button>` elements
- keep menu disabling when dialog is open and when features are unavailable
- apply active/disabled styles with Unocss classes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68696aa5af28832a8cd22dd58917087e