### PR TITLE
Fix trainer battle healing

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -81,8 +81,6 @@ function nextBattle() {
 async function onEnd(type: 'capture' | 'win' | 'lose' | 'draw') {
   const defeated = enemy.value
   enemy.value = null
-  if (dex.activeShlagemon)
-    dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
   if (!defeated) {
     enemy.value = createEnemy()
     return

--- a/test/trainer-battle-heal.test.ts
+++ b/test/trainer-battle-heal.test.ts
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import TrainerBattle from '../src/components/battle/TrainerBattle.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useTrainerBattleStore } from '../src/stores/trainerBattle'
+import { useZoneStore } from '../src/stores/zone'
+import { useZoneProgressStore } from '../src/stores/zoneProgress'
+
+// Ensure player shlagemon is not healed between trainer battles
+
+describe('trainer battle healing', () => {
+  it('keeps player hp between fights', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    const dex = useShlagedexStore()
+    const trainerStore = useTrainerBattleStore()
+    const zone = useZoneStore()
+    useZoneProgressStore() // initialize store used by component
+
+    zone.setZone('plaine-kekette')
+    const player = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(player)
+
+    trainerStore.setQueue([
+      {
+        id: 'test',
+        character: { id: 'test', name: 'Test', gender: 'male' },
+        dialogBefore: '',
+        dialogAfter: '',
+        reward: 1,
+        shlagemons: [
+          { baseId: carapouffe.id, level: 1 },
+          { baseId: carapouffe.id, level: 1 },
+        ],
+      },
+    ])
+
+    const wrapper = mount(TrainerBattle, {
+      global: {
+        plugins: [pinia],
+        stubs: ['BattleRound', 'BattleHeader', 'CharacterImage', 'Button', 'ImageByBackground'],
+      },
+    })
+
+    wrapper.vm.startFight()
+    player.hpCurrent -= 1
+    const hpBefore = player.hpCurrent
+    await wrapper.vm.onEnd('win')
+    expect(player.hpCurrent).toBe(hpBefore)
+  })
+})


### PR DESCRIPTION
## Summary
- prevent active Shlagémon from being healed between trainer fights
- add unit test for trainer battle healing behavior

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve imports and fetch web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6870e0138e00832a94e40be50650ba3e