### PR TITLE
Fix zone panel not visible on desktop when Dex selected

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -55,7 +55,7 @@ const isAchievementVisible = computed(() => achievements.hasAny)
 const isDexUnderGame = computed(() => ui.mobileMainPanel === 'dex')
 
 const displayZonePanel = computed(() =>
-  !isDexUnderGame.value
+  (!isDexUnderGame.value || !isMobile.value)
   && isShlagedexVisible.value
   && (!isMobile.value || mobileTab.current === 'game'),
 )


### PR DESCRIPTION
## Summary
- adjust visibility logic for the zone panel

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError fonts.google.com ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686b74ff8a34832a8c2dded618aa6e00