### PR TITLE
Fix XP bar animation

### DIFF
--- a/src/components/battle/BattleMain.vue
+++ b/src/components/battle/BattleMain.vue
@@ -106,11 +106,11 @@ const winTooltip = computed(() =>
 
 async function handleEnd(result: 'win' | 'lose' | 'draw') {
   const defeated = enemy.value
-  enemy.value = null
   events.emit('battle:end')
   if (dex.activeShlagemon)
     dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
   if (!defeated) {
+    enemy.value = null
     startBattle()
     return
   }
@@ -131,6 +131,7 @@ async function handleEnd(result: 'win' | 'lose' | 'draw') {
     battleStats.addLoss()
     notifyAchievement({ type: 'battle-loss' })
   }
+  enemy.value = null
   startBattle()
 }
 


### PR DESCRIPTION
## Summary
- ensure BattleRound stays mounted while XP is awarded

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68726bcbaf24832aa476b2507b50d3fc