### PR TITLE
Fix range tooltip and invert checkbox label

### DIFF
--- a/src/components/ui/CheckBox.vue
+++ b/src/components/ui/CheckBox.vue
@@ -16,6 +16,7 @@ function onChange(event: Event) {
     class="inline-flex items-center gap-2 text-white"
     :class="props.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'"
   >
+    <slot />
     <input
       type="checkbox"
       :checked="props.modelValue"
@@ -23,6 +24,5 @@ function onChange(event: Event) {
       class="dark:border-white-400/20 h-4 w-4 accent-blue-600 transition-all duration-500 ease-in-out dark:accent-blue-400"
       @change="onChange"
     >
-    <slot />
   </label>
 </template>

--- a/src/components/ui/InputTipRange.vue
+++ b/src/components/ui/InputTipRange.vue
@@ -25,7 +25,7 @@ const percent = computed(() => ((props.modelValue - props.min) / (props.max - pr
       @input="onInput"
     >
     <div
-      class="absolute rounded bg-gray-700 px-1 text-xs text-white -top-5 -translate-x-1/2 dark:bg-gray-200 dark:text-gray-800"
+      class="absolute rounded bg-gray-700 px-1 text-xs text-white -top-4 -translate-x-1/2 dark:bg-gray-200 dark:text-gray-800"
       :style="{ left: `calc(${percent}% )` }"
     >
       {{ props.modelValue.toFixed(2) }}


### PR DESCRIPTION
## Summary
- lower tooltip above range inputs
- show checkbox labels before checkboxes

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6869a69012e8832ab8a98ad0e3571184