### PR TITLE
Add modal with Shlagemon type chart

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -315,6 +315,7 @@ declare global {
   const useToggle: typeof import('@vueuse/core')['useToggle']
   const useTrainerBattleStore: typeof import('./stores/trainerBattle')['useTrainerBattleStore']
   const useTransition: typeof import('@vueuse/core')['useTransition']
+  const useTypeChartModalStore: typeof import('./stores/typeChartModal')['useTypeChartModalStore']
   const useUrlSearchParams: typeof import('@vueuse/core')['useUrlSearchParams']
   const useUserMedia: typeof import('@vueuse/core')['useUserMedia']
   const useUserStore: typeof import('./stores/user')['useUserStore']
@@ -703,6 +704,7 @@ declare module 'vue' {
     readonly useToggle: UnwrapRef<typeof import('@vueuse/core')['useToggle']>
     readonly useTrainerBattleStore: UnwrapRef<typeof import('./stores/trainerBattle')['useTrainerBattleStore']>
     readonly useTransition: UnwrapRef<typeof import('@vueuse/core')['useTransition']>
+    readonly useTypeChartModalStore: UnwrapRef<typeof import('./stores/typeChartModal')['useTypeChartModalStore']>
     readonly useUrlSearchParams: UnwrapRef<typeof import('@vueuse/core')['useUrlSearchParams']>
     readonly useUserMedia: UnwrapRef<typeof import('@vueuse/core')['useUserMedia']>
     readonly useVModel: UnwrapRef<typeof import('@vueuse/core')['useVModel']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -100,6 +100,8 @@ declare module 'vue' {
     ThemeToggle: typeof import('./components/ThemeToggle.vue')['default']
     Tooltip: typeof import('./components/ui/Tooltip.vue')['default']
     TrainerBattle: typeof import('./components/battle/TrainerBattle.vue')['default']
+    TypeChart: typeof import('./components/shlagemon/TypeChart.vue')['default']
+    TypeChartModal: typeof import('./components/shlagemon/TypeChartModal.vue')['default']
     VillagePanel: typeof import('./components/village/VillagePanel.vue')['default']
     Vomit: typeof import('./components/icons/badge/vomit.vue')['default']
     WearableItemModal: typeof import('./components/inventory/WearableItemModal.vue')['default']

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -4,6 +4,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { onUnmounted, ref } from 'vue'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
+import { useTypeChartModalStore } from '~/stores/typeChartModal'
 import DiseaseBadge from './DiseaseBadge.vue'
 import EffectBadge from './EffectBadge.vue'
 
@@ -34,6 +35,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<{ (e: 'faintEnd'): void }>()
+const typeChart = useTypeChartModalStore()
 
 const now = ref(Date.now())
 const timer = window.setInterval(() => {
@@ -44,6 +46,12 @@ onUnmounted(() => window.clearInterval(timer))
 function onAnimationEnd() {
   if (props.fainted)
     emit('faintEnd')
+}
+
+function showTypeChart() {
+  const type = props.mon.base.types[0]
+  if (type)
+    typeChart.open(type.id)
 }
 </script>
 
@@ -58,6 +66,7 @@ function onAnimationEnd() {
         :key="e.id"
         :effect="e"
         :now="now"
+        @click="showTypeChart"
       />
       <DiseaseBadge v-if="props.disease" :remaining="props.diseaseRemaining" />
     </div>

--- a/src/components/battle/EffectBadge.vue
+++ b/src/components/battle/EffectBadge.vue
@@ -5,6 +5,7 @@ import Tooltip from '~/components/ui/Tooltip.vue'
 import { formatDuration } from '~/utils/formatDuration'
 
 const props = defineProps<{ effect: ActiveEffect, now: number }>()
+const emit = defineEmits<{ (e: 'click'): void }>()
 
 const remaining = computed(() => formatDuration(props.effect.expiresAt - props.now))
 
@@ -28,9 +29,13 @@ const colorClasses = computed(() => {
 
 <template>
   <Tooltip :text="tooltipText">
-    <div class="flex items-center gap-1 rounded px-1 text-xs font-mono" :class="colorClasses">
+    <div
+      class="flex items-center gap-1 rounded px-1 text-xs font-mono"
+      :class="colorClasses"
+      @click="emit('click')"
+    >
       <div class="h-4 w-4" :class="[`${props.effect.icon}`, props.effect.iconClass]" />
-      <span class="">{{ remaining }}</span>
+      <span>{{ remaining }}</span>
     </div>
   </Tooltip>
 </template>

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -11,6 +11,7 @@ import MainPanelView from '~/components/panels/MainPanel.vue'
 import ZonePanel from '~/components/panels/ZonePanel.vue'
 import EvolutionModal from '~/components/shlagemon/EvolutionModal.vue'
 import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
+import TypeChartModal from '~/components/shlagemon/TypeChartModal.vue'
 import PanelWrapper from '~/components/ui/PanelWrapper.vue'
 import ZoneMapModal from '~/components/zones/ZoneMapModal.vue'
 import { getZoneBattleTrack, trainerTracks, zoneTracks } from '~/data/music'
@@ -143,6 +144,7 @@ watch<[MainPanel, ZoneId, string | undefined], true>(
       <EvolutionModal />
       <ZoneMapModal />
       <InventoryModal />
+      <TypeChartModal />
     </div>
   </div>
 </template>

--- a/src/components/shlagemon/TypeChart.vue
+++ b/src/components/shlagemon/TypeChart.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { shlagemonTypes } from '~/data/shlagemons-type'
+import ShlagemonType from './ShlagemonType.vue'
+
+const props = defineProps<{ highlight?: string | null }>()
+
+const types = Object.values(shlagemonTypes)
+
+function getMultiplier(att: typeof types[number], def: typeof types[number]) {
+  if (def.weakness.some(w => w.id === att.id))
+    return 1.2
+  if (def.resistance.some(r => r.id === att.id))
+    return 0.8
+  return 1
+}
+</script>
+
+<template>
+  <div class="overflow-auto">
+    <table class="w-full border-collapse text-center text-xs">
+      <thead>
+        <tr>
+          <th class="p-1" />
+          <th v-for="t in types" :key="t.id" class="p-1">
+            <ShlagemonType :value="t" />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="atk in types" :key="atk.id">
+          <th class="p-1 text-right">
+            <ShlagemonType :value="atk" />
+          </th>
+          <td
+            v-for="def in types"
+            :key="def.id"
+            class="border border-gray-200 p-1 dark:border-gray-700"
+            :class="{
+              'bg-blue-200 dark:bg-blue-800': props.highlight === atk.id || props.highlight === def.id,
+              'font-bold': props.highlight === atk.id && props.highlight === def.id,
+            }"
+          >
+            {{ getMultiplier(atk, def) }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/src/components/shlagemon/TypeChartModal.vue
+++ b/src/components/shlagemon/TypeChartModal.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import Modal from '~/components/modal/Modal.vue'
+import PanelWrapper from '~/components/ui/PanelWrapper.vue'
+import { useTypeChartModalStore } from '~/stores/typeChartModal'
+import TypeChart from './TypeChart.vue'
+
+const modal = useTypeChartModalStore()
+</script>
+
+<template>
+  <Modal v-model="modal.isVisible" footer-close>
+    <PanelWrapper title="Table des types">
+      <template #icon>
+        <div class="i-carbon-data-table" />
+      </template>
+      <TypeChart :highlight="modal.highlight" />
+    </PanelWrapper>
+  </Modal>
+</template>

--- a/src/stores/typeChartModal.ts
+++ b/src/stores/typeChartModal.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { createModalStore } from './helpers'
+
+export const useTypeChartModalStore = defineStore('typeChartModal', () => {
+  const { isVisible, open: openModal, close } = createModalStore('game')
+  const highlight = ref<string | null>(null)
+
+  function open(typeId: string) {
+    highlight.value = typeId
+    openModal()
+  }
+
+  return { isVisible, highlight, open, close }
+})


### PR DESCRIPTION
## Summary
- open modal on `EffectBadge` click to show a type chart
- highlight active mon type in the chart
- create `TypeChart` and `TypeChartModal` components
- support store for chart modal
- register modal in layout

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68704d435860832aba88a8c4ecd9e205