### PR TITLE
Fix battle respawn

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -190,6 +190,7 @@ function finishBattle() {
     }
     playerFainted.value = false
     enemyFainted.value = false
+    enemy.value = null
     startBattle()
   }, 500)
 }


### PR DESCRIPTION
## Summary
- ensure next enemy spawns by clearing previous enemy when battle ends

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_686f8c5a2b38832ab4dbd2904fb00403