### PR TITLE
Fix modal rendering in arena duel

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -163,9 +163,9 @@ onUnmounted(() => clearTimeout(nextTimer))
       </h3>
       <Shlagedex />
     </Modal>
-    <Modal v-model="showDuel" close-on-outside-click="false">
+    <Modal v-model="showDuel" :close-on-outside-click="false">
       <ArenaDuel
-        v-if="duelResult === null"
+        v-if="showDuel && duelResult === null"
         :player="arena.team[arena.currentIndex]"
         :enemy="arena.enemyTeam[arena.currentIndex]"
         @end="onDuelEnd"
@@ -189,7 +189,7 @@ onUnmounted(() => clearTimeout(nextTimer))
         </Button>
       </div>
     </Modal>
-    <Modal v-model="showDefeat" close-on-outside-click="false">
+    <Modal v-model="showDefeat" :close-on-outside-click="false">
       <ArenaDefeatDialog @retry="retryBattle" @quit="quitArena" />
     </Modal>
   </div>


### PR DESCRIPTION
## Summary
- avoid warnings by binding modal boolean props
- mount ArenaDuel only once duel modal is visible

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fonts unreachable and many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686bd2601318832a9d0bb486a11d89d9