### PR TITLE
Fix trainer battle defeat logic

### DIFF
--- a/src/components/battle/BattleHeader.vue
+++ b/src/components/battle/BattleHeader.vue
@@ -2,9 +2,11 @@
 import type { Trainer } from '~/type'
 import CharacterImage from '~/components/character/CharacterImage.vue'
 import ImageByBackground from '~/components/ui/ImageByBackground.vue'
+import { computed } from 'vue'
 import { useZoneStore } from '~/stores/zone'
 
-const props = defineProps<{ zoneName?: string, trainer?: Trainer }>()
+const props = defineProps<{ zoneName?: string, trainer?: Trainer, defeated?: number }>()
+const defeated = computed(() => props.defeated ?? 0)
 const zone = useZoneStore()
 </script>
 
@@ -26,7 +28,13 @@ const zone = useZoneStore()
         <div class="h-full flex flex-col items-end">
           <div>{{ props.trainer.character.name }}</div>
           <div class="flex gap-2">
-            <ImageByBackground v-for="i in props.trainer.shlagemons.length" :key="i" src="/items/shlageball/shlageball.png" class="h-4 w-4" />
+            <ImageByBackground
+              v-for="i in props.trainer.shlagemons.length"
+              :key="i"
+              src="/items/shlageball/shlageball.png"
+              class="h-4 w-4"
+              :class="{ 'saturate-0': i <= defeated }"
+            />
           </div>
         </div>
         <CharacterImage :id="props.trainer.character.id" :alt="props.trainer.character.name" class="h-full" />

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -18,6 +18,7 @@ import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useWearableItemStore } from '~/stores/wearableItem'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
+import { watch } from 'vue'
 import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
@@ -47,6 +48,7 @@ const {
   enemy,
   playerHp,
   enemyHp,
+  battleActive,
   playerFainted,
   enemyFainted,
   showAttackCursor,
@@ -187,6 +189,14 @@ function onClickArea(_e: MouseEvent) {
   attack()
 }
 
+watch(
+  battleActive,
+  (active, prev) => {
+    if (!active && prev && (playerFainted.value || enemyFainted.value))
+      finishBattle()
+  },
+)
+
 function finish() {
   if (result.value === 'win') {
     if (trainer.value?.id.startsWith('king-')) {
@@ -251,7 +261,7 @@ onUnmounted(() => {
       @mouseleave="onMouseLeave"
     >
       <template #header>
-        <BattleHeader :trainer="trainer" />
+        <BattleHeader :trainer="trainer" :defeated="enemyIndex" />
       </template>
       <template #player>
         <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />


### PR DESCRIPTION
## Summary
- track defeated mons in trainer battles and grey out their balls
- show defeat screen when the battle loop ends

## Testing
- `pnpm lint` *(fails: Cannot find package)*
- `pnpm typecheck` *(fails: vue-tsc not found)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd0b41870832a95aee43912870e17