### PR TITLE
Arena pair selection refactor

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -1,99 +1,48 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { toast } from 'vue3-toastify'
+import Modal from '~/components/modal/Modal.vue'
+import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
-import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import Button from '~/components/ui/Button.vue'
-import CheckBox from '~/components/ui/CheckBox.vue'
-import SearchInput from '~/components/ui/SearchInput.vue'
-import SortControls from '~/components/ui/SortControls.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { useArenaStore } from '~/stores/arena'
 import { useBattleStore } from '~/stores/battle'
-import { useDexFilterStore } from '~/stores/dexFilter'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
-const filter = useDexFilterStore()
 const battle = useBattleStore()
 const arena = useArenaStore()
 
-const sortOptions = [
-  { label: 'Niveau', value: 'level' },
-  { label: 'Rareté', value: 'rarity' },
-  { label: 'Shiny', value: 'shiny' },
-  { label: 'Nom', value: 'name' },
-  { label: 'Type', value: 'type' },
-  { label: 'Attaque', value: 'attack' },
-  { label: 'Défense', value: 'defense' },
-  { label: 'Nb obtentions', value: 'count' },
-  { label: 'Première capture', value: 'date' },
-]
-
-const displayedMons = computed(() => {
-  let mons = dex.shlagemons.slice()
-  if (filter.search.trim()) {
-    const q = filter.search.toLowerCase()
-    mons = mons.filter(m => m.base.name.toLowerCase().includes(q))
-  }
-  switch (filter.sortBy) {
-    case 'level':
-      mons.sort((a, b) => a.lvl - b.lvl)
-      break
-    case 'rarity':
-      mons.sort((a, b) => a.rarity - b.rarity)
-      break
-    case 'shiny':
-      mons.sort((a, b) => Number(a.isShiny) - Number(b.isShiny))
-      break
-    case 'attack':
-      mons.sort((a, b) => a.attack - b.attack)
-      break
-    case 'defense':
-      mons.sort((a, b) => a.defense - b.defense)
-      break
-    case 'count':
-      mons.sort((a, b) => a.captureCount - b.captureCount)
-      break
-    case 'date':
-      mons.sort((a, b) => new Date(a.captureDate).getTime() - new Date(b.captureDate).getTime())
-      break
-    case 'name':
-      mons.sort((a, b) => a.base.name.localeCompare(b.base.name))
-      break
-    case 'type':
-      mons.sort((a, b) => (a.base.types[0]?.name || '').localeCompare(b.base.types[0]?.name || ''))
-      break
-  }
-  if (!filter.sortAsc)
-    mons.reverse()
-  return mons
-})
-
-const selectedIds = ref<string[]>([])
-const selectionDisabled = computed(() => selectedIds.value.length >= 6)
-
-function toggleSelect(id: string) {
-  const idx = selectedIds.value.indexOf(id)
-  if (idx === -1) {
-    if (selectedIds.value.length < 6)
-      selectedIds.value.push(id)
-  }
-  else {
-    selectedIds.value.splice(idx, 1)
-  }
-}
-
 const enemyTeam = ref(allShlagemons.slice(0, 6))
