### PR TITLE
Fix evolution item modal visibility

### DIFF
--- a/src/stores/evolutionItem.ts
+++ b/src/stores/evolutionItem.ts
@@ -10,7 +10,8 @@ export const useEvolutionItemStore = defineStore('evolutionItem', () => {
   const dex = useShlagedexStore()
   const inventory = useInventoryStore()
 
-  const isVisible = computed(() => current.value !== null)
+  // modal visibility is controlled by this ref
+  const isVisible = ref(false)
   const availableMons = computed(() => {
     if (!current.value)
       return []
@@ -29,9 +30,11 @@ export const useEvolutionItemStore = defineStore('evolutionItem', () => {
 
   function open(item: Item) {
     current.value = item
+    isVisible.value = true
   }
 
   function close() {
+    isVisible.value = false
     current.value = null
   }
 


### PR DESCRIPTION
## Summary
- store `isVisible` state for evolution item modal in a `ref`
- update open/close functions to modify modal visibility

## Testing
- `pnpm test` *(fails: ENETUNREACH fetch fonts, vitest failures)*

------
https://chatgpt.com/codex/tasks/task_e_686a7e184b00832abb3eb7491554ca3e