### PR TITLE
Fix overlapping battle loops

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -6,7 +6,7 @@ import BattleToast from '~/components/battle/BattleToast.vue'
 import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
 import FightKingButton from '~/components/battle/FightKingButton.vue'
 import ZoneMonsModal from '~/components/zones/ZoneMonsModal.vue'
-import { useBattleEffects, useSingleInterval } from '~/composables/battleEngine'
+import { useBattleEffects } from '~/composables/battleEngine'
 import { balls } from '~/data/items/shlageball'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
@@ -88,7 +88,12 @@ const cursorX = ref(0)
 const cursorY = ref(0)
 const cursorClicked = ref(false)
 const { playerEffect, enemyEffect, playerVariant, enemyVariant, showEffect } = useBattleEffects()
-const { start: startInterval, clear: stopInterval } = useSingleInterval(() => tick(), 1000)
+function startInterval() {
+  battle.startLoop(() => tick(), 1000)
+}
+function stopInterval() {
+  battle.stopLoop()
+}
 
 function openCapture() {
   const id = ballStore.current

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -4,7 +4,7 @@ import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CharacterImage from '~/components/character/CharacterImage.vue'
 import Button from '~/components/ui/Button.vue'
-import { useBattleEffects, useSingleInterval } from '~/composables/battleEngine'
+import { useBattleEffects } from '~/composables/battleEngine'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
@@ -54,7 +54,12 @@ const cursorX = ref(0)
 const cursorY = ref(0)
 const cursorClicked = ref(false)
 const { playerEffect, enemyEffect, playerVariant, enemyVariant, showEffect } = useBattleEffects()
-const { start: startInterval, clear: stopInterval } = useSingleInterval(() => tick(), 1000)
+function startInterval() {
+  battle.startLoop(() => tick(), 1000)
+}
+function stopInterval() {
+  battle.stopLoop()
+}
 watch(trainer, (t) => {
   if (t) {
     stage.value = 'before'

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -15,6 +15,20 @@ export const useBattleStore = defineStore('battle', () => {
   const dex = useShlagedexStore()
   const audio = useAudioStore()
   const disease = useDiseaseStore()
+
+  let loopId: number | undefined
+
+  function startLoop(handler: () => void, delay = 1000) {
+    stopLoop()
+    loopId = window.setInterval(handler, delay)
+  }
+
+  function stopLoop() {
+    if (typeof loopId === 'number') {
+      clearInterval(loopId)
+      loopId = undefined
+    }
+  }
   function attack(
     attacker: DexShlagemon,
     defender: DexShlagemon,
@@ -50,5 +64,5 @@ export const useBattleStore = defineStore('battle', () => {
     return { player: playerResult, enemy: enemyResult }
   }
 
-  return { attack, clickAttack, duel }
+  return { attack, clickAttack, duel, startLoop, stopLoop }
 })

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -7,6 +7,7 @@ import ReleaseSchlagemonDialog from '~/components/dialog/ReleaseSchlagemonDialog
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { useMainPanelStore } from './mainPanel'
 
 interface DialogItem {
   id: string
@@ -21,6 +22,7 @@ export const useDialogStore = defineStore('dialog', () => {
   const gameState = useGameStateStore()
   const game = useGameStore()
   const dex = useShlagedexStore()
+  const panel = useMainPanelStore()
 
   const done = ref<DialogDone>({})
   const dialogs: DialogItem[] = [
@@ -46,7 +48,11 @@ export const useDialogStore = defineStore('dialog', () => {
     },
   ]
 
-  const isDialogVisible = computed(() => dialogs.some(d => d.condition() && !done.value[d.id]))
+  const isDialogVisible = computed(() => {
+    if (panel.current === 'trainerBattle')
+      return false
+    return dialogs.some(d => d.condition() && !done.value[d.id])
+  })
 
   function isDone(id: string) {
     return done.value[id] === true

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
+import { useBattleStore } from './battle'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 
@@ -8,6 +9,7 @@ export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop' | 'miniG
 export const useMainPanelStore = defineStore('mainPanel', () => {
   const zone = useZoneStore()
   const dex = useShlagedexStore()
+  const battle = useBattleStore()
   const current = ref<MainPanel>('village')
 
   // Update the panel when the zone changes
@@ -21,6 +23,11 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     },
     { immediate: true },
   )
+
+  watch(current, (value) => {
+    if (value !== 'battle' && value !== 'trainerBattle')
+      battle.stopLoop()
+  })
 
   function showShop() {
     current.value = 'shop'


### PR DESCRIPTION
## Summary
- centralize battle interval handling in the battle store
- trigger loop clean-up when leaving battle panels
- disable dialogs during trainer fights
- update battle components to use the new interval helpers

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686a67f827e0832a966e74a6e1d1e957