### PR TITLE
Fix inventory modal autofocus

### DIFF
--- a/src/components/inventory/InventoryModal.vue
+++ b/src/components/inventory/InventoryModal.vue
@@ -8,7 +8,7 @@ const inventoryModal = useInventoryModalStore()
 </script>
 
 <template>
-  <Modal v-model="inventoryModal.isVisible" footer-close>
+  <Modal v-model="inventoryModal.isVisible" footer-close dialog-autofocus>
     <PanelWrapper title="Inventaire" is-inline>
       <template #icon>
         <div class="i-carbon-inventory-management" />

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -5,9 +5,11 @@ const props = withDefaults(defineProps<{
   modelValue: boolean
   closeOnOutsideClick?: boolean
   footerClose?: boolean
+  dialogAutofocus?: boolean
 }>(), {
   closeOnOutsideClick: true,
   footerClose: false,
+  dialogAutofocus: false,
 })
 const emit = defineEmits(['update:modelValue', 'close'])
 const dialogRef = ref<HTMLDialogElement | null>(null)
@@ -47,6 +49,8 @@ function close() {
   <dialog
     ref="dialogRef"
     class="modal"
+    :autofocus="props.dialogAutofocus || undefined"
+    tabindex="-1"
     @click="onDialogClick"
     @close="emit('update:modelValue', false); emit('close')"
   >


### PR DESCRIPTION
## Summary
- prevent dialog from auto focusing the first input
- keep inventory modal from opening the keyboard by focusing the dialog instead

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined 'coefficient')*

------
https://chatgpt.com/codex/tasks/task_e_686a5851e160832aa5f9d155353e25fd