### PR TITLE
Add shortcuts tab to profile

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -276,6 +276,7 @@ declare global {
   const useSessionStorage: typeof import('@vueuse/core')['useSessionStorage']
   const useShare: typeof import('@vueuse/core')['useShare']
   const useShlagedexStore: typeof import('./stores/shlagedex')['useShlagedexStore']
+  const useShortcutsStore: typeof import('./stores/shortcuts')['useShortcutsStore']
   const useSingleInterval: typeof import('./composables/battleEngine')['useSingleInterval']
   const useSlots: typeof import('vue')['useSlots']
   const useSorted: typeof import('@vueuse/core')['useSorted']
@@ -365,11 +366,17 @@ declare global {
   export type { EventCallback } from './stores/event'
   import('./stores/event')
   // @ts-ignore
+  export type { InventorySort } from './stores/inventoryFilter'
+  import('./stores/inventoryFilter')
+  // @ts-ignore
   export type { MainPanel } from './stores/mainPanel'
   import('./stores/mainPanel')
   // @ts-ignore
   export type { MobileTab } from './stores/mobileTab'
   import('./stores/mobileTab')
+  // @ts-ignore
+  export type { UseItemAction, ShortcutAction, ShortcutEntry } from './stores/shortcuts'
+  import('./stores/shortcuts')
 }
 
 // for vue template auto import
@@ -578,6 +585,7 @@ declare module 'vue' {
     readonly useIntersectionObserver: UnwrapRef<typeof import('@vueuse/core')['useIntersectionObserver']>
     readonly useInterval: UnwrapRef<typeof import('@vueuse/core')['useInterval']>
     readonly useIntervalFn: UnwrapRef<typeof import('@vueuse/core')['useIntervalFn']>
+    readonly useInventoryFilterStore: UnwrapRef<typeof import('./stores/inventoryFilter')['useInventoryFilterStore']>
     readonly useInventoryModalStore: UnwrapRef<typeof import('./stores/inventoryModal')['useInventoryModalStore']>
     readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
@@ -592,6 +600,7 @@ declare module 'vue' {
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>
     readonly useMemoize: UnwrapRef<typeof import('@vueuse/core')['useMemoize']>
     readonly useMemory: UnwrapRef<typeof import('@vueuse/core')['useMemory']>
+    readonly useMiniGameStore: UnwrapRef<typeof import('./stores/miniGame')['useMiniGameStore']>
     readonly useMobileTabStore: UnwrapRef<typeof import('./stores/mobileTab')['useMobileTabStore']>
     readonly useModel: UnwrapRef<typeof import('vue')['useModel']>
     readonly useMounted: UnwrapRef<typeof import('@vueuse/core')['useMounted']>
@@ -641,6 +650,7 @@ declare module 'vue' {
     readonly useSessionStorage: UnwrapRef<typeof import('@vueuse/core')['useSessionStorage']>
     readonly useShare: UnwrapRef<typeof import('@vueuse/core')['useShare']>
     readonly useShlagedexStore: UnwrapRef<typeof import('./stores/shlagedex')['useShlagedexStore']>
+    readonly useShortcutsStore: UnwrapRef<typeof import('./stores/shortcuts')['useShortcutsStore']>
     readonly useSingleInterval: UnwrapRef<typeof import('./composables/battleEngine')['useSingleInterval']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
     readonly useSorted: UnwrapRef<typeof import('@vueuse/core')['useSorted']>
@@ -685,6 +695,7 @@ declare module 'vue' {
     readonly useWindowFocus: UnwrapRef<typeof import('@vueuse/core')['useWindowFocus']>
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
+    readonly useZoneMonsModalStore: UnwrapRef<typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']>
     readonly useZoneProgressStore: UnwrapRef<typeof import('./stores/zoneProgress')['useZoneProgressStore']>
     readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -73,6 +73,7 @@ declare module 'vue' {
     Shlagidolar: typeof import('./components/icons/shlagidolar.vue')['default']
     ShopItemDetail: typeof import('./components/shop/ShopItemDetail.vue')['default']
     ShopPanel: typeof import('./components/panels/ShopPanel.vue')['default']
+    ShortcutsTab: typeof import('./components/profile/ShortcutsTab.vue')['default']
     SortControls: typeof import('./components/ui/SortControls.vue')['default']
     ThemeToggle: typeof import('./components/ThemeToggle.vue')['default']
     Tooltip: typeof import('./components/ui/Tooltip.vue')['default']

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -4,6 +4,7 @@ import Button from '~/components/ui/Button.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
 import { useInterfaceStore } from '~/stores/interface'
 import { useSaveStore } from '~/stores/save'
+import ShortcutsTab from './ShortcutsTab.vue'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits(['update:modelValue'])
@@ -11,7 +12,7 @@ const emit = defineEmits(['update:modelValue'])
 const save = useSaveStore()
 const ui = useInterfaceStore()
 
-const tab = ref<'save' | 'interface'>('save')
+const tab = ref<'save' | 'interface' | 'shortcuts'>('save')
 
 function close() {
   emit('update:modelValue', false)
@@ -47,6 +48,13 @@ function removeSave() {
       >
         Interface
       </button>
+      <button
+        class="rounded px-2 py-1"
+        :class="tab === 'shortcuts' ? 'bg-gray-200 dark:bg-gray-700' : 'bg-gray-100 dark:bg-gray-800'"
+        @click="tab = 'shortcuts'"
+      >
+        Raccourcis
+      </button>
     </nav>
     <div v-if="tab === 'save'" class="flex flex-col gap-4">
       <p class="text-center">
@@ -57,7 +65,7 @@ function removeSave() {
         Supprimer
       </Button>
     </div>
-    <div v-else class="flex flex-col gap-2">
+    <div v-else-if="tab === 'interface'" class="flex flex-col gap-2">
       <label class="flex flex-col gap-1">
         <span>Panel mobile sous le jeu</span>
         <SelectOption
@@ -68,6 +76,9 @@ function removeSave() {
           ]"
         />
       </label>
+    </div>
+    <div v-else class="flex flex-col gap-2">
+      <ShortcutsTab />
     </div>
   </Modal>
 </template>

--- a/src/components/profile/ShortcutsTab.vue
+++ b/src/components/profile/ShortcutsTab.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import Button from '~/components/ui/Button.vue'
+import SelectOption from '~/components/ui/SelectOption.vue'
+import { allItems } from '~/data/items/items'
+import { useShortcutsStore } from '~/stores/shortcuts'
+
+const store = useShortcutsStore()
+
+const itemOptions = allItems.map(i => ({ label: i.name, value: i.id }))
+
+function updateKey(index: number, key: string) {
+  const entry = { ...store.shortcuts[index], key }
+  store.update(index, entry)
+}
+
+function updateItem(index: number, itemId: string) {
+  const entry = { key: store.shortcuts[index].key, action: { type: 'use-item', itemId } }
+  store.update(index, entry)
+}
+
+function addShortcut() {
+  const firstItem = allItems[0]
+  store.add({ key: '', action: { type: 'use-item', itemId: firstItem.id } })
+}
+
+function reset() {
+  store.reset()
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <div v-for="(sc, idx) in store.shortcuts" :key="idx" class="flex items-center gap-2">
+      <input
+        :value="sc.key"
+        class="w-12 border border-gray-300 rounded bg-white px-2 py-1 text-center dark:border-gray-700 dark:bg-gray-800"
+        @input="updateKey(idx, ($event.target as HTMLInputElement).value)"
+      >
+      <SelectOption
+        class="flex-1"
+        :model-value="sc.action.type === 'use-item' ? sc.action.itemId : ''"
+        :options="itemOptions"
+        @update:model-value="val => updateItem(idx, val as string)"
+      />
+    </div>
+    <div class="mt-2 flex gap-2">
+      <Button class="flex-1" @click="addShortcut">
+        Ajouter un raccourci
+      </Button>
+      <Button type="danger" class="flex-1" @click="reset">
+        Réinitialiser
+      </Button>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- extend profile tabs with a new `shortcuts` option
- create `ShortcutsTab` to manage quick item shortcuts
- wire up new tab inside the profile modal

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined...)*

------
https://chatgpt.com/codex/tasks/task_e_686ab85d6360832aa84c9eae2fa2b043