### PR TITLE
Fix trainer battle chaining

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -89,15 +89,13 @@ async function onEnd(type: 'capture' | 'win' | 'lose' | 'draw') {
       if (holder)
         await dex.gainXp(holder, Math.round(xp * 0.5), undefined, trainerStore.levelUpHealPercent)
     }
-    window.setTimeout(() => {
-      const finished = nextBattle()
-      if (finished) {
-        if (trainer.value)
-          progress.defeatKing(zone.current.id)
-        result.value = 'win'
-        stage.value = 'after'
-      }
-    }, 500)
+    const finished = nextBattle()
+    if (finished) {
+      if (trainer.value)
+        progress.defeatKing(zone.current.id)
+      result.value = 'win'
+      stage.value = 'after'
+    }
   }
   else if (type === 'lose') {
     battleStats.addLoss()


### PR DESCRIPTION
## Summary
- fix next trainer fight start when the previous enemy faints

## Testing
- `npm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6870cfb79ed0832aacef2636e20c70ac