### PR TITLE
Introduce sort direction util

### DIFF
--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
-import { ref, watch } from 'vue'
+import { computed, ref } from 'vue'
+import { getSortDirection } from '~/utils/sort'
 
 export type DexSort =
   | 'level'
@@ -15,19 +16,12 @@ export type DexSort =
 export const useDexFilterStore = defineStore('dexFilter', () => {
   const search = ref('')
   const sortBy = ref<DexSort>('level')
-  const sortAsc = ref(false)
-
-  watch(sortBy, (val) => {
-    if (val === 'name' || val === 'type' || val === 'date')
-      sortAsc.value = true
-    else
-      sortAsc.value = false
-  })
+  const sortAsc = computed(() =>
+    getSortDirection(sortBy.value, ['name', 'type', 'date']))
 
   function reset() {
     search.value = ''
     sortBy.value = 'level'
-    sortAsc.value = false
   }
 
   return { search, sortBy, sortAsc, reset }

--- a/src/stores/inventoryFilter.ts
+++ b/src/stores/inventoryFilter.ts
@@ -1,24 +1,18 @@
 import { defineStore } from 'pinia'
-import { ref, watch } from 'vue'
+import { computed, ref } from 'vue'
+import { getSortDirection } from '~/utils/sort'
 
 export type InventorySort = 'name' | 'type' | 'price'
 
 export const useInventoryFilterStore = defineStore('inventoryFilter', () => {
   const search = ref('')
   const sortBy = ref<InventorySort>('name')
-  const sortAsc = ref(true)
-
-  watch(sortBy, (val) => {
-    if (val === 'price')
-      sortAsc.value = false
-    else
-      sortAsc.value = true
-  })
+  const sortAsc = computed(() =>
+    getSortDirection(sortBy.value, ['name', 'type']))
 
   function reset() {
     search.value = ''
     sortBy.value = 'name'
-    sortAsc.value = true
   }
 
   return { search, sortBy, sortAsc, reset }

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,3 @@
+export function getSortDirection<T extends string>(sortBy: T, ascValues: T[]): boolean {
+  return ascValues.includes(sortBy)
+}


### PR DESCRIPTION
## Summary
- add getSortDirection util
- simplify dexFilter and inventoryFilter stores using computed sort direction

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Snapshot mismatch and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_686e75dee35c832ab35d2659bedb2574