### PR TITLE
Add arena defeat dialog

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,7 @@ declare module 'vue' {
     AchievementsPanel: typeof import('./components/achievements/AchievementsPanel.vue')['default']
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
+    ArenaDefeatDialog: typeof import('./components/dialog/ArenaDefeatDialog.vue')['default']
     ArenaPanel: typeof import('./components/arena/ArenaPanel.vue')['default']
     ArenaVictoryDialog: typeof import('./components/dialog/ArenaVictoryDialog.vue')['default']
     ArenaWelcomeDialog: typeof import('./components/dialog/ArenaWelcomeDialog.vue')['default']

--- a/src/components/dialog/ArenaDefeatDialog.vue
+++ b/src/components/dialog/ArenaDefeatDialog.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import DialogBox from '~/components/dialog/DialogBox.vue'
+import { norman } from '~/data/characters/norman'
+
+const emit = defineEmits<{ (e: 'retry'): void, (e: 'quit'): void }>()
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: 'Défaite... Veux-tu retenter ta chance ?',
+    responses: [
+      { label: 'Réessayer', type: 'valid', action: () => emit('retry') },
+      { label: 'Quitter', type: 'danger', action: () => emit('quit') },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :speaker="norman.name"
+    :avatar-url="`/characters/${norman.id}/${norman.id}.png`"
+    :dialog-tree="dialogTree"
+  />
+</template>


### PR DESCRIPTION
## Summary
- add `ArenaDefeatDialog` component
- show defeat dialog in arena panel instead of using `window.confirm`
- reset store or quit arena from the dialog

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError and snapshot failures)*

------
https://chatgpt.com/codex/tasks/task_e_686bc2627328832ab9494742457dfebb