### PR TITLE
Refactor UI logic into new store

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -317,6 +317,7 @@ declare global {
   const useTrainerBattleStore: typeof import('./stores/trainerBattle')['useTrainerBattleStore']
   const useTransition: typeof import('@vueuse/core')['useTransition']
   const useTypeChartModalStore: typeof import('./stores/typeChartModal')['useTypeChartModalStore']
+  const useUIStore: typeof import('./stores/ui')['useUIStore']
   const useUrlSearchParams: typeof import('@vueuse/core')['useUrlSearchParams']
   const useUserMedia: typeof import('@vueuse/core')['useUserMedia']
   const useUserStore: typeof import('./stores/user')['useUserStore']
@@ -588,6 +589,7 @@ declare module 'vue' {
     readonly useEvolutionStore: UnwrapRef<typeof import('./stores/evolution')['useEvolutionStore']>
     readonly useEyeDropper: UnwrapRef<typeof import('@vueuse/core')['useEyeDropper']>
     readonly useFavicon: UnwrapRef<typeof import('@vueuse/core')['useFavicon']>
+    readonly useFeatureLockStore: UnwrapRef<typeof import('./stores/featureLock')['useFeatureLockStore']>
     readonly useFetch: UnwrapRef<typeof import('@vueuse/core')['useFetch']>
     readonly useFileDialog: UnwrapRef<typeof import('@vueuse/core')['useFileDialog']>
     readonly useFileSystemAccess: UnwrapRef<typeof import('@vueuse/core')['useFileSystemAccess']>
@@ -707,6 +709,7 @@ declare module 'vue' {
     readonly useTrainerBattleStore: UnwrapRef<typeof import('./stores/trainerBattle')['useTrainerBattleStore']>
     readonly useTransition: UnwrapRef<typeof import('@vueuse/core')['useTransition']>
     readonly useTypeChartModalStore: UnwrapRef<typeof import('./stores/typeChartModal')['useTypeChartModalStore']>
+    readonly useUIStore: UnwrapRef<typeof import('./stores/ui')['useUIStore']>
     readonly useUrlSearchParams: UnwrapRef<typeof import('@vueuse/core')['useUrlSearchParams']>
     readonly useUserMedia: UnwrapRef<typeof import('@vueuse/core')['useUserMedia']>
     readonly useVModel: UnwrapRef<typeof import('@vueuse/core')['useVModel']>

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-import type { MainPanel } from '~/stores/mainPanel'
-import type { ZoneId } from '~/type/zone'
-import { useMediaQuery } from '@vueuse/core'
-import { computed, watch } from 'vue'
 import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
 import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import InventoryModal from '~/components/inventory/InventoryModal.vue'
@@ -14,85 +10,16 @@ import Shlagedex from '~/components/shlagemon/Shlagedex.vue'
 import TypeChartModal from '~/components/shlagemon/TypeChartModal.vue'
 import PanelWrapper from '~/components/ui/PanelWrapper.vue'
 import ZoneMapModal from '~/components/zones/ZoneMapModal.vue'
-import { getZoneBattleTrack, trainerTracks, zoneTracks } from '~/data/music'
-import { useAchievementsStore } from '~/stores/achievements'
-import { useAudioStore } from '~/stores/audio'
-import { useDialogStore } from '~/stores/dialog'
 import { useFeatureLockStore } from '~/stores/featureLock'
-import { useGameStateStore } from '~/stores/gameState'
 import { useInterfaceStore } from '~/stores/interface'
-import { useInventoryStore } from '~/stores/inventory'
-import { useMainPanelStore } from '~/stores/mainPanel'
-import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { useTrainerBattleStore } from '~/stores/trainerBattle'
-import { useZoneStore } from '~/stores/zone'
+import { useUIStore } from '~/stores/ui'
 
-const gameState = useGameStateStore()
-const zone = useZoneStore()
-const inventory = useInventoryStore()
-const shlagedex = useShlagedexStore()
-const dialogStore = useDialogStore()
-const achievements = useAchievementsStore()
-const mainPanel = useMainPanelStore()
-const audio = useAudioStore()
-const trainerBattle = useTrainerBattleStore()
-const mobileTab = useMobileTabStore()
 const ui = useInterfaceStore()
-const isMobile = useMediaQuery('(max-width: 767px)')
 const lockStore = useFeatureLockStore()
-
-const showMainPanel = computed(() =>
-  dialogStore.isDialogVisible
-  || gameState.hasPokemon
-  || zone.current.type === 'village',
-)
-const isInventoryVisible = computed(() => inventory.list.length > 0)
-const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
-const isAchievementVisible = computed(() => achievements.hasAny)
-
-const isDexUnderGame = computed(() => ui.mobileMainPanel === 'dex')
-
-const displayZonePanel = computed(() =>
-  (!isDexUnderGame.value || !isMobile.value)
-  && isShlagedexVisible.value
-  && (!isMobile.value || mobileTab.current === 'game'),
-)
-const displayGamePanel = computed(() => showMainPanel.value && (!isMobile.value || mobileTab.current === 'game'))
-const displayInventory = computed(() => isInventoryVisible.value && !isMobile.value)
-const displayAchievements = computed(() => isAchievementVisible.value && (!isMobile.value || mobileTab.current === 'achievements'))
-const displayDex = computed(() => {
-  const inGameTab = !isMobile.value || mobileTab.current === 'game'
-  const inDexTab = !isMobile.value || mobileTab.current === 'dex'
-  return isShlagedexVisible.value && (isDexUnderGame.value ? inGameTab : inDexTab)
-})
-
-const group2Classes = computed(() => {
-  const classes = ['panel-group']
-  if (!isMobile.value || displayGamePanel.value || displayZonePanel.value)
-    classes.push('flex-1')
-  return classes.join(' ')
-})
-
-watch<[MainPanel, ZoneId, string | undefined], true>(
-  () => [mainPanel.current, zone.current.id, trainerBattle.current?.id],
-  ([panel, zoneId, trainerId]) => {
-    if (panel === 'battle') {
-      const track = getZoneBattleTrack(zoneId)
-      if (track)
-        audio.fadeToMusic(track)
-      else
-        audio.stopMusic()
-    }
-    else if (panel === 'trainerBattle') {
-      audio.fadeToMusic(trainerTracks[trainerId || `king-${zoneId}`])
-    }
-    else {
-      audio.fadeToMusic(zoneTracks[zoneId])
-    }
-  },
-  { immediate: true },
-)
+const shlagedex = useShlagedexStore()
+const uiStore = useUIStore()
+const { isMobile, displayDex, displayZonePanel, displayGamePanel, displayInventory, displayAchievements, group2Classes } = uiStore
 </script>
 
 <template>

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { useMediaQuery } from '@vueuse/core'
 import Modal from '~/components/modal/Modal.vue'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { useUIStore } from '~/stores/ui'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonList from './ShlagemonList.vue'
 
@@ -13,7 +13,7 @@ const featureLock = useFeatureLockStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 const mobile = useMobileTabStore()
-const isMobile = useMediaQuery('(max-width: 767px)')
+const isMobile = useUIStore().isMobile
 
 const clickTimer = ref<number | null>(null)
 

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { useMediaQuery } from '@vueuse/core'
 import { computed } from 'vue'
 import MultiExpIcon from '~/components/icons/multi-exp.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
@@ -10,6 +9,7 @@ import { useDexFilterStore } from '~/stores/dexFilter'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { useUIStore } from '~/stores/ui'
 import { useWearableItemStore } from '~/stores/wearableItem'
 import ShlagemonImage from './ShlagemonImage.vue'
 import ShlagemonType from './ShlagemonType.vue'
@@ -32,7 +32,7 @@ const filter = useDexFilterStore()
 const dex = useShlagedexStore()
 const wearableItemStore = useWearableItemStore()
 const mobile = useMobileTabStore()
-const isMobile = useMediaQuery('(max-width: 767px)')
+const isMobile = useUIStore().isMobile
 const featureLock = useFeatureLockStore()
 const isLocked = featureLock.isShlagedexLocked
 

--- a/src/components/ui/PanelWrapper.vue
+++ b/src/components/ui/PanelWrapper.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
-import { useMediaQuery } from '@vueuse/core'
+import { useUIStore } from '~/stores/ui'
 
 const props = defineProps<{ title?: string, isInline?: boolean, isScrollable?: boolean, isMobileHidable?: boolean, isLocked?: boolean }>()
 const opened = ref(true)
-const isMobile = useMediaQuery('(max-width: 767px)')
+const isMobile = useUIStore().isMobile
 
 const hidable = computed(() => !isMobile.value || props.isMobileHidable)
 
 function toggle() {
-  console.log('toggle')
   if (!hidable.value)
     return
   if (props.title)

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,0 +1,96 @@
+import type { MainPanel } from './mainPanel'
+import type { ZoneId } from '~/type/zone'
+import { useMediaQuery } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { computed, watch } from 'vue'
+import { getZoneBattleTrack, trainerTracks, zoneTracks } from '~/data/music'
+import { useAchievementsStore } from './achievements'
+import { useAudioStore } from './audio'
+import { useDialogStore } from './dialog'
+import { useGameStateStore } from './gameState'
+import { useInterfaceStore } from './interface'
+import { useInventoryStore } from './inventory'
+import { useMainPanelStore } from './mainPanel'
+import { useMobileTabStore } from './mobileTab'
+import { useShlagedexStore } from './shlagedex'
+import { useTrainerBattleStore } from './trainerBattle'
+import { useZoneStore } from './zone'
+
+export const useUIStore = defineStore('ui', () => {
+  const interfaceStore = useInterfaceStore()
+  const mobileTab = useMobileTabStore()
+  const mainPanel = useMainPanelStore()
+  const zone = useZoneStore()
+  const trainerBattle = useTrainerBattleStore()
+  const audio = useAudioStore()
+  const dialogStore = useDialogStore()
+  const gameState = useGameStateStore()
+  const inventory = useInventoryStore()
+  const shlagedex = useShlagedexStore()
+  const achievements = useAchievementsStore()
+
+  const isMobile = useMediaQuery('(max-width: 767px)')
+
+  const showMainPanel = computed(() =>
+    dialogStore.isDialogVisible
+    || gameState.hasPokemon
+    || zone.current.type === 'village',
+  )
+  const isInventoryVisible = computed(() => inventory.list.length > 0)
+  const isShlagedexVisible = computed(() => shlagedex.shlagemons.length > 0)
+  const isAchievementVisible = computed(() => achievements.hasAny)
+  const isDexUnderGame = computed(() => interfaceStore.mobileMainPanel === 'dex')
+
+  const displayZonePanel = computed(() =>
+    (!isDexUnderGame.value || !isMobile.value)
+    && isShlagedexVisible.value
+    && (!isMobile.value || mobileTab.current === 'game'),
+  )
+
+  const displayGamePanel = computed(() => showMainPanel.value && (!isMobile.value || mobileTab.current === 'game'))
+
+  const displayInventory = computed(() => isInventoryVisible.value && !isMobile.value)
+  const displayAchievements = computed(() => isAchievementVisible.value && (!isMobile.value || mobileTab.current === 'achievements'))
+  const displayDex = computed(() => {
+    const inGameTab = !isMobile.value || mobileTab.current === 'game'
+    const inDexTab = !isMobile.value || mobileTab.current === 'dex'
+    return isShlagedexVisible.value && (isDexUnderGame.value ? inGameTab : inDexTab)
+  })
+
+  const group2Classes = computed(() => {
+    const classes = ['panel-group']
+    if (!isMobile.value || displayGamePanel.value || displayZonePanel.value)
+      classes.push('flex-1')
+    return classes.join(' ')
+  })
+
+  watch<[MainPanel, ZoneId, string | undefined], true>(
+    () => [mainPanel.current, zone.current.id, trainerBattle.current?.id],
+    ([panel, zoneId, trainerId]) => {
+      if (panel === 'battle') {
+        const track = getZoneBattleTrack(zoneId)
+        if (track)
+          audio.fadeToMusic(track)
+        else
+          audio.stopMusic()
+      }
+      else if (panel === 'trainerBattle') {
+        audio.fadeToMusic(trainerTracks[trainerId || `king-${zoneId}`])
+      }
+      else {
+        audio.fadeToMusic(zoneTracks[zoneId])
+      }
+    },
+    { immediate: true },
+  )
+
+  return {
+    isMobile,
+    displayDex,
+    displayZonePanel,
+    displayGamePanel,
+    displayInventory,
+    displayAchievements,
+    group2Classes,
+  }
+})


### PR DESCRIPTION
## Summary
- centralize UI related logic in a new `ui` store
- expose mobile status and panel visibility from the store
- consume `useUIStore` in GameGrid and other components
- keep Pinia persistence configuration

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH fetching fonts & failing snapshots)*

------
https://chatgpt.com/codex/tasks/task_e_687244dcc300832a8d87e6feedc9c029