### PR TITLE
Fix arena team cloning logic

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -57,8 +57,10 @@ function startBattle() {
   const team = arena.selections
     .map(id => dex.shlagemons.find(m => m.id === (id || ''))!)
     .map((mon) => {
-      mon.hpCurrent = mon.hp
-      return mon
+      const clone = structuredClone(mon)
+      applyStats(clone)
+      clone.hpCurrent = clone.hp
+      return clone
     })
   const enemies = enemyTeam.value.map((b) => {
     const m = createDexShlagemon(b)


### PR DESCRIPTION
## Summary
- ensure selected team members are cloned before starting an arena battle
- recompute stats for each clone and reset HP to full

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to fetch web fonts; Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6870ddd9ec9c832a9f93cd1806293193