### PR TITLE
Add feature locking for battle dialogs

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
-import { computed, onUnmounted, ref, toRaw, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
 import { toast } from 'vue3-toastify'
 import ArenaBattleHeader from '~/components/arena/ArenaBattleHeader.vue'
 import ArenaDuel from '~/components/arena/ArenaDuel.vue'
@@ -11,6 +11,7 @@ import ShlagemonQuickSelect from '~/components/shlagemon/ShlagemonQuickSelect.vu
 import Button from '~/components/ui/Button.vue'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
@@ -19,6 +20,7 @@ const dex = useShlagedexStore()
 const arena = useArenaStore()
 const dialog = useDialogStore()
 const panel = useMainPanelStore()
+const featureLock = useFeatureLockStore()
 
 const enemyTeam = computed(() => arena.lineup)
 const showDex = ref(false)
@@ -130,7 +132,11 @@ function quit() {
   panel.showVillage()
 }
 
-onUnmounted(() => clearTimeout(nextTimer))
+onMounted(featureLock.lockAll)
+onUnmounted(() => {
+  clearTimeout(nextTimer)
+  featureLock.unlockAll()
+})
 </script>
 
 <template>

--- a/src/components/battle/TrainerBattle.vue
+++ b/src/components/battle/TrainerBattle.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type'
+import { onMounted, onUnmounted } from 'vue'
 import BattleHeader from '~/components/battle/BattleHeader.vue'
 import BattleRound from '~/components/battle/BattleRound.vue'
 import CharacterImage from '~/components/character/CharacterImage.vue'
@@ -8,6 +9,7 @@ import { EQUILIBRE_RANK } from '~/constants/battle'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from '~/stores/achievements'
 import { useBattleStatsStore } from '~/stores/battleStats'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
@@ -23,6 +25,7 @@ const wearableItemStore = useWearableItemStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
 const panel = useMainPanelStore()
+const featureLock = useFeatureLockStore()
 
 const trainer = computed(() => trainerStore.current)
 const isZoneKing = computed(() => trainer.value?.id.startsWith('king-'))
@@ -132,6 +135,9 @@ function finish() {
 function cancelFight() {
   panel.showBattle()
 }
+
+onMounted(featureLock.lockAll)
+onUnmounted(featureLock.unlockAll)
 </script>
 
 <template>

--- a/src/components/panels/DialogPanel.vue
+++ b/src/components/panels/DialogPanel.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useDialogStore } from '~/stores/dialog'
+import { useFeatureLockStore } from '~/stores/featureLock'
 
 const dialogStore = useDialogStore()
+const featureLock = useFeatureLockStore()
 
 const active = computed(() => {
   for (const d of dialogStore.dialogs) {
@@ -15,6 +18,9 @@ function markDone(id: string | undefined) {
   if (id)
     dialogStore.markDone(id)
 }
+
+onMounted(featureLock.lockAll)
+onUnmounted(featureLock.unlockAll)
 </script>
 
 <template>

--- a/src/stores/featureLock.ts
+++ b/src/stores/featureLock.ts
@@ -22,6 +22,12 @@ export const useFeatureLockStore = defineStore('featureLock', () => {
     zonesLocked.value = true
   }
 
+  function lockAll() {
+    inventoryLocked.value = true
+    shlagedexLocked.value = true
+    zonesLocked.value = true
+  }
+
   function unlockAll() {
     inventoryLocked.value = false
     shlagedexLocked.value = false
@@ -35,6 +41,7 @@ export const useFeatureLockStore = defineStore('featureLock', () => {
     lockInventory,
     lockShlagedex,
     lockZones,
+    lockAll,
     unlockAll,
   }
 })


### PR DESCRIPTION
## Summary
- lock all features while in arena battles
- lock all features while a dialog is active
- lock all features during trainer battles
- expose `lockAll` helper in featureLock store

## Testing
- `pnpm lint`
- `pnpm test` *(fails: cannot fetch fonts, many unit test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687165e9514c832a9f15038bcadd23e3