### PR TITLE
Fix Multi-EXP modal on mobile

### DIFF
--- a/src/stores/multiExp.ts
+++ b/src/stores/multiExp.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useEquipmentStore } from './equipment'
+import { useMobileTabStore } from './mobileTab'
 import { useShlagedexStore } from './shlagedex'
 
 export const useMultiExpStore = defineStore('multiExp', () => {
@@ -12,8 +13,10 @@ export const useMultiExpStore = defineStore('multiExp', () => {
   const holder = computed(() =>
     holderId.value ? dex.shlagemons.find(m => m.id === holderId.value) || null : null,
   )
+  const mobile = useMobileTabStore()
 
   function open() {
+    mobile.set('game')
     isVisible.value = true
   }
 


### PR DESCRIPTION
## Summary
- ensure the mobile interface switches back to the game tab when opening the Multi-EXP modal

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Failed to fetch web fonts and many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686e6c95255c832a951fe874a43efbc1