### PR TITLE
Fix @apply lint warning

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,5 +65,7 @@
     "json",
     "jsonc",
     "yaml"
-  ]
+  ],
+  // Prevent false warnings for UnoCSS directives like `@apply`
+  "css.lint.unknownAtRules": "ignore"
 }


### PR DESCRIPTION
## Summary
- suppress VSCode warnings for `@apply` in UnoCSS by ignoring unknown CSS at-rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869a2b7ed74832a88c4a77b3e0b29a1