### PR TITLE
Update battle music loading

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -13,7 +13,7 @@ import EvolutionModal from '~/components/shlagemon/EvolutionModal.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import PanelWrapper from '~/components/ui/PanelWrapper.vue'
 import ZoneMapModal from '~/components/zones/ZoneMapModal.vue'
-import { trainerTracks, zoneBattleTracks, zoneTracks } from '~/data/music'
+import { getZoneBattleTrack, trainerTracks, zoneTracks } from '~/data/music'
 import { useAchievementsStore } from '~/stores/achievements'
 import { useAudioStore } from '~/stores/audio'
 import { useDialogStore } from '~/stores/dialog'
@@ -78,12 +78,19 @@ const group2Classes = computed(() => {
 watch<[MainPanel, ZoneId, string | undefined], true>(
   () => [mainPanel.current, zone.current.id, trainerBattle.current?.id],
   ([panel, zoneId, trainerId]) => {
-    if (panel === 'battle')
-      audio.fadeToMusic(zoneBattleTracks[zoneId])
-    else if (panel === 'trainerBattle')
+    if (panel === 'battle') {
+      const track = getZoneBattleTrack(zoneId)
+      if (track)
+        audio.fadeToMusic(track)
+      else
+        audio.stopMusic()
+    }
+    else if (panel === 'trainerBattle') {
       audio.fadeToMusic(trainerTracks[trainerId || `king-${zoneId}`])
-    else
+    }
+    else {
       audio.fadeToMusic(zoneTracks[zoneId])
+    }
   },
   { immediate: true },
 )

--- a/src/data/music.ts
+++ b/src/data/music.ts
@@ -21,22 +21,25 @@ export const zoneTracks: Record<ZoneId, string> = {
   'village-paume': '/audio/musics/villages/village-a.ogg',
 }
 
-export const zoneBattleTracks: Record<ZoneId, string> = {
-  'plaine-kekette': '/audio/musics/battle/battle-a.ogg',
-  'bois-de-bouffon': '/audio/musics/battle/battle-b.ogg',
-  'grotte-du-slip': '/audio/musics/battle/battle-c.ogg',
-  'ravin-fesse-molle': '/audio/musics/battle/battle-d.ogg',
-  'grotte-nanard': '/audio/musics/battle/battle-a.ogg',
-  'marais-moudugenou': '/audio/musics/battle/battle-b.ogg',
-  'forteresse-petmoalfiak': '/audio/musics/battle/battle-c.ogg',
-  'route-du-nawak': '/audio/musics/battle/battle-d.ogg',
-  'mont-dracatombe': '/audio/musics/battle/battle-a.ogg',
-  'catacombes-merdifientes': '/audio/musics/battle/battle-b.ogg',
-  'route-aguicheuse': '/audio/musics/battle/battle-c.ogg',
-  'grotte-des-chieurs': '/audio/musics/battle/battle-d.ogg',
-  'trou-du-bide': '/audio/musics/battle/battle-a.ogg',
-  'zone-giga-zob': '/audio/musics/battle/battle-b.ogg',
-  'route-so-dom': '/audio/musics/battle/battle-c.ogg',
+const wildBattleTracks = new Set([
+  'plaine-kekette',
+  'bois-de-bouffon',
+  'chemin-du-slip',
+  'ravin-fesse-molle',
+  'precipice-nanard',
+  'marais-moudugenou',
+  'forteresse-petmoalfiak',
+  'route-du-nawak',
+  'mont-dracatombe',
+  'catacombes-merdifientes',
+  'route-aguicheuse',
+  'vallee-des-chieurs',
+])
+
+export function getZoneBattleTrack(id?: string): string | undefined {
+  if (!id || !wildBattleTracks.has(id))
+    return undefined
+  return `/audio/musics/battle/${id}.ogg`
 }
 
 export const trainerTracks: Record<string, string> = {


### PR DESCRIPTION
## Summary
- derive battle music path from zone ID
- stop music if a wild battle track is missing
- update GameGrid to use helper

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH for fonts, many unit test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686bca2c4fa0832a9cb35a3032bccbbc