### PR TITLE
Fix trainer battle UI lock

### DIFF
--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -4,16 +4,16 @@ import { computed } from 'vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
+import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
 
 const zone = useZoneStore()
 const dex = useShlagedexStore()
-const trainerBattle = useTrainerBattleStore()
+const panel = useMainPanelStore()
 const arena = useArenaStore()
 const progress = useZoneProgressStore()
 const mapModal = useMapModalStore()
@@ -21,7 +21,7 @@ const dialog = useDialogStore()
 const mobile = useMobileTabStore()
 
 const zoneButtonsDisabled = computed(
-  () => trainerBattle.isActive || dialog.isDialogVisible || arena.inBattle,
+  () => panel.current === 'trainerBattle' || dialog.isDialogVisible || arena.inBattle,
 )
 
 function buttonDisabled(z: Zone) {

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -8,10 +8,10 @@ import SearchInput from '~/components/ui/SearchInput.vue'
 import SortControls from '~/components/ui/SortControls.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useDiseaseStore } from '~/stores/disease'
+import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useMultiExpStore } from '~/stores/multiExp'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import ShlagemonImage from './ShlagemonImage.vue'
 import ShlagemonType from './ShlagemonType.vue'
 
@@ -31,11 +31,11 @@ const filter = useDexFilterStore()
 const dex = useShlagedexStore()
 const multiExpStore = useMultiExpStore()
 const disease = useDiseaseStore()
-const trainerBattle = useTrainerBattleStore()
+const panel = useMainPanelStore()
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
 
-const isLocked = computed(() => trainerBattle.isActive || disease.active)
+const isLocked = computed(() => panel.current === 'trainerBattle' || disease.active)
 
 const sortOptions = [
   { label: 'Niveau', value: 'level' },


### PR DESCRIPTION
## Summary
- check current panel for trainer battles instead of store flag
- allow shlagemon selection outside trainer battle

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686f95c8c83c832a8d151cf156dbe0f2