### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/src/modules/keyboard.ts
+++ b/src/modules/keyboard.ts
@@ -1,0 +1,14 @@
+import type { UserModule } from '~/types'
+import { useShortcutsStore } from '~/stores/shortcuts'
+
+export const install: UserModule = ({ isClient }) => {
+  if (!isClient)
+    return
+  const store = useShortcutsStore()
+  window.addEventListener('keydown', (event) => {
+    const target = event.target as HTMLElement | null
+    if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable))
+      return
+    store.handleKeydown(event)
+  })
+}

--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -1,0 +1,54 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useInventoryStore } from './inventory'
+
+export interface UseItemAction {
+  type: 'use-item'
+  itemId: string
+}
+
+export type ShortcutAction = UseItemAction
+
+export interface ShortcutEntry {
+  key: string
+  action: ShortcutAction
+}
+
+const defaultShortcuts: ShortcutEntry[] = [
+  { key: '1', action: { type: 'use-item', itemId: 'potion' } },
+  { key: '2', action: { type: 'use-item', itemId: 'super-potion' } },
+  { key: '3', action: { type: 'use-item', itemId: 'hyper-potion' } },
+]
+
+export const useShortcutsStore = defineStore('shortcuts', () => {
+  const shortcuts = ref<ShortcutEntry[]>([...defaultShortcuts])
+
+  function add(entry: ShortcutEntry) {
+    shortcuts.value.push(entry)
+  }
+
+  function update(index: number, entry: ShortcutEntry) {
+    if (shortcuts.value[index])
+      shortcuts.value[index] = entry
+  }
+
+  function remove(index: number) {
+    shortcuts.value.splice(index, 1)
+  }
+
+  function reset() {
+    shortcuts.value = [...defaultShortcuts]
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    const entry = shortcuts.value.find(s => s.key === e.key)
+    if (!entry)
+      return
+    if (entry.action.type === 'use-item')
+      useInventoryStore().useItem(entry.action.itemId)
+  }
+
+  return { shortcuts, add, update, remove, reset, handleKeydown }
+}, {
+  persist: true,
+})


### PR DESCRIPTION
## Summary
- add `shortcuts` store to manage keyboard shortcuts
- add keyboard module to dispatch keydown events

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686ab5485ec8832abd16606d2e3e5fd5