### PR TITLE
Refactor dex list display

### DIFF
--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -1,79 +1,22 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
 import { useMediaQuery } from '@vueuse/core'
-import MultiExpIcon from '~/components/icons/multi-exp.vue'
 import Modal from '~/components/modal/Modal.vue'
-import SearchInput from '~/components/ui/SearchInput.vue'
-import SortControls from '~/components/ui/SortControls.vue'
-import { useDexFilterStore } from '~/stores/dexFilter'
 import { useDiseaseStore } from '~/stores/disease'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
-import { useMultiExpStore } from '~/stores/multiExp'
+import { useShlagedexStore } from '~/stores/shlagedex'
 import ShlagemonDetail from './ShlagemonDetail.vue'
-import ShlagemonType from './ShlagemonType.vue'
+import ShlagemonList from './ShlagemonList.vue'
 
 const dex = useShlagedexStore()
 const panel = useMainPanelStore()
 const disease = useDiseaseStore()
-const filter = useDexFilterStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 const isLocked = computed(() => panel.current === 'trainerBattle' || disease.active)
-const multiExpStore = useMultiExpStore()
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
-const sortOptions = [
-  { label: 'Niveau', value: 'level' },
-  { label: 'Rareté', value: 'rarity' },
-  { label: 'Shiny', value: 'shiny' },
-  { label: 'Nom', value: 'name' },
-  { label: 'Type', value: 'type' },
-  { label: 'Attaque', value: 'attack' },
-  { label: 'Défense', value: 'defense' },
-  { label: 'Nb obtentions', value: 'count' },
-  { label: 'Première capture', value: 'date' },
-]
-
-const displayedMons = computed(() => {
-  let mons = dex.shlagemons.slice()
-  if (filter.search.trim()) {
-    const q = filter.search.toLowerCase()
-    mons = mons.filter(m => m.base.name.toLowerCase().includes(q))
-  }
-  switch (filter.sortBy) {
-    case 'level':
-      mons.sort((a, b) => a.lvl - b.lvl)
-      break
-    case 'rarity':
-      mons.sort((a, b) => a.rarity - b.rarity)
-      break
-    case 'shiny':
-      mons.sort((a, b) => Number(a.isShiny) - Number(b.isShiny))
-      break
-    case 'attack':
-      mons.sort((a, b) => a.attack - b.attack)
-      break
-    case 'defense':
-      mons.sort((a, b) => a.defense - b.defense)
-      break
-    case 'count':
-      mons.sort((a, b) => a.captureCount - b.captureCount)
-      break
-    case 'date':
-      mons.sort((a, b) => new Date(a.captureDate).getTime() - new Date(b.captureDate).getTime())
-      break
-    case 'name':
-      mons.sort((a, b) => a.base.name.localeCompare(b.base.name))
-      break
-    case 'type':
-      mons.sort((a, b) => (a.base.types[0]?.name || '').localeCompare(b.base.types[0]?.name || ''))
-      break
-  }
-  if (!filter.sortAsc)
-    mons.reverse()
-  return mons
-})
 
 const clickTimer = ref<number | null>(null)
 
@@ -84,16 +27,6 @@ function open(mon: DexShlagemon | null) {
   }
 }
 
