### PR TITLE
Add whack-a-shlag mini game

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Plongez dans un univers délirant peuplé de Shlagémons totalement barrés. Cap
 ## Concept
 
 Chaque Shlagémon dispose de statistiques qui lui sont propres et appartient à une poignée de types complètement improbables. Une interface minimaliste vous permet de choisir votre compagnon, de consulter le _Schlagedex_ et de lancer des combats acharnés.
+Un mini-jeu d'adresse « Whack-a-Shlag » permet aussi de récolter quelques Shlagidolars.
 
 ## Fonctionnalités clés
 
@@ -21,6 +22,7 @@ Chaque Shlagémon dispose de statistiques qui lui sont propres et appartient à 
 - Composants découpés en unités réutilisables (boutons, cartes, panneaux...).
 - Routing basé sur les fichiers et génération statique grâce à `vite-ssg`.
 - Prêt pour le _PWA_ et l'internationalisation.
+- Mini-jeu « Whack-a-Shlag » accessible depuis le village Veaux du Gland.
 
 ## Installation
 
@@ -52,6 +54,8 @@ Les fichiers prêts à être servis se trouvent dans le dossier `dist`.
 
 - Tests unitaires : `pnpm test:unit`
 - Tests end‑to‑end : `pnpm test:e2e`
+
+Depuis le jeu, rendez-vous au village **Veaux du Gland sur Marne** et cliquez sur « Mini-jeu » pour lancer une partie de Whack-a-Shlag.
 
 ## Structure du projet
 

