### PR TITLE
Reset wild opponent after switching Shlagémon

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -72,7 +72,7 @@ watch(
   (mon, prev) => {
     if (mon && prev && prev.id !== mon.id)
       mon.hpCurrent = mon.hp
-    if (mon && !enemy.value)
+    if (mon && prev?.id !== mon?.id)
       startBattle()
   },
 )


### PR DESCRIPTION
## Summary
- spawn a new enemy whenever the active Shlagémon changes during wild combat

## Testing
- `pnpm test:unit` *(fails: "There is 7 zones in the list" messages and HTMLMediaElement not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68725d971e2c832aaa05dc2d2aa92bf6