### PR TITLE
Dynamic audio selection by ID

### DIFF
--- a/src/components/dialog/AnotherShlagemonDialog.vue
+++ b/src/components/dialog/AnotherShlagemonDialog.vue
@@ -36,6 +36,7 @@ const dialogTree = [
   <DialogBox
     :speaker="profMerdant.name"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaDefeatDialog.vue
+++ b/src/components/dialog/ArenaDefeatDialog.vue
@@ -42,6 +42,7 @@ const dialogTree: DialogNode[] = [
   <DialogBox
     :speaker="arena.arenaData?.character.name"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
+    :character-id="arena.arenaData?.character.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -47,6 +47,7 @@ const dialogTree: DialogNode[] = [
   <DialogBox
     :speaker="arena.arenaData?.character.name"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
+    :character-id="arena.arenaData?.character.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -25,6 +25,7 @@ const dialogTree: DialogNode[] = [
   <DialogBox
     :speaker="arena.arenaData!.character.name"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
+    :character-id="arena.arenaData?.character.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/DialogBox.vue
+++ b/src/components/dialog/DialogBox.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import type { DialogNode, DialogResponse } from '~/type/dialog'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import Button from '~/components/ui/Button.vue'
+import { getCharacterTrack, getZoneTrack } from '~/data/music'
 import { useAudioStore } from '~/stores/audio'
+import { useZoneStore } from '~/stores/zone'
 import ImageByBackground from '../ui/ImageByBackground.vue'
 
-const { dialogTree, speaker, avatarUrl, orientation }
+const { dialogTree, speaker, avatarUrl, orientation, characterId }
   = withDefaults(defineProps<{
     dialogTree: DialogNode[]
     speaker: string
     avatarUrl: string
+    characterId: string
     orientation?: 'row' | 'col'
   }>(), {
     orientation: 'row',
@@ -21,9 +25,21 @@ const buttonClass = computed(() =>
 
 const currentNode = ref<DialogNode | undefined>()
 const audio = useAudioStore()
+const zone = useZoneStore()
 
 onMounted(() => {
   currentNode.value = dialogTree[0]
+  const track = getCharacterTrack(characterId)
+  if (track)
+    audio.fadeToMusic(track)
+  else
+    console.warn(`Missing music for character ${characterId}`)
+})
+
+onUnmounted(() => {
+  const track = getZoneTrack(zone.current.id, zone.current.type)
+  if (track)
+    audio.fadeToMusic(track)
 })
 
 function choose(r: DialogResponse) {

--- a/src/components/dialog/DialogStarter.vue
+++ b/src/components/dialog/DialogStarter.vue
@@ -77,6 +77,7 @@ const dialogTree = [
   <DialogBox
     :speaker="profMerdant.name"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/FirstLossDialog.vue
+++ b/src/components/dialog/FirstLossDialog.vue
@@ -57,6 +57,7 @@ const dialogTree: DialogNode[] = [
   <DialogBox
     :speaker="profMerdant.name"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/HalfDexDialog.vue
+++ b/src/components/dialog/HalfDexDialog.vue
@@ -61,6 +61,7 @@ const dialogTree: DialogNode[] = [
   <DialogBox
     :speaker="profSchlag.name"
     avatar-url="/characters/prof-merdant/prof-merdant.png"
+    :character-id="profSchlag.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/Level5Dialog.vue
+++ b/src/components/dialog/Level5Dialog.vue
@@ -61,6 +61,7 @@ const dialogTree: DialogNode[] = [
   <DialogBox
     :speaker="profMerdant.name"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ReleaseShlagemonDialog.vue
+++ b/src/components/dialog/ReleaseShlagemonDialog.vue
@@ -56,6 +56,7 @@ const dialogTree = computed<DialogNode[]>(() => {
   <DialogBox
     :speaker="profMerdant.name"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/data/music.ts
+++ b/src/data/music.ts
@@ -1,64 +1,44 @@
-import type { ZoneId } from '~/type/zone'
+import type { ZoneId, ZoneType } from '~/type/zone'
 
-export const zoneTracks: Record<ZoneId, string> = {
-  'plaine-kekette': '/audio/musics/villages/village-b.ogg',
-  'bois-de-bouffon': '/audio/musics/villages/village-c.ogg',
-  'chemin-du-slip': '/audio/musics/villages/village-a.ogg',
-  'ravin-fesse-molle': '/audio/musics/villages/village-b.ogg',
-  'precipice-nanard': '/audio/musics/villages/village-c.ogg',
-  'marais-moudugenou': '/audio/musics/villages/village-a.ogg',
-  'forteresse-petmoalfiak': '/audio/musics/villages/village-b.ogg',
-  'route-du-nawak': '/audio/musics/villages/village-c.ogg',
-  'mont-dracatombe': '/audio/musics/villages/village-a.ogg',
-  'catacombes-merdifientes': '/audio/musics/villages/village-b.ogg',
-  'route-aguicheuse': '/audio/musics/villages/village-c.ogg',
-  'vallee-des-chieurs': '/audio/musics/villages/village-a.ogg',
-  'trou-du-bide': '/audio/musics/villages/village-b.ogg',
-  'zone-giga-zob': '/audio/musics/villages/village-c.ogg',
-  'route-so-dom': '/audio/musics/villages/village-a.ogg',
-  'village-veaux-du-gland': '/audio/musics/villages/village-b.ogg',
-  'village-boule': '/audio/musics/villages/village-c.ogg',
-  'village-paume': '/audio/musics/villages/village-a.ogg',
-  'village-caca-boudin': '/audio/musics/villages/village-b.ogg',
+type TrackMap = Record<string, string>
 
+function createTrackMap(glob: Record<string, string>): TrackMap {
+  return Object.fromEntries(
+    Object.entries(glob).map(([path, url]) => {
+      const id = path.split('/').pop()!.replace('.ogg', '')
+      return [id, url]
+    }),
+  )
 }
 
-const wildBattleTracks = new Set([
-  'plaine-kekette',
-  'bois-de-bouffon',
-  'chemin-du-slip',
-  'ravin-fesse-molle',
-  'precipice-nanard',
-  'marais-moudugenou',
-  'forteresse-petmoalfiak',
-  'route-du-nawak',
-  'mont-dracatombe',
-  'catacombes-merdifientes',
-  'route-aguicheuse',
-  'vallee-des-chieurs',
-])
+const villageFiles = import.meta.glob('../../public/audio/musics/villages/*.ogg', { eager: true, as: 'url' }) as Record<string, string>
+const battleFiles = import.meta.glob('../../public/audio/musics/battle/*.ogg', { eager: true, as: 'url' }) as Record<string, string>
+const characterFiles = import.meta.glob('../../public/audio/musics/character/*.ogg', { eager: true, as: 'url' }) as Record<string, string>
+
+const villageTracks = createTrackMap(villageFiles)
+const battleTracks = createTrackMap(battleFiles)
+const characterTracks = createTrackMap(characterFiles)
 
 export function getZoneBattleTrack(id?: string): string | undefined {
-  if (!id || !wildBattleTracks.has(id))
+  if (!id)
     return undefined
-  return `/audio/musics/battle/${id}.ogg`
+  if (battleTracks[id])
+    return battleTracks[id]
+  return undefined
 }
 
-export const trainerTracks: Record<string, string> = {
-  'bob': '/audio/musics/trainers/trainer-a.ogg',
-  'king-plaine-kekette': '/audio/musics/trainers/trainer-b.ogg',
-  'king-bois-de-bouffon': '/audio/musics/trainers/trainer-c.ogg',
-  'king-grotte-du-slip': '/audio/musics/trainers/trainer-d.ogg',
-  'king-ravin-fesse-molle': '/audio/musics/trainers/trainer-a.ogg',
-  'king-grotte-nanard': '/audio/musics/trainers/trainer-b.ogg',
-  'king-marais-moudugenou': '/audio/musics/trainers/trainer-c.ogg',
-  'king-forteresse-petmoalfiak': '/audio/musics/trainers/trainer-d.ogg',
-  'king-route-du-nawak': '/audio/musics/trainers/trainer-a.ogg',
-  'king-mont-dracatombe': '/audio/musics/trainers/trainer-b.ogg',
-  'king-catacombes-merdifientes': '/audio/musics/trainers/trainer-c.ogg',
-  'king-route-aguicheuse': '/audio/musics/trainers/trainer-d.ogg',
-  'king-grotte-des-chieurs': '/audio/musics/trainers/trainer-a.ogg',
-  'king-trou-du-bide': '/audio/musics/trainers/trainer-b.ogg',
-  'king-zone-giga-zob': '/audio/musics/trainers/trainer-c.ogg',
-  'king-route-so-dom': '/audio/musics/trainers/trainer-d.ogg',
+export function getCharacterTrack(id?: string): string | undefined {
+  if (!id)
+    return undefined
+  return characterTracks[id]
+}
+
+export function getVillageTrack(id?: string): string | undefined {
+  if (!id)
+    return undefined
+  return villageTracks[id]
+}
+
+export function getZoneTrack(id: ZoneId, type: ZoneType): string | undefined {
+  return type === 'village' ? getVillageTrack(id) : getZoneBattleTrack(id)
 }

--- a/src/modules/audio.ts
+++ b/src/modules/audio.ts
@@ -1,5 +1,5 @@
 import type { UserModule } from '~/types'
-import { zoneTracks } from '~/data/music'
+import { getZoneTrack } from '~/data/music'
 import { useAudioStore } from '~/stores/audio'
 import { useZoneStore } from '~/stores/zone'
 
@@ -8,6 +8,9 @@ export const install: UserModule = ({ isClient }) => {
     return
   const audio = useAudioStore()
   const zone = useZoneStore()
-  if (audio.isMusicEnabled && !audio.currentMusic)
-    audio.playMusic(zoneTracks[zone.current.id])
+  if (audio.isMusicEnabled && !audio.currentMusic) {
+    const track = getZoneTrack(zone.current.id, zone.current.type)
+    if (track)
+      audio.playMusic(track)
+  }
 }


### PR DESCRIPTION
## Summary
- load music files dynamically based on IDs
- play character music in `DialogBox`
- adjust audio initialization and panel logic

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: HTMLMediaElement.prototype.play not implemented, many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687259fd7cb0832abf2e526ccaccca5d