### PR TITLE
Update capture formula and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Un mini-jeu d'adresse « Whack-a-Shlag » permet aussi de récolter quelques Shl
 - Routing basé sur les fichiers et génération statique grâce à `vite-ssg`.
 - Prêt pour le _PWA_ et l'internationalisation.
 - Mini-jeu « Whack-a-Shlag » accessible depuis le village Veaux du Gland.
+- Chances de capture basées sur la vie restante, le coefficient (racine cubique) et le niveau de l'ennemi.
 
 ## Installation
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.5] - 2025-07-07
+
+### Changed
+
+- Capture formula adjusted: coefficient scaling now uses a cube root and level impact is softer.
+
 ## [0.3.4] - 2025-07-06
 
 ### Added

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -3,10 +3,10 @@ import { useDeveloperStore } from '~/stores/developer'
 
 export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
   const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
-  const coefMod = 1 / Math.sqrt(enemy.base.coefficient)
-  const levelMod = 1 / (1 + enemy.lvl / 20)
+  const coefMod = 1 / Math.cbrt(enemy.base.coefficient)
+  const levelMod = 1 / (1 + enemy.lvl / 40)
   // Slightly increase the global capture rate to make encounters less frustrating
-  const difficultyMod = 1.5
+  const difficultyMod = 1.3
   const chance = Math.min(100, hpChance * coefMod * levelMod * ball.catchBonus * difficultyMod)
   const dev = useDeveloperStore()
   if (dev.debug) {

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { balls } from '../src/data/items/shlageball'
 import { carapouffe } from '../src/data/shlagemons'
-import { tryCapture } from '../src/utils/capture'
+import { captureChanceFromHp, tryCapture } from '../src/utils/capture'
 import { createDexShlagemon } from '../src/utils/dexFactory'
 
 describe('capture mechanics', () => {
@@ -23,5 +23,19 @@ describe('capture mechanics', () => {
     mon.rarity = 100
     vi.spyOn(Math, 'random').mockReturnValue(0.99)
     expect(tryCapture(mon, balls[0])).toBe(false)
+  })
+
+  it('hyper ball versus strong foe gives around 10% chance', () => {
+    const mon = createDexShlagemon(carapouffe)
+    mon.base.coefficient = 1000
+    mon.lvl = 100
+    mon.hp = 100
+    mon.hpCurrent = 10
+    const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
+    const coefMod = 1 / Math.cbrt(mon.base.coefficient)
+    const levelMod = 1 / (1 + mon.lvl / 40)
+    const difficultyMod = 1.3
+    const chance = Math.min(100, hpChance * coefMod * levelMod * balls[2].catchBonus * difficultyMod)
+    expect(chance).toBeCloseTo(10, 1)
   })
 })


### PR DESCRIPTION
## Summary
- tweak capture mechanics: cube root coefficient scaling and milder level modifier
- set difficulty constant accordingly
- add corresponding unit test
- document formula change in changelog and readme

## Testing
- `pnpm test:unit` *(fails: Snapshot mismatch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687137ed1934832abafdb3f41ee9da35