### PR TITLE
Fix watch argument types in GameGrid

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -75,9 +75,9 @@ const group2Classes = computed(() => {
   return classes.join(' ')
 })
 
-watch(
-  () => [mainPanel.current, zone.current.id, trainerBattle.current?.id] as const,
-  ([panel, zoneId, trainerId]: [MainPanel, ZoneId, string | undefined]) => {
+watch<[MainPanel, ZoneId, string | undefined], true>(
+  () => [mainPanel.current, zone.current.id, trainerBattle.current?.id],
+  ([panel, zoneId, trainerId]) => {
     if (panel === 'battle')
       audio.fadeToMusic(zoneBattleTracks[zoneId])
     else if (panel === 'trainerBattle')


### PR DESCRIPTION
## Summary
- fix watch call generic types in GameGrid

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: "Could not find a declaration file for module 'howler'" etc.)*
- `pnpm test:unit` *(fails: 22 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_686a97e9cf7c832aa3d9f4a175d2f912