### PR TITLE
Implement capture storage and update tests

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -78,7 +78,6 @@ function handleEnd() {
 
 async function onCaptureEnd(success: boolean) {
   if (success && props.enemy) {
-    dex.captureEnemy(props.enemy)
     notifyAchievement({ type: 'capture', shiny: props.enemy.isShiny })
     if (dex.activeShlagemon) {
       const xp = xpRewardForLevel(props.enemy.lvl)

--- a/src/components/battle/CaptureHandler.vue
+++ b/src/components/battle/CaptureHandler.vue
@@ -7,6 +7,7 @@ import { useBallStore } from '~/stores/ball'
 import { useCaptureLimitModalStore } from '~/stores/captureLimitModal'
 import { useInventoryStore } from '~/stores/inventory'
 import { usePlayerStore } from '~/stores/player'
+import { useShlagedexStore } from '~/stores/shlagedex'
 import { ballHues } from '~/utils/ball'
 import { tryCapture } from '~/utils/capture'
 
@@ -18,6 +19,9 @@ const ballStore = useBallStore()
 const player = usePlayerStore()
 const captureLimitModal = useCaptureLimitModalStore()
 const audio = useAudioStore()
+const dex = useShlagedexStore()
+
+const capturedEnemy = ref<DexShlagemon | null>(null)
 
 const showCapture = ref(false)
 const captureBall = ref(balls[0])
@@ -58,6 +62,7 @@ function openCapture() {
     captureLimitModal.open(props.enemy.lvl)
     return
   }
+  capturedEnemy.value = props.enemy
   inventory.remove(id)
   captureBall.value = balls.find(b => b.id === id) || balls[0]
   props.stopBattle()
@@ -69,6 +74,9 @@ function openCapture() {
 
 function finish(success: boolean) {
   showCapture.value = false
+  if (success && capturedEnemy.value)
+    dex.captureEnemy(capturedEnemy.value)
+  capturedEnemy.value = null
   emit('finish', success)
 }
 </script>

--- a/test/capturehandler.test.ts
+++ b/test/capturehandler.test.ts
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import CaptureHandler from '../src/components/battle/CaptureHandler.vue'
+import { carapouffe } from '../src/data/shlagemons/evolutions/carapouffe'
+import { useBallStore } from '../src/stores/ball'
+import { useInventoryStore } from '../src/stores/inventory'
+import { usePlayerStore } from '../src/stores/player'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import * as captureUtils from '../src/utils/capture'
+import { createDexShlagemon } from '../src/utils/dexFactory'
+
+describe('captureHandler', () => {
+  it('updates store on successful capture', async () => {
+    vi.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const ball = useBallStore()
+    const inventory = useInventoryStore()
+    const player = usePlayerStore()
+
+    ball.current = 'shlageball'
+    inventory.add('shlageball')
+    player.captureLevelCap = 100
+
+    const enemy = createDexShlagemon(carapouffe)
+    const captureSpy = vi.spyOn(dex, 'captureEnemy')
+    vi.spyOn(captureUtils, 'tryCapture').mockReturnValue(true)
+
+    const wrapper = mount(CaptureHandler, {
+      props: { enemy, enemyHp: enemy.hp, stopBattle: vi.fn() },
+      global: { plugins: [pinia], stubs: ['Tooltip', 'ImageByBackground', 'ShlagemonImage'] },
+    })
+
+    await wrapper.get('button').trigger('click')
+    vi.runOnlyPendingTimers()
+    vi.runOnlyPendingTimers()
+    expect(captureSpy).toHaveBeenCalledWith(enemy)
+    expect(dex.shlagemons.some(m => m.base.id === enemy.base.id)).toBe(true)
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- hold a reference to the enemy when starting capture
- call `dex.captureEnemy` from the capture component after success
- adjust battle round logic for new component behaviour
- add a unit test for the capture handler

## Testing
- `pnpm lint`
- `pnpm vitest run test/capturehandler.test.ts` *(fails: fetch fonts, cannot run timers)*

------
https://chatgpt.com/codex/tasks/task_e_6870b8015f10832aa379eb7ab260b410