### PR TITLE
Restart zone battle after defeating trainer

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -225,6 +225,7 @@ function finish() {
       notifyAchievement({ type: 'king-defeated' })
     }
     trainerStore.next()
+    zone.setZone(zone.current.id)
     panel.showBattle()
   }
   else if (result.value === 'lose') {


### PR DESCRIPTION
## Summary
- fix battle flow after trainer fights by resetting zone before returning to the wild battle

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686ad72f0c90832aa51ba33882648d46