### PR TITLE
Fix first loss event and reward potions

### DIFF
--- a/src/components/dialog/FirstLossDialog.vue
+++ b/src/components/dialog/FirstLossDialog.vue
@@ -2,8 +2,10 @@
 import type { DialogNode } from '~/type/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { useInventoryStore } from '~/stores/inventory'
 
 const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
 
 const dialogTree: DialogNode[] = [
   {
@@ -31,10 +33,20 @@ const dialogTree: DialogNode[] = [
     id: 'step4',
     text: 'Le but est de vaincre la puanteur de tous ces Shlagémon !',
     responses: [
+      { label: 'Ok', nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: 'Tiens, prends ces 10 Potions Dégueulasses, ça peut servir.',
+    responses: [
       {
-        label: 'Compris, Professeur !',
+        label: 'Merci !',
         type: 'valid',
-        action: () => emit('done', 'firstLoss'),
+        action: () => {
+          inventory.add('potion', 10)
+          emit('done', 'firstLoss')
+        },
       },
     ],
   },

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -63,8 +63,13 @@ export const useDialogStore = defineStore('dialog', () => {
   ]
 
   const isDialogVisible = computed(() => {
+    const firstLoss = dialogs.find(d => d.id === 'firstLoss')
+    const showFirstLoss = firstLoss?.condition()
+      && !done.value[firstLoss.id]
+
     if (panel.current === 'trainerBattle')
-      return false
+      return Boolean(showFirstLoss)
+
     return dialogs.some(d => d.condition() && !done.value[d.id])
   })
 


### PR DESCRIPTION
## Summary
- show the `firstLoss` dialog even during trainer battles
- update the first loss dialog to give 10 potions

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686adff7c828832a98fac4070df313ce