### PR TITLE
Implement Multi-EXP modal behavior and test

### DIFF
--- a/cypress/e2e/multi-exp.spec.ts
+++ b/cypress/e2e/multi-exp.spec.ts
@@ -1,0 +1,16 @@
+describe('multi-exp item', () => {
+  beforeEach(() => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.clear()
+        win.localStorage.setItem('inventory', JSON.stringify({ items: { 'multi-exp': 1 } }))
+      },
+    })
+  })
+
+  it('opens modal on use', () => {
+    cy.get('nav .i-carbon-inventory-management').parents('button').click()
+    cy.contains('Multi-EXP').parents().contains('Utiliser').click()
+    cy.contains('dialog', 'Choisir le porteur du Multi-EXP').should('be.visible')
+  })
+})

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -10,12 +10,14 @@ import { useBallStore } from '~/stores/ball'
 import { useEvolutionItemStore } from '~/stores/evolutionItem'
 import { useInventoryStore } from '~/stores/inventory'
 import { useInventoryFilterStore } from '~/stores/inventoryFilter'
+import { useInventoryModalStore } from '~/stores/inventoryModal'
 import { useMultiExpStore } from '~/stores/multiExp'
 
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
 const evoItemStore = useEvolutionItemStore()
 const multiExpStore = useMultiExpStore()
+const inventoryModal = useInventoryModalStore()
 const filter = useInventoryFilterStore()
 const sortOptions = [
   { label: 'Type', value: 'type' },
@@ -58,6 +60,8 @@ function onUse(item: Item) {
     evoItemStore.open(item)
   }
   else if (item.id === 'multi-exp') {
+    if (inventoryModal.isVisible)
+      inventoryModal.close()
     multiExpStore.open()
   }
   else {


### PR DESCRIPTION
## Summary
- open Multi-EXP modal from inventory and close inventory modal first
- test modal opening with Cypress

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined, snapshots mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_686e7e4284e8832aaeeb22fb3d7f5f54