### PR TITLE
Fix zone persistence

### DIFF
--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -81,6 +81,7 @@ export const useZoneStore = defineStore('zone', () => {
   return {
     zones,
     current,
+    currentId,
     currentZoneId,
     selectedAt,
     wildCooldownRemaining,

--- a/test/zone-persist.test.ts
+++ b/test/zone-persist.test.ts
@@ -1,0 +1,18 @@
+import { createPinia, setActivePinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { describe, expect, it } from 'vitest'
+import { useZoneStore } from '../src/stores/zone'
+
+describe('zone persistence', () => {
+  it('restores current zone from storage', () => {
+    const pinia = createPinia()
+    pinia.use(piniaPluginPersistedstate)
+    setActivePinia(pinia)
+
+    // simulate previously saved zone
+    window.localStorage.setItem('zone', JSON.stringify({ currentId: 'village-boule' }))
+
+    const zone = useZoneStore()
+    expect(zone.current.id).toBe('village-boule')
+  })
+})


### PR DESCRIPTION
## Summary
- export `currentId` so persistedstate plugin can save it
- add unit test for restoring the zone from localStorage

## Testing
- `pnpm test --run` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_68712633b29c832a8ccf6b759977f09d