### PR TITLE
Add outline button variant

### DIFF
--- a/src/components/panels/ShopPanel.vue
+++ b/src/components/panels/ShopPanel.vue
@@ -39,7 +39,7 @@ function closeShop() {
     <div v-else class="tiny-scrollbar flex-1 overflow-auto">
       <ShopItemDetail :item="selectedItem" @close="selectedItem = null" />
     </div>
-    <Button type="danger" class="mt-2 flex self-center gap-2 text-xs" @click="closeShop">
+    <Button type="outline" class="mt-2 flex self-center gap-2 text-xs" @click="closeShop">
       <div class="i-carbon:exit" />
       Quitter la boutique
     </Button>

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -18,6 +18,8 @@ const variantClass = computed(() => {
       return 'flex-1 p-2 rounded bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
     case 'primary':
       return 'rounded px-2 py-1 text-white bg-blue-600 dark:bg-blue-700 hover:bg-blue-700 dark:hover:bg-blue-800'
+    case 'outline':
+      return 'rounded px-2 py-1 border border-cyan-600 text-cyan-600 hover:bg-cyan-50 dark:border-cyan-700 dark:text-cyan-400 dark:hover:bg-cyan-800/20'
     default:
       return 'rounded px-2 py-1 text-white bg-cyan-600 dark:bg-cyan-700 hover:bg-cyan-700 dark:hover:bg-cyan-800/80'
   }

--- a/src/type/button.ts
+++ b/src/type/button.ts
@@ -5,3 +5,4 @@ export type ButtonType =
   | 'icon'
   | 'menu'
   | 'default'
+  | 'outline'


### PR DESCRIPTION
## Summary
- extend `ButtonType` with `outline`
- support `outline` style in `Button.vue`
- use the outline style on the Quitter la boutique button

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve imports / network fetch issues)*

------
https://chatgpt.com/codex/tasks/task_e_6870af7824f8832a8d9205c145129be7