### PR TITLE
Highlight mobile map button when new zone unlocked

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -336,6 +336,7 @@ declare global {
   const useZoneMonsModalStore: typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']
   const useZoneProgressStore: typeof import('./stores/zoneProgress')['useZoneProgressStore']
   const useZoneStore: typeof import('./stores/zone')['useZoneStore']
+  const useZoneVisitStore: typeof import('./stores/zoneVisit')['useZoneVisitStore']
   const watch: typeof import('vue')['watch']
   const watchArray: typeof import('@vueuse/core')['watchArray']
   const watchAtMost: typeof import('@vueuse/core')['watchAtMost']
@@ -725,6 +726,7 @@ declare module 'vue' {
     readonly useZoneMonsModalStore: UnwrapRef<typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']>
     readonly useZoneProgressStore: UnwrapRef<typeof import('./stores/zoneProgress')['useZoneProgressStore']>
     readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>
+    readonly useZoneVisitStore: UnwrapRef<typeof import('./stores/zoneVisit')['useZoneVisitStore']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>
     readonly watchArray: UnwrapRef<typeof import('@vueuse/core')['watchArray']>
     readonly watchAtMost: UnwrapRef<typeof import('@vueuse/core')['watchAtMost']>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -11,6 +11,7 @@ import { useInventoryModalStore } from '~/stores/inventoryModal'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMapModalStore } from '~/stores/mapModal'
 import { useMobileTabStore } from '~/stores/mobileTab'
+import { useZoneVisitStore } from '~/stores/zoneVisit'
 
 const mobile = useMobileTabStore()
 const inventoryModal = useInventoryModalStore()
@@ -22,6 +23,9 @@ const mapModal = useMapModalStore()
 const ui = useInterfaceStore()
 const panel = useMainPanelStore()
 const lockStore = useFeatureLockStore()
+const visit = useZoneVisitStore()
+
+const highlightMap = computed(() => visit.hasNewZone && !mapModal.isVisible)
 
 const menuDisabled = computed(() => dialog.isDialogVisible || panel.current === 'arena')
 const dexDisabled = menuDisabled
@@ -63,7 +67,7 @@ function onSecondButton() {
     </button>
     <button
       class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"
-      :class="ui.mobileMainPanel === 'zone' && mobile.current === 'dex' ? 'active' : ''"
+      :class="[ui.mobileMainPanel === 'zone' && mobile.current === 'dex' ? 'active' : '', highlightMap ? 'animate-pulse' : '']"
       :disabled="dexDisabled"
       @click="onSecondButton"
     >

--- a/src/stores/mapModal.ts
+++ b/src/stores/mapModal.ts
@@ -1,8 +1,15 @@
 import { defineStore } from 'pinia'
 import { createModalStore } from './helpers'
+import { useZoneVisitStore } from './zoneVisit'
 
 export const useMapModalStore = defineStore('mapModal', () => {
-  const { isVisible, open, close } = createModalStore('game')
+  const { isVisible, open: rawOpen, close } = createModalStore('game')
+  const visit = useZoneVisitStore()
+
+  function open() {
+    rawOpen()
+    visit.markAllAccessibleVisited()
+  }
 
   return { isVisible, open, close }
 })

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -7,6 +7,7 @@ import { kings as kingsData } from '~/data/kings'
 import { zonesData } from '~/data/zones'
 import { useArenaStore } from './arena'
 import { useShlagedexStore } from './shlagedex'
+import { useZoneVisitStore } from './zoneVisit'
 
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
@@ -20,6 +21,8 @@ export const useZoneStore = defineStore('zone', () => {
     const zone = zones.value.find(z => z.id === currentId.value)
     return zone ?? zones.value[0]
   })
+  const visit = useZoneVisitStore()
+  visit.markVisited(currentId.value)
   const xpZones = computed(() => zones.value.filter(z => z.maxLevel > 0))
 
   const wildCooldownRemaining = computed(() => {
@@ -71,6 +74,8 @@ export const useZoneStore = defineStore('zone', () => {
       const dex = useShlagedexStore()
       if (dex.activeShlagemon && !same)
         dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
+      const visit = useZoneVisitStore()
+      visit.markVisited(id)
     }
   }
 


### PR DESCRIPTION
## Summary
- add zoneVisit store to track visited zones
- highlight mobile menu button when new zones are available
- mark zones visited upon opening the map modal or changing zones

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined ...)*

------
https://chatgpt.com/codex/tasks/task_e_68723e509bf0832a8680c5be0b932b99