### PR TITLE
Fix defeat count

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -214,12 +214,14 @@ function checkEnd() {
     enemyFainted.value = enemyHp.value <= 0
     clearTimeout(nextBattleTimer)
     nextBattleTimer = window.setTimeout(async () => {
+      const playerWon = enemyHp.value <= 0 && playerHp.value > 0
+      const playerLost = playerHp.value <= 0 && enemyHp.value > 0
       events.emit('battle:end')
       if (dex.activeShlagemon) {
         dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
         playerHp.value = dex.activeShlagemon.hpCurrent
       }
-      if (enemyHp.value <= 0 && playerHp.value > 0) {
+      if (playerWon) {
         const stronger = enemy.value && dex.activeShlagemon
           ? enemy.value.lvl > dex.activeShlagemon.lvl
           : false
@@ -240,7 +242,7 @@ function checkEnd() {
           }
         }
       }
-      else if (playerHp.value <= 0 && enemyHp.value > 0) {
+      else if (playerLost) {
         battleStats.addLoss()
         notifyAchievement({ type: 'battle-loss' })
       }


### PR DESCRIPTION
## Summary
- ensure losses are counted before healing in wild battles

## Testing
- `pnpm test:unit` *(fails: Failed to fetch fonts, Cannot read properties of undefined, snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_686ae656a05c832aad906146d8fbf355