--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -224,6 +224,7 @@ declare global {
   const useMediaQuery: typeof import('@vueuse/core')['useMediaQuery']
   const useMemoize: typeof import('@vueuse/core')['useMemoize']
   const useMemory: typeof import('@vueuse/core')['useMemory']
+  const useMiniGameStore: typeof import('./stores/miniGame')['useMiniGameStore']
   const useMobileTabStore: typeof import('./stores/mobileTab')['useMobileTabStore']
   const useModel: typeof import('vue')['useModel']
   const useMounted: typeof import('@vueuse/core')['useMounted']
@@ -589,6 +590,7 @@ declare module 'vue' {
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>
     readonly useMemoize: UnwrapRef<typeof import('@vueuse/core')['useMemoize']>
     readonly useMemory: UnwrapRef<typeof import('@vueuse/core')['useMemory']>
+    readonly useMiniGameStore: UnwrapRef<typeof import('./stores/miniGame')['useMiniGameStore']>
     readonly useMobileTabStore: UnwrapRef<typeof import('./stores/mobileTab')['useMobileTabStore']>
     readonly useModel: UnwrapRef<typeof import('vue')['useModel']>
     readonly useMounted: UnwrapRef<typeof import('@vueuse/core')['useMounted']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -74,6 +74,7 @@ declare module 'vue' {
     Tooltip: typeof import('./components/ui/Tooltip.vue')['default']
     TrainerBattle: typeof import('./components/battle/TrainerBattle.vue')['default']
     VillagePanel: typeof import('./components/village/VillagePanel.vue')['default']
+    WhackAShlag: typeof import('./components/minigame/WhackAShlag.vue')['default']
     Xp: typeof import('./components/icons/xp.vue')['default']
     ZoneActions: typeof import('./components/village/ZoneActions.vue')['default']
     ZoneMapModal: typeof import('./components/zones/ZoneMapModal.vue')['default']

--- a/src/components/minigame/WhackAShlag.vue
+++ b/src/components/minigame/WhackAShlag.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+import Button from '~/components/ui/Button.vue'
+import ImageByBackground from '~/components/ui/ImageByBackground.vue'
+import { allShlagemons } from '~/data/shlagemons'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMiniGameStore } from '~/stores/miniGame'
+
+const panel = useMainPanelStore()
+const mini = useMiniGameStore()
+
+const slots = ref<(string | null)[]>(Array.from({ length: 9 }).fill(null))
+let spawnTimer: number | undefined
+
+function spawn() {
+  if (!mini.isRunning)
+    return
+  const idx = Math.floor(Math.random() * 9)
+  const mon = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
+  slots.value = Array.from({ length: 9 }).fill(null)
+  slots.value[idx] = mon.id
+}
+
+function hit(i: number) {
+  if (slots.value[i]) {
+    mini.hit()
+    slots.value[i] = null
+  }
+}
+
+function quit() {
+  mini.finish()
+  panel.showVillage()
+}
+
+onMounted(() => {
+  mini.start()
+  spawn()
+  spawnTimer = window.setInterval(spawn, 800)
+})
+
+onUnmounted(() => {
+  clearInterval(spawnTimer)
+  if (mini.isRunning)
+    mini.finish()
+})
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-2" md="gap-3">
+    <div class="text-sm">
+      Temps : {{ mini.timeLeft }}s - Score : {{ mini.score }}
+    </div>
+    <div class="grid grid-cols-3 grid-rows-3 gap-1" md="gap-2">
+      <button
+        v-for="(s, i) in slots"
+        :key="i"
+        class="h-20 w-20 rounded bg-gray-200 dark:bg-gray-700"
+        md="h-24 w-24"
+        @click="hit(i)"
+      >
+        <ImageByBackground
+          v-if="s"
+          :src="`/shlagemons/${s}/${s}.png`"
+          alt="slug"
+          class="h-full w-full"
+        />
+      </button>
+    </div>
+    <div class="text-sm">
+      Niveau : {{ mini.level }}
+    </div>
+    <Button class="text-xs" @click="quit">
+      Quitter
+    </Button>
+  </div>
+</template>

--- a/src/components/panels/MainPanel.vue
+++ b/src/components/panels/MainPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import BattleMain from '~/components/battle/BattleMain.vue'
 import TrainerBattle from '~/components/battle/TrainerBattle.vue'
+import WhackAShlag from '~/components/minigame/WhackAShlag.vue'
 import DialogPanel from '~/components/panels/DialogPanel.vue'
 import ShopPanel from '~/components/panels/ShopPanel.vue'
 import VillagePanel from '~/components/village/VillagePanel.vue'
@@ -18,6 +19,8 @@ const currentComponent = computed(() => {
       return BattleMain
     case 'trainerBattle':
       return TrainerBattle
+    case 'miniGame':
+      return WhackAShlag
     case 'village':
       return VillagePanel
     default:

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -26,6 +26,8 @@ function onAction(id: string) {
     panel.showShop()
   else if (id === 'explore')
     panel.showTrainerBattle()
+  else if (id === 'minigame')
+    panel.showMiniGame()
 }
 
 function fightKing() {

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -124,7 +124,17 @@ const zonesSpeciales: Zone[] = [
     maxLevel: 0,
     actions: [],
   },
-  { id: 'village-veaux-du-gland', name: 'Veaux du Gland sur Marne', type: 'village', actions: [{ id: 'shop', label: 'Entrer dans le Magasin' }], minLevel: 10, maxLevel: 0 },
+  {
+    id: 'village-veaux-du-gland',
+    name: 'Veaux du Gland sur Marne',
+    type: 'village',
+    actions: [
+      { id: 'shop', label: 'Entrer dans le Magasin' },
+      { id: 'minigame', label: 'Mini-jeu' },
+    ],
+    minLevel: 10,
+    maxLevel: 0,
+  },
   { id: 'village-boule', name: 'Village Sux-Mais-Bouls', type: 'village', actions: [{ id: 'shop', label: 'Entrer dans le Magasin' }], minLevel: 25, maxLevel: 0 },
   { id: 'village-paume', name: 'Village Caca-Boudin', type: 'village', actions: [{ id: 'shop', label: 'Entrer dans le Magasin' }], minLevel: 50, maxLevel: 0 },
 ]

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -18,6 +18,7 @@ export type AchievementEvent =
   | { type: 'battle-win', stronger: boolean }
   | { type: 'item-used' }
   | { type: 'king-defeated' }
+  | { type: 'minigame-win' }
 
 export const useAchievementsStore = defineStore('achievements', () => {
   const game = useGameStore()
@@ -33,6 +34,7 @@ export const useAchievementsStore = defineStore('achievements', () => {
     itemsUsed: 0,
     kings: 0,
     shiny: 0,
+    minigameWins: 0,
   })
 
   const unlocked = useLocalStorage<Record<string, boolean>>(
@@ -47,6 +49,7 @@ export const useAchievementsStore = defineStore('achievements', () => {
     counters.itemsUsed = 0
     counters.kings = 0
     counters.shiny = 0
+    counters.minigameWins = 0
     unlocked.value = {}
   }
 
@@ -131,6 +134,18 @@ export const useAchievementsStore = defineStore('achievements', () => {
       title: 'Dépensier',
       description: `Utiliser ${n.toLocaleString()} objet${n > 1 ? 's' : ''} pendant vos combats ou explorations.`,
       icon: 'carbon:shopping-bag',
+    }
+    defs.push(def)
+    defMap[def.id] = def
+  })
+
+  const minigameThresholds = [1, 5, 10]
+  minigameThresholds.forEach((n) => {
+    const def = {
+      id: `minigame-${n}`,
+      title: n === 1 ? 'Première partie gagnée' : `${n} victoires mini-jeu`,
+      description: `Remporter ${n} partie${n > 1 ? 's' : ''} du mini-jeu Whack-a-Shlag.`,
+      icon: 'carbon:game-console',
     }
     defs.push(def)
     defMap[def.id] = def
@@ -254,6 +269,9 @@ export const useAchievementsStore = defineStore('achievements', () => {
       case 'king-defeated':
         counters.kings += 1
         break
+      case 'minigame-win':
+        counters.minigameWins += 1
+        break
     }
   }
 
@@ -272,6 +290,7 @@ export const useAchievementsStore = defineStore('achievements', () => {
   watch(() => counters.itemsUsed, v => checkThresholds(v, 'item', itemThresholds))
   watch(() => counters.kings, v => checkThresholds(v, 'king', kingThresholds))
   watch(() => counters.shiny, v => checkThresholds(v, 'shiny', shinyThresholds))
+  watch(() => counters.minigameWins, v => checkThresholds(v, 'minigame', minigameThresholds))
 
   function checkZoneCompletion() {
     zonesData.forEach((z) => {

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 
-export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop'
+export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop' | 'miniGame'
 
 export const useMainPanelStore = defineStore('mainPanel', () => {
   const zone = useZoneStore()
@@ -36,9 +36,13 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     current.value = 'trainerBattle'
   }
 
+  function showMiniGame() {
+    current.value = 'miniGame'
+  }
+
   function showVillage() {
     current.value = 'village'
   }
 
-  return { current, showShop, showBattle, showTrainerBattle, showVillage }
+  return { current, showShop, showBattle, showTrainerBattle, showMiniGame, showVillage }
 })

--- a/src/stores/miniGame.ts
+++ b/src/stores/miniGame.ts
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { notifyAchievement } from './achievements'
+import { useGameStore } from './game'
+
+function scoreToWin(level: number) {
+  return level * 10
+}
+
+export const useMiniGameStore = defineStore('miniGame', () => {
+  const level = ref(1)
+  const score = ref(0)
+  const wins = ref(0)
+  const isRunning = ref(false)
+  const timeLeft = ref(30)
+  let timer: number | undefined
+
+  function start() {
+    score.value = 0
+    timeLeft.value = 30
+    isRunning.value = true
+    clearInterval(timer)
+    timer = window.setInterval(() => {
+      timeLeft.value -= 1
+      if (timeLeft.value <= 0)
+        finish()
+    }, 1000)
+  }
+
+  function hit() {
+    if (isRunning.value)
+      score.value += 1
+  }
+
+  function finish() {
+    clearInterval(timer)
+    isRunning.value = false
+    const goal = scoreToWin(level.value)
+    if (score.value >= goal) {
+      const game = useGameStore()
+      game.addShlagidolar(level.value * 100)
+      level.value += 1
+      wins.value += 1
+      notifyAchievement({ type: 'minigame-win' })
+    }
+    else {
+      level.value = 1
+    }
+  }
+
+  return { level, score, wins, isRunning, timeLeft, start, hit, finish, scoreToWin }
+}, {
+  persist: true,
+})

--- a/test/minigame.test.ts
+++ b/test/minigame.test.ts
@@ -1,0 +1,27 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useGameStore } from '../src/stores/game'
+import { useMiniGameStore } from '../src/stores/miniGame'
+
+describe('mini game store', () => {
+  it('rewards and levels up when score is sufficient', () => {
+    setActivePinia(createPinia())
+    const mini = useMiniGameStore()
+    const game = useGameStore()
+    mini.level = 1
+    mini.score = mini.scoreToWin(1)
+    mini.finish()
+    expect(game.shlagidolar).toBe(100)
+    expect(mini.level).toBe(2)
+    expect(mini.wins).toBe(1)
+  })
+
+  it('resets level when score is too low', () => {
+    setActivePinia(createPinia())
+    const mini = useMiniGameStore()
+    mini.level = 3
+    mini.score = 0
+    mini.finish()
+    expect(mini.level).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- extend main panel with mini game support
- implement MiniGame store with scoring and rewards
- add WhackAShlag component and include in panel
- enable village action for minigame
- handle minigame event in achievements
- document mini-game in README
- test MiniGame store

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686a243c02dc832a9e481b5e0b805037