### PR TITLE
Add first loss dialog

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -141,6 +141,7 @@ declare global {
   const useBase64: typeof import('@vueuse/core')['useBase64']
   const useBattery: typeof import('@vueuse/core')['useBattery']
   const useBattleEffects: typeof import('./composables/battleEngine')['useBattleEffects']
+  const useBattleStatsStore: typeof import('./stores/battleStats')['useBattleStatsStore']
   const useBattleStore: typeof import('./stores/battle')['useBattleStore']
   const useBluetooth: typeof import('@vueuse/core')['useBluetooth']
   const useBreakpoints: typeof import('@vueuse/core')['useBreakpoints']
@@ -276,6 +277,7 @@ declare global {
   const useSessionStorage: typeof import('@vueuse/core')['useSessionStorage']
   const useShare: typeof import('@vueuse/core')['useShare']
   const useShlagedexStore: typeof import('./stores/shlagedex')['useShlagedexStore']
+  const useShortcutsStore: typeof import('./stores/shortcuts')['useShortcutsStore']
   const useSingleInterval: typeof import('./composables/battleEngine')['useSingleInterval']
   const useSlots: typeof import('vue')['useSlots']
   const useSorted: typeof import('@vueuse/core')['useSorted']
@@ -365,11 +367,17 @@ declare global {
   export type { EventCallback } from './stores/event'
   import('./stores/event')
   // @ts-ignore
+  export type { InventorySort } from './stores/inventoryFilter'
+  import('./stores/inventoryFilter')
+  // @ts-ignore
   export type { MainPanel } from './stores/mainPanel'
   import('./stores/mainPanel')
   // @ts-ignore
   export type { MobileTab } from './stores/mobileTab'
   import('./stores/mobileTab')
+  // @ts-ignore
+  export type { UseItemAction, ShortcutAction, ShortcutEntry } from './stores/shortcuts'
+  import('./stores/shortcuts')
 }
 
 // for vue template auto import
@@ -509,6 +517,7 @@ declare module 'vue' {
     readonly useBase64: UnwrapRef<typeof import('@vueuse/core')['useBase64']>
     readonly useBattery: UnwrapRef<typeof import('@vueuse/core')['useBattery']>
     readonly useBattleEffects: UnwrapRef<typeof import('./composables/battleEngine')['useBattleEffects']>
+    readonly useBattleStatsStore: UnwrapRef<typeof import('./stores/battleStats')['useBattleStatsStore']>
     readonly useBattleStore: UnwrapRef<typeof import('./stores/battle')['useBattleStore']>
     readonly useBluetooth: UnwrapRef<typeof import('@vueuse/core')['useBluetooth']>
     readonly useBreakpoints: UnwrapRef<typeof import('@vueuse/core')['useBreakpoints']>
@@ -578,6 +587,7 @@ declare module 'vue' {
     readonly useIntersectionObserver: UnwrapRef<typeof import('@vueuse/core')['useIntersectionObserver']>
     readonly useInterval: UnwrapRef<typeof import('@vueuse/core')['useInterval']>
     readonly useIntervalFn: UnwrapRef<typeof import('@vueuse/core')['useIntervalFn']>
+    readonly useInventoryFilterStore: UnwrapRef<typeof import('./stores/inventoryFilter')['useInventoryFilterStore']>
     readonly useInventoryModalStore: UnwrapRef<typeof import('./stores/inventoryModal')['useInventoryModalStore']>
     readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
@@ -592,6 +602,7 @@ declare module 'vue' {
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>
     readonly useMemoize: UnwrapRef<typeof import('@vueuse/core')['useMemoize']>
     readonly useMemory: UnwrapRef<typeof import('@vueuse/core')['useMemory']>
+    readonly useMiniGameStore: UnwrapRef<typeof import('./stores/miniGame')['useMiniGameStore']>
     readonly useMobileTabStore: UnwrapRef<typeof import('./stores/mobileTab')['useMobileTabStore']>
     readonly useModel: UnwrapRef<typeof import('vue')['useModel']>
     readonly useMounted: UnwrapRef<typeof import('@vueuse/core')['useMounted']>
@@ -641,6 +652,7 @@ declare module 'vue' {
     readonly useSessionStorage: UnwrapRef<typeof import('@vueuse/core')['useSessionStorage']>
     readonly useShare: UnwrapRef<typeof import('@vueuse/core')['useShare']>
     readonly useShlagedexStore: UnwrapRef<typeof import('./stores/shlagedex')['useShlagedexStore']>
+    readonly useShortcutsStore: UnwrapRef<typeof import('./stores/shortcuts')['useShortcutsStore']>
     readonly useSingleInterval: UnwrapRef<typeof import('./composables/battleEngine')['useSingleInterval']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
     readonly useSorted: UnwrapRef<typeof import('@vueuse/core')['useSorted']>
@@ -685,6 +697,7 @@ declare module 'vue' {
     readonly useWindowFocus: UnwrapRef<typeof import('@vueuse/core')['useWindowFocus']>
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
+    readonly useZoneMonsModalStore: UnwrapRef<typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']>
     readonly useZoneProgressStore: UnwrapRef<typeof import('./stores/zoneProgress')['useZoneProgressStore']>
     readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -35,6 +35,7 @@ declare module 'vue' {
     EvolutionItemModal: typeof import('./components/inventory/EvolutionItemModal.vue')['default']
     EvolutionModal: typeof import('./components/shlagemon/EvolutionModal.vue')['default']
     FightKingButton: typeof import('./components/battle/FightKingButton.vue')['default']
+    FirstLossDialog: typeof import('./components/dialog/FirstLossDialog.vue')['default']
     GameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     HalfDexDialog: typeof import('./components/dialog/HalfDexDialog.vue')['default']
     Header: typeof import('./components/layout/Header.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -13,6 +13,7 @@ import { notifyAchievement } from '~/stores/achievements'
 import { useAudioStore } from '~/stores/audio'
 import { useBallStore } from '~/stores/ball'
 import { useBattleStore } from '~/stores/battle'
+import { useBattleStatsStore } from '~/stores/battleStats'
 import { useDiseaseStore } from '~/stores/disease'
 import { useEventStore } from '~/stores/event'
 import { useGameStore } from '~/stores/game'
@@ -34,6 +35,7 @@ const disease = useDiseaseStore()
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
 const multiExpStore = useMultiExpStore()
+const battleStats = useBattleStatsStore()
 const zoneMonsModal = useZoneMonsModalStore()
 const events = useEventStore()
 const audio = useAudioStore()
@@ -237,6 +239,9 @@ function checkEnd() {
             await dex.gainXp(holder, share, zone.current.maxLevel)
           }
         }
+      }
+      else if (playerHp.value <= 0 && enemyHp.value > 0) {
+        battleStats.addLoss()
       }
       playerFainted.value = false
       enemyFainted.value = false

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -8,6 +8,7 @@ import { useBattleEffects } from '~/composables/battleEngine'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStore } from '~/stores/battle'
+import { useBattleStatsStore } from '~/stores/battleStats'
 import { useDiseaseStore } from '~/stores/disease'
 import { useEventStore } from '~/stores/event'
 import { useGameStore } from '~/stores/game'
@@ -27,6 +28,7 @@ const panel = useMainPanelStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
 const multiExpStore = useMultiExpStore()
+const battleStats = useBattleStatsStore()
 const disease = useDiseaseStore()
 const events = useEventStore()
 const equilibrerank = 2
@@ -201,6 +203,7 @@ function checkEnd() {
       }
 
       if (playerHp.value <= 0) {
+        battleStats.addLoss()
         result.value = 'lose'
         stage.value = 'after'
         playerFainted.value = false

--- a/src/components/dialog/FirstLossDialog.vue
+++ b/src/components/dialog/FirstLossDialog.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import DialogBox from '~/components/dialog/DialogBox.vue'
+import { profMerdant } from '~/data/characters/prof-merdant'
+
+const emit = defineEmits(['done'])
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: 'Eh ben dis donc, tu viens de perdre ton premier combat !',
+    responses: [
+      { label: '...', nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: 'Faut vraiment être un peu débile pour se faire battre par un Shlagémon.',
+    responses: [
+      { label: 'Oups', nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: 'Pour gagner, clique plein de fois sur le Shlagémon avec ton doigt ou ta souris pour lui enlever de la vie.',
+    responses: [
+      { label: 'Je vais essayer', nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: 'Le but est de vaincre la puanteur de tous ces Shlagémon !',
+    responses: [
+      {
+        label: 'Compris, Professeur !',
+        type: 'valid',
+        action: () => emit('done', 'firstLoss'),
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :speaker="profMerdant.name"
+    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :dialog-tree="dialogTree"
+  />
+</template>

--- a/src/stores/battleStats.ts
+++ b/src/stores/battleStats.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useBattleStatsStore = defineStore('battleStats', () => {
+  const losses = ref(0)
+
+  function addLoss() {
+    losses.value += 1
+  }
+
+  function reset() {
+    losses.value = 0
+  }
+
+  return { losses, addLoss, reset }
+}, {
+  persist: true,
+})

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -2,12 +2,14 @@ import { defineStore } from 'pinia'
 import { markRaw } from 'vue'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
 import DialogStarter from '~/components/dialog/DialogStarter.vue'
+import FirstLossDialog from '~/components/dialog/FirstLossDialog.vue'
 import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
 import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import ReleaseShlagemonDialog from '~/components/dialog/ReleaseShlagemonDialog.vue'
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { useBattleStatsStore } from './battleStats'
 import { useMainPanelStore } from './mainPanel'
 
 interface DialogItem {
@@ -24,6 +26,7 @@ export const useDialogStore = defineStore('dialog', () => {
   const game = useGameStore()
   const dex = useShlagedexStore()
   const panel = useMainPanelStore()
+  const stats = useBattleStatsStore()
 
   const done = ref<DialogDone>({})
   const dialogs: DialogItem[] = [
@@ -51,6 +54,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'release',
       component: markRaw(ReleaseShlagemonDialog),
       condition: () => dex.shlagemons.length >= 10,
+    },
+    {
+      id: 'firstLoss',
+      component: markRaw(FirstLossDialog),
+      condition: () => stats.losses > 0,
     },
   ]
 

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { useAchievementsStore } from './achievements'
 import { useBallStore } from './ball'
+import { useBattleStatsStore } from './battleStats'
 import { useDexFilterStore } from './dexFilter'
 import { useDialogStore } from './dialog'
 import { useGameStore } from './game'
@@ -14,6 +15,7 @@ export const useSaveStore = defineStore('save', () => {
   const dex = useShlagedexStore()
   const gameState = useGameStateStore()
   const game = useGameStore()
+  const battleStats = useBattleStatsStore()
   const inventory = useInventoryStore()
   const dialog = useDialogStore()
   const zone = useZoneStore()
@@ -31,6 +33,7 @@ export const useSaveStore = defineStore('save', () => {
     zone.reset()
     zoneProgress.reset()
     achievements.reset()
+    battleStats.reset()
     ball.reset()
     dexFilter.reset()
   }


### PR DESCRIPTION
## Summary
- track number of lost battles
- trigger new dialog after the first loss
- create dialog component with Professor Merdant advice
- persist loss stats in save store

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686aba1ad5c8832a8c7c29a11b8112b3