### PR TITLE
Add XP bar and effects visibility props

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -32,7 +32,6 @@ declare module 'vue' {
     Bonus: typeof import('./components/icons/bonus.vue')['default']
     BonusDetails: typeof import('./components/panels/BonusDetails.vue')['default']
     Button: typeof import('./components/ui/Button.vue')['default']
-    CaptureHandler: typeof import('./components/battle/CaptureHandler.vue')['default']
     CaptureLimitModal: typeof import('./components/battle/CaptureLimitModal.vue')['default']
     CaptureMenu: typeof import('./components/battle/CaptureMenu.vue')['default']
     CharacterImage: typeof import('./components/character/CharacterImage.vue')['default']

--- a/src/components/arena/ArenaDuel.vue
+++ b/src/components/arena/ArenaDuel.vue
@@ -1,94 +1,23 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { onMounted, onUnmounted, ref } from 'vue'
-import BattleScene from '~/components/battle/BattleScene.vue'
-import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
-import BattleToast from '~/components/battle/BattleToast.vue'
-import { useBattleEffects } from '~/composables/battleEngine'
-import { useBattleStore } from '~/stores/battle'
+import BattleRound from '~/components/battle/BattleRound.vue'
 
 const props = defineProps<{ player: DexShlagemon, enemy: DexShlagemon }>()
 const emit = defineEmits<{ (e: 'end', win: boolean): void }>()
 
-const battle = useBattleStore()
-const playerHp = ref(0)
-const enemyHp = ref(0)
-const battleActive = ref(false)
-const flashPlayer = ref(false)
-const flashEnemy = ref(false)
-const playerFainted = ref(false)
-const enemyFainted = ref(false)
-const { playerEffect, enemyEffect, playerVariant, enemyVariant, showEffect } = useBattleEffects()
-
-let loop: number | undefined
-
-function start() {
-  playerHp.value = props.player.hpCurrent
-  enemyHp.value = props.enemy.hpCurrent
-  battleActive.value = true
-  loop = window.setInterval(tick, 1000)
+function onEnd(result: 'win' | 'lose' | 'draw') {
+  emit('end', result === 'win')
 }
-
-function stop() {
-  if (loop !== undefined) {
-    clearInterval(loop)
-    loop = undefined
-  }
-}
-
-function finish() {
-  battleActive.value = false
-  stop()
-  playerFainted.value = playerHp.value <= 0
-  enemyFainted.value = enemyHp.value <= 0
-  emit('end', enemyHp.value <= 0 && playerHp.value > 0)
-}
-
-function tick() {
-  if (!battleActive.value)
-    return
-  const { player: resPlayer, enemy: resEnemy } = battle.duel(props.player, props.enemy)
-  showEffect('enemy', resPlayer.effect, resPlayer.crit)
-  enemyHp.value = props.enemy.hpCurrent
-  flashEnemy.value = true
-  setTimeout(() => (flashEnemy.value = false), 100)
-  if (resEnemy) {
-    showEffect('player', resEnemy.effect, resEnemy.crit)
-    playerHp.value = props.player.hpCurrent
-    flashPlayer.value = true
-    setTimeout(() => (flashPlayer.value = false), 100)
-  }
-  if (enemyHp.value <= 0 || playerHp.value <= 0)
-    finish()
-}
-
-onMounted(start)
-onUnmounted(stop)
 </script>
 
 <template>
-  <BattleScene>
-    <template #player>
-      <BattleShlagemon
-        :mon="player"
-        :hp="playerHp"
-        :fainted="playerFainted"
-        flipped
-        :class="{ flash: flashPlayer }"
-      >
-        <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-      </BattleShlagemon>
-    </template>
-    <template #enemy>
-      <BattleShlagemon
-        :mon="enemy"
-        :hp="enemyHp"
-        :fainted="enemyFainted"
-        color="bg-red-500"
-        :class="{ flash: flashEnemy }"
-      >
-        <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
-      </BattleShlagemon>
-    </template>
-  </BattleScene>
+  <BattleRound
+    :player="props.player"
+    :enemy="props.enemy"
+    :click-attack="false"
+    :capture-enabled="false"
+    :show-xp-bar="false"
+    :show-effects="false"
+    @end="onEnd"
+  />
 </template>

--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -18,9 +18,13 @@ const props = withDefaults(defineProps<{
   enemy: DexShlagemon
   clickAttack?: boolean
   captureEnabled?: boolean
+  showXpBar?: boolean
+  showEffects?: boolean
 }>(), {
   clickAttack: true,
   captureEnabled: true,
+  showXpBar: true,
+  showEffects: true,
 })
 
 const emit = defineEmits<{
@@ -192,6 +196,7 @@ onMounted(() => {
     :cursor-x="cursorX"
     :cursor-y="cursorY"
     :cursor-clicked="cursorClicked"
+    :show-xp-bar="props.showXpBar"
     @click="onClick"
     @mousemove="onMouseMove"
     @mouseenter="onMouseEnter"
@@ -203,7 +208,7 @@ onMounted(() => {
         :hp="playerHp"
         :fainted="playerFainted"
         flipped
-        :effects="dex.effects"
+        :effects="props.showEffects ? dex.effects : []"
         :disease="disease.active"
         :disease-remaining="disease.remaining"
         :class="{ flash: flashPlayer }"

--- a/src/components/battle/BattleScene.vue
+++ b/src/components/battle/BattleScene.vue
@@ -6,6 +6,7 @@ const props = withDefaults(defineProps<Props>(), {
   cursorX: 0,
   cursorY: 0,
   cursorClicked: false,
+  showXpBar: true,
 })
 
 const emit = defineEmits<{
@@ -22,6 +23,7 @@ interface Props {
   cursorX?: number
   cursorY?: number
   cursorClicked?: boolean
+  showXpBar?: boolean
 }
 </script>
 
@@ -51,7 +53,7 @@ interface Props {
     </div>
     <slot />
     <ShlagemonXpBar
-      v-if="dex.activeShlagemon"
+      v-if="props.showXpBar && dex.activeShlagemon"
       class="max-w-160 w-full self-center"
       :mon="dex.activeShlagemon"
     />


### PR DESCRIPTION
## Summary
- control Xp bar visibility in BattleScene and BattleRound
- allow hiding effects in BattleRound
- replace ArenaDuel logic with BattleRound wrapper
- regenerate component types

## Testing
- `pnpm build`
- `pnpm test` *(fails: "Snapshots 1 failed" etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6870da4da80c832a800bab9cbf649c19