### PR TITLE
Add indicator for owned enemies

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleCapture from '~/components/battle/BattleCapture.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
@@ -42,6 +42,12 @@ const displayedPlayer = ref(props.player)
 const nextPlayer = ref<DexShlagemon | null>(null)
 const displayedEnemy = ref(props.enemy)
 const nextEnemy = ref<DexShlagemon | null>(null)
+
+const showOwnedBall = computed(() => zone.current.type === 'sauvage')
+const enemyOwned = computed(() => {
+  const id = displayedEnemy.value?.base.id
+  return id ? dex.capturedBaseIds.has(id) : false
+})
 
 const {
   enemy: currentEnemy,
@@ -227,6 +233,8 @@ onMounted(() => {
             :hp="enemyHp"
             color="bg-red-500"
             :fainted="enemyFainted"
+            :show-ball="showOwnedBall"
+            :owned="enemyOwned"
             :class="{ flash: flashEnemy }"
             @faint-end="onEnemyFaintEnd"
           >

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -83,7 +83,7 @@ function showTypeChart() {
       lvl {{ props.mon.lvl }}
     </div>
     <div class="mt-1 flex items-center gap-1">
-      <Tooltip text="Vous avez déjà capturé ce Shlagémon">
+      <Tooltip text="Vous possédez déjà ce Shlagémon">
         <img
           v-if="props.showBall && props.owned"
           src="/items/shlageball/shlageball.png"


### PR DESCRIPTION
## Summary
- show a Schlagéball icon beside enemy name if already owned
- tweak tooltip text

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Test timed out, missing fonts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68725e1f5c9c832a813084b15f8b7a87