### PR TITLE
Remove redundant trainer UI block

### DIFF
--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -159,23 +159,6 @@ function cancelFight() {
       </div>
     </div>
     <template v-else-if="stage === 'battle' && dex.activeShlagemon && enemy">
-      <div class="w-full flex items-center justify-end gap-2 overflow-hidden font-bold">
-        <div class="flex items-center gap-2">
-          <div class="h-full flex flex-col items-end">
-            <div>{{ trainer.character.name }}</div>
-            <div class="flex gap-2">
-              <ImageByBackground
-                v-for="i in trainer.shlagemons.length"
-                :key="i"
-                src="/items/shlageball/shlageball.png"
-                class="h-4 w-4"
-                :class="{ 'saturate-0': i <= enemyIndex }"
-              />
-            </div>
-          </div>
-          <CharacterImage :id="trainer.character.id" :alt="trainer.character.name" class="h-full" />
-        </div>
-      </div>
       <BattleRound
 
         :player="dex.activeShlagemon"


### PR DESCRIPTION
## Summary
- refactor TrainerBattle to rely solely on `BattleHeader`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, Snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6871364480b8832a8fa4c0341f19a248