### PR TITLE
Restrict capture by badge level

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -149,6 +149,7 @@ declare global {
   const useBroadcastChannel: typeof import('@vueuse/core')['useBroadcastChannel']
   const useBrowserLocation: typeof import('@vueuse/core')['useBrowserLocation']
   const useCached: typeof import('@vueuse/core')['useCached']
+  const useCaptureLimitModalStore: typeof import('./stores/captureLimitModal')['useCaptureLimitModalStore']
   const useClipboard: typeof import('@vueuse/core')['useClipboard']
   const useClipboardItems: typeof import('@vueuse/core')['useClipboardItems']
   const useCloned: typeof import('@vueuse/core')['useCloned']
@@ -530,6 +531,7 @@ declare module 'vue' {
     readonly useBroadcastChannel: UnwrapRef<typeof import('@vueuse/core')['useBroadcastChannel']>
     readonly useBrowserLocation: UnwrapRef<typeof import('@vueuse/core')['useBrowserLocation']>
     readonly useCached: UnwrapRef<typeof import('@vueuse/core')['useCached']>
+    readonly useCaptureLimitModalStore: UnwrapRef<typeof import('./stores/captureLimitModal')['useCaptureLimitModalStore']>
     readonly useClipboard: UnwrapRef<typeof import('@vueuse/core')['useClipboard']>
     readonly useClipboardItems: UnwrapRef<typeof import('@vueuse/core')['useClipboardItems']>
     readonly useCloned: UnwrapRef<typeof import('@vueuse/core')['useCloned']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -28,6 +28,7 @@ declare module 'vue' {
     Bonus: typeof import('./components/icons/bonus.vue')['default']
     BonusDetails: typeof import('./components/panels/BonusDetails.vue')['default']
     Button: typeof import('./components/ui/Button.vue')['default']
+    CaptureLimitModal: typeof import('./components/battle/CaptureLimitModal.vue')['default']
     CaptureMenu: typeof import('./components/battle/CaptureMenu.vue')['default']
     CaptureOverlay: typeof import('./components/battle/CaptureOverlay.vue')['default']
     CharacterImage: typeof import('./components/character/CharacterImage.vue')['default']

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -3,6 +3,7 @@ import { toast } from 'vue3-toastify'
 import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
+import CaptureLimitModal from '~/components/battle/CaptureLimitModal.vue'
 import CaptureOverlay from '~/components/battle/CaptureOverlay.vue'
 import FightKingButton from '~/components/battle/FightKingButton.vue'
 import ZoneMonsModal from '~/components/zones/ZoneMonsModal.vue'
@@ -14,11 +15,13 @@ import { useAudioStore } from '~/stores/audio'
 import { useBallStore } from '~/stores/ball'
 import { useBattleStore } from '~/stores/battle'
 import { useBattleStatsStore } from '~/stores/battleStats'
+import { useCaptureLimitModalStore } from '~/stores/captureLimitModal'
 import { useDiseaseStore } from '~/stores/disease'
 import { useEventStore } from '~/stores/event'
 import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
 import { useMultiExpStore } from '~/stores/multiExp'
+import { usePlayerStore } from '~/stores/player'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneMonsModalStore } from '~/stores/zoneMonsModal'
@@ -36,6 +39,8 @@ const disease = useDiseaseStore()
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
 const multiExpStore = useMultiExpStore()
+const player = usePlayerStore()
+const captureLimitModal = useCaptureLimitModalStore()
 const battleStats = useBattleStatsStore()
 const zoneMonsModal = useZoneMonsModalStore()
 const events = useEventStore()
@@ -80,6 +85,8 @@ const captureButtonTooltip = computed(() => {
     return 'Pas de Schlagéball, capture impossible'
   if (enemyHp.value <= 0)
     return 'Impossible de capturer un Shlagémon K.O.'
+  if (enemy.value && enemy.value.lvl > player.captureLevelCap)
+    return 'Un badge est nécessaire pour capturer ce niveau'
   return 'Capturer le Shlagémon'
 })
 const flashPlayer = ref(false)
@@ -102,6 +109,10 @@ function openCapture() {
   const id = ballStore.current
   if (!enemy.value || (inventory.items[id] || 0) <= 0 || enemyHp.value <= 0)
     return
+  if (enemy.value.lvl > player.captureLevelCap) {
+    captureLimitModal.open(enemy.value.lvl)
+    return
+  }
   inventory.remove(id)
   captureBall.value = balls.find(b => b.id === id) || balls[0]
   battleActive.value = false
@@ -393,6 +404,7 @@ onUnmounted(() => {
       />
     </div>
     <ZoneMonsModal />
+    <CaptureLimitModal />
   </div>
 </template>
 

--- a/src/components/battle/CaptureLimitModal.vue
+++ b/src/components/battle/CaptureLimitModal.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import { useCaptureLimitModalStore } from '~/stores/captureLimitModal'
+
+const modal = useCaptureLimitModalStore()
+</script>
+
+<template>
+  <Modal v-model="modal.isVisible" footer-close>
+    <div class="flex flex-col items-center gap-2">
+      <p class="text-center text-sm">
+        Pour pouvoir attraper ce Schlagémon de niveau {{ modal.requiredLevel }}, il vous faut un badge.
+        Rendez-vous dans le village pour défier la reine et remporter ce droit.
+      </p>
+    </div>
+  </Modal>
+</template>

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -78,9 +78,6 @@ function fightKing() {
     >
       Arène
     </Button>
-    <div v-else-if="hasArena && arenaCompleted" class="text-xs font-bold">
-      Arène vaincue !
-    </div>
     <Button
       v-if="hasKing && !progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
       class="text-xs"

--- a/src/stores/captureLimitModal.ts
+++ b/src/stores/captureLimitModal.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useMobileTabStore } from './mobileTab'
+
+export const useCaptureLimitModalStore = defineStore('captureLimitModal', () => {
+  const isVisible = ref(false)
+  const requiredLevel = ref(0)
+  const mobile = useMobileTabStore()
+
+  function open(level: number) {
+    requiredLevel.value = level
+    mobile.set('game')
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+  }
+
+  return { isVisible, requiredLevel, open, close }
+})

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -1,12 +1,14 @@
 import type { Character } from '~/type/character'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { getArena } from '~/data/arenas'
 
 export const usePlayerStore = defineStore('player', () => {
   const pseudo = ref('')
   const realName = ref('')
   const gender = ref<Character['gender']>('unknown')
   const arenaBadges = ref<Record<string, boolean>>({})
+  const captureLevelCap = ref(20)
 
   const badgeCount = computed(() =>
     Object.values(arenaBadges.value).filter(v => v).length,
@@ -35,10 +37,14 @@ export const usePlayerStore = defineStore('player', () => {
     realName.value = ''
     gender.value = 'unknown'
     arenaBadges.value = {}
+    captureLevelCap.value = 20
   }
 
   function earnBadge(id: string) {
     arenaBadges.value[id] = true
+    const arena = getArena(id)
+    if (arena)
+      captureLevelCap.value = Math.max(captureLevelCap.value, arena.badge.levelCap)
   }
 
   function hasBadge(id: string) {
@@ -52,6 +58,7 @@ export const usePlayerStore = defineStore('player', () => {
     character,
     arenaBadges,
     levelCap,
+    captureLevelCap,
     setPlayer,
     earnBadge,
     hasBadge,


### PR DESCRIPTION
## Summary
- add capture limit modal component and store
- track highest badge capture level on player
- gate capture attempts by capture level cap
- hide arena button once completed

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686ce9cdd87c832a99fc23f3c514e941