### PR TITLE
Improve village action buttons layout

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -66,6 +66,7 @@ declare module 'vue' {
     MobileMenu: typeof import('./components/layout/MobileMenu.vue')['default']
     Modal: typeof import('./components/modal/Modal.vue')['default']
     MultiExp: typeof import('./components/icons/multi-exp.vue')['default']
+    NavigationButton: typeof import('./components/ui/NavigationButton.vue')['default']
     NumberInput: typeof import('./components/ui/NumberInput.vue')['default']
     PanelWrapper: typeof import('./components/ui/PanelWrapper.vue')['default']
     PlayerInfos: typeof import('./components/panels/PlayerInfos.vue')['default']

--- a/src/components/ui/NavigationButton.vue
+++ b/src/components/ui/NavigationButton.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ icon: string, label: string, disabled?: boolean }>(), {
+  disabled: false,
+})
+const emit = defineEmits(['click'])
+</script>
+
+<template>
+  <button
+    class="grid grid-rows-2 max-h-[120px] gap-1 rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 flex-shrink-0"
+    :class="props.disabled ? 'opacity-50 cursor-not-allowed' : ''"
+    :disabled="props.disabled"
+    @click="emit('click')"
+  >
+    <div class="flex-center">
+      <div class="h-6 w-6" :class="props.icon" />
+    </div>
+    <div class="flex-center">
+      <span>{{ props.label }}</span>
+    </div>
+  </button>
+</template>

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import Button from '~/components/ui/Button.vue'
+import NavigationButton from '~/components/ui/NavigationButton.vue'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
@@ -26,6 +26,19 @@ const currentKing = computed(() =>
 const kingLabel = computed(() =>
   currentKing.value?.character.gender === 'female' ? 'reine' : 'roi',
 )
+
+function actionIcon(id: string) {
+  switch (id) {
+    case 'shop':
+      return 'i-carbon:shopping-bag'
+    case 'explore':
+      return 'i-mdi:compass'
+    case 'minigame':
+      return 'i-carbon:game-console'
+    default:
+      return ''
+  }
+}
 
 function onAction(id: string) {
   if (arena.inBattle)
@@ -63,38 +76,41 @@ function fightKing() {
 </script>
 
 <template>
-  <div class="flex flex-col items-center gap-1" md="gap-2">
-    <Button
+  <div class="actions-grid grid w-full gap-2 p-1" md="gap-3 p-2">
+    <NavigationButton
       v-for="action in zone.current.actions"
       :key="action.id"
-      class="text-xs"
+      :icon="actionIcon(action.id)"
+      :label="action.label"
       :disabled="arena.inBattle"
       @click="onAction(action.id)"
-    >
-      {{ action.label }}
-    </Button>
-    <Button
+    />
+    <NavigationButton
       v-if="hasArena && !arenaCompleted"
-      class="text-xs"
+      icon="i-mdi:sword-cross"
+      label="Arène"
       :disabled="arena.inBattle"
       @click="openArena"
-    >
-      Arène
-    </Button>
-    <Button
+    />
+    <NavigationButton
       v-if="hasKing && !progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
-      class="text-xs"
+      icon="i-game-icons:crown"
+      :label="`Défier la ${kingLabel} de la zone`"
       :disabled="arena.inBattle"
       @click="fightKing"
-    >
-      Défier la {{ kingLabel }} de la zone
-    </Button>
+    />
     <div
       v-else-if="hasKing && progress.isKingDefeated(zone.current.id)"
-      class="text-xs font-bold"
+      class="flex-center text-xs font-bold"
     >
       {{ kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1) }}
       vaincu{{ kingLabel === 'reine' ? 'e' : '' }} !
     </div>
   </div>
 </template>
+
+<style scoped>
+.actions-grid {
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+}
+</style>


### PR DESCRIPTION
## Summary
- add reusable `NavigationButton` component
- switch village action layout to use `NavigationButton`
- update component typings

## Testing
- `pnpm test:unit` *(fails: vitest not found)*
- `pnpm lint` *(fails: cannot find @antfu/eslint-config)*

------
https://chatgpt.com/codex/tasks/task_e_68725c30cfd0832abdd5f0e305a7ff5f