### PR TITLE
Add zone Schlagemon list modal

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -319,6 +319,7 @@ declare global {
   const useWindowFocus: typeof import('@vueuse/core')['useWindowFocus']
   const useWindowScroll: typeof import('@vueuse/core')['useWindowScroll']
   const useWindowSize: typeof import('@vueuse/core')['useWindowSize']
+  const useZoneMonsModalStore: typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']
   const useZoneProgressStore: typeof import('./stores/zoneProgress')['useZoneProgressStore']
   const useZoneStore: typeof import('./stores/zone')['useZoneStore']
   const watch: typeof import('vue')['watch']
@@ -682,6 +683,7 @@ declare module 'vue' {
     readonly useWindowFocus: UnwrapRef<typeof import('@vueuse/core')['useWindowFocus']>
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
+    readonly useZoneMonsModalStore: UnwrapRef<typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']>
     readonly useZoneProgressStore: UnwrapRef<typeof import('./stores/zoneProgress')['useZoneProgressStore']>
     readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -77,6 +77,7 @@ declare module 'vue' {
     Xp: typeof import('./components/icons/xp.vue')['default']
     ZoneActions: typeof import('./components/village/ZoneActions.vue')['default']
     ZoneMapModal: typeof import('./components/zones/ZoneMapModal.vue')['default']
+    ZoneMonsModal: typeof import('./components/zones/ZoneMonsModal.vue')['default']
     ZonePanel: typeof import('./components/panels/ZonePanel.vue')['default']
   }
 }

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -5,6 +5,7 @@ import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
 import FightKingButton from '~/components/battle/FightKingButton.vue'
+import ZoneMonsModal from '~/components/zones/ZoneMonsModal.vue'
 import { useBattleEffects, useSingleInterval } from '~/composables/battleEngine'
 import { balls } from '~/data/items/shlageball'
 import { allShlagemons } from '~/data/shlagemons'
@@ -18,6 +19,7 @@ import { useInventoryStore } from '~/stores/inventory'
 import { useMultiExpStore } from '~/stores/multiExp'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
+import { useZoneMonsModalStore } from '~/stores/zoneMonsModal'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
 import { ballHues } from '~/utils/ball'
 import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
@@ -31,6 +33,7 @@ const disease = useDiseaseStore()
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
 const multiExpStore = useMultiExpStore()
+const zoneMonsModal = useZoneMonsModalStore()
 const events = useEventStore()
 const equilibrerank = 2
 let nextBattleTimer: number | undefined
@@ -282,7 +285,9 @@ onUnmounted(() => {
     <div v-if="zone.current.maxLevel" class="relative mb-1 flex items-center justify-center gap-1 font-bold">
       <div class="absolute left-0 flex gap-2">
         <Tooltip :text="captureTooltip">
-          <img src="/items/shlageball/shlageball.png" alt="king" class="h-6 w-6" :class="{ 'opacity-50': !hasAllZoneMons }">
+          <Button type="icon" aria-label="Schlagemons de la zone" @click="zoneMonsModal.open()">
+            <img src="/items/shlageball/shlageball.png" alt="liste" class="h-6 w-6" :class="{ 'opacity-50': !hasAllZoneMons }">
+          </Button>
         </Tooltip>
         <Tooltip :text="winTooltip">
           <span :class="{ 'font-bold': wins >= progress.fightsBeforeKing }">{{ wins.toLocaleString() }}</span>
@@ -351,6 +356,7 @@ onUnmounted(() => {
         @finish="onCaptureEnd"
       />
     </div>
+    <ZoneMonsModal />
   </div>
 </template>
 

--- a/src/components/zones/ZoneMonsModal.vue
+++ b/src/components/zones/ZoneMonsModal.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
+import PanelWrapper from '~/components/ui/PanelWrapper.vue'
+import { useShlagedexStore } from '~/stores/shlagedex'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneMonsModalStore } from '~/stores/zoneMonsModal'
+
+const modal = useZoneMonsModalStore()
+const zone = useZoneStore()
+const dex = useShlagedexStore()
+
+const mons = computed(() => zone.current.shlagemons || [])
+function owned(id: string) {
+  return dex.shlagemons.some(m => m.base.id === id)
+}
+</script>
+
+<template>
+  <Modal v-model="modal.isVisible" footer-close>
+    <PanelWrapper :title="`Schlagemons de ${zone.current.name}`" is-inline>
+      <template #icon>
+        <img src="/items/shlageball/shlageball.png" alt="ball" class="h-4 w-4">
+      </template>
+      <div class="flex flex-wrap justify-center gap-2">
+        <div
+          v-for="mon in mons"
+          :key="mon.id"
+          class="flex flex-col items-center text-xs"
+        >
+          <ShlagemonImage
+            :id="mon.id"
+            :alt="mon.name"
+            class="h-16 w-16 object-contain"
+            :class="owned(mon.id) ? '' : 'grayscale opacity-50'"
+          />
+          <span>{{ mon.name }}</span>
+        </div>
+      </div>
+    </PanelWrapper>
+  </Modal>
+</template>

--- a/src/stores/zoneMonsModal.ts
+++ b/src/stores/zoneMonsModal.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useMobileTabStore } from './mobileTab'
+
+export const useZoneMonsModalStore = defineStore('zoneMonsModal', () => {
+  const isVisible = ref(false)
+  const mobile = useMobileTabStore()
+
+  function open() {
+    mobile.set('game')
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+  }
+
+  return { isVisible, open, close }
+})


### PR DESCRIPTION
## Summary
- show zone Schlageball tooltip as a clickable button
- list current zone Schlagemons in a modal
- grey out unowned mons

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686a24983d70832a95cfe93e79262f01