### PR TITLE
Add XP bar to trainer battles

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -3,6 +3,7 @@ import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CharacterImage from '~/components/character/CharacterImage.vue'
+import ShlagemonXpBar from '~/components/shlagemon/ShlagemonXpBar.vue'
 import Button from '~/components/ui/Button.vue'
 import { useBattleEffects } from '~/composables/battleEngine'
 import { allShlagemons } from '~/data/shlagemons'
@@ -324,6 +325,11 @@ onUnmounted(() => {
         Continuer
       </Button>
     </div>
+    <ShlagemonXpBar
+      v-if="dex.activeShlagemon"
+      class="max-w-160 w-full self-center"
+      :mon="dex.activeShlagemon"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- show the ShlagemonXpBar component during trainer battles

## Testing
- `pnpm exec eslint src/components/battle/TrainerBattle.vue`
- `pnpm test:unit` *(fails: FetchError for fonts and various failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_686f6f6fb908832a9390981b3bf5cc98