### PR TITLE
Restore sort toggling for dex and inventory filters

### DIFF
--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
-import { getSortDirection } from '~/utils/sort'
+import { ref, watch } from 'vue'
 
 export type DexSort =
   | 'level'
@@ -16,12 +15,19 @@ export type DexSort =
 export const useDexFilterStore = defineStore('dexFilter', () => {
   const search = ref('')
   const sortBy = ref<DexSort>('level')
-  const sortAsc = computed(() =>
-    getSortDirection(sortBy.value, ['name', 'type', 'date']))
+  const sortAsc = ref(false)
+
+  watch(sortBy, (val) => {
+    if (val === 'name' || val === 'type' || val === 'date')
+      sortAsc.value = true
+    else
+      sortAsc.value = false
+  })
 
   function reset() {
     search.value = ''
     sortBy.value = 'level'
+    sortAsc.value = false
   }
 
   return { search, sortBy, sortAsc, reset }

--- a/src/stores/inventoryFilter.ts
+++ b/src/stores/inventoryFilter.ts
@@ -1,18 +1,24 @@
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
-import { getSortDirection } from '~/utils/sort'
+import { ref, watch } from 'vue'
 
 export type InventorySort = 'name' | 'type' | 'price'
 
 export const useInventoryFilterStore = defineStore('inventoryFilter', () => {
   const search = ref('')
   const sortBy = ref<InventorySort>('name')
-  const sortAsc = computed(() =>
-    getSortDirection(sortBy.value, ['name', 'type']))
+  const sortAsc = ref(true)
+
+  watch(sortBy, (val) => {
+    if (val === 'price')
+      sortAsc.value = false
+    else
+      sortAsc.value = true
+  })
 
   function reset() {
     search.value = ''
     sortBy.value = 'name'
+    sortAsc.value = true
   }
 
   return { search, sortBy, sortAsc, reset }

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,3 +1,0 @@
-export function getSortDirection<T extends string>(sortBy: T, ascValues: T[]): boolean {
-  return ascValues.includes(sortBy)
-}


### PR DESCRIPTION
## Summary
- fix ability to toggle sort direction in dex & inventory filters
- remove unused helper

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686e82dfefc4832a89ae31e57fec9321