### PR TITLE
Implement feature lock support across UI

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -18,6 +18,7 @@ import { getZoneBattleTrack, trainerTracks, zoneTracks } from '~/data/music'
 import { useAchievementsStore } from '~/stores/achievements'
 import { useAudioStore } from '~/stores/audio'
 import { useDialogStore } from '~/stores/dialog'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useGameStateStore } from '~/stores/gameState'
 import { useInterfaceStore } from '~/stores/interface'
 import { useInventoryStore } from '~/stores/inventory'
@@ -39,6 +40,7 @@ const trainerBattle = useTrainerBattleStore()
 const mobileTab = useMobileTabStore()
 const ui = useInterfaceStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
+const lockStore = useFeatureLockStore()
 
 const showMainPanel = computed(() =>
   dialogStore.isDialogVisible
@@ -100,14 +102,14 @@ watch<[MainPanel, ZoneId, string | undefined], true>(
       md="flex-row justify-between"
     >
       <div class="panel-group overflow-hidden" md="max-w-80 basis-1/4">
-        <PanelWrapper v-if="displayInventory" title="Inventaire" class="overflow-hidden" :is-locked="dialogStore.isDialogVisible">
+        <PanelWrapper v-if="displayInventory" title="Inventaire" class="overflow-hidden" :is-locked="lockStore.isInventoryLocked">
           <template #icon>
             <div class="i-carbon-inventory-management" />
           </template>
           <InventoryPanel />
         </PanelWrapper>
 
-        <PanelWrapper v-if="displayAchievements" title="Succès" class="overflow-hidden" :is-locked="dialogStore.isDialogVisible">
+        <PanelWrapper v-if="displayAchievements" title="Succès" class="overflow-hidden">
           <template #icon>
             <div class="i-carbon-trophy" />
           </template>
@@ -116,7 +118,7 @@ watch<[MainPanel, ZoneId, string | undefined], true>(
       </div>
 
       <div :class="group2Classes" class="overflow-hidden" md="basis-1/2">
-        <PanelWrapper is-inline :is-locked="dialogStore.isDialogVisible">
+        <PanelWrapper is-inline>
           <PlayerInfos />
         </PanelWrapper>
 
@@ -124,7 +126,7 @@ watch<[MainPanel, ZoneId, string | undefined], true>(
           <MainPanelView class="flex-1" />
         </PanelWrapper>
 
-        <PanelWrapper v-if="displayZonePanel" title="Zones" class="overflow-hidden" is-mobile-hidable :is-locked="dialogStore.isDialogVisible">
+        <PanelWrapper v-if="displayZonePanel" title="Zones" class="overflow-hidden" is-mobile-hidable :is-locked="lockStore.areZonesLocked">
           <template #icon>
             <div class="i-carbon-map" />
           </template>
@@ -133,7 +135,7 @@ watch<[MainPanel, ZoneId, string | undefined], true>(
       </div>
 
       <div v-if="displayDex" class="panel-group max-h-40vh overflow-hidden" md="max-w-80 basis-1/4 flex-1 max-h-none">
-        <PanelWrapper title="Shlagédex" class="overflow-hidden" is-mobile-hidable :is-locked="dialogStore.isDialogVisible">
+        <PanelWrapper title="Shlagédex" class="overflow-hidden" is-mobile-hidable :is-locked="lockStore.isShlagedexLocked">
           <template #icon>
             <SchlagedexIcon class="h-4 w-4" />
           </template>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -4,6 +4,7 @@ import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import { useAchievementsStore } from '~/stores/achievements'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
+import { useFeatureLockStore } from '~/stores/featureLock'
 import { useInterfaceStore } from '~/stores/interface'
 import { useInventoryStore } from '~/stores/inventory'
 import { useInventoryModalStore } from '~/stores/inventoryModal'
@@ -20,11 +21,12 @@ const achievements = useAchievementsStore()
 const mapModal = useMapModalStore()
 const ui = useInterfaceStore()
 const panel = useMainPanelStore()
+const lockStore = useFeatureLockStore()
 
 const menuDisabled = computed(() => dialog.isDialogVisible || panel.current === 'arena')
 const dexDisabled = menuDisabled
 const achievementsDisabled = computed(() => menuDisabled.value || !achievements.hasAny)
-const inventoryDisabled = computed(() => menuDisabled.value || inventory.list.length === 0 || arena.inBattle)
+const inventoryDisabled = computed(() => menuDisabled.value || inventory.list.length === 0 || arena.inBattle || lockStore.isInventoryLocked)
 
 watch(
   () => dialog.isDialogVisible,

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -2,25 +2,16 @@
 import type { DexShlagemon } from '~/type/shlagemon'
 import { useMediaQuery } from '@vueuse/core'
 import Modal from '~/components/modal/Modal.vue'
-import { useDiseaseStore } from '~/stores/disease'
 import { useFeatureLockStore } from '~/stores/featureLock'
-import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonList from './ShlagemonList.vue'
 
 const dex = useShlagedexStore()
-const panel = useMainPanelStore()
-const disease = useDiseaseStore()
 const featureLock = useFeatureLockStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
-const isLocked = computed(() =>
-  panel.current === 'trainerBattle'
-  || disease.active
-  || featureLock.isShlagedexLocked,
-)
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
 
@@ -34,7 +25,7 @@ function open(mon: DexShlagemon | null) {
 }
 
 function changeActive(mon: DexShlagemon) {
-  if (isLocked.value)
+  if (featureLock.isShlagedexLocked)
     return
   dex.setActiveShlagemon(mon)
   if (isMobile.value)

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -7,9 +7,7 @@ import CheckBox from '~/components/ui/CheckBox.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import SortControls from '~/components/ui/SortControls.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
-import { useDiseaseStore } from '~/stores/disease'
 import { useFeatureLockStore } from '~/stores/featureLock'
-import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useWearableItemStore } from '~/stores/wearableItem'
@@ -33,17 +31,10 @@ const props = withDefaults(defineProps<Props>(), {
 const filter = useDexFilterStore()
 const dex = useShlagedexStore()
 const wearableItemStore = useWearableItemStore()
-const disease = useDiseaseStore()
-const panel = useMainPanelStore()
 const mobile = useMobileTabStore()
 const isMobile = useMediaQuery('(max-width: 767px)')
 const featureLock = useFeatureLockStore()
-
-const isLocked = computed(() =>
-  panel.current === 'trainerBattle'
-  || disease.active
-  || featureLock.isShlagedexLocked,
-)
+const isLocked = featureLock.isShlagedexLocked
 
 const sortOptions = [
   { label: 'Niveau', value: 'level' },

--- a/src/stores/inventoryModal.ts
+++ b/src/stores/inventoryModal.ts
@@ -1,8 +1,16 @@
 import { defineStore } from 'pinia'
+import { useFeatureLockStore } from './featureLock'
 import { createModalStore } from './helpers'
 
 export const useInventoryModalStore = defineStore('inventoryModal', () => {
-  const { isVisible, open, close } = createModalStore('game')
+  const { isVisible, open: openModal, close } = createModalStore('game')
+  const lockStore = useFeatureLockStore()
+
+  function open() {
+    if (lockStore.isInventoryLocked)
+      return
+    openModal()
+  }
 
   return { isVisible, open, close }
 })


### PR DESCRIPTION
## Summary
- wire `useFeatureLockStore` into `GameGrid` and lock panels accordingly
- disable inventory UI via store lock in `MobileMenu`
- simplify Shlagedex and ShlagemonList by relying on store getters
- block inventory modal when inventory is locked

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_687181476044832a895a12cf0ac73c4c