### PR TITLE
Add arena dialogs

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,8 @@ declare module 'vue' {
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     ArenaPanel: typeof import('./components/arena/ArenaPanel.vue')['default']
+    ArenaVictoryDialog: typeof import('./components/dialog/ArenaVictoryDialog.vue')['default']
+    ArenaWelcomeDialog: typeof import('./components/dialog/ArenaWelcomeDialog.vue')['default']
     AttackCursor: typeof import('./components/battle/AttackCursor.vue')['default']
     AudioSettingsModal: typeof import('./components/audio/AudioSettingsModal.vue')['default']
     Badge: typeof import('./components/ui/Badge.vue')['default']

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import DialogBox from '~/components/dialog/DialogBox.vue'
+import { norman } from '~/data/characters/norman'
+import { useArenaStore } from '~/stores/arena'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { usePlayerStore } from '~/stores/player'
+
+const emit = defineEmits(['done'])
+
+const arena = useArenaStore()
+const player = usePlayerStore()
+const panel = useMainPanelStore()
+
+function collectBadge() {
+  player.earnBadge('norman')
+  arena.reset()
+  panel.showVillage()
+  emit('done', 'arenaVictory')
+}
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: 'F\u00E9licitations ! Tu as triomph\u00E9 de l\u0027ar\u00E8ne.',
+    responses: [
+      {
+        label: 'R\u00E9cup\u00E9rer le badge',
+        type: 'valid',
+        action: collectBadge,
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :speaker="norman.name"
+    :avatar-url="`/characters/${norman.id}/${norman.id}.png`"
+    :dialog-tree="dialogTree"
+  />
+</template>

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import DialogBox from '~/components/dialog/DialogBox.vue'
+import { norman } from '~/data/characters/norman'
+
+const emit = defineEmits(['done'])
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: `Bienvenue dans l'ar\u00E8ne ! Choisis six Shlag\u00E9mons et pr\u00E9pare-toi \u00E0 empester la victoire.`,
+    responses: [
+      {
+        label: 'C\u0027est parti !',
+        type: 'valid',
+        action: () => emit('done', 'arenaWelcome'),
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :speaker="norman.name"
+    :avatar-url="`/characters/${norman.id}/${norman.id}.png`"
+    :dialog-tree="dialogTree"
+  />
+</template>

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
 import { markRaw } from 'vue'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
+import ArenaVictoryDialog from '~/components/dialog/ArenaVictoryDialog.vue'
+import ArenaWelcomeDialog from '~/components/dialog/ArenaWelcomeDialog.vue'
 import DialogStarter from '~/components/dialog/DialogStarter.vue'
 import FirstLossDialog from '~/components/dialog/FirstLossDialog.vue'
 import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
@@ -9,6 +11,7 @@ import ReleaseShlagemonDialog from '~/components/dialog/ReleaseShlagemonDialog.v
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { useArenaStore } from './arena'
 import { useBattleStatsStore } from './battleStats'
 import { useMainPanelStore } from './mainPanel'
 
@@ -27,6 +30,7 @@ export const useDialogStore = defineStore('dialog', () => {
   const dex = useShlagedexStore()
   const panel = useMainPanelStore()
   const stats = useBattleStatsStore()
+  const arena = useArenaStore()
 
   const done = ref<DialogDone>({})
   const dialogs: DialogItem[] = [
@@ -54,6 +58,16 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'release',
       component: markRaw(ReleaseShlagemonDialog),
       condition: () => dex.shlagemons.length >= 10,
+    },
+    {
+      id: 'arenaWelcome',
+      component: markRaw(ArenaWelcomeDialog),
+      condition: () => panel.current === 'arena',
+    },
+    {
+      id: 'arenaVictory',
+      component: markRaw(ArenaVictoryDialog),
+      condition: () => arena.badgeEarned,
     },
     {
       id: 'firstLoss',


### PR DESCRIPTION
## Summary
- greet the player when opening arena
- award badge with a victory dialog
- register new dialogs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot mismatch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bb99fdea0832a9fbd5be1e63f9a9d