### PR TITLE
refactor modal store logic

### DIFF
--- a/src/stores/captureLimitModal.ts
+++ b/src/stores/captureLimitModal.ts
@@ -1,20 +1,14 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useCaptureLimitModalStore = defineStore('captureLimitModal', () => {
-  const isVisible = ref(false)
+  const { isVisible, open: openModal, close } = createModalStore({ mobileTab: 'game' })
   const requiredLevel = ref(0)
-  const mobile = useMobileTabStore()
 
   function open(level: number) {
     requiredLevel.value = level
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
+    openModal()
   }
 
   return { isVisible, requiredLevel, open, close }

--- a/src/stores/helpers.ts
+++ b/src/stores/helpers.ts
@@ -1,0 +1,19 @@
+import type { MobileTab } from './mobileTab'
+import { ref } from 'vue'
+import { useMobileTabStore } from './mobileTab'
+
+export function createModalStore(options?: { mobileTab?: MobileTab }) {
+  const isVisible = ref(false)
+
+  function open() {
+    if (options?.mobileTab)
+      useMobileTabStore().set(options.mobileTab)
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+  }
+
+  return { isVisible, open, close }
+}

--- a/src/stores/inventoryModal.ts
+++ b/src/stores/inventoryModal.ts
@@ -1,19 +1,7 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useInventoryModalStore = defineStore('inventoryModal', () => {
-  const isVisible = ref(false)
-  const mobile = useMobileTabStore()
-
-  function open() {
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
-  }
-
+  const { isVisible, open, close } = createModalStore({ mobileTab: 'game' })
   return { isVisible, open, close }
 })

--- a/src/stores/mapModal.ts
+++ b/src/stores/mapModal.ts
@@ -1,19 +1,7 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useMapModalStore = defineStore('mapModal', () => {
-  const isVisible = ref(false)
-  const mobile = useMobileTabStore()
-
-  function open() {
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
-  }
-
+  const { isVisible, open, close } = createModalStore({ mobileTab: 'game' })
   return { isVisible, open, close }
 })

--- a/src/stores/zoneMonsModal.ts
+++ b/src/stores/zoneMonsModal.ts
@@ -1,19 +1,7 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { useMobileTabStore } from './mobileTab'
+import { createModalStore } from './helpers'
 
 export const useZoneMonsModalStore = defineStore('zoneMonsModal', () => {
-  const isVisible = ref(false)
-  const mobile = useMobileTabStore()
-
-  function open() {
-    mobile.set('game')
-    isVisible.value = true
-  }
-
-  function close() {
-    isVisible.value = false
-  }
-
+  const { isVisible, open, close } = createModalStore({ mobileTab: 'game' })
   return { isVisible, open, close }
 })


### PR DESCRIPTION
## Summary
- add a `createModalStore` helper
- refactor modal stores to use the helper

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: TypeScript errors)*
- `pnpm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686e71c0a638832ab123e1e3fd24e4ac