### PR TITLE
Add arena duel flow

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
     ArenaDefeatDialog: typeof import('./components/dialog/ArenaDefeatDialog.vue')['default']
+    ArenaDuel: typeof import('./components/arena/ArenaDuel.vue')['default']
     ArenaPanel: typeof import('./components/arena/ArenaPanel.vue')['default']
     ArenaVictoryDialog: typeof import('./components/dialog/ArenaVictoryDialog.vue')['default']
     ArenaWelcomeDialog: typeof import('./components/dialog/ArenaWelcomeDialog.vue')['default']

--- a/src/components/arena/ArenaDuel.vue
+++ b/src/components/arena/ArenaDuel.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+import { onMounted, onUnmounted, ref } from 'vue'
+import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
+import BattleToast from '~/components/battle/BattleToast.vue'
+import { useBattleEffects } from '~/composables/battleEngine'
+import { useBattleStore } from '~/stores/battle'
+
+const props = defineProps<{ player: DexShlagemon, enemy: DexShlagemon }>()
+const emit = defineEmits<{ (e: 'end', win: boolean): void }>()
+
+const battle = useBattleStore()
+const playerHp = ref(0)
+const enemyHp = ref(0)
+const battleActive = ref(false)
+const flashPlayer = ref(false)
+const flashEnemy = ref(false)
+const playerFainted = ref(false)
+const enemyFainted = ref(false)
+const { playerEffect, enemyEffect, playerVariant, enemyVariant, showEffect } = useBattleEffects()
+
+let loop: number | undefined
+
+function start() {
+  playerHp.value = props.player.hpCurrent
+  enemyHp.value = props.enemy.hpCurrent
+  battleActive.value = true
+  loop = window.setInterval(tick, 1000)
+}
+
+function stop() {
+  if (loop !== undefined) {
+    clearInterval(loop)
+    loop = undefined
+  }
+}
+
+function finish() {
+  battleActive.value = false
+  stop()
+  playerFainted.value = playerHp.value <= 0
+  enemyFainted.value = enemyHp.value <= 0
+  emit('end', enemyHp.value <= 0 && playerHp.value > 0)
+}
+
+function tick() {
+  if (!battleActive.value)
+    return
+  const { player: resPlayer, enemy: resEnemy } = battle.duel(props.player, props.enemy)
+  showEffect('enemy', resPlayer.effect, resPlayer.crit)
+  enemyHp.value = props.enemy.hpCurrent
+  flashEnemy.value = true
+  setTimeout(() => (flashEnemy.value = false), 100)
+  if (resEnemy) {
+    showEffect('player', resEnemy.effect, resEnemy.crit)
+    playerHp.value = props.player.hpCurrent
+    flashPlayer.value = true
+    setTimeout(() => (flashPlayer.value = false), 100)
+  }
+  if (enemyHp.value <= 0 || playerHp.value <= 0)
+    finish()
+}
+
+onMounted(start)
+onUnmounted(stop)
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-2">
+    <div class="w-full flex items-center justify-center gap-4">
+      <div class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
+        <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
+        <BattleShlagemon :mon="player" :hp="playerHp" :fainted="playerFainted" flipped />
+      </div>
+      <div class="vs font-bold">
+        VS
+      </div>
+      <div class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
+        <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
+        <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.flash {
+  animation: flash 0.1s ease-in;
+}
+@keyframes flash {
+  from {
+    filter: brightness(2);
+  }
+  to {
+    filter: brightness(1);
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- show quick duel results after each fight in the arena
- add ArenaDuel component for displaying 1v1 battles

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined & snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_686bc6a3bbc4832a8e172eda4b54aad4