### PR TITLE
Close modal after setting main Shlagemon

### DIFF
--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -162,7 +162,11 @@ function isActive(mon: DexShlagemon) {
       </div>
     </div>
     <Modal v-model="showDetail" footer-close @close="showDetail = false">
-      <ShlagemonDetail :mon="detailMon" @release="showDetail = false" />
+      <ShlagemonDetail
+        :mon="detailMon"
+        @release="showDetail = false"
+        @active="showDetail = false"
+      />
     </Modal>
   </section>
 </template>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -13,6 +13,7 @@ import { useShlagedexStore } from '~/stores/shlagedex'
 const props = defineProps<{ mon: DexShlagemon | null }>()
 const emit = defineEmits<{
   (e: 'release'): void
+  (e: 'active'): void
 }>()
 
 const statColors = [
@@ -52,8 +53,10 @@ const showConfirm = ref(false)
 const isActive = computed(() => props.mon?.id === store.activeShlagemon?.id)
 
 function setActive() {
-  if (props.mon)
+  if (props.mon) {
     store.setActiveShlagemon(props.mon)
+    emit('active')
+  }
 }
 
 const isActiveAndSick = computed(() =>


### PR DESCRIPTION
## Summary
- emit `active` event from `ShlagemonDetail`
- close modal on `active` event in `Shlagedex`

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*
- `pnpm test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686ab823dc64832ab2779c1d73bc816b