### PR TITLE
Fix capture mechanics

### DIFF
--- a/src/components/battle/BattleCapture.vue
+++ b/src/components/battle/BattleCapture.vue
@@ -74,6 +74,7 @@ function open() {
 
 function finish(success: boolean) {
   showCapture.value = false
+  audio.playSfx(success ? '/audio/sfx/capture-success.ogg' : '/audio/sfx/capture-fail.ogg')
   if (success && capturedEnemy.value)
     dex.captureEnemy(capturedEnemy.value)
   capturedEnemy.value = null

--- a/src/components/battle/CaptureMenu.vue
+++ b/src/components/battle/CaptureMenu.vue
@@ -3,6 +3,7 @@ import type { Ball, DexShlagemon } from '~/type'
 import { computed, ref } from 'vue'
 import { toast } from 'vue3-toastify'
 import { balls as ballData } from '~/data/items/shlageball'
+import { useAudioStore } from '~/stores/audio'
 import { useInventoryStore } from '~/stores/inventory'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { tryCapture } from '~/utils/capture'
@@ -12,6 +13,7 @@ const emit = defineEmits<{ (e: 'capture', success: boolean): void }>()
 
 const inventory = useInventoryStore()
 const dex = useShlagedexStore()
+const audio = useAudioStore()
 const animBall = ref<string | null>(null)
 
 const availableBalls = computed(() =>
@@ -30,10 +32,12 @@ function useBall(ball: Ball) {
   if (success) {
     dex.captureEnemy(props.enemy)
     emit('capture', true)
+    audio.playSfx('/audio/sfx/capture-success.ogg')
     toast(`Vous avez capturé ${props.enemy.base.name} !`)
   }
   else {
     emit('capture', false)
+    audio.playSfx('/audio/sfx/capture-fail.ogg')
     toast('Raté !')
   }
 }

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -21,8 +21,8 @@ export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
 export function captureChanceFromHp(ratio: number): number {
   const r = Math.min(1, Math.max(0, ratio))
   if (r <= 0.1)
-    return 80
-  return 80 + (r - 0.1) / 0.9 * 20
+    return 100
+  return 100 - ((r - 0.1) / 0.9) * 20
 }
 
 export function simpleCapture(enemy: DexShlagemon): boolean {


### PR DESCRIPTION
## Summary
- capture is easier when HP is lower
- play sound when capture succeeds or fails

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots mismatched, other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68725cb482c4832aa004d9724fd870ea