### PR TITLE
Fix arena panel hydration fallback

### DIFF
--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -87,5 +87,11 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
 }, {
   persist: {
     pick: ['current'],
+    afterHydrate(ctx) {
+      const store = ctx.store as ReturnType<typeof useMainPanelStore>
+      const arenaStore = useArenaStore()
+      if (store.current === 'arena' && !arenaStore.inBattle)
+        store.reset()
+    },
   },
 })

--- a/test/mainpanel-hydration.test.ts
+++ b/test/mainpanel-hydration.test.ts
@@ -1,0 +1,24 @@
+import { createPinia, setActivePinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { describe, expect, it } from 'vitest'
+import { useMainPanelStore } from '../src/stores/mainPanel'
+import { useZoneStore } from '../src/stores/zone'
+
+// Verify that stored value "arena" does not persist when no arena battle is active
+
+describe('main panel hydration', () => {
+  it('falls back from arena panel when not in battle', () => {
+    const pinia = createPinia()
+    pinia.use(piniaPluginPersistedstate)
+    setActivePinia(pinia)
+
+    // simulate persisted state
+    window.localStorage.setItem('mainPanel', JSON.stringify({ current: 'arena' }))
+
+    const zone = useZoneStore()
+    const panel = useMainPanelStore()
+
+    const expected = zone.current.type === 'village' ? 'village' : 'battle'
+    expect(panel.current).toBe(expected)
+  })
+})


### PR DESCRIPTION
## Summary
- reset panel on hydration when no arena battle is active
- add unit test verifying arena panel fallback on reload

## Testing
- `pnpm test --run mainpanel-hydration.test.ts`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient') and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68712324094c832a8a88f58bb8617182