### PR TITLE
Fix battle timers clearing

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -33,6 +33,7 @@ const ballStore = useBallStore()
 const multiExpStore = useMultiExpStore()
 const events = useEventStore()
 const equilibrerank = 2
+let nextBattleTimer: number | undefined
 
 const wins = computed(() => progress.getWins(zone.current.id))
 const hasAllZoneMons = computed(() => {
@@ -105,7 +106,8 @@ function onCaptureEnd(success: boolean) {
       playerHp.value = dex.activeShlagemon.hpCurrent
     }
     enemy.value = null
-    setTimeout(startBattle, 1000)
+    clearTimeout(nextBattleTimer)
+    nextBattleTimer = window.setTimeout(startBattle, 1000)
   }
   else {
     battleActive.value = true
@@ -114,6 +116,7 @@ function onCaptureEnd(success: boolean) {
 }
 
 function startBattle() {
+  clearTimeout(nextBattleTimer)
   const active = dex.activeShlagemon
   if (!active)
     return
@@ -192,7 +195,8 @@ function checkEnd() {
     stopInterval()
     playerFainted.value = playerHp.value <= 0
     enemyFainted.value = enemyHp.value <= 0
-    setTimeout(async () => {
+    clearTimeout(nextBattleTimer)
+    nextBattleTimer = window.setTimeout(async () => {
       events.emit('battle:end')
       if (dex.activeShlagemon) {
         dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
@@ -268,6 +272,7 @@ watch(
 
 onUnmounted(() => {
   stopInterval()
+  clearTimeout(nextBattleTimer)
 })
 </script>
 

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -30,6 +30,7 @@ const multiExpStore = useMultiExpStore()
 const disease = useDiseaseStore()
 const events = useEventStore()
 const equilibrerank = 2
+let nextBattleTimer: number | undefined
 
 const trainer = computed(() => trainerStore.current)
 const isZoneKing = computed(() => trainer.value?.id.startsWith('king-'))
@@ -85,6 +86,7 @@ function startFight() {
 }
 
 function startBattle() {
+  clearTimeout(nextBattleTimer)
   const t = trainer.value
   if (!t || !dex.activeShlagemon)
     return
@@ -159,7 +161,8 @@ function checkEnd() {
       dex.activeShlagemon.hpCurrent = playerHp.value
     playerFainted.value = playerHp.value <= 0
     enemyFainted.value = enemyHp.value <= 0
-    setTimeout(async () => {
+    clearTimeout(nextBattleTimer)
+    nextBattleTimer = window.setTimeout(async () => {
       events.emit('battle:end')
       if (enemyHp.value <= 0 && playerHp.value > 0) {
         if (dex.activeShlagemon && enemy.value) {
@@ -229,6 +232,7 @@ function cancelFight() {
 
 onUnmounted(() => {
   stopInterval()
+  clearTimeout(nextBattleTimer)
 })
 </script>
 


### PR DESCRIPTION
## Summary
- add `nextBattleTimer` to manage battle delays
- cancel pending battle timers when starting new battles
- clear battle timers on component unmount

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined & snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68696acba848832aaf37cdf604f5aac3