### PR TITLE
Add configurable Kings data

### DIFF
--- a/src/data/kings.ts
+++ b/src/data/kings.ts
@@ -1,0 +1,43 @@
+import type { Character } from '~/type/character'
+import type { FightZoneId } from '~/type/zone'
+import type { Trainer } from '~/types'
+import { caillou } from './characters/caillou'
+import { marcon } from './characters/marcon'
+import { marineLahaine } from './characters/marine-lahaine'
+import { norman } from './characters/norman'
+import { profMerdant } from './characters/prof-merdant'
+import { sachatte } from './characters/sachatte'
+import { zonesData } from './zones'
+
+function createKing(zoneId: FightZoneId, character: Character, dialogBefore: string, dialogAfter: string): Trainer {
+  const zone = zonesData.find(z => z.id === zoneId)!
+  const level = zone.maxLevel + 1
+  const size = zone.maxLevel < 10 ? 3 : 6
+  const shlagemons = (zone.shlagemons ?? []).slice(0, size).map(b => ({ baseId: b.id, level }))
+  return {
+    id: `king-${zoneId}`,
+    character,
+    dialogBefore,
+    dialogAfter,
+    reward: zone.maxLevel,
+    shlagemons,
+  }
+}
+
+export const kings: Trainer[] = [
+  createKing('plaine-kekette', caillou, 'Je protege cette plaine, prepare-toi!', 'Hum, tu m\'as battu, chanceux.'),
+  createKing('bois-de-bouffon', sachatte, 'Ces bois seront ta tombe.', 'Je reviendrai plus fort.'),
+  createKing('grotte-du-slip', norman, 'Entres dans ma grotte si tu l\'oses.', 'Ta victoire ne sera que temporaire.'),
+  createKing('ravin-fesse-molle', marineLahaine, 'Le ravin te verra chuter!', 'Incroyable... tu as gagne.'),
+  createKing('grotte-nanard', marcon, 'Le vieux Nanard t\'attend.', 'Le vieux Nanard te regarde avec degout.'),
+  createKing('marais-moudugenou', sachatte, 'Tu vas couler dans le marais!', 'Tu t\'extirpes du marais victorieux.'),
+  createKing('forteresse-petmoalfiak', profMerdant, 'Ma forteresse est imprenable!', 'Tu as brise ma forteresse...'),
+  createKing('route-du-nawak', caillou, 'Perds-toi sur cette route!', 'Tu t\'en sors, pour l\'instant.'),
+  createKing('mont-dracatombe', norman, 'Le sommet est pour les braves!', 'Le mont te cede la victoire.'),
+  createKing('catacombes-merdifientes', marineLahaine, 'Les catacombes sont ton futur tombeau.', 'Je sombre dans l\'ombre des catacombes.'),
+  createKing('route-aguicheuse', marcon, 'Tentes-tu ta chance ici?', 'Bien joue, voyageur.'),
+  createKing('grotte-des-chieurs', sachatte, 'Personne ne ressort de cette grotte.', 'Tu as dompte la puanteur.'),
+  createKing('trou-du-bide', caillou, 'Mon trou ne te fera pas de cadeau.', 'Je m\'incline... pour cette fois.'),
+  createKing('zone-giga-zob', profMerdant, 'Bienvenue en enfer!', 'Impossible... comment as-tu fait ?'),
+  createKing('route-so-dom', marcon, 'Derniere ligne droite, minus!', 'Tu es vraiment le meilleur.'),
+]

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -2,13 +2,7 @@ import type { Trainer } from '~/type/trainer'
 import type { Zone } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { caillou } from '~/data/characters/caillou'
-import { marcon } from '~/data/characters/marcon'
-import { marineLahaine } from '~/data/characters/marine-lahaine'
-import { norman } from '~/data/characters/norman'
-import { profMerdant } from '~/data/characters/prof-merdant'
-import { sachatte } from '~/data/characters/sachatte'
-import { allShlagemons } from '~/data/shlagemons'
+import { kings as kingsData } from '~/data/kings'
 import { zonesData } from '~/data/zones'
 import { useShlagedexStore } from './shlagedex'
 
@@ -30,49 +24,8 @@ export const useZoneStore = defineStore('zone', () => {
     const hasKing = z.hasKing ?? z.type === 'sauvage'
     if (!hasKing)
       return undefined
-    if (!kings.value[id]) {
-      const level = z.maxLevel + 1
-
-      let character = profMerdant
-      switch (id) {
-        case 'plaine-kekette':
-          character = caillou
-          break
-        case 'bois-de-bouffon':
-          character = sachatte
-          break
-        case 'grotte-du-slip':
-          character = norman
-          break
-        case 'ravin-fesse-molle':
-          character = marineLahaine
-          break
-        case 'grotte-nanard':
-          character = marcon
-          break
-        case 'marais-moudugenou':
-          character = sachatte
-          break
-      }
-
-      const kingDexSize = z.maxLevel < 10 ? 3 : 6
-      const trainer: Trainer = {
-        id: `king-${z.id}`,
-        character,
-        dialogBefore: 'Prépare-toi à perdre !',
-        dialogAfter: 'Tu as gagné... pour cette fois.',
-        reward: 5,
-        shlagemons: Array.from({ length: kingDexSize }, () => {
-          const list = z.shlagemons?.length ? z.shlagemons! : allShlagemons
-          const base = list[Math.floor(Math.random() * list.length)]
-          return {
-            baseId: base.id,
-            level,
-          }
-        }),
-      }
-      kings.value[id] = trainer
-    }
+    if (!kings.value[id])
+      kings.value[id] = kingsData.find(k => k.id === `king-${id}`)!
     return kings.value[id]
   }
 


### PR DESCRIPTION
## Summary
- replace king type with `Trainer`
- store all kings in a generated array of trainers
- reference new kings data in zone store

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError from unocss webfont)*

------
https://chatgpt.com/codex/tasks/task_e_686a83e3dd4c832ab2373c1ff2976e64