### PR TITLE
Fix MultiXP assignment

### DIFF
--- a/src/components/inventory/MultiExpModal.vue
+++ b/src/components/inventory/MultiExpModal.vue
@@ -24,6 +24,7 @@ function select(monId: string) {
           v-for="mon in dex.shlagemons"
           :key="mon.id"
           class="flex items-center justify-between border rounded p-2"
+          :class="store.holderId === mon.id ? 'bg-orange-100 dark:bg-orange-900' : ''"
         >
           <div class="flex items-center gap-2">
             <ShlagemonImage :id="mon.base.id" :alt="mon.base.name" class="h-6 w-6" />

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -127,7 +127,7 @@ function isActive(mon: DexShlagemon) {
         @click.stop="onClick(mon)"
         @dblclick.stop="onDoubleClick(mon)"
       >
-        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="absolute left-1 top-1 h-4 w-4" />
+        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="absolute right-1 top-1 h-4 w-4" />
         <div class="absolute bottom-0 right-2 text-xs">
           lvl {{ mon.lvl }}
         </div>

--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -91,13 +91,6 @@ const captureInfo = computed(() => {
       <div class="flex items-center gap-1">
         <span :class="mon.isShiny ? 'shiny-text' : ''">{{ mon.base.name }}</span>
         - lvl {{ mon.lvl }}<span v-if="isActiveAndSick"> (malade)</span>
-        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="h-4 w-4" />
-        <template v-if="multiExpStore.holderId === mon.id">
-          <MultiExpIcon class="h-4 w-4" />
-          <Button type="icon" class="ml-1" @click="multiExpStore.removeHolder()">
-            <div i-carbon-trash-can />
-          </Button>
-        </template>
       </div>
       <Tooltip text="Plus un Pokémon est rare, plus son potentiel de puissance est élevé.">
         <ShlagemonRarity :rarity="mon.rarity" class="rounded-tr-0 -m-r-4 -m-t-4" />
@@ -106,12 +99,20 @@ const captureInfo = computed(() => {
     <div class="flex gap-2">
       <ShlagemonType v-for="type in mon.base.types" :key="type.id" :value="type" />
     </div>
-    <ShlagemonImage
-      :id="mon.base.id"
-      :alt="mon.base.name"
-      :shiny="mon.isShiny"
-      class="mx-auto mb-2 max-h-40 object-contain"
-    />
+    <div class="relative mx-auto mb-2 max-w-max">
+      <ShlagemonImage
+        :id="mon.base.id"
+        :alt="mon.base.name"
+        :shiny="mon.isShiny"
+        class="max-h-40 object-contain"
+      />
+      <div v-if="multiExpStore.holderId === mon.id" class="absolute right-0 top-0 flex items-center gap-1">
+        <MultiExpIcon class="h-5 w-5" />
+        <Button type="icon" class="h-5 w-5" @click="multiExpStore.removeHolder()">
+          <div i-carbon-trash-can />
+        </Button>
+      </div>
+    </div>
     <p class="tiny-scrollbar mb-4 max-h-25 overflow-auto text-sm italic -m-r-4">
       {{ mon.base.description }}
     </p>

--- a/src/stores/multiExp.ts
+++ b/src/stores/multiExp.ts
@@ -28,6 +28,8 @@ export const useMultiExpStore = defineStore('multiExp', () => {
     }
     const mon = dex.shlagemons.find(m => m.id === monId)
     if (mon) {
+      if (mon.heldItemId)
+        mon.heldItemId = null
       mon.heldItemId = 'multi-exp'
       inventory.remove('multi-exp')
     }


### PR DESCRIPTION
## Summary
- allow removing held item before assigning MultiXP
- highlight current MultiXP holder in modal
- show MultiXP icon on the right in Shlagedex
- display held item over monster image in detail view

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` *(fails: command did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_686d95256374832abdb1e5fdd15ef6da