+const showDex = ref(false)
+const activeSlot = ref<number | null>(null)
+
+const playerSelection = computed(() =>
+  arena.selections.map(id => dex.shlagemons.find(m => m.id === id) || null),
+)
 
 onMounted(() => {
   enemyTeam.value = allShlagemons.slice().sort(() => Math.random() - 0.5).slice(0, 6)
+  arena.setLineup(enemyTeam.value)
+})
+
+function openDex(i: number) {
+  activeSlot.value = i
+  showDex.value = true
+}
+
+watch(() => dex.activeShlagemon, (mon) => {
+  if (!showDex.value || activeSlot.value === null || !mon)
+    return
+  arena.selectPlayer(activeSlot.value, mon.id)
+  showDex.value = false
 })
 
 function startBattle() {
-  const team = selectedIds.value
-    .map(id => dex.shlagemons.find(m => m.id === id)!)
+  const team = arena.selections
+    .map(id => dex.shlagemons.find(m => m.id === (id || ''))!)
     .map((mon) => {
       mon.hpCurrent = mon.hp
       return mon
@@ -125,67 +74,35 @@ function startBattle() {
 
 <template>
   <div class="h-full flex flex-col gap-2">
-    <div class="mb-2 flex flex-wrap gap-2">
-      <SortControls
-        v-model:sort-by="filter.sortBy"
-        v-model:sort-asc="filter.sortAsc"
-        :options="sortOptions"
-      />
-      <SearchInput v-model="filter.search" class="flex-1" />
-    </div>
-    <div class="tiny-scrollbar flex flex-col gap-2 overflow-auto">
+    <div class="flex flex-col gap-2">
       <div
-        v-for="mon in displayedMons"
-        :key="mon.id"
-        class="relative flex items-center justify-between border rounded p-2"
-        hover="bg-gray-100 dark:bg-gray-800"
+        v-for="(enemy, i) in enemyTeam"
+        :key="enemy.id"
+        class="flex items-center gap-2 border rounded p-2"
       >
-        <div class="absolute bottom-0 right-2 text-xs">
-          lvl {{ mon.lvl }}
-        </div>
-        <div class="flex items-center gap-2">
-          <ShlagemonImage
-            :id="mon.base.id"
-            :alt="mon.base.name"
-            :shiny="mon.isShiny"
-            class="h-12 w-12 object-contain -m-y-2"
-          />
-          <div class="flex flex-col overflow-hidden">
-            <div class="name">
-              {{ mon.base.name }}
-            </div>
-            <div class="flex gap-1">
-              <ShlagemonType
-                v-for="t in mon.base.types"
-                :key="t.id"
-                :value="t"
-                size="xs"
-              />
-            </div>
-          </div>
-        </div>
-        <CheckBox
-          class="ml-2"
-          :model-value="selectedIds.includes(mon.id)"
-          :disabled="selectionDisabled && !selectedIds.includes(mon.id)"
-          @update:model-value="toggleSelect(mon.id)"
-          @click.stop
-        />
+        <ShlagemonImage :id="enemy.id" :alt="enemy.name" class="h-8 w-8 object-contain" />
+        <button
+          class="flex flex-1 items-center justify-center gap-2 border rounded bg-gray-50 p-2 dark:bg-gray-800"
+          hover="bg-gray-100 dark:bg-gray-700"
+          @click="openDex(i)"
+        >
+          <template v-if="playerSelection[i]">
+            <ShlagemonImage
+              :id="playerSelection[i]!.base.id"
+              :alt="playerSelection[i]!.base.name"
+              :shiny="playerSelection[i]!.isShiny"
+              class="h-8 w-8 object-contain"
+            />
+            <span class="text-sm">{{ playerSelection[i]!.base.name }}</span>
+          </template>
+          <span v-else class="text-xs">Choisir un Shlagémon</span>
+        </button>
       </div>
-    </div>
-    <div class="mt-2 flex items-center justify-center gap-2" md="gap-3">
-      <ShlagemonImage
-        v-for="mon in enemyTeam"
-        :id="mon.id"
-        :key="mon.id"
-        :alt="mon.name"
-        class="h-8 w-8 object-contain" md="h-10 w-10"
-      />
     </div>
     <Button
       type="primary"
       class="mx-auto mt-2"
-      :disabled="selectedIds.length < 6"
+      :disabled="playerSelection.some(m => !m)"
       @click="startBattle"
     >
       Combattre
@@ -193,5 +110,11 @@ function startBattle() {
     <p class="text-center text-xs">
       Le combat est automatique et se déroule sans clics.
     </p>
+    <Modal v-model="showDex" footer-close>
+      <h3 v-if="activeSlot !== null" class="mb-2 text-center text-lg font-bold">
+        Choisir un Shlagémon contre {{ enemyTeam[activeSlot].name }}
+      </h3>
+      <Shlagedex />
+    </Modal>
   </div>
 </template>

--- a/src/stores/arena.ts
+++ b/src/stores/arena.ts
@@ -1,4 +1,4 @@
-import type { DexShlagemon } from '~/type/shlagemon'
+import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
@@ -7,9 +7,20 @@ export type ArenaResult = 'none' | 'win' | 'lose'
 export const useArenaStore = defineStore('arena', () => {
   const team = ref<DexShlagemon[]>([])
   const enemyTeam = ref<DexShlagemon[]>([])
+  const lineup = ref<BaseShlagemon[]>([])
+  const selections = ref<(string | null)[]>([])
   const currentIndex = ref(0)
   const result = ref<ArenaResult>('none')
   const badgeEarned = ref(false)
+
+  function setLineup(enemies: BaseShlagemon[]) {
+    lineup.value = enemies
+    selections.value = Array.from({ length: enemies.length }).fill(null)
+  }
+
+  function selectPlayer(index: number, id: string | null) {
+    selections.value[index] = id
+  }
 
   function start(player: DexShlagemon[], enemy: DexShlagemon[]) {
     team.value = player
@@ -28,10 +39,25 @@ export const useArenaStore = defineStore('arena', () => {
   function reset() {
     team.value = []
     enemyTeam.value = []
+    lineup.value = []
+    selections.value = []
     currentIndex.value = 0
     result.value = 'none'
     badgeEarned.value = false
   }
 
-  return { team, enemyTeam, currentIndex, result, badgeEarned, start, finish, reset }
+  return {
+    team,
+    enemyTeam,
+    lineup,
+    selections,
+    currentIndex,
+    result,
+    badgeEarned,
+    setLineup,
+    selectPlayer,
+    start,
+    finish,
+    reset,
+  }
 })


### PR DESCRIPTION
## Summary
- refactor arena store to track enemy lineup and player selections
- replace checkbox list with matchup slots in `ArenaPanel`
- open a Shlagedex modal per slot to pick a Shlagémon

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined and snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686bbe453ad8832ab4263e533652e02d