### PR TITLE
Fix wording for Shlagémon and currencies

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -55,7 +55,7 @@ declare module 'vue' {
     Profile: typeof import('./components/profile/Profile.vue')['default']
     ProgressBar: typeof import('./components/ui/ProgressBar.vue')['default']
     README: typeof import('./components/README.md')['default']
-    ReleaseSchlagemonDialog: typeof import('./components/dialog/ReleaseSchlagemonDialog.vue')['default']
+    ReleaseShlagemonDialog: typeof import('./components/dialog/ReleaseShlagemonDialog.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     Schlagedex: typeof import('./components/icons/schlagedex.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -50,12 +50,12 @@ const hasAllZoneMons = computed(() => {
 
 const captureTooltip = computed(() =>
   hasAllZoneMons.value
-    ? 'Vous avez capturé tous les Schlagemon de la zone'
-    : 'Vous n\'avez pas capturé tous les Schlagemon de la zone',
+    ? 'Vous avez capturé tous les Shlagémon de la zone'
+    : 'Vous n\'avez pas capturé tous les Shlagémon de la zone',
 )
 
 const winTooltip = computed(() =>
-  `Vous avez vaincu ${wins.value.toLocaleString()} Schlagemon dans cette zone`,
+  `Vous avez vaincu ${wins.value.toLocaleString()} Shlagémon dans cette zone`,
 )
 
 const playerHp = ref(0)
@@ -297,7 +297,7 @@ onUnmounted(() => {
     <div v-if="zone.current.maxLevel" class="relative mb-1 flex items-center justify-center gap-1 font-bold">
       <div class="absolute left-0 flex gap-2">
         <Tooltip :text="captureTooltip">
-          <Button type="icon" aria-label="Schlagemons de la zone" @click="zoneMonsModal.open()">
+          <Button type="icon" aria-label="Shlagémons de la zone" @click="zoneMonsModal.open()">
             <img src="/items/shlageball/shlageball.png" alt="liste" class="h-6 w-6" :class="{ 'opacity-50': !hasAllZoneMons }">
           </Button>
         </Tooltip>

--- a/src/components/dialog/HalfDexDialog.vue
+++ b/src/components/dialog/HalfDexDialog.vue
@@ -25,7 +25,7 @@ const dialogTree: DialogNode[] = [
   },
   {
     id: 'step3',
-    text: 'Pour célébrer, je t\'offre 10 Schlagediamonds. Ils brillent presque autant que toi.',
+    text: 'Pour célébrer, je t\'offre 10 Shlagédiamants. Ils brillent presque autant que toi.',
     responses: [
       { label: 'Retour', nextId: 'step2', type: 'danger' },
       { label: 'Continuer', nextId: 'step4', type: 'primary' },

--- a/src/components/dialog/ReleaseShlagemonDialog.vue
+++ b/src/components/dialog/ReleaseShlagemonDialog.vue
@@ -14,7 +14,7 @@ function imageUrl(id: string) {
 const dialogTree = computed<DialogNode[]>(() => {
   const start: DialogNode = {
     id: 'start',
-    text: `Salut, j'ai une bonne nouvelle pour toi, je vais te d\xE9barrasser d'un de tes schlag\xE9mones pour que cela schlage beaucoup moins dans ton schlagidex.`,
+    text: `Salut, j'ai une bonne nouvelle pour toi, je vais te d\xE9barrasser d'un de tes Shlagémons pour que cela shlage beaucoup moins dans ton shlagidex.`,
     responses: [
       { label: 'Continuer', nextId: 'choice', type: 'primary' },
     ],
@@ -22,7 +22,7 @@ const dialogTree = computed<DialogNode[]>(() => {
 
   const choice: DialogNode = {
     id: 'choice',
-    text: 'Choisis le schlag\xE9mon dont tu veux te d\xE9barrasser :',
+    text: 'Choisis le Shlagémon dont tu veux te d\xE9barrasser :',
     responses: dex.shlagemons.map(mon => ({
       label: mon.base.name,
       imageUrl: imageUrl(mon.base.id),

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -106,7 +106,7 @@ const captureInfo = computed(() => {
       {{ mon.base.description }}
     </p>
     <CheckBox v-model="allowEvolution" class="mb-4 flex items-center gap-2 text-sm">
-      Autoriser ce Schlagemon à évoluer ?
+      Autoriser ce Shlagémon à évoluer ?
     </CheckBox>
     <div class="grid grid-cols-2 gap-2 text-sm">
       <div
@@ -138,7 +138,7 @@ const captureInfo = computed(() => {
     <Modal v-model="showConfirm" :close-on-outside-click="false">
       <div class="flex flex-col items-center gap-4">
         <h3 class="text-lg font-bold">
-          Relâcher un Schlagemon ?
+          Relâcher un Shlagémon ?
         </h3>
         <p class="text-center text-sm">
           Attention, si vous le relâchez, il ira schlagiser tout le territoire.

--- a/src/components/ui/CurrencyAmount.vue
+++ b/src/components/ui/CurrencyAmount.vue
@@ -9,7 +9,10 @@ const props = defineProps<{
   currency: 'shlagidolar' | 'shlagidiamond'
 }>()
 
-const currencyName = computed(() => props.currency === 'shlagidiamond' ? 'Shlagidiamond' : 'Shlagidolar')
+const currencyName = computed(() => {
+  const base = props.currency === 'shlagidiamond' ? 'Shlagédiamant' : 'Shlagédollar'
+  return props.amount > 1 ? `${base}s` : base
+})
 const icon = computed(() => props.currency === 'shlagidiamond' ? ShlagediamondIcon : ShlagidolarIcon)
 </script>
 

--- a/src/components/zones/ZoneMonsModal.vue
+++ b/src/components/zones/ZoneMonsModal.vue
@@ -18,7 +18,7 @@ function owned(id: string) {
 
 <template>
   <Modal v-model="modal.isVisible" footer-close>
-    <PanelWrapper :title="`Schlagemons de ${zone.current.name}`" is-inline>
+    <PanelWrapper :title="`Shlagémons de ${zone.current.name}`" is-inline>
       <template #icon>
         <img src="/items/shlageball/shlageball.png" alt="ball" class="h-4 w-4">
       </template>

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -67,8 +67,8 @@ export const useAchievementsStore = defineStore('achievements', () => {
   moneyThresholds.forEach((n) => {
     const def = {
       id: `money-${n}`,
-      title: `${n.toLocaleString()} Shlagidolars`,
-      description: `Accumuler au moins ${n.toLocaleString()} Shlagidolars pour montrer votre richesse.`,
+      title: `${n.toLocaleString()} Shlagédollars`,
+      description: `Accumuler au moins ${n.toLocaleString()} Shlagédollars pour montrer votre richesse.`,
       icon: 'carbon:money',
     }
     defs.push(def)

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -4,7 +4,7 @@ import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.v
 import DialogStarter from '~/components/dialog/DialogStarter.vue'
 import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
 import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
-import ReleaseSchlagemonDialog from '~/components/dialog/ReleaseSchlagemonDialog.vue'
+import ReleaseShlagemonDialog from '~/components/dialog/ReleaseShlagemonDialog.vue'
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -49,7 +49,7 @@ export const useDialogStore = defineStore('dialog', () => {
     },
     {
       id: 'release',
-      component: markRaw(ReleaseSchlagemonDialog),
+      component: markRaw(ReleaseShlagemonDialog),
       condition: () => dex.shlagemons.length >= 10,
     },
   ]

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -22,11 +22,11 @@ export interface DexShlagemon extends Stats {
   base: BaseShlagemon
   baseStats: Stats
   /**
-   * ISO string representing the first time this Schlagemon was obtained.
+   * ISO string representing the first time this Shlagémon was obtained.
    */
   captureDate: string
   /**
-   * Number of times this Schlagemon has been captured or created via evolution.
+   * Number of times this Shlagémon has been captured or created via evolution.
    */
   captureCount: number
   lvl: number


### PR DESCRIPTION
## Summary
- ensure all texts use **Shlagémon** without the `c`
- adjust currency strings to `Shlagédollar` and `Shlagédiamant`
- fix pluralization in the UI
- rename `ReleaseShlagemonDialog` component and update imports

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined & snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686a847f8a1c832a8f786eb32b45ca60