### PR TITLE
Add SEO meta tags for social sharing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,8 +10,64 @@ useHead({
       content: 'Attrapes tous les Shlagémons pour éviter qu\'ils ne pourrissent la terre entière.',
     },
     {
+      name: 'keywords',
+      content: 'shlagemon, jeu, pokemon, parodie, capture, combat',
+    },
+    {
+      name: 'author',
+      content: 'Shlagémon Team',
+    },
+    {
       name: 'theme-color',
       content: () => isDark.value ? '#0d9488' : '#ffffff',
+    },
+    {
+      property: 'og:title',
+      content: 'Shlagémon - Ça sent très fort',
+    },
+    {
+      property: 'og:description',
+      content: 'Attrapes tous les Shlagémons pour éviter qu\'ils ne pourrissent la terre entière.',
+    },
+    {
+      property: 'og:type',
+      content: 'website',
+    },
+    {
+      property: 'og:url',
+      content: 'https://shlagemon.web.app',
+    },
+    {
+      property: 'og:image',
+      content: 'https://shlagemon.web.app/items/shlageball/shlageball.png',
+    },
+    {
+      property: 'og:site_name',
+      content: 'Shlagémon',
+    },
+    {
+      name: 'twitter:card',
+      content: 'summary_large_image',
+    },
+    {
+      name: 'twitter:title',
+      content: 'Shlagémon - Ça sent très fort',
+    },
+    {
+      name: 'twitter:description',
+      content: 'Attrapes tous les Shlagémons pour éviter qu\'ils ne pourrissent la terre entière.',
+    },
+    {
+      name: 'twitter:image',
+      content: 'https://shlagemon.web.app/items/shlageball/shlageball.png',
+    },
+    {
+      name: 'twitter:site',
+      content: '@shlagemon',
+    },
+    {
+      name: 'twitter:creator',
+      content: '@shlagemon',
     },
   ],
   link: [
@@ -19,6 +75,14 @@ useHead({
       rel: 'icon',
       type: 'image/svg+xml',
       href: () => preferredDark.value ? '/favicon-dark.svg' : '/favicon.svg',
+    },
+    {
+      rel: 'canonical',
+      href: 'https://shlagemon.web.app',
+    },
+    {
+      rel: 'image_src',
+      href: 'https://shlagemon.web.app/items/shlageball/shlageball.png',
     },
   ],
 })


### PR DESCRIPTION
## Summary
- extend `useHead` config with SEO meta tags for Open Graph and Twitter

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*
- `pnpm typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ab9de2c78832a9e1361d7f782a9fd