### PR TITLE
Fix attribute forwarding in main and shop panels

### DIFF
--- a/src/components/panels/MainPanel.vue
+++ b/src/components/panels/MainPanel.vue
@@ -9,6 +9,8 @@ import VillagePanel from '~/components/village/VillagePanel.vue'
 import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
 
+defineOptions({ inheritAttrs: false })
+
 const dialogStore = useDialogStore()
 const panelStore = useMainPanelStore()
 
@@ -33,6 +35,6 @@ const currentComponent = computed(() => {
 </script>
 
 <template>
-  <DialogPanel v-if="dialogStore.isDialogVisible" />
-  <component :is="currentComponent" v-else />
+  <DialogPanel v-if="dialogStore.isDialogVisible" v-bind="$attrs" />
+  <component :is="currentComponent" v-else v-bind="$attrs" />
 </template>

--- a/src/components/panels/ShopPanel.vue
+++ b/src/components/panels/ShopPanel.vue
@@ -19,27 +19,29 @@ function closeShop() {
 </script>
 
 <template>
-  <h2 class="mb-2 text-center font-bold">
-    Boutique
-  </h2>
-  <div v-if="!selectedItem" class="flex flex-col gap-2 overflow-auto">
-    <ItemCard
-      v-for="item in shopItems"
-      :key="item.id"
-      :item="item"
-      class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
-      @click="selectedItem = item"
-    >
-      <Button class="ml-auto text-xs" @click.stop="selectedItem = item">
-        Détails
-      </Button>
-    </ItemCard>
+  <div class="flex flex-1 flex-col" v-bind="$attrs">
+    <h2 class="mb-2 text-center font-bold">
+      Boutique
+    </h2>
+    <div v-if="!selectedItem" class="flex flex-col gap-2 overflow-auto">
+      <ItemCard
+        v-for="item in shopItems"
+        :key="item.id"
+        :item="item"
+        class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
+        @click="selectedItem = item"
+      >
+        <Button class="ml-auto text-xs" @click.stop="selectedItem = item">
+          Détails
+        </Button>
+      </ItemCard>
+    </div>
+    <div v-else class="flex-1 overflow-auto">
+      <ShopItemDetail :item="selectedItem" @close="selectedItem = null" />
+    </div>
+    <Button type="danger" class="mt-2 flex self-center gap-2" @click="closeShop">
+      <div class="i-carbon:exit" />
+      Quitter la boutique
+    </Button>
   </div>
-  <div v-else class="flex-1 overflow-auto">
-    <ShopItemDetail :item="selectedItem" @close="selectedItem = null" />
-  </div>
-  <Button type="danger" class="mt-2 flex self-center gap-2" @click="closeShop">
-    <div class="i-carbon:exit" />
-    Quitter la boutique
-  </Button>
 </template>


### PR DESCRIPTION
## Summary
- ensure attributes from GameGrid pass down to the active panel
- wrap `ShopPanel` content in a single div so classes apply correctly

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined & snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686cf24b7798832aa2b9f25f58c27606