### PR TITLE
Lock zone change in arena

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -7,6 +7,7 @@ import { useDialogStore } from '~/stores/dialog'
 import { useInterfaceStore } from '~/stores/interface'
 import { useInventoryStore } from '~/stores/inventory'
 import { useInventoryModalStore } from '~/stores/inventoryModal'
+import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
 
@@ -18,8 +19,9 @@ const arena = useArenaStore()
 const achievements = useAchievementsStore()
 const mapModal = useMapModalStore()
 const ui = useInterfaceStore()
+const panel = useMainPanelStore()
 
-const menuDisabled = computed(() => dialog.isDialogVisible)
+const menuDisabled = computed(() => dialog.isDialogVisible || panel.current === 'arena')
 const dexDisabled = menuDisabled
 const achievementsDisabled = computed(() => menuDisabled.value || !achievements.hasAny)
 const inventoryDisabled = computed(() => menuDisabled.value || inventory.list.length === 0 || arena.inBattle)

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -21,7 +21,11 @@ const dialog = useDialogStore()
 const mobile = useMobileTabStore()
 
 const zoneButtonsDisabled = computed(
-  () => panel.current === 'trainerBattle' || dialog.isDialogVisible || arena.inBattle,
+  () =>
+    panel.current === 'trainerBattle'
+    || panel.current === 'arena'
+    || dialog.isDialogVisible
+    || arena.inBattle,
 )
 
 function buttonDisabled(z: Zone) {


### PR DESCRIPTION
## Summary
- disable zone changes while arena panel is open
- block mobile menu interactions when arena panel is visible

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: fetch errors & failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68712cd94d38832a9f06380982e650b4