### PR TITLE
feat: add arena battle header

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -12,6 +12,7 @@ declare module 'vue' {
     AchievementsPanel: typeof import('./components/achievements/AchievementsPanel.vue')['default']
     ActiveShlagemon: typeof import('./components/panels/ActiveShlagemon.vue')['default']
     AnotherShlagemonDialog: typeof import('./components/dialog/AnotherShlagemonDialog.vue')['default']
+    ArenaBattleHeader: typeof import('./components/arena/ArenaBattleHeader.vue')['default']
     ArenaDefeatDialog: typeof import('./components/dialog/ArenaDefeatDialog.vue')['default']
     ArenaDuel: typeof import('./components/arena/ArenaDuel.vue')['default']
     ArenaEnemyStats: typeof import('./components/arena/ArenaEnemyStats.vue')['default']

--- a/src/components/arena/ArenaBattleHeader.vue
+++ b/src/components/arena/ArenaBattleHeader.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
+import { useArenaStore } from '~/stores/arena'
+
+const arena = useArenaStore()
+</script>
+
+<template>
+  <div class="w-full flex items-center justify-center gap-2 overflow-hidden font-bold">
+    <div class="flex gap-1 md:gap-2">
+      <div
+        v-for="(mon, i) in arena.enemyTeam"
+        :key="mon.id"
+        class="h-8 w-8 flex-center border rounded md:h-10 md:w-10"
+        :class="[
+          i === arena.currentIndex
+            ? 'bg-blue-500/40 border-blue-500 dark:border-blue-400'
+            : 'bg-gray-200 dark:bg-gray-700 border-gray-300 dark:border-gray-600',
+        ]"
+      >
+        <ShlagemonImage
+          :id="mon.base.id"
+          :alt="mon.base.name"
+          class="h-full w-full object-contain"
+          :class="{ 'saturate-0': i < arena.currentIndex }"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -2,6 +2,7 @@
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import { computed, onUnmounted, ref, toRaw, watch } from 'vue'
 import { toast } from 'vue3-toastify'
+import ArenaBattleHeader from '~/components/arena/ArenaBattleHeader.vue'
 import ArenaDuel from '~/components/arena/ArenaDuel.vue'
 import ArenaEnemyStats from '~/components/arena/ArenaEnemyStats.vue'
 import Modal from '~/components/modal/Modal.vue'
@@ -210,7 +211,11 @@ onUnmounted(() => clearTimeout(nextTimer))
         :player="arena.team[arena.currentIndex]"
         :enemy="arena.enemyTeam[arena.currentIndex]"
         @end="onDuelEnd"
-      />
+      >
+        <template #header>
+          <ArenaBattleHeader />
+        </template>
+      </ArenaDuel>
       <div v-else class="flex flex-col items-center gap-2">
         <div
           :class="duelResult === 'win'


### PR DESCRIPTION
## Summary
- show enemy lineup when fighting in the arena
- display active enemy with blue background
- dim defeated enemies and grey the upcoming ones

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Test timed out and other errors)*
- `pnpm test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb0fb858832aa293a535188e1a58