### PR TITLE
Improve capture difficulty

### DIFF
--- a/src/components/battle/CaptureOverlay.vue
+++ b/src/components/battle/CaptureOverlay.vue
@@ -2,7 +2,7 @@
 import type { Ball, DexShlagemon } from '~/type'
 import { onMounted, ref } from 'vue'
 import { ballHues } from '~/utils/ball'
-import { simpleCapture } from '~/utils/capture'
+import { tryCapture } from '~/utils/capture'
 
 const props = defineProps<{ target: DexShlagemon, ball: Ball }>()
 const emit = defineEmits<{ (e: 'finish', success: boolean): void }>()
@@ -11,7 +11,7 @@ const shake = ref(0)
 
 function attempt(step: number) {
   shake.value = step
-  const success = simpleCapture(props.target)
+  const success = tryCapture(props.target, props.ball)
   if (success) {
     setTimeout(() => emit('finish', true), 500)
   }

--- a/src/data/items/shlageball.ts
+++ b/src/data/items/shlageball.ts
@@ -22,7 +22,7 @@ export const superShlageball: Ball = {
   price: 25,
   currency: 'shlagidolar',
   image: '/items/shlageball/shlageball.png',
-  catchBonus: 1.5,
+  catchBonus: 2,
   animation: '/items/shlageball/shlageball.png',
 }
 
@@ -35,7 +35,7 @@ export const hyperShlageball: Ball = {
   price: 50,
   currency: 'shlagidolar',
   image: '/items/shlageball/shlageball.png',
-  catchBonus: 2,
+  catchBonus: 3,
   animation: '/items/shlageball/shlageball.png',
 }
 

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -1,10 +1,10 @@
 import type { Ball, DexShlagemon } from '~/type'
 
 export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
-  const hpRatio = enemy.hpCurrent / enemy.hp
-  const baseChance = (1 - hpRatio) * 100
-  const rarityMod = 1 / (enemy.rarity / 100)
-  const chance = baseChance * ball.catchBonus * rarityMod
+  const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
+  const coefMod = 1 / Math.sqrt(enemy.base.coefficient)
+  const levelMod = 1 / (1 + enemy.lvl / 20)
+  const chance = hpChance * coefMod * levelMod * ball.catchBonus
   return Math.random() * 100 < chance
 }
 


### PR DESCRIPTION
## Summary
- factor coefficient and level into capture chance, update overlay
- buff Super and Hyper Shlagéballs to encourage use

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined, snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_686e6c38751c832ab8727585bf97aa61