### PR TITLE
Fix zone reselect heals bug

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -279,11 +279,13 @@ watch(
   },
 )
 
+let lastZoneId = zone.current.id
 watch(
-  () => zone.current.id,
+  () => zone.selectedAt,
   () => {
-    if (dex.activeShlagemon)
+    if (dex.activeShlagemon && lastZoneId !== zone.current.id)
       dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
+    lastZoneId = zone.current.id
     stopInterval()
     battleActive.value = false
     startBattle()

--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -26,10 +26,6 @@ const actionLabel = computed(() => {
     return props.disabled ? 'Équipé' : 'Équiper'
   return 'Utiliser'
 })
-
-function toggle() {
-  opened.value = !opened.value
-}
 </script>
 
 <template>

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -9,6 +9,7 @@ import { useShlagedexStore } from './shlagedex'
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
   const currentId = ref<string>(zones.value[0].id)
+  const selectedAt = ref<number>(Date.now())
   const current = computed(() => {
     const zone = zones.value.find(z => z.id === currentId.value)
     return zone ?? zones.value[0]
@@ -44,9 +45,11 @@ export const useZoneStore = defineStore('zone', () => {
 
   function setZone(id: string) {
     if (zones.value.some(z => z.id === id)) {
+      const same = currentId.value === id
       currentId.value = id
+      selectedAt.value = Date.now()
       const dex = useShlagedexStore()
-      if (dex.activeShlagemon)
+      if (dex.activeShlagemon && !same)
         dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
     }
   }
@@ -58,6 +61,7 @@ export const useZoneStore = defineStore('zone', () => {
   return {
     zones,
     current,
+    selectedAt,
     rewardMultiplier,
     setZone,
     getKing,


### PR DESCRIPTION
## Summary
- add a timestamp when selecting a zone
- detect zone reselection in battle and restart combat without healing
- fix duplicated function in InventoryItemCard.vue

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Could not find a declaration file for module 'howler')*
- `pnpm test` *(fails: Snapshot mismatched and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ac8f8a21c832abeb81452dd898b03