### PR TITLE
Add CI workflow and setup instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Unit tests
+        run: pnpm test:unit

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Un mini-jeu d'adresse « Whack-a-Shlag » permet aussi de récolter quelques Shl
    ```bash
    pnpm install
    ```
+   Vous pouvez aussi lancer le script `./scripts/setup.sh` pour préparer l'environnement.
 
 ## Utilisation
 
@@ -51,6 +52,8 @@ pnpm build
 Les fichiers prêts à être servis se trouvent dans le dossier `dist`.
 
 ### Tests
+
+> Avant d'exécuter `pnpm lint` ou `pnpm test:*`, assurez-vous d'avoir installé les dépendances avec `pnpm install`.
 
 - Tests unitaires : `pnpm test:unit`
 - Tests end‑to‑end : `pnpm test:e2e`

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enable corepack to ensure pnpm is available
+corepack enable > /dev/null
+
+# Install project dependencies
+pnpm install


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install deps before lint and test
- document that dependencies must be installed before running lint or tests
- provide setup script for local development and CI

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686bcab9e6f4832a8c549ad751aa1ef7