### PR TITLE
Add clear button for search inputs

### DIFF
--- a/src/components/ui/SearchInput.vue
+++ b/src/components/ui/SearchInput.vue
@@ -6,14 +6,27 @@ const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>()
 function onInput(e: Event) {
   emit('update:modelValue', (e.target as HTMLInputElement).value)
 }
+function clear() {
+  emit('update:modelValue', '')
+}
 </script>
 
 <template>
-  <input
-    :value="props.modelValue"
-    type="text"
-    :placeholder="props.placeholder"
-    class="focus:border-primary min-w-36 flex-1 border border-gray-300 rounded bg-white px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 focus:outline-none"
-    @input="onInput"
-  >
+  <div class="relative min-w-36 flex-1">
+    <input
+      :value="props.modelValue"
+      type="text"
+      :placeholder="props.placeholder"
+      class="focus:border-primary w-full border border-gray-300 rounded bg-white px-2 py-1 pr-6 text-sm dark:border-gray-700 dark:bg-gray-800 focus:outline-none"
+      @input="onInput"
+    >
+    <button
+      v-if="props.modelValue"
+      type="button"
+      class="absolute right-1 top-1/2 h-4 w-4 flex items-center justify-center rounded text-gray-500 -translate-y-1/2 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
+      @click="clear"
+    >
+      <div i-carbon-close />
+    </button>
+  </div>
 </template>

--- a/src/components/ui/SortControls.vue
+++ b/src/components/ui/SortControls.vue
@@ -28,7 +28,7 @@ function toggleAsc() {
       @update:model-value="updateSortBy"
     />
     <button
-      class="ml-1 text-lg icon-btn"
+      class="icon-btn ml-1 text-lg"
       :aria-label="props.sortAsc ? 'Tri ascendant' : 'Tri descendant'"
       @click="toggleAsc"
     >

--- a/src/layouts/404.vue
+++ b/src/layouts/404.vue
@@ -13,7 +13,7 @@ useHead({
     </div>
     <RouterView />
     <div>
-      <button text-sm btn m="3 t8" @click="router.back()">
+      <button btn text-sm m="3 t8" @click="router.back()">
         {{ t('button.back') }}
       </button>
     </div>


### PR DESCRIPTION
## Summary
- add clear button icon to `SearchInput`
- reorder UnoCSS classes in `SortControls` and `404` after lint fix

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: FetchError ENETUNREACH for fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_686b76b26848832a8a75711df5906366