### PR TITLE
Add range slider component and improve audio settings

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -39,6 +39,7 @@ declare module 'vue' {
     HalfDexDialog: typeof import('./components/dialog/HalfDexDialog.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']
     ImageByBackground: typeof import('./components/ui/ImageByBackground.vue')['default']
+    InputTipRange: typeof import('./components/ui/InputTipRange.vue')['default']
     InventoryItemCard: typeof import('./components/inventory/InventoryItemCard.vue')['default']
     InventoryModal: typeof import('./components/inventory/InventoryModal.vue')['default']
     InventoryPanel: typeof import('./components/panels/InventoryPanel.vue')['default']

--- a/src/components/audio/AudioSettingsModal.vue
+++ b/src/components/audio/AudioSettingsModal.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import Modal from '~/components/modal/Modal.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
+import InputTipRange from '~/components/ui/InputTipRange.vue'
 import { useAudioStore } from '~/stores/audio'
 
 const props = defineProps<{ modelValue: boolean }>()
@@ -19,30 +20,20 @@ const audio = useAudioStore()
       <h3 class="text-center text-lg font-bold">
         Paramètres audio
       </h3>
-      <div class="flex items-center justify-between">
+      <CheckBox v-model="audio.isMusicEnabled" class="flex items-center justify-between">
         <span>Musique</span>
-        <CheckBox v-model="audio.isMusicEnabled" />
-      </div>
-      <input
-        v-model.number="audio.musicVolume"
-        type="range"
-        min="0"
-        max="1"
-        step="0.01"
+      </CheckBox>
+      <InputTipRange
+        v-model="audio.musicVolume"
         :disabled="!audio.isMusicEnabled"
-      >
-      <div class="flex items-center justify-between">
+      />
+      <CheckBox v-model="audio.isSfxEnabled" class="flex items-center justify-between">
         <span>Effets</span>
-        <CheckBox v-model="audio.isSfxEnabled" />
-      </div>
-      <input
-        v-model.number="audio.sfxVolume"
-        type="range"
-        min="0"
-        max="1"
-        step="0.01"
+      </CheckBox>
+      <InputTipRange
+        v-model="audio.sfxVolume"
         :disabled="!audio.isSfxEnabled"
-      >
+      />
     </div>
   </Modal>
 </template>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -105,10 +105,9 @@ const captureInfo = computed(() => {
     <p class="tiny-scrollbar mb-4 max-h-25 overflow-auto text-sm italic -m-r-4">
       {{ mon.base.description }}
     </p>
-    <label class="mb-4 flex items-center gap-2 text-sm">
-      <CheckBox v-model="allowEvolution" />
+    <CheckBox v-model="allowEvolution" class="mb-4 flex items-center gap-2 text-sm">
       Autoriser ce Schlagemon à évoluer ?
-    </label>
+    </CheckBox>
     <div class="grid grid-cols-2 gap-2 text-sm">
       <div
         v-for="(stat, i) in stats"

--- a/src/components/ui/CheckBox.vue
+++ b/src/components/ui/CheckBox.vue
@@ -12,15 +12,17 @@ function onChange(event: Event) {
 
 <template>
   <label
-    class="text-white"
+    v-bind="$attrs"
+    class="inline-flex items-center gap-2 text-white"
     :class="props.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'"
   >
     <input
       type="checkbox"
       :checked="props.modelValue"
       :disabled="props.disabled"
-      class="dark:border-white-400/20 h-4 w-4 transition-all duration-500 ease-in-out dark:scale-100 dark:checked:scale-100 dark:hover:scale-110"
+      class="dark:border-white-400/20 h-4 w-4 accent-blue-600 transition-all duration-500 ease-in-out dark:accent-blue-400"
       @change="onChange"
     >
+    <slot />
   </label>
 </template>

--- a/src/components/ui/InputTipRange.vue
+++ b/src/components/ui/InputTipRange.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ modelValue: number, min?: number, max?: number, step?: number, disabled?: boolean }>(), {
+  min: 0,
+  max: 1,
+  step: 0.01,
+})
+const emit = defineEmits<{ (e: 'update:modelValue', value: number): void }>()
+function onInput(e: Event) {
+  const value = Number.parseFloat((e.target as HTMLInputElement).value)
+  emit('update:modelValue', value)
+}
+const percent = computed(() => ((props.modelValue - props.min) / (props.max - props.min)) * 100)
+</script>
+
+<template>
+  <div class="relative w-full">
+    <input
+      type="range"
+      :min="props.min"
+      :max="props.max"
+      :step="props.step"
+      :value="props.modelValue"
+      :disabled="props.disabled"
+      class="range-input"
+      @input="onInput"
+    >
+    <div
+      class="absolute rounded bg-gray-700 px-1 text-xs text-white -top-5 -translate-x-1/2 dark:bg-gray-200 dark:text-gray-800"
+      :style="{ left: `calc(${percent}% )` }"
+    >
+      {{ props.modelValue.toFixed(2) }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.range-input {
+  @apply appearance-none w-full h-2 rounded bg-gray-300 dark:bg-gray-700 outline-none accent-blue-600 dark:accent-blue-400;
+}
+.range-input::-webkit-slider-thumb {
+  @apply appearance-none h-4 w-4 rounded-full bg-blue-600 dark:bg-blue-400 cursor-pointer;
+}
+.range-input::-moz-range-thumb {
+  @apply h-4 w-4 rounded-full bg-blue-600 dark:bg-blue-400 cursor-pointer;
+}
+</style>

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -1,12 +1,16 @@
+import type { AudioSettings } from '~/type'
 import { Howl } from 'howler'
 import { defineStore } from 'pinia'
-import { ref, watch } from 'vue'
+import { reactive, ref, toRefs, watch } from 'vue'
 
 export const useAudioStore = defineStore('audio', () => {
-  const musicVolume = ref(0.5)
-  const sfxVolume = ref(0.7)
-  const isMusicEnabled = ref(true)
-  const isSfxEnabled = ref(true)
+  const settings = reactive<AudioSettings>({
+    musicVolume: 0.5,
+    sfxVolume: 0.7,
+    isMusicEnabled: true,
+    isSfxEnabled: true,
+  })
+  const { musicVolume, sfxVolume, isMusicEnabled, isSfxEnabled } = toRefs(settings)
   const currentMusic = ref<Howl | null>(null)
 
   const tracks = {

--- a/src/type/audio.ts
+++ b/src/type/audio.ts
@@ -1,0 +1,6 @@
+export interface AudioSettings {
+  musicVolume: number
+  sfxVolume: number
+  isMusicEnabled: boolean
+  isSfxEnabled: boolean
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,3 +1,4 @@
+export * from './audio'
 export * from './ball'
 export * from './button'
 export * from './dialog'


### PR DESCRIPTION
## Summary
- add new `InputTipRange` slider widget
- improve `CheckBox` to accept slots and attrs
- refactor AudioSettings modal to use new slider and clickable labels
- create `AudioSettings` interface and expose in store index
- refactor audio store state using `reactive`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6869a26e7360832a9b71bfc16841d2e4