### PR TITLE
Fix watch call in MobileMenu

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -18,10 +18,13 @@ const dexDisabled = menuDisabled
 const achievementsDisabled = computed(() => menuDisabled.value || !achievements.hasAny)
 const inventoryDisabled = computed(() => menuDisabled.value || inventory.list.length === 0)
 
-watch(dialog.isDialogVisible, (val) => {
-  if (val)
-    mobile.set('game')
-})
+watch(
+  () => dialog.isDialogVisible,
+  (val) => {
+    if (val)
+      mobile.set('game')
+  },
+)
 
 function toggleInventory() {
   if (inventoryModal.isVisible)


### PR DESCRIPTION
## Summary
- fix `watch` usage for `dialog.isDialogVisible` in MobileMenu

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Could not find a declaration file for module 'howler', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6869a34ef47c832aa250aacd253b7ff1