### PR TITLE
Add level up & evolution SFX

### DIFF
--- a/src/stores/evolution.ts
+++ b/src/stores/evolution.ts
@@ -1,6 +1,7 @@
 import type { BaseShlagemon, DexShlagemon } from '~/type'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { useAudioStore } from './audio'
 
 interface EvolutionRequest {
   mon: DexShlagemon
@@ -11,10 +12,12 @@ interface EvolutionRequest {
 export const useEvolutionStore = defineStore('evolution', () => {
   const pending = ref<EvolutionRequest | null>(null)
   const isVisible = computed(() => pending.value !== null)
+  const audio = useAudioStore()
 
   function requestEvolution(mon: DexShlagemon, to: BaseShlagemon) {
     return new Promise<boolean>((resolve) => {
       pending.value = { mon, to, resolve }
+      audio.playSfx('/audio/sfx/evolution.ogg')
     })
   }
 

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -15,6 +15,7 @@ import {
   xpForLevel,
 } from '~/utils/dexFactory'
 import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
+import { useAudioStore } from './audio'
 import { useDiseaseStore } from './disease'
 import { useEvolutionStore } from './evolution'
 import { useZoneProgressStore } from './zoneProgress'
@@ -25,6 +26,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const highestLevel = ref(0)
   const effects = ref<ActiveEffect[]>([])
   const progress = useZoneProgressStore()
+  const audio = useAudioStore()
   const disease = useDiseaseStore()
   const baseMap = Object.fromEntries(allShlagemons.map(b => [b.id, b]))
   cleanupEffects()
@@ -313,6 +315,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     while (mon.lvl < maxLevel && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)
       mon.lvl += 1
+      audio.playSfx('/audio/sfx/lvl-up.ogg')
       const prevHp = mon.hpCurrent
       applyStats(mon)
       const healAmount = Math.round((mon.hp * healPercent) / 100)


### PR DESCRIPTION
## Summary
- play evolution SFX when an evolution popup appears
- play level up SFX when a Schlagemon levels up

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686bd23bc594832aa2f39669f612ffb1