### PR TITLE
Fix auto end of battle

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -260,6 +260,14 @@ watch(
   },
 )
 
+watch(
+  battleActive,
+  (active, prev) => {
+    if (!active && prev && (playerFainted.value || enemyFainted.value))
+      finishBattle()
+  },
+)
+
 onUnmounted(() => {
   stopBattle()
   clearTimeout(nextBattleTimer)


### PR DESCRIPTION
## Summary
- stop next battle delay when battle ends
- finish wild battles when enemy or player faints

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined, fonts fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_686fc578ea44832a9553bb539d3efe35