### PR TITLE
Fix arena player HP & highlight color

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -66,6 +66,7 @@ const {
 })
 
 function startBattle() {
+  dex.setActiveShlagemon(displayedPlayer.value)
   coreStartBattle(displayedEnemy.value)
 }
 

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -144,7 +144,7 @@ function changeActive(mon: DexShlagemon) {
             ? 'bg-blue-500/20 dark:bg-blue-500/20 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400'
             : '',
           isHighlighted(mon) && !isActive(mon)
-            ? 'bg-gray-200/30 dark:bg-gray-700/30 ring-2 ring-gray-400 dark:ring-gray-600'
+            ? 'bg-blue-500/10 dark:bg-blue-500/20 ring-2 ring-blue-500 dark:ring-blue-400'
             : '',
         ]"
         @click.stop="handleClick(mon)"


### PR DESCRIPTION
## Summary
- ensure player's Shlagémon is set active before arena battles
- make highlighted Shlagémon blue in quick select list

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch fonts, vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870f61f4940832a9469d46ed9e3970b