### PR TITLE
Fix ItemCard currency default

### DIFF
--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -17,7 +17,7 @@ const props = defineProps<{ item: Item }>()
       <span class="font-bold">{{ props.item.name }}</span>
       <span class="text-xs">{{ props.item.description }}</span>
     </div>
-    <CurrencyAmount :amount="props.item.price" :currency="props.item.currency" />
+    <CurrencyAmount :amount="props.item.price" :currency="props.item.currency ?? 'shlagidolar'" />
     <slot />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- avoid undefined currency in ItemCard

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6869a38d7c00832a8e7e965cf95c1b51