### PR TITLE
Add battle active getter and use in components

### DIFF
--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -4,16 +4,16 @@ import { computed } from 'vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
-import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
 
 const zone = useZoneStore()
 const dex = useShlagedexStore()
-const panel = useMainPanelStore()
+const trainerBattle = useTrainerBattleStore()
 const arena = useArenaStore()
 const progress = useZoneProgressStore()
 const mapModal = useMapModalStore()
@@ -21,7 +21,7 @@ const dialog = useDialogStore()
 const mobile = useMobileTabStore()
 
 const zoneButtonsDisabled = computed(
-  () => panel.current === 'trainerBattle' || dialog.isDialogVisible || arena.inBattle,
+  () => trainerBattle.isActive || dialog.isDialogVisible || arena.inBattle,
 )
 
 function buttonDisabled(z: Zone) {

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -8,10 +8,10 @@ import SearchInput from '~/components/ui/SearchInput.vue'
 import SortControls from '~/components/ui/SortControls.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useDiseaseStore } from '~/stores/disease'
-import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useMultiExpStore } from '~/stores/multiExp'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import ShlagemonImage from './ShlagemonImage.vue'
 import ShlagemonType from './ShlagemonType.vue'
 
@@ -31,11 +31,11 @@ const filter = useDexFilterStore()
 const dex = useShlagedexStore()
 const multiExpStore = useMultiExpStore()
 const disease = useDiseaseStore()
-const panel = useMainPanelStore()
+const trainerBattle = useTrainerBattleStore()
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
 
-const isLocked = computed(() => panel.current === 'trainerBattle' || disease.active)
+const isLocked = computed(() => trainerBattle.isActive || disease.active)
 
 const sortOptions = [
   { label: 'Niveau', value: 'level' },

--- a/src/stores/trainerBattle.ts
+++ b/src/stores/trainerBattle.ts
@@ -18,6 +18,7 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   }
 
   const current = computed(() => queue.value[currentIndex.value] ?? null)
+  const isActive = computed(() => Boolean(current.value))
 
   function next() {
     currentIndex.value += 1
@@ -31,5 +32,14 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   // init with default trainers
   setQueue(trainersData)
 
-  return { queue, current, next, add, setQueue, reset, levelUpHealPercent }
+  return {
+    queue,
+    current,
+    isActive,
+    next,
+    add,
+    setQueue,
+    reset,
+    levelUpHealPercent,
+  }
 })

--- a/test/trainer-store.test.ts
+++ b/test/trainer-store.test.ts
@@ -8,4 +8,20 @@ describe('trainer battle store', () => {
     const store = useTrainerBattleStore()
     expect(store.levelUpHealPercent).toBe(15)
   })
+
+  it('isActive reflects queue state', () => {
+    setActivePinia(createPinia())
+    const store = useTrainerBattleStore()
+    store.reset()
+    expect(store.isActive).toBe(false)
+    store.setQueue([{
+      id: 'test',
+      character: { id: 'test', name: 'Test', gender: 'male' },
+      dialogBefore: '',
+      dialogAfter: '',
+      reward: 1,
+      shlagemons: [],
+    }])
+    expect(store.isActive).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- expose `isActive` computed from `current` in `useTrainerBattleStore`
- use trainer battle active state in `ZonePanel` and `ShlagemonList`
- test that trainer battle active state updates with queue

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined...)*

------
https://chatgpt.com/codex/tasks/task_e_686f7cfc9c80832a863bd7656ecea936