### PR TITLE
Fix badge reward logic

### DIFF
--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
+import { toast } from 'vue3-toastify'
 import DialogBox from '~/components/dialog/DialogBox.vue'
 import { useArenaStore } from '~/stores/arena'
 import { useMainPanelStore } from '~/stores/mainPanel'
@@ -16,12 +17,12 @@ const progress = useZoneProgressStore()
 const zone = useZoneStore()
 
 function collectBadge() {
-  if (arena.arenaData)
-    player.earnBadge(arena.arenaData.badge.id)
-  if (arena.arenaData)
-    progress.completeArena(arena.arenaData.id)
-  if (arena.arenaData)
-    zone.completeArena(arena.arenaData.id)
+  if (!arena.arenaData)
+    return
+  player.earnBadge(arena.arenaData.id)
+  progress.completeArena(zone.current.id)
+  zone.completeArena(zone.current.id)
+  toast.success(`Badge ${arena.arenaData.badge.name} obtenu !`)
   arena.reset()
   panel.showVillage()
   emit('done', 'arenaVictory')


### PR DESCRIPTION
## Summary
- fix ArenaVictoryDialog badge collection to update stores correctly
- show a toast when obtaining a badge

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686e6a1627b0832aae4c55bc5451ad76