### PR TITLE
Remove duplicate zone header in battle screen

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -153,16 +153,6 @@ function onCapture() {
         <span :class="{ 'font-bold': wins >= progress.fightsBeforeKing }">{{ wins.toLocaleString() }}</span>
       </Tooltip>
     </div>
-    <div class="w-full flex items-center justify-center gap-2 overflow-hidden font-bold">
-      <div class="flex flex-col items-center justify-center p-x-20">
-        <div class="overflow-ellipsis w-full overflow-hidden text-ellipsis whitespace-nowrap text-center" :title="zone.current.name">
-          {{ zone.current.name }}
-        </div>
-        <div v-if="zone.current.maxLevel" class="whitespace-nowrap text-xs">
-          lvl {{ zone.current.minLevel }} à {{ zone.current.maxLevel }}
-        </div>
-      </div>
-    </div>
     <BattleRound
       v-if="dex.activeShlagemon && enemy"
       :player="dex.activeShlagemon"


### PR DESCRIPTION
## Summary
- clean up `BattleMain.vue` template
- only keep `<BattleHeader>` via `header` slot and remove redundant zone information

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687134501638832aac5b70970f67f647