### PR TITLE
Add arena panel

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,7 @@ declare module 'vue' {
     AchievementsPanel: typeof import('./components/achievements/AchievementsPanel.vue')['default']
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
+    ArenaPanel: typeof import('./components/panels/ArenaPanel.vue')['default']
     AttackCursor: typeof import('./components/battle/AttackCursor.vue')['default']
     AudioSettingsModal: typeof import('./components/audio/AudioSettingsModal.vue')['default']
     Badge: typeof import('./components/ui/Badge.vue')['default']

--- a/src/components/panels/ArenaPanel.vue
+++ b/src/components/panels/ArenaPanel.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="h-full flex-center">
+    <p class="font-bold">
+      Arène (en construction)
+    </p>
+  </div>
+</template>

--- a/src/components/panels/MainPanel.vue
+++ b/src/components/panels/MainPanel.vue
@@ -2,6 +2,7 @@
 import BattleMain from '~/components/battle/BattleMain.vue'
 import TrainerBattle from '~/components/battle/TrainerBattle.vue'
 import WhackAShlag from '~/components/minigame/WhackAShlag.vue'
+import ArenaPanel from '~/components/panels/ArenaPanel.vue'
 import DialogPanel from '~/components/panels/DialogPanel.vue'
 import ShopPanel from '~/components/panels/ShopPanel.vue'
 import VillagePanel from '~/components/village/VillagePanel.vue'
@@ -21,6 +22,8 @@ const currentComponent = computed(() => {
       return TrainerBattle
     case 'miniGame':
       return WhackAShlag
+    case 'arena':
+      return ArenaPanel
     case 'village':
       return VillagePanel
     default:


### PR DESCRIPTION
## Summary
- support the arena panel in the main panel store
- include an `ArenaPanel` component and load it in `MainPanel.vue`

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*
- `pnpm test:e2e` *(fails: Xvfb not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b89b53830832a97e0595256a6200e