### PR TITLE
Add arena cancel button and reset panel on zone change

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -189,6 +189,14 @@ onUnmounted(() => clearTimeout(nextTimer))
           >
             Combattre
           </Button>
+          <Button
+            type="danger"
+            variant="outline"
+            class="mx-auto"
+            @click="quit"
+          >
+            Abandonner
+          </Button>
         </div>
         <Modal v-model="showDex" footer-close>
           <h3 v-if="activeSlot !== null" class="mb-2 text-center text-lg font-bold">
@@ -235,7 +243,7 @@ onUnmounted(() => clearTimeout(nextTimer))
             Réessayer
           </Button>
           <Button type="danger" @click="quit">
-            Quitter
+            Quitter l'arène
           </Button>
         </template>
       </div>

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -20,8 +20,7 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
   watch(
     () => zone.current.type,
     (type) => {
-      if (current.value === 'battle' || current.value === 'village')
-        current.value = type === 'village' ? 'village' : 'battle'
+      current.value = type === 'village' ? 'village' : 'battle'
     },
     { immediate: true },
   )


### PR DESCRIPTION
## Summary
- allow canceling an arena before it starts
- display explicit "Quitter l'arène" button after a defeat
- reset main panel to the new zone when travelling

## Testing
- `pnpm lint` *(fails: Cannot find package '@antfu/eslint-config')*
- `pnpm test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687130174be8832a83338dbca161c39a