### PR TITLE
Make capturing slightly easier

### DIFF
--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -5,7 +5,9 @@ export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
   const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
   const coefMod = 1 / Math.sqrt(enemy.base.coefficient)
   const levelMod = 1 / (1 + enemy.lvl / 20)
-  const chance = hpChance * coefMod * levelMod * ball.catchBonus
+  // Slightly increase the global capture rate to make encounters less frustrating
+  const difficultyMod = 1.5
+  const chance = Math.min(100, hpChance * coefMod * levelMod * ball.catchBonus * difficultyMod)
   const dev = useDeveloperStore()
   if (dev.debug) {
     console.warn(


### PR DESCRIPTION
## Summary
- bump capture rate by adding `difficultyMod` multiplier

## Testing
- `npm test --silent` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6870ce40744c832a8a5d141108b56c26