### PR TITLE
Add spawn weighting by coefficient

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -25,6 +25,7 @@ import { useZoneMonsModalStore } from '~/stores/zoneMonsModal'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
 import { ballHues } from '~/utils/ball'
 import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
+import { pickRandomByCoefficient } from '~/utils/spawn'
 
 const dex = useShlagedexStore()
 const game = useGameStore()
@@ -138,7 +139,7 @@ function startBattle() {
   const available = zone.current.shlagemons?.length
     ? zone.current.shlagemons
     : allShlagemons
-  const base = available[Math.floor(Math.random() * available.length)]
+  const base = pickRandomByCoefficient(available)
   const rank = zone.getZoneRank(zone.current.id) * equilibrerank
   const created = createDexShlagemon(base, false, rank)
   const min = Number(zone.current.minLevel ?? 1)

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -1,0 +1,13 @@
+import type { BaseShlagemon } from '~/type'
+
+export function pickRandomByCoefficient(list: BaseShlagemon[]): BaseShlagemon {
+  const total = list.reduce((sum, mon) => sum + 1 / mon.coefficient, 0)
+  const r = Math.random() * total
+  let acc = 0
+  for (const mon of list) {
+    acc += 1 / mon.coefficient
+    if (r < acc)
+      return mon
+  }
+  return list[list.length - 1]
+}

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { pickRandomByCoefficient } from '../src/utils/spawn'
+
+const m1 = { id: 'm1', name: 'm1', description: '', types: [], coefficient: 1 }
+const m50 = { id: 'm50', name: 'm50', description: '', types: [], coefficient: 50 }
+const m100 = { id: 'm100', name: 'm100', description: '', types: [], coefficient: 100 }
+
+const list = [m1, m50, m100]
+
+describe('spawn weighting', () => {
+  it('prefers lower coefficient', () => {
+    const counts = { m1: 0, m50: 0, m100: 0 }
+    for (let i = 0; i < 10000; i++)
+      counts[pickRandomByCoefficient(list).id]++
+    expect(counts.m1).toBeGreaterThan(counts.m50)
+    expect(counts.m50).toBeGreaterThan(counts.m100)
+  })
+})


### PR DESCRIPTION
## Summary
- add `pickRandomByCoefficient` utility
- use coefficient based weighting when selecting wild enemies
- test spawn coefficient weighting

## Testing
- `pnpm test` *(fails: fetch errors for fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686b783abd50832aa356fb0b23bc158e