### PR TITLE
Fix arena mon selection

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { BaseShlagemon } from '~/type/shlagemon'
+import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import { computed, onUnmounted, ref, toRaw, watch } from 'vue'
 import { toast } from 'vue3-toastify'
 import ArenaDuel from '~/components/arena/ArenaDuel.vue'
@@ -44,6 +44,13 @@ function openDex(i: number) {
 function openEnemy(mon: BaseShlagemon) {
   enemyDetail.value = mon
   showEnemy.value = true
+}
+
+function onMonSelected(mon: DexShlagemon) {
+  if (activeSlot.value === null)
+    return
+  arena.selectPlayer(activeSlot.value, mon.id)
+  showDex.value = false
 }
 
 watch(() => dex.activeShlagemon, (mon) => {
@@ -186,7 +193,10 @@ onUnmounted(() => clearTimeout(nextTimer))
           <h3 v-if="activeSlot !== null" class="mb-2 text-center text-lg font-bold">
             Choisir un Shlagémon contre {{ enemyTeam[activeSlot].name }}
           </h3>
-          <ShlagemonQuickSelect :selected="arena.selections.filter(Boolean) as string[]" />
+          <ShlagemonQuickSelect
+            :selected="arena.selections.filter(Boolean) as string[]"
+            @select="onMonSelected"
+          />
         </Modal>
 
         <Modal v-model="showEnemy" footer-close>

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -19,12 +19,14 @@ interface Props {
   mons: DexShlagemon[]
   showCheckbox?: boolean
   disabledIds?: string[]
+  highlightIds?: string[]
   onItemClick?: (mon: DexShlagemon) => void
 }
 
 const props = withDefaults(defineProps<Props>(), {
   showCheckbox: false,
   disabledIds: () => [],
+  highlightIds: () => [],
 })
 
 const filter = useDexFilterStore()
@@ -107,6 +109,10 @@ function isActive(mon: DexShlagemon) {
   return dex.activeShlagemon?.id === mon.id
 }
 
+function isHighlighted(mon: DexShlagemon) {
+  return props.highlightIds.includes(mon.id)
+}
+
 function changeActive(mon: DexShlagemon) {
   if (isLocked.value)
     return
@@ -133,7 +139,14 @@ function changeActive(mon: DexShlagemon) {
         :key="mon.id"
         class="relative flex cursor-pointer items-center justify-between border rounded p-1"
         hover="bg-gray-100 dark:bg-gray-800"
-        :class="isActive(mon) ? 'bg-blue-500/20 dark:bg-blue-500/20 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400' : ''"
+        :class="[
+          isActive(mon)
+            ? 'bg-blue-500/20 dark:bg-blue-500/20 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400'
+            : '',
+          isHighlighted(mon) && !isActive(mon)
+            ? 'bg-gray-200/30 dark:bg-gray-700/30 ring-2 ring-gray-400 dark:ring-gray-600'
+            : '',
+        ]"
         @click.stop="handleClick(mon)"
       >
         <MultiExpIcon

--- a/src/components/shlagemon/ShlagemonQuickSelect.vue
+++ b/src/components/shlagemon/ShlagemonQuickSelect.vue
@@ -21,7 +21,7 @@ function choose(mon: DexShlagemon) {
   <ShlagemonList
     :mons="dex.shlagemons"
     :show-checkbox="false"
-    :disabled-ids="props.selected"
+    :highlight-ids="props.selected"
     :on-item-click="choose"
   />
 </template>


### PR DESCRIPTION
## Summary
- allow re-selecting active mon while picking for arena
- highlight already selected mons in quick select list
- enable moving mons between slots in arena

## Testing
- `pnpm lint` *(fails: Cannot find package '@antfu/eslint-config')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e58a4540832aa1ce785671fc9530