### PR TITLE
Refactor modal stores using shared helper

### DIFF
--- a/src/stores/captureLimitModal.ts
+++ b/src/stores/captureLimitModal.ts
@@ -1,20 +1,14 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useCaptureLimitModalStore = defineStore('captureLimitModal', () => {
-  const isVisible = ref(false)
+  const { isVisible, open: openModal, close } = createModalStore('game')
   const requiredLevel = ref(0)
-  const mobile = useMobileTabStore()
 
   function open(level: number) {
     requiredLevel.value = level
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
+    openModal()
   }
 
   return { isVisible, requiredLevel, open, close }

--- a/src/stores/helpers.ts
+++ b/src/stores/helpers.ts
@@ -1,0 +1,24 @@
+import type { MobileTab } from './mobileTab'
+import { ref } from 'vue'
+import { useMobileTabStore } from './mobileTab'
+
+/**
+ * Simple utility to manage modal visibility.
+ * Optionally switches the mobile tab when opened.
+ */
+export function createModalStore(tab?: MobileTab) {
+  const isVisible = ref(false)
+  const mobile = tab ? useMobileTabStore() : undefined
+
+  function open() {
+    if (tab)
+      mobile!.set(tab)
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+  }
+
+  return { isVisible, open, close }
+}

--- a/src/stores/inventoryModal.ts
+++ b/src/stores/inventoryModal.ts
@@ -1,19 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useInventoryModalStore = defineStore('inventoryModal', () => {
-  const isVisible = ref(false)
-  const mobile = useMobileTabStore()
-
-  function open() {
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
-  }
+  const { isVisible, open, close } = createModalStore('game')
 
   return { isVisible, open, close }
 })

--- a/src/stores/mapModal.ts
+++ b/src/stores/mapModal.ts
@@ -1,19 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useMapModalStore = defineStore('mapModal', () => {
-  const isVisible = ref(false)
-  const mobile = useMobileTabStore()
-
-  function open() {
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
-  }
+  const { isVisible, open, close } = createModalStore('game')
 
   return { isVisible, open, close }
 })

--- a/src/stores/zoneMonsModal.ts
+++ b/src/stores/zoneMonsModal.ts
@@ -1,19 +1,8 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useZoneMonsModalStore = defineStore('zoneMonsModal', () => {
-  const isVisible = ref(false)
-  const mobile = useMobileTabStore()
-
-  function open() {
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
-  }
+  const { isVisible, open, close } = createModalStore('game')
 
   return { isVisible, open, close }
 })


### PR DESCRIPTION
## Summary
- create `createModalStore` helper for common modal logic
- use the helper in zone, map, inventory and capture limit modal stores

## Testing
- `pnpm test` *(fails: Snapshot mismatch and zone data errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e714ad8fc832a9a94acd594f3db40