### PR TITLE
Fix arena dialog flow

### DIFF
--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import Button from '~/components/ui/Button.vue'
 import { useArenaStore } from '~/stores/arena'
+import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
@@ -12,6 +13,7 @@ const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
 const arena = useArenaStore()
+const dialog = useDialogStore()
 
 const hasKing = computed(() =>
   zone.current.hasKing ?? zone.current.type === 'sauvage',
@@ -45,6 +47,7 @@ function openArena() {
   const data = zone.current.arena?.arena
   if (data)
     arena.setArena(data)
+  dialog.resetArenaDialogs()
   panel.showArena()
 }
 

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -95,11 +95,16 @@ export const useDialogStore = defineStore('dialog', () => {
     done.value[id] = true
   }
 
+  function resetArenaDialogs() {
+    done.value.arenaWelcome = false
+    done.value.arenaVictory = false
+  }
+
   function reset() {
     done.value = {}
   }
 
-  return { done, isDone, markDone, reset, dialogs, isDialogVisible }
+  return { done, isDone, markDone, reset, resetArenaDialogs, dialogs, isDialogVisible }
 }, {
   persist: true,
 })


### PR DESCRIPTION
## Summary
- ensure arena dialogs show each time by exposing resetArenaDialogs
- reset arena dialogs when entering the arena

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, missing snapshots, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ced07ffec832a9286ee69d8102e6b