### PR TITLE
Fix structuredClone error in ArenaPanel

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type/shlagemon'
-import { computed, onUnmounted, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, toRaw, watch } from 'vue'
 import { toast } from 'vue3-toastify'
 import ArenaDuel from '~/components/arena/ArenaDuel.vue'
 import ArenaEnemyStats from '~/components/arena/ArenaEnemyStats.vue'
@@ -57,7 +57,7 @@ function startBattle() {
   const team = arena.selections
     .map(id => dex.shlagemons.find(m => m.id === (id || ''))!)
     .map((mon) => {
-      const clone = structuredClone(mon)
+      const clone = structuredClone(toRaw(mon))
       applyStats(clone)
       clone.hpCurrent = clone.hp
       return clone


### PR DESCRIPTION
## Summary
- ensure ArenaPanel clones raw shlagemon objects before applying stats

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6870e0d18ef4832a8df049e07b2c1a1d