### PR TITLE
Remove manual duel continue button

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -232,13 +232,10 @@ onUnmounted(() => clearTimeout(nextTimer))
         >
           {{ duelResult === 'win' ? 'Victoire !' : 'Défaite...' }}
         </div>
-        <Button v-if="duelResult === 'win' && hasNextDuel" type="primary" @click="proceedNext">
-          Suivant
-        </Button>
-        <Button v-else-if="duelResult === 'win'" type="primary" @click="closeVictory">
+        <Button v-if="duelResult === 'win' && !hasNextDuel" type="primary" @click="closeVictory">
           Fermer
         </Button>
-        <template v-else>
+        <template v-else-if="duelResult === 'lose'">
           <Button type="primary" @click="retry">
             Réessayer
           </Button>


### PR DESCRIPTION
## Summary
- trim the victory buttons in ArenaPanel
- automatically progress to the next duel without showing a 'Suivant' button

## Testing
- `pnpm lint`
- `pnpm test` *(fails: cannot fetch fonts and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68714957baf4832a986990e944d44431