### PR TITLE
Handle dual type damage

### DIFF
--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -37,13 +37,13 @@ export const useBattleStore = defineStore('battle', () => {
     reduced = false,
   ): AttackResult {
     const atkType = attacker.base.types[0]
-    const defType = defender.base.types[0]
+    const defTypes = defender.base.types
     const atkBonus = isPlayerAttacker ? 1 + dex.bonusPercent / 100 : 1
     const musicBonus = audio.isMusicEnabled ? 1.1 : 1
     const shinyBonus = attacker.isShiny ? 1.15 : 1
     const defBonus = isPlayerDefender ? 1 + dex.bonusPercent / 100 : 1
     const baseAttack = Math.round(attacker.attack * atkBonus * musicBonus * shinyBonus)
-    const result = computeDamage(baseAttack, atkType, defType)
+    const result = computeDamage(baseAttack, atkType, defTypes)
     // Application des bonus/malus d'attaque et de défense (potions et bonus global)
     const defenseFactor = 100 / (100 + defender.defense)
     const rawDamage = result.damage * defenseFactor / defBonus

--- a/src/utils/combat.ts
+++ b/src/utils/combat.ts
@@ -26,9 +26,14 @@ export function getTypeMultiplier(
 export function computeDamage(
   base: number,
   attackType: ShlagemonType,
-  targetType: ShlagemonType,
+  targetTypes: ShlagemonType | ShlagemonType[],
 ): { damage: number, effect: 'super' | 'not' | 'normal', crit: 'critical' | 'weak' | 'normal' } {
-  const { multiplier: typeMultiplier, effect } = getTypeMultiplier(attackType, targetType)
+  const types = Array.isArray(targetTypes) ? targetTypes : [targetTypes]
+  const typeMultiplier = types
+    .map(t => getTypeMultiplier(attackType, t).multiplier)
+    .reduce((acc, cur) => acc * cur, 1)
+  const effect: 'super' | 'not' | 'normal'
+    = typeMultiplier > 1 ? 'super' : typeMultiplier < 1 ? 'not' : 'normal'
   const variance = 0.8 + Math.random() * 0.4 // entre x0.8 et x1.2
   let multiplier = typeMultiplier * variance
   let crit: 'critical' | 'weak' | 'normal' = 'normal'

--- a/test/computeDamage.test.ts
+++ b/test/computeDamage.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+import { shlagemonTypes } from '../src/data/shlagemons-type'
+import { computeDamage } from '../src/utils/combat'
+
+describe('computeDamage dual type', () => {
+  it('applies multipliers from both target types', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const result = computeDamage(100, shlagemonTypes.poison, [shlagemonTypes.fee, shlagemonTypes.normal])
+    expect(result.damage).toBe(120)
+    expect(result.effect).toBe('super')
+    expect(result.crit).toBe('normal')
+  })
+
+  it('handles resistance and weakness', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const result = computeDamage(100, shlagemonTypes.combat, [shlagemonTypes.normal, shlagemonTypes.vol])
+    expect(result.damage).toBe(96)
+    expect(result.effect).toBe('not')
+    expect(result.crit).toBe('normal')
+  })
+})


### PR DESCRIPTION
## Summary
- update `computeDamage` to apply multipliers of all defender types
- adjust battle store to pass all defender types
- test dual type damage scenarios

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68704b091f7c832a97d0f7af6c62e5ec