### PR TITLE
Forward slot to BattleRound

### DIFF
--- a/src/components/arena/ArenaDuel.vue
+++ b/src/components/arena/ArenaDuel.vue
@@ -19,5 +19,7 @@ function onEnd(result: 'win' | 'lose' | 'draw') {
     :show-xp-bar="false"
     :show-effects="false"
     @end="onEnd"
-  />
+  >
+    <slot name="header" />
+  </BattleRound>
 </template>


### PR DESCRIPTION
## Summary
- forward ArenaDuel header slot to BattleRound

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshot mismatched and network errors)*

------
https://chatgpt.com/codex/tasks/task_e_687132a79fe8832a85db385cbe9b9232