### PR TITLE
Add generic Badge component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -14,6 +14,7 @@ declare module 'vue' {
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     AttackCursor: typeof import('./components/battle/AttackCursor.vue')['default']
     AudioSettingsModal: typeof import('./components/audio/AudioSettingsModal.vue')['default']
+    Badge: typeof import('./components/ui/Badge.vue')['default']
     BallSelectionModal: typeof import('./components/ball/BallSelectionModal.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
     BattleShlagemon: typeof import('./components/battle/BattleShlagemon.vue')['default']

--- a/src/components/ui/Badge.vue
+++ b/src/components/ui/Badge.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { BadgeColor, BadgeSize, BadgeVariant } from '~/type/badge'
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  color?: BadgeColor
+  variant?: BadgeVariant
+  size?: BadgeSize
+  icon?: string
+}>(), {
+  color: 'primary',
+  variant: 'solid',
+  size: 'sm',
+})
+
+const colorClasses = computed(() => {
+  const map: Record<BadgeColor, Record<BadgeVariant, string>> = {
+    primary: {
+      solid: 'text-white bg-blue-600 dark:bg-blue-700',
+      outline: 'border border-blue-600 dark:border-blue-700 text-blue-600 dark:text-blue-400',
+      soft: 'bg-blue-600/20 dark:bg-blue-700/20 text-blue-600 dark:text-blue-400',
+      ghost: 'text-blue-600 dark:text-blue-400',
+      dashed: 'border border-dashed border-blue-600 dark:border-blue-700 text-blue-600 dark:text-blue-400',
+    },
+    alert: {
+      solid: 'text-yellow-900 bg-yellow-400 dark:bg-yellow-500',
+      outline: 'border border-yellow-500 text-yellow-600 dark:text-yellow-500',
+      soft: 'bg-yellow-400/20 dark:bg-yellow-500/20 text-yellow-700 dark:text-yellow-500',
+      ghost: 'text-yellow-600 dark:text-yellow-500',
+      dashed: 'border border-dashed border-yellow-500 text-yellow-600 dark:text-yellow-500',
+    },
+    danger: {
+      solid: 'text-white bg-red-600 dark:bg-red-700',
+      outline: 'border border-red-600 dark:border-red-700 text-red-600 dark:text-red-400',
+      soft: 'bg-red-600/20 dark:bg-red-700/20 text-red-600 dark:text-red-400',
+      ghost: 'text-red-600 dark:text-red-400',
+      dashed: 'border border-dashed border-red-600 dark:border-red-700 text-red-600 dark:text-red-400',
+    },
+    info: {
+      solid: 'text-white bg-cyan-600 dark:bg-cyan-700',
+      outline: 'border border-cyan-600 dark:border-cyan-700 text-cyan-600 dark:text-cyan-400',
+      soft: 'bg-cyan-600/20 dark:bg-cyan-700/20 text-cyan-600 dark:text-cyan-400',
+      ghost: 'text-cyan-600 dark:text-cyan-400',
+      dashed: 'border border-dashed border-cyan-600 dark:border-cyan-700 text-cyan-600 dark:text-cyan-400',
+    },
+    neutral: {
+      solid: 'text-gray-800 dark:text-gray-200 bg-gray-200 dark:bg-gray-700',
+      outline: 'border border-gray-400 dark:border-gray-500 text-gray-700 dark:text-gray-300',
+      soft: 'bg-gray-400/20 dark:bg-gray-600/20 text-gray-700 dark:text-gray-300',
+      ghost: 'text-gray-700 dark:text-gray-300',
+      dashed: 'border border-dashed border-gray-400 dark:border-gray-500 text-gray-700 dark:text-gray-300',
+    },
+  }
+  return map[props.color][props.variant]
+})
+
+const sizeClasses = computed(() => {
+  switch (props.size) {
+    case 'xs':
+      return 'text-xs px-1 py-0.5'
+    case 'lg':
+      return 'text-base px-3 py-1'
+    case 'xl':
+      return 'text-lg px-4 py-2'
+    case 'md':
+      return 'text-sm px-2 py-0.5'
+    default:
+      return 'text-xs px-2 py-0.5'
+  }
+})
+</script>
+
+<template>
+  <span
+    class="absolute right-0 top-0 flex translate-x-1/2 items-center gap-1 rounded-full -translate-y-1/2"
+    :class="[colorClasses, sizeClasses]"
+  >
+    <span v-if="props.icon" class="h-4 w-4" :class="`i-${props.icon}`" />
+    <slot />
+  </span>
+</template>

--- a/src/components/ui/SortControls.vue
+++ b/src/components/ui/SortControls.vue
@@ -28,7 +28,7 @@ function toggleAsc() {
       @update:model-value="updateSortBy"
     />
     <button
-      class="ml-1 text-lg icon-btn"
+      class="icon-btn ml-1 text-lg"
       :aria-label="props.sortAsc ? 'Tri ascendant' : 'Tri descendant'"
       @click="toggleAsc"
     >

--- a/src/layouts/404.vue
+++ b/src/layouts/404.vue
@@ -13,7 +13,7 @@ useHead({
     </div>
     <RouterView />
     <div>
-      <button text-sm btn m="3 t8" @click="router.back()">
+      <button btn text-sm m="3 t8" @click="router.back()">
         {{ t('button.back') }}
       </button>
     </div>

--- a/src/type/badge.ts
+++ b/src/type/badge.ts
@@ -1,0 +1,3 @@
+export type BadgeColor = 'primary' | 'alert' | 'danger' | 'info' | 'neutral'
+export type BadgeVariant = 'solid' | 'outline' | 'soft' | 'ghost' | 'dashed'
+export type BadgeSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,4 +1,5 @@
 export * from './audio'
+export * from './badge'
 export * from './ball'
 export * from './button'
 export * from './dialog'


### PR DESCRIPTION
## Summary
- add badge types for color, size and variants
- expose badge types in type index
- generate a new Badge UI component with Unocss classes
- update components declaration
- fix Unocss class ordering via eslint auto-fix

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_686b75eaa738832aa1ae63054a4dff13