### PR TITLE
Fix missing background clip style

### DIFF
--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -167,6 +167,7 @@ const captureInfo = computed(() => {
 .shiny-text {
   background: linear-gradient(90deg, #ff00cc, #3333ff, #00ffff, #00ff00, #ffff00, #ff9900, #ff0000);
   background-size: 400% 400%;
+  background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: shiny-rainbow 5s linear infinite;


### PR DESCRIPTION
## Summary
- ensure shiny text styles set standard `background-clip` property for broader browser support

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined; fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6869a39e6c38832ab6456edf3f52aa2b