### PR TITLE
delay enemy swap until faint ends

### DIFF
--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -102,7 +102,7 @@ function showTypeChart() {
 
 <style scoped>
 .faint {
-  animation: faint 0.5s forwards;
+  animation: faint 0.6s ease forwards;
 }
 
 @keyframes faint {


### PR DESCRIPTION
## Summary
- ensure Shlagemon faint animation plays fully before swapping entities
- use new refs to queue upcoming enemy or player
- ease faint animation slightly

## Testing
- `pnpm test` *(fails: failed network requests and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870c851487c832aa4847a3fa32adb1c