### PR TITLE
Handle arena defeat as dialog screen

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -1,27 +1,23 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type/shlagemon'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import { toast } from 'vue3-toastify'
 import ArenaDuel from '~/components/arena/ArenaDuel.vue'
 import ArenaEnemyStats from '~/components/arena/ArenaEnemyStats.vue'
-import ArenaDefeatDialog from '~/components/dialog/ArenaDefeatDialog.vue'
 import Modal from '~/components/modal/Modal.vue'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ShlagemonQuickSelect from '~/components/shlagemon/ShlagemonQuickSelect.vue'
 import Button from '~/components/ui/Button.vue'
 import { useArenaStore } from '~/stores/arena'
-import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
 const arena = useArenaStore()
-const panel = useMainPanelStore()
 
-const enemyTeam = ref<BaseShlagemon[]>([])
+const enemyTeam = computed(() => arena.lineup)
 const showDex = ref(false)
 const activeSlot = ref<number | null>(null)
-const showDefeat = ref(false)
 const showDuel = ref(false)
 const showEnemy = ref(false)
 const enemyDetail = ref<BaseShlagemon | null>(null)
@@ -35,11 +31,6 @@ const hasNextDuel = computed(() =>
 const playerSelection = computed(() =>
   arena.selections.map(id => dex.shlagemons.find(m => m.id === id) || null),
 )
-
-onMounted(() => {
-  enemyTeam.value = arena.lineup
-  arena.setLineup(enemyTeam.value)
-})
 
 function openDex(i: number) {
   activeSlot.value = i
@@ -57,20 +48,6 @@ watch(() => dex.activeShlagemon, (mon) => {
   arena.selectPlayer(activeSlot.value, mon.id)
   showDex.value = false
 })
-
-function retryBattle() {
-  arena.reset()
-  enemyTeam.value = arena.lineup
-  arena.setLineup(enemyTeam.value)
-  showDefeat.value = false
-  showEnemy.value = false
-}
-
-function quitArena() {
-  showDefeat.value = false
-  arena.reset()
-  panel.showVillage()
-}
 
 function startBattle() {
   const team = arena.selections
@@ -125,7 +102,6 @@ function closeVictory() {
 function closeAfterDefeat() {
   clearTimeout(nextTimer)
   showDuel.value = false
-  showDefeat.value = true
 }
 
 onUnmounted(() => clearTimeout(nextTimer))
@@ -192,10 +168,6 @@ onUnmounted(() => clearTimeout(nextTimer))
 
         <Modal v-model="showEnemy" footer-close>
           <ArenaEnemyStats v-if="enemyDetail" :mon="enemyDetail" />
-        </Modal>
-
-        <Modal v-model="showDefeat" :close-on-outside-click="false">
-          <ArenaDefeatDialog @retry="retryBattle" @quit="quitArena" />
         </Modal>
       </div>
     </div>

--- a/src/components/dialog/ArenaDefeatDialog.vue
+++ b/src/components/dialog/ArenaDefeatDialog.vue
@@ -2,17 +2,37 @@
 import type { DialogNode } from '~/type/dialog'
 import DialogBox from '~/components/dialog/DialogBox.vue'
 import { useArenaStore } from '~/stores/arena'
+import { useDialogStore } from '~/stores/dialog'
+import { useMainPanelStore } from '~/stores/mainPanel'
 
-const emit = defineEmits<{ (e: 'retry'): void, (e: 'quit'): void }>()
+const emit = defineEmits(['done'])
 const arena = useArenaStore()
+const dialog = useDialogStore()
+const panel = useMainPanelStore()
+
+function retry() {
+  const data = arena.arenaData
+  if (!data)
+    return
+  dialog.resetArenaDialogs()
+  arena.reset()
+  arena.setArena(data)
+  emit('done', 'arenaDefeat')
+}
+
+function quit() {
+  arena.reset()
+  panel.showVillage()
+  emit('done', 'arenaDefeat')
+}
 
 const dialogTree: DialogNode[] = [
   {
     id: 'start',
     text: 'Défaite... Veux-tu retenter ta chance ?',
     responses: [
-      { label: 'Réessayer', type: 'valid', action: () => emit('retry') },
-      { label: 'Quitter', type: 'danger', action: () => emit('quit') },
+      { label: 'Réessayer', type: 'valid', action: retry },
+      { label: 'Quitter', type: 'danger', action: quit },
     ],
   },
 ]

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { markRaw } from 'vue'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
+import ArenaDefeatDialog from '~/components/dialog/ArenaDefeatDialog.vue'
 import ArenaVictoryDialog from '~/components/dialog/ArenaVictoryDialog.vue'
 import ArenaWelcomeDialog from '~/components/dialog/ArenaWelcomeDialog.vue'
 import DialogStarter from '~/components/dialog/DialogStarter.vue'
@@ -70,6 +71,11 @@ export const useDialogStore = defineStore('dialog', () => {
       condition: () => arena.badgeEarned,
     },
     {
+      id: 'arenaDefeat',
+      component: markRaw(ArenaDefeatDialog),
+      condition: () => arena.result === 'lose',
+    },
+    {
       id: 'firstLoss',
       component: markRaw(FirstLossDialog),
       condition: () => stats.losses > 0,
@@ -98,6 +104,7 @@ export const useDialogStore = defineStore('dialog', () => {
   function resetArenaDialogs() {
     done.value.arenaWelcome = false
     done.value.arenaVictory = false
+    done.value.arenaDefeat = false
   }
 
   function reset() {


### PR DESCRIPTION
## Summary
- display arena defeat as a screen using the dialog system
- reset defeat dialog state when retrying or re-entering an arena
- clean up ArenaPanel logic now that defeat modal is removed

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: FetchError for google fonts, snapshot and store related errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cfd7e0b2c832aa06ac6ae15420ad2