### PR TITLE
Fix arena defeat screen persistence

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -87,7 +87,7 @@ function onDuelEnd(win: boolean) {
   duelResult.value = win ? 'win' : 'lose'
   if (!win) {
     arena.finish(false)
-    nextTimer = window.setTimeout(closeAfterDefeat, 500)
+    // keep the duel open so the player can choose what to do
     return
   }
 
@@ -111,11 +111,6 @@ function closeVictory() {
   clearTimeout(nextTimer)
   showDuel.value = false
   toast.success('Victoire !')
-}
-
-function closeAfterDefeat() {
-  clearTimeout(nextTimer)
-  showDuel.value = false
 }
 
 function retry() {


### PR DESCRIPTION
## Summary
- keep the duel panel visible after a defeat
- remove obsolete closeAfterDefeat helper

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined, Zone route-du-nawak not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687155032d80832a9e73d04a8ac267bc