### PR TITLE
Rename spender achievements

### DIFF
--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -156,10 +156,17 @@ export const useAchievementsStore = defineStore('achievements', () => {
   })
 
   const itemThresholds = [1, 10, 100, 1000, 10000]
+  const itemTitles: Record<number, string> = {
+    1: 'Premier craquage',
+    10: 'Acheteur en série',
+    100: 'Shopaholic confirmé',
+    1000: 'Banqueroute imminente',
+    10000: 'Flambeur intersidéral',
+  }
   itemThresholds.forEach((n) => {
     const def = {
       id: `item-${n}`,
-      title: 'Dépensier',
+      title: itemTitles[n],
       description: `Utiliser ${n.toLocaleString()} objet${n > 1 ? 's' : ''} pendant vos combats ou explorations.`,
       icon: 'carbon:shopping-bag',
     }


### PR DESCRIPTION
## Summary
- keep humorous spender achievement names
- use a mapping for the item achievement titles for improved readability

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetching fonts, plus multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686aed414108832a9b56194f27e97a1d