### PR TITLE
Persist main panel state

### DIFF
--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useArenaStore } from './arena'
 import { useBattleStore } from './battle'
 import { useShlagedexStore } from './shlagedex'
@@ -20,10 +20,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
   watch(
     () => zone.current.type,
     (type) => {
-      if (type === 'village')
-        current.value = 'village'
-      else
-        current.value = 'battle'
+      if (current.value === 'battle' || current.value === 'village')
+        current.value = type === 'village' ? 'village' : 'battle'
     },
     { immediate: true },
   )
@@ -71,6 +69,10 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     current.value = 'village'
   }
 
+  function reset() {
+    current.value = zone.current.type === 'village' ? 'village' : 'battle'
+  }
+
   return {
     current,
     showShop,
@@ -79,6 +81,11 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     showMiniGame,
     showArena,
     showVillage,
+    reset,
     isBattle,
   }
+}, {
+  persist: {
+    pick: ['current'],
+  },
 })

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -7,6 +7,7 @@ import { useDialogStore } from './dialog'
 import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
 import { useInventoryStore } from './inventory'
+import { useMainPanelStore } from './mainPanel'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 import { useZoneProgressStore } from './zoneProgress'
@@ -23,6 +24,7 @@ export const useSaveStore = defineStore('save', () => {
   const achievements = useAchievementsStore()
   const ball = useBallStore()
   const dexFilter = useDexFilterStore()
+  const mainPanel = useMainPanelStore()
 
   function reset() {
     dex.reset()
@@ -36,6 +38,7 @@ export const useSaveStore = defineStore('save', () => {
     battleStats.reset()
     ball.reset()
     dexFilter.reset()
+    mainPanel.reset()
   }
 
   return { reset }

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -10,7 +10,9 @@ import { useShlagedexStore } from './shlagedex'
 
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
+  // Persist the current zone id so the user stays in the same zone after reload
   const currentId = ref<string>(zones.value[0].id)
+  const currentZoneId = computed(() => currentId.value)
   const selectedAt = ref<number>(Date.now())
   const arena = useArenaStore()
   const now = useNow({ interval: 100 })
@@ -79,6 +81,7 @@ export const useZoneStore = defineStore('zone', () => {
   return {
     zones,
     current,
+    currentZoneId,
     selectedAt,
     wildCooldownRemaining,
     rewardMultiplier,


### PR DESCRIPTION
## Summary
- persist last active main panel so reload keeps context
- expose reset method for main panel
- include main panel in overall save reset
- clarify zone persistence with `currentZoneId`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed Suites/Tests)*

------
https://chatgpt.com/codex/tasks/task_e_6870f765c2a4832aa54114c81c0a2018