### PR TITLE
Fix mobile menu watcher

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -18,10 +18,13 @@ const dexDisabled = menuDisabled
 const achievementsDisabled = computed(() => menuDisabled.value || !achievements.hasAny)
 const inventoryDisabled = computed(() => menuDisabled.value || inventory.list.length === 0)
 
-watch(dialog.isDialogVisible, (val) => {
-  if (val)
-    mobile.set('game')
-})
+watch(
+  () => dialog.isDialogVisible,
+  (val) => {
+    if (val)
+      mobile.set('game')
+  },
+)
 
 function toggleInventory() {
   if (inventoryModal.isVisible)


### PR DESCRIPTION
## Summary
- fix `watch` call in MobileMenu.vue to observe reactive value

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Could not find module declarations and other TS errors)*
- `pnpm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6869a2e90e2c832a8b7e500bf326ca54