### PR TITLE
Centralize battle rank constant

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -6,6 +6,7 @@ import BattleRound from '~/components/battle/BattleRound.vue'
 import CaptureLimitModal from '~/components/battle/CaptureLimitModal.vue'
 import FightKingButton from '~/components/battle/FightKingButton.vue'
 import ZoneMonsModal from '~/components/zones/ZoneMonsModal.vue'
+import { EQUILIBRE_RANK } from '~/constants/battle'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useAudioStore } from '~/stores/audio'
@@ -31,7 +32,6 @@ const battleStats = useBattleStatsStore()
 const zoneMonsModal = useZoneMonsModalStore()
 
 const enemy = ref(null as DexShlagemon | null)
-const equilibrerank = 2
 
 function createEnemy(): DexShlagemon | null {
   const active = dex.activeShlagemon
@@ -47,7 +47,7 @@ function createEnemy(): DexShlagemon | null {
   }
   const base = pickRandomByCoefficient(pool)
   progress.registerEncounter(zone.current.id, base.id)
-  const rank = zone.getZoneRank(zone.current.id) * equilibrerank
+  const rank = zone.getZoneRank(zone.current.id) * EQUILIBRE_RANK
   const created = createDexShlagemon(base, false, rank)
   const min = Number(zone.current.minLevel ?? 1)
   const zoneMax = Number(zone.current.maxLevel ?? (min + 1))

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -4,6 +4,7 @@ import BattleHeader from '~/components/battle/BattleHeader.vue'
 import BattleRound from '~/components/battle/BattleRound.vue'
 import CharacterImage from '~/components/character/CharacterImage.vue'
 import Button from '~/components/ui/Button.vue'
+import { EQUILIBRE_RANK } from '~/constants/battle'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStatsStore } from '~/stores/battleStats'
@@ -31,7 +32,6 @@ const stage = ref<'before' | 'battle' | 'after'>('before')
 const result = ref<'none' | 'win' | 'lose'>('none')
 const enemyIndex = ref(0)
 const enemy = ref(null as DexShlagemon | null)
-const equilibrerank = 2
 
 function createEnemy(): DexShlagemon | null {
   const t = trainer.value
@@ -44,7 +44,7 @@ function createEnemy(): DexShlagemon | null {
   if (!base)
     return null
   const rank = t.id.startsWith('king-') ? zone.getZoneRank(zone.current.id) : 1
-  const mon = createDexShlagemon(base, false, rank * equilibrerank)
+  const mon = createDexShlagemon(base, false, rank * EQUILIBRE_RANK)
   mon.lvl = spec.level
   applyStats(mon)
   return mon

--- a/src/constants/battle.ts
+++ b/src/constants/battle.ts
@@ -1,0 +1,1 @@
+export const EQUILIBRE_RANK = 2

--- a/test/battle-nan.test.ts
+++ b/test/battle-nan.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import BattleMain from '../src/components/battle/BattleMain.vue'
+import { EQUILIBRE_RANK } from '../src/constants/battle'
 import { carapouffe } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useZoneStore } from '../src/stores/zone'
@@ -11,6 +12,7 @@ describe('battle NaN bug', () => {
     vi.useFakeTimers()
     const pinia = createPinia()
     setActivePinia(pinia)
+    expect(EQUILIBRE_RANK).toBe(2)
     const dex = useShlagedexStore()
     const zone = useZoneStore()
     dex.createShlagemon(carapouffe)

--- a/test/battle-switch.test.ts
+++ b/test/battle-switch.test.ts
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import BattleMain from '../src/components/battle/BattleMain.vue'
+import { EQUILIBRE_RANK } from '../src/constants/battle'
 import { carapouffe, salamiches } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 
@@ -11,6 +12,7 @@ describe('battleMain switch', () => {
     vi.useFakeTimers()
     const pinia = createPinia()
     setActivePinia(pinia)
+    expect(EQUILIBRE_RANK).toBe(2)
     const dex = useShlagedexStore()
     const mon1 = dex.createShlagemon(carapouffe)
     const mon2 = dex.createShlagemon(salamiches)

--- a/test/trainer-battle-heal.test.ts
+++ b/test/trainer-battle-heal.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import TrainerBattle from '../src/components/battle/TrainerBattle.vue'
+import { EQUILIBRE_RANK } from '../src/constants/battle'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useTrainerBattleStore } from '../src/stores/trainerBattle'
@@ -14,6 +15,7 @@ describe('trainer battle healing', () => {
   it('keeps player hp between fights', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
+    expect(EQUILIBRE_RANK).toBe(2)
 
     const dex = useShlagedexStore()
     const trainerStore = useTrainerBattleStore()

--- a/test/zone-heal.test.ts
+++ b/test/zone-heal.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import BattleMain from '../src/components/battle/BattleMain.vue'
+import { EQUILIBRE_RANK } from '../src/constants/battle'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useZoneStore } from '../src/stores/zone'
@@ -13,6 +14,7 @@ describe('zone change healing', () => {
     vi.useFakeTimers()
     const pinia = createPinia()
     setActivePinia(pinia)
+    expect(EQUILIBRE_RANK).toBe(2)
     const dex = useShlagedexStore()
     const zone = useZoneStore()
 


### PR DESCRIPTION
## Summary
- define EQUILIBRE_RANK in a shared constant file
- use EQUILIBRE_RANK in BattleMain.vue and TrainerBattle.vue
- import the constant in related tests

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined; snapshots mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_6870e9e61e34832aacca964e1a7cbf71