### PR TITLE
Add back button in shop item detail

### DIFF
--- a/src/components/shop/ShopItemDetail.vue
+++ b/src/components/shop/ShopItemDetail.vue
@@ -96,9 +96,12 @@ const details = computed(() => props.item.details || props.item.description)
         <NumberInput v-model="qty" class="h-fu" :min="1" :max="maxQty" />
       </div>
     </div>
-    <div class="mt-2 flex">
+    <div class="mt-2 flex gap-2">
       <Button type="primary" :disabled="!canBuy(qty)" class="flex flex-1 items-center gap-2" @click="buy">
-        Acheter  <CurrencyAmount :amount="props.item.price * qty" :currency="props.item.currency ?? 'shlagidolar'" />
+        Acheter <CurrencyAmount :amount="props.item.price * qty" :currency="props.item.currency ?? 'shlagidolar'" />
+      </Button>
+      <Button class="text-xs" @click="emit('close')">
+        Retour
       </Button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a small "Retour" button beside the main buy button

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH during Unocss fetch)*

------
https://chatgpt.com/codex/tasks/task_e_686be2893e6c832a85010b6709218b96