### PR TITLE
Affiche icônes de complétion des zones

### DIFF
--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -74,6 +74,18 @@ function classes(z: Zone) {
 
   return classes.join(' ')
 }
+
+function allCaptured(z: Zone) {
+  const list = z.shlagemons
+  if (!list?.length)
+    return false
+  return list.every(base => dex.shlagemons.some(mon => mon.base.id === base.id))
+}
+
+function kingDefeated(z: Zone) {
+  const hasKing = z.hasKing ?? z.type === 'sauvage'
+  return hasKing && progress.isKingDefeated(z.id)
+}
 </script>
 
 <template>
@@ -99,7 +111,16 @@ function classes(z: Zone) {
         <span>{{ z.name }}</span>
       </div>
       <div class="flex items-center justify-center gap-2">
-        <!-- mettre ici les infos de la zone -->
+        <img
+          v-if="allCaptured(z)"
+          src="/items/shlageball/shlageball.png"
+          alt="capturé"
+          class="h-4 w-4"
+        >
+        <div
+          v-if="kingDefeated(z)"
+          class="i-game-icons:crown h-4 w-4"
+        />
       </div>
     </button>
   </div>


### PR DESCRIPTION
## Summary
- show Shlageball icon when all creatures of a zone are captured
- show crown icon when the king of a zone is defeated

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch font, several failing unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_686b7fe600f4832aac7462f024abb043