### PR TITLE
Fix defeated property usage in TrainerBattle

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -169,7 +169,7 @@ function cancelFight() {
                 :key="i"
                 src="/items/shlageball/shlageball.png"
                 class="h-4 w-4"
-                :class="{ 'saturate-0': i <= defeated }"
+                :class="{ 'saturate-0': i <= enemyIndex }"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- correct usage of `enemyIndex` when displaying pokeballs during trainer battles

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined; many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68704ce9b0e4832a990b31f34d0a27ef