### PR TITLE
Add arena translations and tests

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,3 +12,8 @@ intro:
   aka: Also known as
   whats-your-name: What's your name?
 not-found: Not found
+arena:
+  title: Arena
+  fight: Fight
+  auto_battle: Battle happens automatically with no clicks.
+  retry_confirm: Defeat... Retry?

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -12,3 +12,8 @@ intro:
   aka: Aussi connu sous le nom de
   whats-your-name: Comment t'appelles-tu ?
 not-found: Page non trouvée
+arena:
+  title: Arène
+  fight: Combattre
+  auto_battle: Le combat est automatique et se déroule sans clics.
+  retry_confirm: Défaite... Recommencer ?

--- a/test/arena.test.ts
+++ b/test/arena.test.ts
@@ -1,0 +1,58 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { canarchichon, carapouffe, salamiches } from '../src/data/shlagemons'
+import { useArenaStore } from '../src/stores/arena'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+function createTeams() {
+  const dex = useShlagedexStore()
+  const player = [
+    dex.createShlagemon(carapouffe),
+    dex.createShlagemon(salamiches),
+    dex.createShlagemon(canarchichon),
+  ]
+  const enemy = [
+    dex.createShlagemon(salamiches),
+    dex.createShlagemon(canarchichon),
+    dex.createShlagemon(carapouffe),
+  ]
+  return { player, enemy }
+}
+
+describe('useArenaStore', () => {
+  it('initializes with selected teams', () => {
+    setActivePinia(createPinia())
+    const arena = useArenaStore()
+    const { player, enemy } = createTeams()
+    arena.start(player, enemy)
+    expect(arena.team).toEqual(player)
+    expect(arena.enemyTeam).toEqual(enemy)
+    expect(arena.currentIndex).toBe(0)
+    expect(arena.result).toBe('none')
+    expect(arena.badgeEarned).toBe(false)
+  })
+
+  it('chains fights and awards badge on win', () => {
+    setActivePinia(createPinia())
+    const arena = useArenaStore()
+    const { player, enemy } = createTeams()
+    arena.start(player, enemy)
+    for (let i = 0; i < player.length; i++)
+      arena.currentIndex = i
+    arena.finish(true)
+    expect(arena.currentIndex).toBe(player.length - 1)
+    expect(arena.result).toBe('win')
+    expect(arena.badgeEarned).toBe(true)
+  })
+
+  it('handles defeat correctly', () => {
+    setActivePinia(createPinia())
+    const arena = useArenaStore()
+    const { player, enemy } = createTeams()
+    arena.start(player, enemy)
+    arena.currentIndex = 1
+    arena.finish(false)
+    expect(arena.result).toBe('lose')
+    expect(arena.badgeEarned).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- translate Arena-related strings in English and French
- add unit tests for `useArenaStore`

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686b97bd56a8832ab2400d1d9301b6bb