### PR TITLE
Add enemy transition & delay new battle

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -168,16 +168,19 @@ onMounted(() => {
       </BattleShlagemon>
     </template>
     <template #enemy>
-      <BattleShlagemon
-        :mon="props.enemy"
-        :hp="enemyHp"
-        color="bg-red-500"
-        :fainted="enemyFainted"
-        :class="{ flash: flashEnemy }"
-        @faint-end="onEnemyFaintEnd"
-      >
-        <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-      </BattleShlagemon>
+      <Transition name="fade" mode="out-in">
+        <BattleShlagemon
+          :key="props.enemy?.id"
+          :mon="props.enemy"
+          :hp="enemyHp"
+          color="bg-red-500"
+          :fainted="enemyFainted"
+          :class="{ flash: flashEnemy }"
+          @faint-end="onEnemyFaintEnd"
+        >
+          <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
+        </BattleShlagemon>
+      </Transition>
     </template>
     <slot />
   </BattleScene>
@@ -189,3 +192,14 @@ onMounted(() => {
     @finished="onCaptureEnd"
   />
 </template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -89,13 +89,15 @@ async function onEnd(type: 'capture' | 'win' | 'lose' | 'draw') {
       if (holder)
         await dex.gainXp(holder, Math.round(xp * 0.5), undefined, trainerStore.levelUpHealPercent)
     }
-    const finished = nextBattle()
-    if (finished) {
-      if (trainer.value)
-        progress.defeatKing(zone.current.id)
-      result.value = 'win'
-      stage.value = 'after'
-    }
+    window.setTimeout(() => {
+      const finished = nextBattle()
+      if (finished) {
+        if (trainer.value)
+          progress.defeatKing(zone.current.id)
+        result.value = 'win'
+        stage.value = 'after'
+      }
+    }, 500)
   }
   else if (type === 'lose') {
     battleStats.addLoss()


### PR DESCRIPTION
## Summary
- delay enemy replacement in `TrainerBattle.vue`
- add fade transition when enemy changes in `BattleRound.vue`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetching web fonts, snapshot mismatches and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870c656e340832ab46d16acdc3c69de