### PR TITLE
Fix FightKingButton when zone has no king

### DIFF
--- a/src/components/battle/FightKingButton.vue
+++ b/src/components/battle/FightKingButton.vue
@@ -13,18 +13,19 @@ const progress = useZoneProgressStore()
 
 const currentKing = computed(() => zone.getKing(zone.current.id))
 const kingLabel = computed(() =>
-  currentKing.value!.character.gender === 'female' ? 'la reine' : 'le roi',
+  currentKing.value?.character.gender === 'female' ? 'la reine' : 'le roi',
 )
 
 const visible = computed(() =>
-  !progress.isKingDefeated(zone.current.id)
+  !!currentKing.value
+  && !progress.isKingDefeated(zone.current.id)
   && progress.canFightKing(zone.current.id),
 )
 
 function fightKing() {
-  const trainer = zone.getKing(zone.current.id)
+  const trainer = currentKing.value
   if (!trainer)
-    throw new Error('King not found')
+    return
   trainerBattle.setQueue([trainer])
   panel.showTrainerBattle()
 }


### PR DESCRIPTION
## Summary
- handle zones without kings in FightKingButton

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686a82ba2650832a980ce3805276e184