### PR TITLE
Fix arena id and capture level cap update

### DIFF
--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -34,7 +34,7 @@ export const arena20: Arena = {
 }
 
 export const arena40: Arena = {
-  id: 'arena20',
+  id: 'arena40',
   character: profMerdant,
   level: 21,
   badge: {
@@ -55,6 +55,7 @@ export const arena40: Arena = {
 
 export const arenas: Arena[] = [
   arena20,
+  arena40,
 ]
 
 export function getArena(id: string): Arena | undefined {

--- a/test/arena-badge.test.ts
+++ b/test/arena-badge.test.ts
@@ -1,0 +1,14 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { usePlayerStore } from '../src/stores/player'
+
+describe('arena badge', () => {
+  it('updates captureLevelCap after earning second arena badge', () => {
+    setActivePinia(createPinia())
+    const player = usePlayerStore()
+    expect(player.captureLevelCap).toBe(20)
+
+    player.earnBadge('arena40')
+    expect(player.captureLevelCap).toBe(40)
+  })
+})


### PR DESCRIPTION
## Summary
- fix `arena40` identifier and include it in the arenas list
- add regression test to ensure badge updates capture level cap

## Testing
- `pnpm test` *(fails: ENETUNREACH fetching fonts and other assertions)*

------
https://chatgpt.com/codex/tasks/task_e_687132721fc4832ab9f1c4f9f2acd8f1