### PR TITLE
Implement encounter variety rule

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -163,7 +163,15 @@ function startBattle() {
   const available = zone.current.shlagemons?.length
     ? zone.current.shlagemons
     : allShlagemons
-  const base = pickRandomByCoefficient(available)
+  let pool = available
+  const last = progress.lastEncounters[zone.current.id]
+  if (last?.length >= 3 && last.every(id => id === last[0])) {
+    const filtered = available.filter(b => b.id !== last[0])
+    if (filtered.length)
+      pool = filtered
+  }
+  const base = pickRandomByCoefficient(pool)
+  progress.registerEncounter(zone.current.id, base.id)
   const rank = zone.getZoneRank(zone.current.id) * equilibrerank
   const created = createDexShlagemon(base, false, rank)
   const min = Number(zone.current.minLevel ?? 1)

--- a/src/stores/zoneProgress.ts
+++ b/src/stores/zoneProgress.ts
@@ -6,6 +6,7 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
   const fightsBeforeKing = 10
   const kingsDefeated = ref<Record<string, boolean>>({})
   const arenasCompleted = ref<Record<string, boolean>>({})
+  const lastEncounters = ref<Record<string, string[]>>({})
 
   function addWin(id: string) {
     wins.value[id] = (wins.value[id] || 0) + 1
@@ -31,6 +32,22 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
     arenasCompleted.value[id] = true
   }
 
+  function registerEncounter(zoneId: string, monId: string) {
+    const list = lastEncounters.value[zoneId] || []
+    list.push(monId)
+    while (list.length > 3)
+      list.shift()
+    lastEncounters.value[zoneId] = list
+  }
+
+  function streakExceeded(zoneId: string, monId: string) {
+    const list = lastEncounters.value[zoneId]
+    return list?.length >= 3
+      && list[list.length - 1] === monId
+      && list[list.length - 2] === monId
+      && list[list.length - 3] === monId
+  }
+
   function isArenaCompleted(id: string) {
     return !!arenasCompleted.value[id]
   }
@@ -46,6 +63,7 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
     kingsDefeated,
     fightsBeforeKing,
     arenasCompleted,
+    lastEncounters,
     addWin,
     getWins,
     canFightKing,
@@ -53,6 +71,8 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
     isKingDefeated,
     completeArena,
     isArenaCompleted,
+    registerEncounter,
+    streakExceeded,
     reset,
   }
 }, {


### PR DESCRIPTION
## Summary
- record recent encounters per zone in `zoneProgress` store
- prevent encountering same monster more than three times consecutively

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*
- `pnpm typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e6840fd34832abc1dd8d85991db9c