### PR TITLE
Refactor battle UI scene

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -356,6 +356,9 @@ declare global {
   export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
   import('vue')
   // @ts-ignore
+  export type { BattleCoreOptions } from './composables/useBattleCore'
+  import('./composables/useBattleCore')
+  // @ts-ignore
   export type { Achievement, AchievementEvent } from './stores/achievements'
   import('./stores/achievements')
   // @ts-ignore
@@ -528,6 +531,7 @@ declare module 'vue' {
     readonly useBallStore: UnwrapRef<typeof import('./stores/ball')['useBallStore']>
     readonly useBase64: UnwrapRef<typeof import('@vueuse/core')['useBase64']>
     readonly useBattery: UnwrapRef<typeof import('@vueuse/core')['useBattery']>
+    readonly useBattleCore: UnwrapRef<typeof import('./composables/useBattleCore')['useBattleCore']>
     readonly useBattleEffects: UnwrapRef<typeof import('./composables/battleEngine')['useBattleEffects']>
     readonly useBattleStatsStore: UnwrapRef<typeof import('./stores/battleStats')['useBattleStatsStore']>
     readonly useBattleStore: UnwrapRef<typeof import('./stores/battle')['useBattleStore']>
@@ -554,6 +558,7 @@ declare module 'vue' {
     readonly useDebounce: UnwrapRef<typeof import('@vueuse/core')['useDebounce']>
     readonly useDebounceFn: UnwrapRef<typeof import('@vueuse/core')['useDebounceFn']>
     readonly useDebouncedRefHistory: UnwrapRef<typeof import('@vueuse/core')['useDebouncedRefHistory']>
+    readonly useDeveloperStore: UnwrapRef<typeof import('./stores/developer')['useDeveloperStore']>
     readonly useDeviceMotion: UnwrapRef<typeof import('@vueuse/core')['useDeviceMotion']>
     readonly useDeviceOrientation: UnwrapRef<typeof import('@vueuse/core')['useDeviceOrientation']>
     readonly useDevicePixelRatio: UnwrapRef<typeof import('@vueuse/core')['useDevicePixelRatio']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -26,6 +26,7 @@ declare module 'vue' {
     BattleCapture: typeof import('./components/battle/BattleCapture.vue')['default']
     BattleHeader: typeof import('./components/battle/BattleHeader.vue')['default']
     BattleMain: typeof import('./components/battle/BattleMain.vue')['default']
+    BattleScene: typeof import('./components/battle/BattleScene.vue')['default']
     BattleShlagemon: typeof import('./components/battle/BattleShlagemon.vue')['default']
     BattleToast: typeof import('./components/battle/BattleToast.vue')['default']
     Bonus: typeof import('./components/icons/bonus.vue')['default']

--- a/src/components/arena/ArenaDuel.vue
+++ b/src/components/arena/ArenaDuel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
 import { onMounted, onUnmounted, ref } from 'vue'
+import BattleScene from '~/components/battle/BattleScene.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import { useBattleEffects } from '~/composables/battleEngine'
@@ -66,33 +67,18 @@ onUnmounted(stop)
 </script>
 
 <template>
-  <div class="flex flex-col items-center gap-2">
-    <div class="w-full flex items-center justify-center gap-4">
+  <BattleScene>
+    <template #player>
       <div class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
         <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
         <BattleShlagemon :mon="player" :hp="playerHp" :fainted="playerFainted" flipped />
       </div>
-      <div class="vs font-bold">
-        VS
-      </div>
+    </template>
+    <template #enemy>
       <div class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
         <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
         <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" />
       </div>
-    </div>
-  </div>
+    </template>
+  </BattleScene>
 </template>
-
-<style scoped>
-.flash {
-  animation: flash 0.1s ease-in;
-}
-@keyframes flash {
-  from {
-    filter: brightness(2);
-  }
-  to {
-    filter: brightness(1);
-  }
-}
-</style>

--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { toast } from 'vue3-toastify'
-import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleCapture from '~/components/battle/BattleCapture.vue'
 import BattleHeader from '~/components/battle/BattleHeader.vue'
+import BattleScene from '~/components/battle/BattleScene.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CaptureLimitModal from '~/components/battle/CaptureLimitModal.vue'
@@ -279,49 +279,60 @@ onUnmounted(() => {
         <span :class="{ 'font-bold': wins >= progress.fightsBeforeKing }">{{ wins.toLocaleString() }}</span>
       </Tooltip>
     </div>
-    <BattleHeader :zone-name="zone.current.name" />
-    <div v-if="dex.activeShlagemon && enemy" class="max-w-160 w-full flex flex-1 self-center gap-2">
-      <BattleShlagemon
-        :mon="dex.activeShlagemon"
-        :hp="playerHp"
-        :fainted="playerFainted"
-        flipped
-        :effects="dex.effects"
-        :disease="disease.active"
-        :disease-remaining="disease.remaining"
-        :class="{ flash: flashPlayer }"
-      >
-        <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-      </BattleShlagemon>
-      <div class="self-center font-bold">
-        VS
-      </div>
-      <BattleShlagemon
-        v-if="enemy"
-        class="mon"
-        :class="{ flash: flashEnemy }"
-        :mon="enemy"
-        :hp="enemyHp"
-        :fainted="enemyFainted"
-        color="bg-red-500"
-        show-ball
-        :owned="enemyCaptured"
-        @click="onClick"
-        @mousemove="onMouseMove"
-        @mouseenter="onMouseEnter"
-        @mouseleave="onMouseLeave"
-      >
-        <AttackCursor v-if="showAttackCursor" :x="cursorX" :y="cursorY" :clicked="cursorClicked" />
-        <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-      </BattleShlagemon>
-      <BattleCapture
-        v-if="enemy"
-        :enemy="enemy"
-        :enemy-hp="enemyHp"
-        :stop-battle="stopBattle"
-        @finish="onCaptureEnd"
-      />
-    </div>
+    <BattleScene
+      v-if="dex.activeShlagemon && enemy"
+      class="max-w-160 w-full flex-1 self-center"
+      :show-attack-cursor="showAttackCursor"
+      :cursor-x="cursorX"
+      :cursor-y="cursorY"
+      :cursor-clicked="cursorClicked"
+      @click="onClick"
+      @mousemove="onMouseMove"
+      @mouseenter="onMouseEnter"
+      @mouseleave="onMouseLeave"
+    >
+      <template #header>
+        <BattleHeader :zone-name="zone.current.name" />
+      </template>
+      <template #player>
+        <BattleShlagemon
+          :mon="dex.activeShlagemon"
+          :hp="playerHp"
+          :fainted="playerFainted"
+          flipped
+          :effects="dex.effects"
+          :disease="disease.active"
+          :disease-remaining="disease.remaining"
+          :class="{ flash: flashPlayer }"
+        >
+          <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
+        </BattleShlagemon>
+      </template>
+      <template #enemy>
+        <BattleShlagemon
+          v-if="enemy"
+          class="mon"
+          :class="{ flash: flashEnemy }"
+          :mon="enemy"
+          :hp="enemyHp"
+          :fainted="enemyFainted"
+          color="bg-red-500"
+          show-ball
+          :owned="enemyCaptured"
+        >
+          <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
+        </BattleShlagemon>
+      </template>
+      <template #capture>
+        <BattleCapture
+          v-if="enemy"
+          :enemy="enemy"
+          :enemy-hp="enemyHp"
+          :stop-battle="stopBattle"
+          @finish="onCaptureEnd"
+        />
+      </template>
+    </BattleScene>
     <ShlagemonXpBar
       v-if="dex.activeShlagemon"
       class="max-w-160 w-full self-center"
@@ -333,20 +344,7 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
-.flash {
-  animation: flash 0.1s ease-in;
-}
-
 .mon {
   @apply relative flex flex-1 h-full flex-col items-center justify-end;
-}
-
-@keyframes flash {
-  from {
-    filter: brightness(2);
-  }
-  to {
-    filter: brightness(1);
-  }
 }
 </style>

--- a/src/components/battle/BattleScene.vue
+++ b/src/components/battle/BattleScene.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import AttackCursor from '~/components/battle/AttackCursor.vue'
+
+interface Props {
+  showAttackCursor?: boolean
+  cursorX?: number
+  cursorY?: number
+  cursorClicked?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showAttackCursor: false,
+  cursorX: 0,
+  cursorY: 0,
+  cursorClicked: false,
+})
+
+const emit = defineEmits<{
+  (e: 'click', event: MouseEvent): void
+  (e: 'mousemove', event: MouseEvent): void
+  (e: 'mouseenter'): void
+  (e: 'mouseleave'): void
+}>()
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-2">
+    <slot name="header" />
+    <div
+      class="relative w-full flex flex-1 items-center justify-center gap-4"
+      @click="e => emit('click', e)"
+      @mousemove="e => emit('mousemove', e)"
+      @mouseenter="emit('mouseenter')"
+      @mouseleave="emit('mouseleave')"
+    >
+      <slot name="player" />
+      <div class="vs font-bold">
+        VS
+      </div>
+      <slot name="enemy" />
+      <AttackCursor
+        v-if="props.showAttackCursor"
+        :x="props.cursorX"
+        :y="props.cursorY"
+        :clicked="props.cursorClicked"
+      />
+      <slot name="capture" />
+    </div>
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+:deep(.flash) {
+  animation: flash 0.1s ease-in;
+}
+@keyframes flash {
+  from {
+    filter: brightness(2);
+  }
+  to {
+    filter: brightness(1);
+  }
+}
+</style>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleHeader from '~/components/battle/BattleHeader.vue'
+import BattleScene from '~/components/battle/BattleScene.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
 import BattleToast from '~/components/battle/BattleToast.vue'
 import CharacterImage from '~/components/character/CharacterImage.vue'
@@ -241,16 +241,22 @@ onUnmounted(() => {
         </Button>
       </div>
     </div>
-    <div
+    <BattleScene
       v-else-if="stage === 'battle'"
       class="w-full text-center"
+      :show-attack-cursor="showAttackCursor"
+      :cursor-x="cursorX"
+      :cursor-y="cursorY"
+      :cursor-clicked="cursorClicked"
       @click="onClickArea"
       @mousemove="onMouseMove"
       @mouseenter="onMouseEnter"
       @mouseleave="onMouseLeave"
     >
-      <BattleHeader :trainer="trainer" />
-      <div class="flex flex-1 items-center justify-center gap-4">
+      <template #header>
+        <BattleHeader :trainer="trainer" />
+      </template>
+      <template #player>
         <div v-if="dex.activeShlagemon" class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
           <BattleShlagemon
@@ -262,16 +268,14 @@ onUnmounted(() => {
             :disease-remaining="disease.remaining"
           />
         </div>
-        <div class="vs font-bold">
-          VS
-        </div>
+      </template>
+      <template #enemy>
         <div v-if="enemy" class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
           <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
           <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" />
         </div>
-        <AttackCursor v-if="showAttackCursor" :x="cursorX" :y="cursorY" :clicked="cursorClicked" />
-      </div>
-    </div>
+      </template>
+    </BattleScene>
     <div v-else class="flex flex-col items-center gap-2 text-center">
       <CharacterImage :id="trainer.character.id" :alt="trainer.character.name" class="h-24" />
       <div v-if="result === 'win'">
@@ -294,17 +298,3 @@ onUnmounted(() => {
     />
   </div>
 </template>
-
-<style scoped>
-.flash {
-  animation: flash 0.1s ease-in;
-}
-@keyframes flash {
-  from {
-    filter: brightness(2);
-  }
-  to {
-    filter: brightness(1);
-  }
-}
-</style>


### PR DESCRIPTION
## Summary
- add reusable `BattleScene` component for common battle UI logic
- use `BattleScene` in `BattleMain`, `TrainerBattle` and `ArenaDuel`
- update generated component type files

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined & failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_686fac8589a8832a8562b72de3731881