### PR TITLE
Fix flash style duplications

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -342,9 +342,3 @@ onUnmounted(() => {
     <CaptureLimitModal />
   </div>
 </template>
-
-<style scoped>
-.mon {
-  @apply relative flex flex-1 h-full flex-col items-center justify-end;
-}
-</style>

--- a/src/components/battle/BattleScene.vue
+++ b/src/components/battle/BattleScene.vue
@@ -49,17 +49,3 @@ const emit = defineEmits<{
     <slot />
   </div>
 </template>
-
-<style scoped>
-:deep(.flash) {
-  animation: flash 0.1s ease-in;
-}
-@keyframes flash {
-  from {
-    filter: brightness(2);
-  }
-  to {
-    filter: brightness(1);
-  }
-}
-</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import App from './App.vue'
 
 import '@unocss/reset/tailwind.css'
 import './styles/main.css'
+import './styles/battle.css'
 import 'uno.css'
 import 'vue3-toastify/dist/index.css'
 

--- a/src/styles/battle.css
+++ b/src/styles/battle.css
@@ -1,0 +1,12 @@
+.flash {
+  animation: flash 0.1s ease-in;
+}
+
+@keyframes flash {
+  from {
+    filter: brightness(2);
+  }
+  to {
+    filter: brightness(1);
+  }
+}


### PR DESCRIPTION
## Summary
- remove duplicate styles from battle components
- move `.flash` animation into global CSS
- import `battle.css` globally

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686fb75c7dfc832aa1fad2591ddc9f5e