### PR TITLE
Add feature lock tests

### DIFF
--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -8,6 +8,7 @@ import SearchInput from '~/components/ui/SearchInput.vue'
 import SortControls from '~/components/ui/SortControls.vue'
 import { useBallStore } from '~/stores/ball'
 import { useEvolutionItemStore } from '~/stores/evolutionItem'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useInventoryStore } from '~/stores/inventory'
 import { useInventoryFilterStore } from '~/stores/inventoryFilter'
 import { useInventoryModalStore } from '~/stores/inventoryModal'
@@ -19,6 +20,7 @@ const evoItemStore = useEvolutionItemStore()
 const wearableStore = useWearableItemStore()
 const inventoryModal = useInventoryModalStore()
 const filter = useInventoryFilterStore()
+const featureLock = useFeatureLockStore()
 const sortOptions = [
   { label: 'Type', value: 'type' },
   { label: 'Nom', value: 'name' },
@@ -46,12 +48,16 @@ const filteredList = computed(() => {
 })
 
 function isDisabled(item: Item) {
+  if (featureLock.isInventoryLocked)
+    return true
   if ('catchBonus' in item)
     return ballStore.current === item.id
   return item.type === 'evolution' && !evoItemStore.canUse(item)
 }
 
 function onUse(item: Item) {
+  if (featureLock.isInventoryLocked)
+    return
   if ('catchBonus' in item) {
     ballStore.setBall(item.id as any)
     toast(`Vous avez équipé la ${item.name}`)

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue'
 import ProgressBar from '~/components/ui/ProgressBar.vue'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
@@ -19,13 +20,15 @@ const progress = useZoneProgressStore()
 const mapModal = useMapModalStore()
 const dialog = useDialogStore()
 const mobile = useMobileTabStore()
+const featureLock = useFeatureLockStore()
 
 const zoneButtonsDisabled = computed(
   () =>
     panel.current === 'trainerBattle'
     || panel.current === 'arena'
     || dialog.isDialogVisible
-    || arena.inBattle,
+    || arena.inBattle
+    || featureLock.areZonesLocked,
 )
 
 function buttonDisabled(z: Zone) {

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -3,6 +3,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { useMediaQuery } from '@vueuse/core'
 import Modal from '~/components/modal/Modal.vue'
 import { useDiseaseStore } from '~/stores/disease'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -12,9 +13,14 @@ import ShlagemonList from './ShlagemonList.vue'
 const dex = useShlagedexStore()
 const panel = useMainPanelStore()
 const disease = useDiseaseStore()
+const featureLock = useFeatureLockStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
-const isLocked = computed(() => panel.current === 'trainerBattle' || disease.active)
+const isLocked = computed(() =>
+  panel.current === 'trainerBattle'
+  || disease.active
+  || featureLock.isShlagedexLocked,
+)
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
 

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -8,6 +8,7 @@ import SearchInput from '~/components/ui/SearchInput.vue'
 import SortControls from '~/components/ui/SortControls.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useDiseaseStore } from '~/stores/disease'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -36,8 +37,13 @@ const disease = useDiseaseStore()
 const panel = useMainPanelStore()
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
+const featureLock = useFeatureLockStore()
 
-const isLocked = computed(() => panel.current === 'trainerBattle' || disease.active)
+const isLocked = computed(() =>
+  panel.current === 'trainerBattle'
+  || disease.active
+  || featureLock.isShlagedexLocked,
+)
 
 const sortOptions = [
   { label: 'Niveau', value: 'level' },

--- a/test/feature-lock.test.ts
+++ b/test/feature-lock.test.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import InventoryPanel from '../src/components/panels/InventoryPanel.vue'
+import ZonePanel from '../src/components/panels/ZonePanel.vue'
+import ShlagemonList from '../src/components/shlagemon/ShlagemonList.vue'
+import { carapouffe } from '../src/data/shlagemons'
+import { useFeatureLockStore } from '../src/stores/featureLock'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('feature lock flags', () => {
+  it('disables zone buttons when zones are locked', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const featureLock = useFeatureLockStore()
+    featureLock.lockZones()
+    const wrapper = mount(ZonePanel, { global: { plugins: [pinia] } })
+    await wrapper.vm.$nextTick()
+    const buttons = wrapper.findAll('div.zone-grid button')
+    expect(buttons.length).toBeGreaterThan(0)
+    expect(buttons.every(b => b.attributes('disabled') !== undefined)).toBe(true)
+  })
+
+  it('disables Shlagédex selection when locked', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    dex.createShlagemon(carapouffe)
+    const featureLock = useFeatureLockStore()
+    featureLock.lockShlagedex()
+    const wrapper = mount(ShlagemonList, {
+      props: { mons: dex.shlagemons, showCheckbox: true },
+      global: { plugins: [pinia] },
+    })
+    await wrapper.vm.$nextTick()
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.attributes('disabled')).not.toBeUndefined()
+  })
+
+  it('disables inventory actions when locked', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const inventory = useInventoryStore()
+    inventory.add('potion')
+    const featureLock = useFeatureLockStore()
+    featureLock.lockInventory()
+    const wrapper = mount(InventoryPanel, { global: { plugins: [pinia] } })
+    await wrapper.vm.$nextTick()
+    const button = wrapper.find('button[disabled]')
+    expect(button.exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- disable UI actions using feature lock store
- test that feature locks disable zone, dex and inventory actions

## Testing
- `npx vitest run test/feature-lock.test.ts` *(fails: Cannot read properties of undefined (reading 'coefficient'))*
- `npx vitest run` *(fails: ENETUNREACH while fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68716b20f398832a9513391efa576163