### PR TITLE
Fix fainted flags when starting battle

### DIFF
--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -54,6 +54,8 @@ export function useBattleCore(options: BattleCoreOptions) {
       active.hpCurrent = active.hp
     playerHp.value = active.hpCurrent
     enemyHp.value = enemy.value.hpCurrent
+    playerFainted.value = false
+    enemyFainted.value = false
     battleActive.value = true
     startInterval()
   }


### PR DESCRIPTION
## Summary
- reset `playerFainted` and `enemyFainted` whenever a battle starts

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6870d77130b8832a88e4cc609ce5692b