### PR TITLE
Implement keyboard shortcut capture component

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -215,6 +215,7 @@ declare global {
   const useInventoryModalStore: typeof import('./stores/inventoryModal')['useInventoryModalStore']
   const useInventoryStore: typeof import('./stores/inventory')['useInventoryStore']
   const useKeyModifier: typeof import('@vueuse/core')['useKeyModifier']
+  const useKeyboardCaptureStore: typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']
   const useLastChanged: typeof import('@vueuse/core')['useLastChanged']
   const useLink: typeof import('vue-router/auto')['useLink']
   const useLocalStorage: typeof import('@vueuse/core')['useLocalStorage']
@@ -591,6 +592,7 @@ declare module 'vue' {
     readonly useInventoryModalStore: UnwrapRef<typeof import('./stores/inventoryModal')['useInventoryModalStore']>
     readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
+    readonly useKeyboardCaptureStore: UnwrapRef<typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']>
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>
     readonly useLink: UnwrapRef<typeof import('vue-router/auto')['useLink']>
     readonly useLocalStorage: UnwrapRef<typeof import('@vueuse/core')['useLocalStorage']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -45,6 +45,8 @@ declare module 'vue' {
     InventoryModal: typeof import('./components/inventory/InventoryModal.vue')['default']
     InventoryPanel: typeof import('./components/panels/InventoryPanel.vue')['default']
     ItemCard: typeof import('./components/shop/ItemCard.vue')['default']
+    Kbd: typeof import('./components/ui/Kbd.vue')['default']
+    KeyCapture: typeof import('./components/ui/KeyCapture.vue')['default']
     Level5Dialog: typeof import('./components/dialog/Level5Dialog.vue')['default']
     MainPanel: typeof import('./components/panels/MainPanel.vue')['default']
     MobileMenu: typeof import('./components/layout/MobileMenu.vue')['default']

--- a/src/components/settings/ShortcutsTab.vue
+++ b/src/components/settings/ShortcutsTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Button from '~/components/ui/Button.vue'
+import KeyCapture from '~/components/ui/KeyCapture.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
 import { allItems } from '~/data/items/items'
 import { useShortcutsStore } from '~/stores/shortcuts'
@@ -31,11 +32,11 @@ function reset() {
 <template>
   <div class="flex flex-col gap-2">
     <div v-for="(sc, idx) in store.shortcuts" :key="idx" class="flex items-center gap-2">
-      <input
-        :value="sc.key"
-        class="w-12 border border-gray-300 rounded bg-white px-2 py-1 text-center dark:border-gray-700 dark:bg-gray-800"
-        @input="updateKey(idx, ($event.target as HTMLInputElement).value)"
-      >
+      <KeyCapture
+        class="w-12"
+        :model-value="sc.key"
+        @update:model-value="val => updateKey(idx, val)"
+      />
       <SelectOption
         class="flex-1"
         :model-value="sc.action.type === 'use-item' ? sc.action.itemId : ''"

--- a/src/components/ui/Kbd.vue
+++ b/src/components/ui/Kbd.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type Size = 'sm' | 'md' | 'lg' | 'xl'
+
+const props = withDefaults(defineProps<{ keyName: string, size?: Size, waiting?: boolean }>(), {
+  size: 'md',
+  waiting: false,
+})
+
+const KEY_LABELS: Record<string, string> = {
+  'Control': 'Ctrl',
+  'Alt': 'Alt',
+  'Shift': 'Maj',
+  'Meta': 'Windows',
+  'Tab': 'Tab',
+  ' ': 'Space',
+  'ArrowUp': '↑',
+  'ArrowDown': '↓',
+  'ArrowLeft': '←',
+  'ArrowRight': '→',
+}
+
+const label = computed(() => KEY_LABELS[props.keyName] ?? props.keyName)
+
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'text-xs px-1 py-0.5'
+    case 'lg':
+      return 'text-base px-3 py-1'
+    case 'xl':
+      return 'text-lg px-4 py-1'
+    default:
+      return 'text-sm px-2 py-0.5'
+  }
+})
+</script>
+
+<template>
+  <kbd
+    :class="`
+      inline-flex items-center justify-center border rounded select-none bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-500 ${sizeClass} ${props.waiting ? 'animate-pulse opacity-70' : ''}
+    `"
+  >
+    {{ label }}
+  </kbd>
+</template>

--- a/src/components/ui/KeyCapture.vue
+++ b/src/components/ui/KeyCapture.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { useKeyboardCaptureStore } from '~/stores/keyboardCapture'
+import Kbd from './Kbd.vue'
+
+const props = defineProps<{ modelValue: string }>()
+const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
+
+const captureStore = useKeyboardCaptureStore()
+const waiting = ref(false)
+
+function startCapture() {
+  waiting.value = true
+  captureStore.start()
+}
+
+function stopCapture() {
+  waiting.value = false
+  captureStore.stop()
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (!waiting.value)
+    return
+  e.preventDefault()
+  stopCapture()
+  emit('update:modelValue', e.key)
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown))
+onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
+</script>
+
+<template>
+  <Kbd
+    :key-name="waiting ? '?' : props.modelValue || '?'"
+    :waiting="waiting"
+    @click="startCapture"
+  />
+</template>

--- a/src/modules/keyboard.ts
+++ b/src/modules/keyboard.ts
@@ -1,13 +1,17 @@
 import type { UserModule } from '~/types'
+import { useKeyboardCaptureStore } from '~/stores/keyboardCapture'
 import { useShortcutsStore } from '~/stores/shortcuts'
 
 export const install: UserModule = ({ isClient }) => {
   if (!isClient)
     return
   const store = useShortcutsStore()
+  const capture = useKeyboardCaptureStore()
   window.addEventListener('keydown', (event) => {
     const target = event.target as HTMLElement | null
     if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable))
+      return
+    if (capture.capturing)
       return
     store.handleKeydown(event)
   })

--- a/src/stores/keyboardCapture.ts
+++ b/src/stores/keyboardCapture.ts
@@ -1,0 +1,13 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useKeyboardCaptureStore = defineStore('keyboardCapture', () => {
+  const capturing = ref(false)
+  function start() {
+    capturing.value = true
+  }
+  function stop() {
+    capturing.value = false
+  }
+  return { capturing, start, stop }
+})


### PR DESCRIPTION
## Summary
- add `Kbd` component for rendering keyboard keys
- add `KeyCapture` component to capture key presses
- manage capture state with `keyboardCapture` store
- integrate new components in shortcuts tab
- avoid handling shortcuts during capture

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686ad11d7b44832ab8be484791c67a7f