### PR TITLE
fix arena defeat flow

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,7 +12,6 @@ declare module 'vue' {
     AchievementsPanel: typeof import('./components/achievements/AchievementsPanel.vue')['default']
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
-    ArenaDefeatDialog: typeof import('./components/dialog/ArenaDefeatDialog.vue')['default']
     ArenaDuel: typeof import('./components/arena/ArenaDuel.vue')['default']
     ArenaEnemyStats: typeof import('./components/arena/ArenaEnemyStats.vue')['default']
     ArenaPanel: typeof import('./components/arena/ArenaPanel.vue')['default']

--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -9,11 +9,15 @@ import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ShlagemonQuickSelect from '~/components/shlagemon/ShlagemonQuickSelect.vue'
 import Button from '~/components/ui/Button.vue'
 import { useArenaStore } from '~/stores/arena'
+import { useDialogStore } from '~/stores/dialog'
+import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
 const arena = useArenaStore()
+const dialog = useDialogStore()
+const panel = useMainPanelStore()
 
 const enemyTeam = computed(() => arena.lineup)
 const showDex = ref(false)
@@ -104,6 +108,23 @@ function closeAfterDefeat() {
   showDuel.value = false
 }
 
+function retry() {
+  const data = arena.arenaData
+  if (!data)
+    return
+  dialog.resetArenaDialogs()
+  arena.reset()
+  arena.setArena(data)
+  duelResult.value = null
+  showDuel.value = false
+}
+
+function quit() {
+  arena.reset()
+  dialog.resetArenaDialogs()
+  panel.showVillage()
+}
+
 onUnmounted(() => clearTimeout(nextTimer))
 </script>
 
@@ -192,9 +213,14 @@ onUnmounted(() => clearTimeout(nextTimer))
         <Button v-else-if="duelResult === 'win'" type="primary" @click="closeVictory">
           Fermer
         </Button>
-        <Button v-else type="danger" @click="closeAfterDefeat">
-          OK
-        </Button>
+        <template v-else>
+          <Button type="primary" @click="retry">
+            Réessayer
+          </Button>
+          <Button type="danger" @click="quit">
+            Quitter
+          </Button>
+        </template>
       </div>
     </div>
   </div>

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -73,7 +73,7 @@ const lvlMax = 100
 if (savagesZonesDescription.length < lvlMax / lvlsByZone) {
   console.warn(`There is ${savagesZonesDescription.length} zones in the list, it should be ${100 / 5}}`)
 }
-const savageZones: Zone[] = savagesZonesDescription.map((desc, index) => ({
+const savageZones: Zone[] = savagesZonesDescription.map((desc, _index) => ({
   id: desc.id,
   name: desc.name,
   type: 'sauvage',

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia'
 import { markRaw } from 'vue'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
-import ArenaDefeatDialog from '~/components/dialog/ArenaDefeatDialog.vue'
 import ArenaVictoryDialog from '~/components/dialog/ArenaVictoryDialog.vue'
 import ArenaWelcomeDialog from '~/components/dialog/ArenaWelcomeDialog.vue'
 import DialogStarter from '~/components/dialog/DialogStarter.vue'
@@ -71,11 +70,6 @@ export const useDialogStore = defineStore('dialog', () => {
       condition: () => arena.badgeEarned,
     },
     {
-      id: 'arenaDefeat',
-      component: markRaw(ArenaDefeatDialog),
-      condition: () => arena.result === 'lose',
-    },
-    {
       id: 'firstLoss',
       component: markRaw(FirstLossDialog),
       condition: () => stats.losses > 0,
@@ -104,7 +98,6 @@ export const useDialogStore = defineStore('dialog', () => {
   function resetArenaDialogs() {
     done.value.arenaWelcome = false
     done.value.arenaVictory = false
-    done.value.arenaDefeat = false
   }
 
   function reset() {


### PR DESCRIPTION
## Summary
- handle arena defeat inside panel instead of dialog
- update button actions when battle is lost
- remove unused defeat dialog from store
- fix unused variable warning in zones data

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686d942d4900832abfe1500e44c0d577