### PR TITLE
Add arena tracking to village zones

### DIFF
--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -4,16 +4,24 @@ import DialogBox from '~/components/dialog/DialogBox.vue'
 import { useArenaStore } from '~/stores/arena'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { usePlayerStore } from '~/stores/player'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
 
 const emit = defineEmits(['done'])
 
 const arena = useArenaStore()
 const player = usePlayerStore()
 const panel = useMainPanelStore()
+const progress = useZoneProgressStore()
+const zone = useZoneStore()
 
 function collectBadge() {
   if (arena.arenaData)
     player.earnBadge(arena.arenaData.badge.id)
+  if (arena.arenaData)
+    progress.completeArena(arena.arenaData.id)
+  if (arena.arenaData)
+    zone.completeArena(arena.arenaData.id)
   arena.reset()
   panel.showVillage()
   emit('done', 'arenaVictory')

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -96,6 +96,10 @@ function kingDefeated(z: Zone) {
   const hasKing = z.hasKing ?? z.type === 'sauvage'
   return hasKing && progress.isKingDefeated(z.id)
 }
+
+function arenaDefeated(z: Zone) {
+  return !!z.arena && progress.isArenaCompleted(z.id)
+}
 </script>
 
 <template>
@@ -140,6 +144,10 @@ function kingDefeated(z: Zone) {
           <div
             v-if="kingDefeated(z)"
             class="i-game-icons:crown h-4 w-4"
+          />
+          <div
+            v-if="arenaDefeated(z)"
+            class="i-mdi:sword-cross h-4 w-4"
           />
         </div>
       </button>

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import Button from '~/components/ui/Button.vue'
-import { getArena } from '~/data/arenas'
 import { useArenaStore } from '~/stores/arena'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
@@ -17,6 +16,8 @@ const arena = useArenaStore()
 const hasKing = computed(() =>
   zone.current.hasKing ?? zone.current.type === 'sauvage',
 )
+const hasArena = computed(() => !!zone.current.arena)
+const arenaCompleted = computed(() => progress.isArenaCompleted(zone.current.id))
 const currentKing = computed(() =>
   hasKing.value ? zone.getKing(zone.current.id) : undefined,
 )
@@ -36,12 +37,15 @@ function onAction(id: string) {
   else if (id === 'minigame') {
     panel.showMiniGame()
   }
-  else if (id === 'arena') {
-    const data = getArena(zone.current.id)
-    if (data)
-      arena.setArena(data)
-    panel.showArena()
-  }
+}
+
+function openArena() {
+  if (arena.inBattle)
+    return
+  const data = zone.current.arena?.arena
+  if (data)
+    arena.setArena(data)
+  panel.showArena()
 }
 
 function fightKing() {
@@ -66,6 +70,17 @@ function fightKing() {
     >
       {{ action.label }}
     </Button>
+    <Button
+      v-if="hasArena && !arenaCompleted"
+      class="text-xs"
+      :disabled="arena.inBattle"
+      @click="openArena"
+    >
+      Arène
+    </Button>
+    <div v-else-if="hasArena && arenaCompleted" class="text-xs font-bold">
+      Arène vaincue !
+    </div>
     <Button
       v-if="hasKing && !progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
       class="text-xs"

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -1,5 +1,6 @@
 import type { BaseShlagemon } from '~/type'
 import type { SavageZoneId, Zone } from '~/type/zone'
+import { arenas } from './arenas'
 import { abraquemar } from './shlagemons/abraquemar'
 import { alakalbar } from './shlagemons/alakalbar'
 import aspigros from './shlagemons/aspigros'
@@ -104,8 +105,11 @@ const villageZones: Zone[] = [
     actions: [
       { id: 'shop', label: 'Entrer dans le Magasin' },
       { id: 'minigame', label: 'Mini-jeu' },
-      { id: 'arena', label: 'Arène' },
     ],
+    arena: {
+      arena: arenas.find(a => a.id === 'village-veaux-du-gland')!,
+      completed: false,
+    },
     minLevel: 10,
     maxLevel: 0,
   },

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -45,6 +45,12 @@ export const useZoneStore = defineStore('zone', () => {
     return idx >= 0 ? idx + 1 : 1
   }
 
+  function completeArena(id: string) {
+    const z = zones.value.find(z => z.id === id)
+    if (z?.arena)
+      z.arena.completed = true
+  }
+
   const rewardMultiplier = computed(() => {
     const zone = current.value
     if (!zone.maxLevel)
@@ -79,6 +85,7 @@ export const useZoneStore = defineStore('zone', () => {
     setZone,
     getKing,
     getZoneRank,
+    completeArena,
     reset,
   }
 }, {

--- a/src/stores/zoneProgress.ts
+++ b/src/stores/zoneProgress.ts
@@ -5,6 +5,7 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
   const wins = ref<Record<string, number>>({})
   const fightsBeforeKing = 10
   const kingsDefeated = ref<Record<string, boolean>>({})
+  const arenasCompleted = ref<Record<string, boolean>>({})
 
   function addWin(id: string) {
     wins.value[id] = (wins.value[id] || 0) + 1
@@ -26,20 +27,32 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
     return !!kingsDefeated.value[id]
   }
 
+  function completeArena(id: string) {
+    arenasCompleted.value[id] = true
+  }
+
+  function isArenaCompleted(id: string) {
+    return !!arenasCompleted.value[id]
+  }
+
   function reset() {
     wins.value = {}
     kingsDefeated.value = {}
+    arenasCompleted.value = {}
   }
 
   return {
     wins,
     kingsDefeated,
     fightsBeforeKing,
+    arenasCompleted,
     addWin,
     getWins,
     canFightKing,
     defeatKing,
     isKingDefeated,
+    completeArena,
+    isArenaCompleted,
     reset,
   }
 }, {

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -1,3 +1,4 @@
+import type { Arena } from './arena'
 import type { BaseShlagemon } from './shlagemon'
 
 export type ZoneType = 'village' | 'grotte' | 'sauvage'
@@ -22,6 +23,11 @@ export interface Zone {
   hasKing?: boolean
   /** Achievement title when all Shlagemon are captured */
   completionAchievement?: string
+  /** Optional arena available in this zone */
+  arena?: {
+    arena: Arena
+    completed: boolean
+  }
 }
 
 export type ZoneId = SavageZoneId | VillageZoneId


### PR DESCRIPTION
## Summary
- define optional `arena` info inside `Zone` type
- attach arena data to villages and remove old action
- show arena button when available and mark as completed
- display icon on map when arena defeated
- persist arena completion in store and zone progress

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError for fonts and various failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ce6ea3f78832a8e400d5f1690fd51