### PR TITLE
Fix battle toast visibility

### DIFF
--- a/src/components/arena/ArenaDuel.vue
+++ b/src/components/arena/ArenaDuel.vue
@@ -69,16 +69,26 @@ onUnmounted(stop)
 <template>
   <BattleScene>
     <template #player>
-      <div class="mon relative flex flex-1 flex-col items-center justify-end" :class="{ flash: flashPlayer }">
+      <BattleShlagemon
+        :mon="player"
+        :hp="playerHp"
+        :fainted="playerFainted"
+        flipped
+        :class="{ flash: flashPlayer }"
+      >
         <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-        <BattleShlagemon :mon="player" :hp="playerHp" :fainted="playerFainted" flipped />
-      </div>
+      </BattleShlagemon>
     </template>
     <template #enemy>
-      <div class="mon relative flex flex-1 flex-col items-center" :class="{ flash: flashEnemy }">
+      <BattleShlagemon
+        :mon="enemy"
+        :hp="enemyHp"
+        :fainted="enemyFainted"
+        color="bg-red-500"
+        :class="{ flash: flashEnemy }"
+      >
         <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-        <BattleShlagemon :mon="enemy" :hp="enemyHp" :fainted="enemyFainted" color="bg-red-500" />
-      </div>
+      </BattleShlagemon>
     </template>
   </BattleScene>
 </template>

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -52,6 +52,7 @@ function onAnimationEnd() {
     class="relative h-full flex flex-1 flex-col items-center"
     :class="{ 'saturate-10 contrast-200': props.disease }"
   >
+    <slot />
     <div class="absolute left-0 top-2 z-150 flex flex-col gap-1">
       <EffectBadge
         v-for="e in props.effects"


### PR DESCRIPTION
## Summary
- show battle toast via slot in `BattleShlagemon`
- use the new slot in `ArenaDuel`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot mismatch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68704b40ecf8832a8da24db3540b2ffd