### PR TITLE
Add flexible quantity controls to shop

### DIFF
--- a/src/components/ui/NumberInput.vue
+++ b/src/components/ui/NumberInput.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-const props = withDefaults(defineProps<{ modelValue?: number, min?: number }>(), { min: 1 })
+const props = withDefaults(
+  defineProps<{ modelValue?: number, min?: number, max?: number }>(),
+  { min: 1 },
+)
 const emit = defineEmits<{ (e: 'update:modelValue', value: number): void }>()
 function onInput(e: Event) {
   emit('update:modelValue', Number((e.target as HTMLInputElement).value))
@@ -10,6 +13,7 @@ function onInput(e: Event) {
   <input
     type="number"
     :min="props.min"
+    :max="props.max"
     :value="props.modelValue"
     class="focus:border-primary w-full border border-gray-300 rounded bg-white px-2 py-1 text-center text-sm dark:border-gray-700 dark:bg-gray-800 focus:outline-none"
     @input="onInput"


### PR DESCRIPTION
## Summary
- allow adjustable quantities in shop detail with increment/decrement buttons and a MAX button
- support max attribute in `NumberInput`

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bdcc80470832a9b6b319273b47678