### PR TITLE
Add arena badge tracking

### DIFF
--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -6,6 +6,13 @@ export const usePlayerStore = defineStore('player', () => {
   const pseudo = ref('')
   const realName = ref('')
   const gender = ref<Character['gender']>('unknown')
+  const arenaBadges = ref<Record<string, boolean>>({})
+
+  const badgeCount = computed(() =>
+    Object.values(arenaBadges.value).filter(v => v).length,
+  )
+
+  const levelCap = computed(() => 10 + badgeCount.value * 10)
 
   const character = computed<Character>(() => ({
     id: 'player',
@@ -27,9 +34,29 @@ export const usePlayerStore = defineStore('player', () => {
     pseudo.value = ''
     realName.value = ''
     gender.value = 'unknown'
+    arenaBadges.value = {}
   }
 
-  return { pseudo, realName, gender, character, setPlayer, reset }
+  function earnBadge(id: string) {
+    arenaBadges.value[id] = true
+  }
+
+  function hasBadge(id: string) {
+    return !!arenaBadges.value[id]
+  }
+
+  return {
+    pseudo,
+    realName,
+    gender,
+    character,
+    arenaBadges,
+    levelCap,
+    setPlayer,
+    earnBadge,
+    hasBadge,
+    reset,
+  }
 }, {
   persist: true,
 })


### PR DESCRIPTION
## Summary
- keep track of arena badges in player store
- expose a computed level cap based on obtained badges

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot mismatch & ENETUNREACH for fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686b95aca37c832abfc6f804bd60c55c