### PR TITLE
Improve mobile panels

### DIFF
--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -18,16 +18,20 @@ const filteredList = computed(() => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
-    <Button class="w-full flex items-center justify-between text-sm" @click="showLocked = !showLocked">
-      <span>{{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés</span>
-      <CheckBox :model-value="showLocked" @update:model-value="showLocked = $event" @click.stop />
-    </Button>
-    <SearchInput v-model="search" class="w-full" />
-    <AchievementItem
-      v-for="a in filteredList"
-      :key="a.id"
-      :achievement="a"
-    />
+  <div class="h-full flex flex-col gap-2">
+    <div class="flex flex-col gap-2">
+      <Button class="w-full flex items-center justify-between text-sm" @click="showLocked = !showLocked">
+        <span>{{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés</span>
+        <CheckBox :model-value="showLocked" @update:model-value="showLocked = $event" @click.stop />
+      </Button>
+      <SearchInput v-model="search" class="w-full" />
+    </div>
+    <div class="flex flex-col gap-2 overflow-auto">
+      <AchievementItem
+        v-for="a in filteredList"
+        :key="a.id"
+        :achievement="a"
+      />
+    </div>
   </div>
 </template>

--- a/src/components/inventory/InventoryModal.vue
+++ b/src/components/inventory/InventoryModal.vue
@@ -9,7 +9,7 @@ const inventoryModal = useInventoryModalStore()
 
 <template>
   <Modal v-model="inventoryModal.isVisible" footer-close>
-    <PanelWrapper title="Inventaire">
+    <PanelWrapper title="Inventaire" is-inline>
       <template #icon>
         <div class="i-carbon-inventory-management" />
       </template>

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -105,13 +105,13 @@ watch(
       </div>
 
       <div v-if="displayInventory || displayAchievements" class="zone" md="col-span-3 row-span-12 col-start-1 row-start-1 flex flex-col gap-2">
-        <PanelWrapper v-if="displayInventory" title="Inventaire">
+        <PanelWrapper v-if="displayInventory" title="Inventaire" is-inline>
           <template #icon>
             <div class="i-carbon-inventory-management" />
           </template>
           <InventoryPanel />
         </PanelWrapper>
-        <PanelWrapper v-if="displayAchievements" title="Succès">
+        <PanelWrapper v-if="displayAchievements" title="Succès" is-inline>
           <template #icon>
             <div class="i-carbon-trophy" />
           </template>
@@ -120,7 +120,7 @@ watch(
       </div>
 
       <div v-if="displayDex" class="zone tiny-scrollbar" md="col-span-3 row-span-12 col-start-10 row-start-1  overflow-auto">
-        <PanelWrapper title="Shlagédex">
+        <PanelWrapper title="Shlagédex" is-inline>
           <template #icon>
             <SchlagedexIcon class="h-4 w-4" />
           </template>

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -46,17 +46,19 @@ function onUse(item: Item) {
 </script>
 
 <template>
-  <section v-if="inventory.list.length" class="flex flex-col gap-2">
+  <section v-if="inventory.list.length" class="h-full flex flex-col gap-2">
     <SearchInput v-model="search" class="w-full" />
-    <InventoryItemCard
-      v-for="entry in filteredList"
-      :key="entry.item.id"
-      :item="entry.item"
-      :qty="entry.qty"
-      :disabled="isDisabled(entry.item)"
-      @use="onUse(entry.item)"
-      @sell="inventory.sell(entry.item.id)"
-    />
+    <div class="flex flex-col gap-2 overflow-auto">
+      <InventoryItemCard
+        v-for="entry in filteredList"
+        :key="entry.item.id"
+        :item="entry.item"
+        :qty="entry.qty"
+        :disabled="isDisabled(entry.item)"
+        @use="onUse(entry.item)"
+        @sell="inventory.sell(entry.item.id)"
+      />
+    </div>
   </section>
   <EvolutionItemModal />
   <MultiExpModal />

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -108,7 +108,7 @@ function isActive(mon: DexShlagemon) {
 </script>
 
 <template>
-  <section v-if="dex.shlagemons.length">
+  <section v-if="dex.shlagemons.length" class="h-full flex flex-col">
     <div class="mb-2 flex flex-wrap gap-2">
       <div class="min-w-36 flex flex-1 items-center">
         <SelectOption
@@ -126,7 +126,7 @@ function isActive(mon: DexShlagemon) {
       </div>
       <SearchInput v-model="filter.search" />
     </div>
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-2 overflow-auto">
       <div
         v-for="mon in displayedMons"
         :key="mon.id"

--- a/src/components/ui/PanelWrapper.vue
+++ b/src/components/ui/PanelWrapper.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
+
 const props = defineProps<{ title?: string, isInline?: boolean }>()
 const opened = ref(true)
+const isMobile = useMediaQuery('(max-width: 767px)')
 function toggle() {
+  if (isMobile.value)
+    return
   if (props.title)
     opened.value = !opened.value
 }
@@ -9,12 +14,12 @@ function toggle() {
 
 <template>
   <div class="panel-wrapper" v-bind="$attrs" :class="isInline ? '' : 'overflow-hidden'" md="">
-    <div v-if="props.title" class="mb-1 flex cursor-pointer items-center justify-between" @click="toggle">
+    <div v-if="props.title" class="mb-1 flex items-center justify-between" :class="isMobile ? '' : 'cursor-pointer'" @click="toggle">
       <div class="flex items-center gap-1">
         <slot name="icon" />
         <span class="font-bold">{{ props.title }}</span>
       </div>
-      <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
+      <div v-if="!isMobile" class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
     </div>
     <div v-show="opened" class="tiny-scrollbar flex flex-1 flex-col" :class="isInline ? ' flex items-center justify-center' : 'overflow-auto'">
       <slot />


### PR DESCRIPTION
## Summary
- disable panel collapsing on mobile
- keep filter areas fixed in achievement, inventory and shlagedex panels
- adjust wrappers to avoid nested scrolling

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined / fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6869a700b3d0832a92e9f85ccb3b1a3f