### PR TITLE
Fix battle core createEnemy usage

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -57,35 +57,38 @@ const {
   enemyVariant,
   startBattle: coreStartBattle,
   attack: coreAttack,
-} = useBattleCore(() => {
-  const active = dex.activeShlagemon
-  if (!active)
-    return null
-  const available = zone.current.shlagemons?.length
-    ? zone.current.shlagemons
-    : allShlagemons
-  let pool = available
-  const last = progress.lastEncounters[zone.current.id]
-  if (last?.length >= 3 && last.every(id => id === last[0])) {
-    const filtered = available.filter(b => b.id !== last[0])
-    if (filtered.length)
-      pool = filtered
-  }
-  const base = pickRandomByCoefficient(pool)
-  progress.registerEncounter(zone.current.id, base.id)
-  const rank = zone.getZoneRank(zone.current.id) * equilibrerank
-  const created = createDexShlagemon(base, false, rank)
-  const min = Number(zone.current.minLevel ?? 1)
-  const zoneMax = Number(zone.current.maxLevel ?? (min + 1))
-  const max = Math.max(zoneMax - 1, min)
-  const lvl = Math.floor(Math.random() * (max - min + 1)) + min
-  created.lvl = lvl
-  applyStats(created)
-  if (created.isShiny) {
-    toast('Vous avez rencontré un Shiny !')
-    audio.playSfx('/audio/sfx/shiny.ogg')
-  }
-  return created
+} = useBattleCore({
+  createEnemy: () => {
+    const active = dex.activeShlagemon
+    if (!active)
+      return null
+
+    const available = zone.current.shlagemons?.length
+      ? zone.current.shlagemons
+      : allShlagemons
+    let pool = available
+    const last = progress.lastEncounters[zone.current.id]
+    if (last?.length >= 3 && last.every(id => id === last[0])) {
+      const filtered = available.filter(b => b.id !== last[0])
+      if (filtered.length)
+        pool = filtered
+    }
+    const base = pickRandomByCoefficient(pool)
+    progress.registerEncounter(zone.current.id, base.id)
+    const rank = zone.getZoneRank(zone.current.id) * equilibrerank
+    const created = createDexShlagemon(base, false, rank)
+    const min = Number(zone.current.minLevel ?? 1)
+    const zoneMax = Number(zone.current.maxLevel ?? (min + 1))
+    const max = Math.max(zoneMax - 1, min)
+    const lvl = Math.floor(Math.random() * (max - min + 1)) + min
+    created.lvl = lvl
+    applyStats(created)
+    if (created.isShiny) {
+      toast('Vous avez rencontré un Shiny !')
+      audio.playSfx('/audio/sfx/shiny.ogg')
+    }
+    return created
+  },
 })
 
 const wins = computed(() => progress.getWins(zone.current.id))

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -63,21 +63,23 @@ const {
   startBattle: coreStartBattle,
   attack: coreAttack,
   stopBattle,
-} = useBattleCore(() => {
-  const t = trainer.value
-  if (!t || !dex.activeShlagemon)
-    return null
-  const spec = t.shlagemons[enemyIndex.value]
-  if (!spec)
-    return null
-  const base = allShlagemons.find(b => b.id === spec.baseId)
-  if (!base)
-    return null
-  const rank = t.id.startsWith('king-') ? zone.getZoneRank(zone.current.id) : 1
-  const created = createDexShlagemon(base, false, rank * equilibrerank)
-  created.lvl = spec.level
-  applyStats(created)
-  return created
+} = useBattleCore({
+  createEnemy: () => {
+    const t = trainer.value
+    if (!t || !dex.activeShlagemon)
+      return null
+    const spec = t.shlagemons[enemyIndex.value]
+    if (!spec)
+      return null
+    const base = allShlagemons.find(b => b.id === spec.baseId)
+    if (!base)
+      return null
+    const rank = t.id.startsWith('king-') ? zone.getZoneRank(zone.current.id) : 1
+    const created = createDexShlagemon(base, false, rank * equilibrerank)
+    created.lvl = spec.level
+    applyStats(created)
+    return created
+  },
 })
 watch(trainer, (t) => {
   if (t) {


### PR DESCRIPTION
## Summary
- fix `useBattleCore` usage by passing `createEnemy` in an options object for `BattleMain` and `TrainerBattle`

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined, fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f8034cf70832a9b69d74bb7bc5a3c