### PR TITLE
Change inventory buttons for Shlagéballs

### DIFF
--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -16,6 +16,12 @@ const details = computed(() => props.item.details || props.item.description)
 const ballFilter = computed(() =>
   'catchBonus' in props.item ? { filter: `hue-rotate(${ballHues[props.item.id]})` } : {},
 )
+
+const actionLabel = computed(() => {
+  if ('catchBonus' in props.item)
+    return props.disabled ? 'Équipé' : 'Équiper'
+  return 'Utiliser'
+})
 </script>
 
 <template>
@@ -44,7 +50,7 @@ const ballFilter = computed(() =>
         @click="emit('use')"
       >
         <div i-carbon-play inline-block />
-        Utiliser
+        {{ actionLabel }}
       </Button>
       <!--
       <Button type="danger" class="text-xs" @click="emit('sell')">


### PR DESCRIPTION
## Summary
- show "Équiper" when a Shlagéball can be equipped
- show "Équipé" when the Shlagéball is already equipped

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH when fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686a58b5bc70832a85a96f5836f8acc4