### PR TITLE
Fix UI reactivity on resize

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
 import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import InventoryModal from '~/components/inventory/InventoryModal.vue'
@@ -19,7 +20,15 @@ const ui = useInterfaceStore()
 const lockStore = useFeatureLockStore()
 const shlagedex = useShlagedexStore()
 const uiStore = useUIStore()
-const { isMobile, displayDex, displayZonePanel, displayGamePanel, displayInventory, displayAchievements, group2Classes } = uiStore
+const {
+  isMobile,
+  displayDex,
+  displayZonePanel,
+  displayGamePanel,
+  displayInventory,
+  displayAchievements,
+  group2Classes,
+} = storeToRefs(uiStore)
 </script>
 
 <template>

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import { storeToRefs } from 'pinia'
 import Modal from '~/components/modal/Modal.vue'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMobileTabStore } from '~/stores/mobileTab'
@@ -13,7 +14,7 @@ const featureLock = useFeatureLockStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 const mobile = useMobileTabStore()
-const isMobile = useUIStore().isMobile
+const { isMobile } = storeToRefs(useUIStore())
 
 const clickTimer = ref<number | null>(null)
 

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import MultiExpIcon from '~/components/icons/multi-exp.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
@@ -32,7 +33,7 @@ const filter = useDexFilterStore()
 const dex = useShlagedexStore()
 const wearableItemStore = useWearableItemStore()
 const mobile = useMobileTabStore()
-const isMobile = useUIStore().isMobile
+const { isMobile } = storeToRefs(useUIStore())
 const featureLock = useFeatureLockStore()
 const isLocked = featureLock.isShlagedexLocked
 

--- a/src/components/ui/PanelWrapper.vue
+++ b/src/components/ui/PanelWrapper.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import { useUIStore } from '~/stores/ui'
 
 const props = defineProps<{ title?: string, isInline?: boolean, isScrollable?: boolean, isMobileHidable?: boolean, isLocked?: boolean }>()
 const opened = ref(true)
-const isMobile = useUIStore().isMobile
+const { isMobile } = storeToRefs(useUIStore())
 
 const hidable = computed(() => !isMobile.value || props.isMobileHidable)
 


### PR DESCRIPTION
## Summary
- use `storeToRefs` for UI store values so `isMobile` updates on resize
- fix import order to satisfy linter

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68725bc2bdac832a8ccca11b671a6ca1