### PR TITLE
Add basic arena data and dialog flow

### DIFF
--- a/src/components/dialog/ArenaDefeatDialog.vue
+++ b/src/components/dialog/ArenaDefeatDialog.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
-import { norman } from '~/data/characters/norman'
+import { useArenaStore } from '~/stores/arena'
 
 const emit = defineEmits<{ (e: 'retry'): void, (e: 'quit'): void }>()
+const arena = useArenaStore()
 
 const dialogTree: DialogNode[] = [
   {
@@ -19,8 +20,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="norman.name"
-    :avatar-url="`/characters/${norman.id}/${norman.id}.png`"
+    :speaker="arena.arenaData?.character.name"
+    :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
-import { norman } from '~/data/characters/norman'
 import { useArenaStore } from '~/stores/arena'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { usePlayerStore } from '~/stores/player'
@@ -13,7 +12,8 @@ const player = usePlayerStore()
 const panel = useMainPanelStore()
 
 function collectBadge() {
-  player.earnBadge('norman')
+  if (arena.arenaData)
+    player.earnBadge(arena.arenaData.badge.id)
   arena.reset()
   panel.showVillage()
   emit('done', 'arenaVictory')
@@ -36,8 +36,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="norman.name"
-    :avatar-url="`/characters/${norman.id}/${norman.id}.png`"
+    :speaker="arena.arenaData?.character.name"
+    :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
-import { norman } from '~/data/characters/norman'
+import { useArenaStore } from '~/stores/arena'
 
 const emit = defineEmits(['done'])
+const arena = useArenaStore()
 
 const dialogTree: DialogNode[] = [
   {
     id: 'start',
-    text: `Bienvenue dans l'ar\u00E8ne ! Choisis six Shlag\u00E9mons et pr\u00E9pare-toi \u00E0 empester la victoire.`,
+    text: `Bienvenue dans l'ar\u00E8ne, cette ar\u00E8ne te permet de capturer des schlagemon de niveau ${arena.arenaData?.badge.levelCap ?? ''} et sup\u00E9rieur \u00E0 ${arena.arenaData?.badge.levelCap ?? ''}. Les combats se d\u00E9roulent en un contre un sans potion ni attaque manuelle. Choisis des schlag\u00E9mons entra\u00EEn\u00E9s et puissants contre les types oppos\u00E9s.`,
     responses: [
       {
         label: 'C\u0027est parti !',
@@ -22,8 +23,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="norman.name"
-    :avatar-url="`/characters/${norman.id}/${norman.id}.png`"
+    :speaker="arena.arenaData?.character.name"
+    :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import Button from '~/components/ui/Button.vue'
+import { getArena } from '~/data/arenas'
 import { useArenaStore } from '~/stores/arena'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
@@ -26,14 +27,21 @@ const kingLabel = computed(() =>
 function onAction(id: string) {
   if (arena.inBattle)
     return
-  if (id === 'shop')
+  if (id === 'shop') {
     panel.showShop()
-  else if (id === 'explore')
+  }
+  else if (id === 'explore') {
     panel.showTrainerBattle()
-  else if (id === 'minigame')
+  }
+  else if (id === 'minigame') {
     panel.showMiniGame()
-  else if (id === 'arena')
+  }
+  else if (id === 'arena') {
+    const data = getArena(zone.current.id)
+    if (data)
+      arena.setArena(data)
     panel.showArena()
+  }
 }
 
 function fightKing() {

--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -1,0 +1,34 @@
+import type { Arena } from '~/type'
+import { profMerdant } from './characters/prof-merdant'
+import aspigros from './shlagemons/aspigros'
+import { canarchichon } from './shlagemons/canarchichon'
+import chenipaon from './shlagemons/chenipaon'
+import { rouxPasCool } from './shlagemons/rouxPasCool'
+import { sacdepates } from './shlagemons/sacdepates'
+import { sperectum } from './shlagemons/sperectum'
+
+export const arenas: Arena[] = [
+  {
+    id: 'village-veaux-du-gland',
+    character: profMerdant,
+    level: 21,
+    badge: {
+      id: 'badge-merdant',
+      name: 'Badge Merdant',
+      levelCap: 40,
+      image: '',
+    },
+    lineup: [
+      sacdepates,
+      rouxPasCool,
+      canarchichon,
+      sperectum,
+      aspigros,
+      chenipaon,
+    ],
+  },
+]
+
+export function getArena(id: string): Arena | undefined {
+  return arenas.find(a => a.id === id)
+}

--- a/src/stores/arena.ts
+++ b/src/stores/arena.ts
@@ -1,4 +1,4 @@
-import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
+import type { Arena, BaseShlagemon, DexShlagemon } from '~/type'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
@@ -8,6 +8,7 @@ export const useArenaStore = defineStore('arena', () => {
   const team = ref<DexShlagemon[]>([])
   const enemyTeam = ref<DexShlagemon[]>([])
   const lineup = ref<BaseShlagemon[]>([])
+  const arenaData = ref<Arena | null>(null)
   const selections = ref<(string | null)[]>([])
   const currentIndex = ref(0)
   const result = ref<ArenaResult>('none')
@@ -17,6 +18,11 @@ export const useArenaStore = defineStore('arena', () => {
   function setLineup(enemies: BaseShlagemon[]) {
     lineup.value = enemies
     selections.value = Array.from({ length: enemies.length }).fill(null)
+  }
+
+  function setArena(arena: Arena) {
+    arenaData.value = arena
+    setLineup(arena.lineup)
   }
 
   function selectPlayer(index: number, id: string | null) {
@@ -48,6 +54,7 @@ export const useArenaStore = defineStore('arena', () => {
     team.value = []
     enemyTeam.value = []
     lineup.value = []
+    arenaData.value = null
     selections.value = []
     currentIndex.value = 0
     result.value = 'none'
@@ -59,11 +66,13 @@ export const useArenaStore = defineStore('arena', () => {
     team,
     enemyTeam,
     lineup,
+    arenaData,
     selections,
     currentIndex,
     result,
     badgeEarned,
     inBattle,
+    setArena,
     setLineup,
     selectPlayer,
     start,

--- a/src/type/arena.ts
+++ b/src/type/arena.ts
@@ -1,0 +1,17 @@
+import type { Character } from './character'
+import type { BaseShlagemon } from './shlagemon'
+
+export interface ArenaBadge {
+  id: string
+  name: string
+  levelCap: number
+  image?: string
+}
+
+export interface Arena {
+  id: string
+  badge: ArenaBadge
+  character: Character
+  lineup: BaseShlagemon[]
+  level: number
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,3 +1,4 @@
+export * from './arena'
 export * from './audio'
 export * from './badge'
 export * from './ball'


### PR DESCRIPTION
## Summary
- implement Arena and ArenaBadge types
- seed first arena data with Professeur Merdant and badge info
- adapt arena store to use arena data
- load arena from current village action
- update dialog components to reference current arena character
- hide selection panel during automatic arena battles

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError for fonts and multiple failing unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c430682c8832a9094b65423493f47