-function onClick(mon: DexShlagemon) {
-  clearTimeout(clickTimer.value as any)
-  clickTimer.value = window.setTimeout(() => open(mon), 300)
-}
-
-function onDoubleClick(mon: DexShlagemon) {
-  clearTimeout(clickTimer.value as any)
-  changeActive(mon)
-}
-
 function changeActive(mon: DexShlagemon) {
   if (isLocked.value)
     return
@@ -102,65 +35,28 @@ function changeActive(mon: DexShlagemon) {
     mobile.set('game')
 }
 
-function isActive(mon: DexShlagemon) {
-  return dex.activeShlagemon?.id === mon.id
+function onItemClick(mon: DexShlagemon) {
+  if (clickTimer.value) {
+    clearTimeout(clickTimer.value)
+    clickTimer.value = null
+    changeActive(mon)
+  }
+  else {
+    clickTimer.value = window.setTimeout(() => {
+      open(mon)
+      clickTimer.value = null
+    }, 300)
+  }
 }
 </script>
 
 <template>
   <section v-if="dex.shlagemons.length" class="h-full flex flex-col">
-    <div class="mb-2 flex flex-wrap gap-2">
-      <SortControls
-        v-model:sort-by="filter.sortBy"
-        v-model:sort-asc="filter.sortAsc"
-        :options="sortOptions"
-      />
-      <SearchInput v-model="filter.search" />
-    </div>
-    <div class="tiny-scrollbar flex flex-col gap-2 overflow-auto">
-      <div
-        v-for="mon in displayedMons"
-        :key="mon.id"
-        class="relative flex cursor-pointer items-center justify-between border rounded p-2"
-        hover="bg-gray-100 dark:bg-gray-800"
-        :class="isActive(mon) ? 'bg-blue-500/20 dark:bg-blue-500/20 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400' : ''"
-        @click.stop="onClick(mon)"
-        @dblclick.stop="onDoubleClick(mon)"
-      >
-        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="absolute right-1 top-1 h-4 w-4" />
-        <div class="absolute bottom-0 right-2 text-xs">
-          lvl {{ mon.lvl }}
-        </div>
-        <div class="flex items-center gap-2">
-          <ShlagemonImage
-            :id="mon.base.id"
-            :alt="mon.base.name"
-            :shiny="mon.isShiny"
-            class="h-12 w-12 object-contain -m-y-2"
-          />
-          <div class="flex flex-col overflow-hidden">
-            <div class="name">
-              {{ mon.base.name }}
-            </div>
-            <div class="flex gap-1">
-              <ShlagemonType
-                v-for="t in mon.base.types"
-                :key="t.id"
-                :value="t"
-                size="xs"
-              />
-            </div>
-          </div>
-        </div>
-        <CheckBox
-          class="ml-2"
-          :model-value="isActive(mon)"
-          :disabled="isLocked"
-          @update:model-value="() => changeActive(mon)"
-          @click.stop
-        />
-      </div>
-    </div>
+    <ShlagemonList
+      :mons="dex.shlagemons"
+      show-checkbox
+      :on-item-click="onItemClick"
+    />
     <Modal v-model="showDetail" footer-close @close="showDetail = false">
       <ShlagemonDetail
         :mon="detailMon"

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+import { useMediaQuery } from '@vueuse/core'
+import { computed } from 'vue'
+import MultiExpIcon from '~/components/icons/multi-exp.vue'
+import CheckBox from '~/components/ui/CheckBox.vue'
+import SearchInput from '~/components/ui/SearchInput.vue'
+import SortControls from '~/components/ui/SortControls.vue'
+import { useDexFilterStore } from '~/stores/dexFilter'
+import { useDiseaseStore } from '~/stores/disease'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMobileTabStore } from '~/stores/mobileTab'
+import { useMultiExpStore } from '~/stores/multiExp'
+import { useShlagedexStore } from '~/stores/shlagedex'
+import ShlagemonImage from './ShlagemonImage.vue'
+import ShlagemonType from './ShlagemonType.vue'
+
+interface Props {
+  mons: DexShlagemon[]
+  showCheckbox?: boolean
+  disabledIds?: string[]
+  onItemClick?: (mon: DexShlagemon) => void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showCheckbox: false,
+  disabledIds: () => [],
+})
+
+const filter = useDexFilterStore()
+const dex = useShlagedexStore()
+const multiExpStore = useMultiExpStore()
+const disease = useDiseaseStore()
+const panel = useMainPanelStore()
+const mobile = useMobileTabStore()
+const isMobile = useMediaQuery('(max-width: 767px)')
+
+const isLocked = computed(() => panel.current === 'trainerBattle' || disease.active)
+
+const sortOptions = [
+  { label: 'Niveau', value: 'level' },
+  { label: 'Rareté', value: 'rarity' },
+  { label: 'Shiny', value: 'shiny' },
+  { label: 'Nom', value: 'name' },
+  { label: 'Type', value: 'type' },
+  { label: 'Attaque', value: 'attack' },
+  { label: 'Défense', value: 'defense' },
+  { label: 'Nb obtentions', value: 'count' },
+  { label: 'Première capture', value: 'date' },
+] as const
+
+const displayedMons = computed(() => {
+  let mons = props.mons.slice()
+  if (filter.search.trim()) {
+    const q = filter.search.toLowerCase()
+    mons = mons.filter(m => m.base.name.toLowerCase().includes(q))
+  }
+  switch (filter.sortBy) {
+    case 'level':
+      mons.sort((a, b) => a.lvl - b.lvl)
+      break
+    case 'rarity':
+      mons.sort((a, b) => a.rarity - b.rarity)
+      break
+    case 'shiny':
+      mons.sort((a, b) => Number(a.isShiny) - Number(b.isShiny))
+      break
+    case 'attack':
+      mons.sort((a, b) => a.attack - b.attack)
+      break
+    case 'defense':
+      mons.sort((a, b) => a.defense - b.defense)
+      break
+    case 'count':
+      mons.sort((a, b) => a.captureCount - b.captureCount)
+      break
+    case 'date':
+      mons.sort(
+        (a, b) =>
+          new Date(a.captureDate).getTime() - new Date(b.captureDate).getTime(),
+      )
+      break
+    case 'name':
+      mons.sort((a, b) => a.base.name.localeCompare(b.base.name))
+      break
+    case 'type':
+      mons.sort(
+        (a, b) =>
+          (a.base.types[0]?.name || '').localeCompare(
+            b.base.types[0]?.name || '',
+          ),
+      )
+      break
+  }
+  if (!filter.sortAsc)
+    mons.reverse()
+  return mons
+})
+
+function handleClick(mon: DexShlagemon) {
+  if (props.disabledIds.includes(mon.id))
+    return
+  props.onItemClick?.(mon)
+}
+
+function isActive(mon: DexShlagemon) {
+  return dex.activeShlagemon?.id === mon.id
+}
+
+function changeActive(mon: DexShlagemon) {
+  if (isLocked.value)
+    return
+  dex.setActiveShlagemon(mon)
+  if (isMobile.value)
+    mobile.set('game')
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <div class="mb-2 flex flex-wrap gap-2">
+      <SortControls
+        v-model:sort-by="filter.sortBy"
+        v-model:sort-asc="filter.sortAsc"
+        :options="sortOptions"
+      />
+      <SearchInput v-model="filter.search" />
+    </div>
+    <div class="tiny-scrollbar flex flex-col gap-2 overflow-auto">
+      <div
+        v-for="mon in displayedMons"
+        :key="mon.id"
+        class="relative flex cursor-pointer items-center justify-between border rounded p-2"
+        hover="bg-gray-100 dark:bg-gray-800"
+        :class="isActive(mon) ? 'bg-blue-500/20 dark:bg-blue-500/20 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400' : ''"
+        @click.stop="handleClick(mon)"
+      >
+        <MultiExpIcon v-if="multiExpStore.holderId === mon.id" class="absolute right-1 top-1 h-4 w-4" />
+        <div class="absolute bottom-0 right-2 text-xs">
+          lvl {{ mon.lvl }}
+        </div>
+        <div class="flex items-center gap-2">
+          <ShlagemonImage
+            :id="mon.base.id"
+            :alt="mon.base.name"
+            :shiny="mon.isShiny"
+            class="h-12 w-12 object-contain -m-y-2"
+          />
+          <div class="flex flex-col overflow-hidden">
+            <div class="name">
+              {{ mon.base.name }}
+            </div>
+            <div class="flex gap-1">
+              <ShlagemonType
+                v-for="t in mon.base.types"
+                :key="t.id"
+                :value="t"
+                size="xs"
+              />
+            </div>
+          </div>
+        </div>
+        <CheckBox
+          v-if="props.showCheckbox"
+          class="ml-2"
+          :model-value="isActive(mon)"
+          :disabled="isLocked || props.disabledIds.includes(mon.id)"
+          @update:model-value="() => changeActive(mon)"
+          @click.stop
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/shlagemon/ShlagemonQuickSelect.vue
+++ b/src/components/shlagemon/ShlagemonQuickSelect.vue
@@ -1,120 +1,27 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { computed, ref, watch } from 'vue'
-import SearchInput from '~/components/ui/SearchInput.vue'
-import SortControls from '~/components/ui/SortControls.vue'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import ShlagemonImage from './ShlagemonImage.vue'
-import ShlagemonType from './ShlagemonType.vue'
+import ShlagemonList from './ShlagemonList.vue'
 
 interface Props {
   selected?: string[]
 }
 
 const props = withDefaults(defineProps<Props>(), { selected: () => [] })
-
 const emit = defineEmits<{ (e: 'select', mon: DexShlagemon): void }>()
 const dex = useShlagedexStore()
-
-const search = ref('')
-const sortBy = ref<'level' | 'rarity' | 'name' | 'type' | 'shiny' | 'attack' | 'defense' | 'count' | 'date'>('level')
-const sortAsc = ref(false)
-
-watch(sortBy, (val) => {
-  if (val === 'name' || val === 'type' || val === 'date')
-    sortAsc.value = true
-  else
-    sortAsc.value = false
-})
-
-const sortOptions = [
-  { label: 'Niveau', value: 'level' },
-  { label: 'Rareté', value: 'rarity' },
-  { label: 'Shiny', value: 'shiny' },
-  { label: 'Nom', value: 'name' },
-  { label: 'Type', value: 'type' },
-  { label: 'Attaque', value: 'attack' },
-  { label: 'Défense', value: 'defense' },
-  { label: 'Nb obtentions', value: 'count' },
-  { label: 'Première capture', value: 'date' },
-]
-
-const displayedMons = computed(() => {
-  let mons = dex.shlagemons.slice()
-  if (search.value.trim()) {
-    const q = search.value.toLowerCase()
-    mons = mons.filter(m => m.base.name.toLowerCase().includes(q))
-  }
-  switch (sortBy.value) {
-    case 'level':
-      mons.sort((a, b) => a.lvl - b.lvl)
-      break
-    case 'rarity':
-      mons.sort((a, b) => a.rarity - b.rarity)
-      break
-    case 'shiny':
-      mons.sort((a, b) => Number(a.isShiny) - Number(b.isShiny))
-      break
-    case 'attack':
-      mons.sort((a, b) => a.attack - b.attack)
-      break
-    case 'defense':
-      mons.sort((a, b) => a.defense - b.defense)
-      break
-    case 'count':
-      mons.sort((a, b) => a.captureCount - b.captureCount)
-      break
-    case 'date':
-      mons.sort((a, b) => new Date(a.captureDate).getTime() - new Date(b.captureDate).getTime())
-      break
-    case 'name':
-      mons.sort((a, b) => a.base.name.localeCompare(b.base.name))
-      break
-    case 'type':
-      mons.sort((a, b) => (a.base.types[0]?.name || '').localeCompare(b.base.types[0]?.name || ''))
-      break
-  }
-  if (!sortAsc.value)
-    mons.reverse()
-  return mons
-})
 
 function choose(mon: DexShlagemon) {
   dex.setActiveShlagemon(mon)
   emit('select', mon)
 }
-
-function isSelected(mon: DexShlagemon) {
-  return props.selected.includes(mon.id)
-}
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
-    <div class="flex gap-2">
-      <SortControls v-model:sort-by="sortBy" v-model:sort-asc="sortAsc" :options="sortOptions" />
-      <SearchInput v-model="search" />
-    </div>
-    <div class="tiny-scrollbar max-h-60 flex flex-col gap-2 overflow-auto">
-      <button
-        v-for="mon in displayedMons"
-        :key="mon.id"
-        class="flex items-center justify-between gap-2 border rounded p-2 text-left"
-        :class="isSelected(mon) ? 'opacity-50' : ''"
-        @click="choose(mon)"
-      >
-        <span class="w-6 text-xs font-bold">lvl {{ mon.lvl }}</span>
-        <ShlagemonImage
-          :id="mon.base.id"
-          :alt="mon.base.name"
-          :shiny="mon.isShiny"
-          class="h-8 w-8 object-contain"
-        />
-        <div class="flex gap-1">
-          <ShlagemonType v-for="t in mon.base.types" :key="t.id" :value="t" />
-        </div>
-        <span class="flex-1 truncate text-xs">{{ mon.base.name }}</span>
-      </button>
-    </div>
-  </div>
+  <ShlagemonList
+    :mons="dex.shlagemons"
+    :show-checkbox="false"
+    :disabled-ids="props.selected"
+    :on-item-click="choose"
+  />
 </template>

--- a/test/double-click.test.ts
+++ b/test/double-click.test.ts
@@ -25,7 +25,8 @@ describe('shlagedex double click', () => {
       },
     })
     const item = wrapper.find('div.relative')
-    await item.trigger('dblclick')
+    await item.trigger('click')
+    await item.trigger('click')
     expect(dex.activeShlagemon?.id).toBe(mon.id)
   })
 })


### PR DESCRIPTION
## Summary
- add ShlagemonList to centralize list rendering
- refactor QuickSelect to reuse the new component
- simplify Shlagedex using ShlagemonList
- adapt double-click unit test

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined & snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686e7e783ecc832aa481532c905da074