### PR TITLE
Fix multi-exp modal and add equipment system

### DIFF
--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -111,6 +111,8 @@ export const multiExp: Item = {
   currency: 'shlagidiamond',
   icon: 'i-game-icons:three-friends',
   iconClass: 'text-orange-500 dark:text-orange-300',
+  unique: true,
+  wearable: true,
 }
 
 export const thunderStone: Item = {

--- a/src/stores/equipment.ts
+++ b/src/stores/equipment.ts
@@ -1,0 +1,58 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useInventoryStore } from './inventory'
+import { useShlagedexStore } from './shlagedex'
+
+export const useEquipmentStore = defineStore('equipment', () => {
+  const holders = ref<Record<string, string | null>>({})
+  const dex = useShlagedexStore()
+  const inventory = useInventoryStore()
+
+  function equip(monId: string, itemId: string) {
+    const mon = dex.shlagemons.find(m => m.id === monId)
+    if (!mon)
+      return
+    if (mon.heldItemId) {
+      holders.value[mon.heldItemId] = null
+      inventory.add(mon.heldItemId)
+    }
+    const current = holders.value[itemId]
+    if (current) {
+      const other = dex.shlagemons.find(m => m.id === current)
+      if (other)
+        other.heldItemId = null
+    }
+    mon.heldItemId = itemId
+    holders.value[itemId] = monId
+    inventory.remove(itemId)
+  }
+
+  function unequip(monId: string) {
+    const mon = dex.shlagemons.find(m => m.id === monId)
+    if (!mon || !mon.heldItemId)
+      return
+    const itemId = mon.heldItemId
+    mon.heldItemId = null
+    holders.value[itemId] = null
+    inventory.add(itemId)
+  }
+
+  function unequipItem(itemId: string) {
+    const holderId = holders.value[itemId]
+    if (!holderId)
+      return
+    const mon = dex.shlagemons.find(m => m.id === holderId)
+    if (mon)
+      mon.heldItemId = null
+    holders.value[itemId] = null
+    inventory.add(itemId)
+  }
+
+  function getHolder(itemId: string) {
+    return holders.value[itemId] || null
+  }
+
+  return { holders, equip, unequip, unequipItem, getHolder }
+}, {
+  persist: true,
+})

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -6,7 +6,6 @@ import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from './achievements'
 import { useArenaStore } from './arena'
 import { useGameStore } from './game'
-import { useMultiExpStore } from './multiExp'
 import { useShlagedexStore } from './shlagedex'
 
 export const useInventoryStore = defineStore('inventory', () => {
@@ -45,6 +44,8 @@ export const useInventoryStore = defineStore('inventory', () => {
     const item = allItems.find(i => i.id === id)
     if (!item)
       return false
+    if (item.unique && (items.value[id] || dex.shlagemons.some(m => m.heldItemId === id)))
+      return false
     const cost = item.price * qty
     if (item.currency === 'shlagidiamond') {
       if (game.shlagidiamond < cost)
@@ -72,11 +73,6 @@ export const useInventoryStore = defineStore('inventory', () => {
     if (arena.inBattle || !items.value[id])
       return false
     notifyAchievement({ type: 'item-used' })
-    if (id === 'multi-exp') {
-      const me = useMultiExpStore()
-      me.open()
-      return true
-    }
     if (id === 'potion') {
       dex.healActive(50)
       remove(id)

--- a/src/stores/multiExp.ts
+++ b/src/stores/multiExp.ts
@@ -1,14 +1,14 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import { useInventoryStore } from './inventory'
+import { useEquipmentStore } from './equipment'
 import { useShlagedexStore } from './shlagedex'
 
 export const useMultiExpStore = defineStore('multiExp', () => {
-  const holderId = ref<string | null>(null)
   const isVisible = ref(false)
   const dex = useShlagedexStore()
-  const inventory = useInventoryStore()
+  const equipment = useEquipmentStore()
 
+  const holderId = computed(() => equipment.getHolder('multi-exp'))
   const holder = computed(() =>
     holderId.value ? dex.shlagemons.find(m => m.id === holderId.value) || null : null,
   )
@@ -22,28 +22,12 @@ export const useMultiExpStore = defineStore('multiExp', () => {
   }
 
   function setHolder(monId: string) {
-    const previous = holder.value
-    if (previous) {
-      previous.heldItemId = null
-    }
-    const mon = dex.shlagemons.find(m => m.id === monId)
-    if (mon) {
-      if (mon.heldItemId)
-        mon.heldItemId = null
-      mon.heldItemId = 'multi-exp'
-      inventory.remove('multi-exp')
-    }
-    holderId.value = monId
+    equipment.equip(monId, 'multi-exp')
     close()
   }
 
   function removeHolder() {
-    const mon = holder.value
-    if (!mon)
-      return
-    mon.heldItemId = null
-    inventory.add('multi-exp')
-    holderId.value = null
+    equipment.unequipItem('multi-exp')
   }
 
   return { holderId, holder, isVisible, open, close, setHolder, removeHolder }

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -19,6 +19,10 @@ export interface Item {
   /** UnoCSS classes applied to the icon */
   iconClass?: string
   image?: string
+  /** When true, only one instance can be owned */
+  unique?: boolean
+  /** Whether this item can be equipped by a Shlagémon */
+  wearable?: boolean
 }
 
 export interface InventoryEntry {


### PR DESCRIPTION
## Summary
- mark items as unique or wearable and update Multi-EXP data
- prevent buying a unique item more than once
- introduce an equipment store to track which Shlagémon holds an item
- rework multi-exp store to rely on equipment store
- adjust inventory store logic

## Testing
- `pnpm lint`
- `pnpm test` *(fails: tests rely on network fetches and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_686e671137e8832aa9d91a4260d64ad5