### PR TITLE
Handle Howler autoplay lock

### DIFF
--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -39,11 +39,15 @@ export const useAudioStore = defineStore('audio', () => {
   }
 
   function createMusic(src: string) {
-    return new Howl({
+    const music = new Howl({
       src: [src],
       volume: musicVolume.value,
       loop: true,
+      onplayerror: () => {
+        music.once('unlock', () => music.play())
+      },
     })
+    return music
   }
 
   function playMusic(track: string) {
@@ -101,7 +105,13 @@ export const useAudioStore = defineStore('audio', () => {
   function playSfx(effect: string) {
     if (import.meta.env.VITEST || !isSfxEnabled.value)
       return
-    const sfx = new Howl({ src: [effect], volume: sfxVolume.value })
+    const sfx = new Howl({
+      src: [effect],
+      volume: sfxVolume.value,
+      onplayerror: () => {
+        sfx.once('unlock', () => sfx.play())
+      },
+    })
     sfx.play()
   }
 


### PR DESCRIPTION
## Summary
- retry playback when AudioContext is locked by browsers

## Testing
- `pnpm test` *(fails: "There is 7 zones in the list, it should be 20}")*

------
https://chatgpt.com/codex/tasks/task_e_6872643e9cec832a8a8c0a8db241ddce