### PR TITLE
Fix optional payload in event system

### DIFF
--- a/src/stores/event.ts
+++ b/src/stores/event.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 
-export type EventCallback<T = any> = (payload: T) => void
+export type EventCallback<T = any> = (payload?: T) => void
 
 export const useEventStore = defineStore('event', () => {
   const listeners = new Map<string, Set<EventCallback>>()
@@ -15,7 +15,7 @@ export const useEventStore = defineStore('event', () => {
     listeners.get(event)?.delete(cb as EventCallback)
   }
 
-  function emit<T = any>(event: string, payload: T) {
+  function emit<T = any>(event: string, payload?: T) {
     listeners.get(event)?.forEach(cb => cb(payload))
   }
 


### PR DESCRIPTION
## Summary
- update event type signature to make payload optional
- allow emitting events without payload

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6869a2dcd344832a936d4c2b54b86805