### PR TITLE
Fix arena enemy scaling

### DIFF
--- a/src/components/arena/ArenaEnemyStats.vue
+++ b/src/components/arena/ArenaEnemyStats.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type/shlagemon'
 import { computed } from 'vue'
+import { useArenaStore } from '~/stores/arena'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const props = defineProps<{ mon: BaseShlagemon }>()
 
+const arena = useArenaStore()
+
 const dexMon = computed(() => {
-  const m = createDexShlagemon(props.mon)
+  const lvl = arena.arenaData?.level ?? 1
+  const coefficientMultiplier = lvl / props.mon.coefficient
+  const m = createDexShlagemon(props.mon, false, coefficientMultiplier)
+  m.lvl = lvl
   applyStats(m)
   return m
 })

--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -73,8 +73,9 @@ function startBattle() {
       return clone
     })
   const enemies = enemyTeam.value.map((b) => {
-    const m = createDexShlagemon(b)
     const lvl = arena.arenaData?.level ?? 1
+    const coefficientMultiplier = lvl / b.coefficient
+    const m = createDexShlagemon(b, false, coefficientMultiplier)
     m.lvl = lvl
     applyStats(m)
     return m

--- a/test/arena-enemy-coefficient.test.ts
+++ b/test/arena-enemy-coefficient.test.ts
@@ -1,0 +1,34 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import ArenaPanel from '../src/components/arena/ArenaPanel.vue'
+import { arena20 } from '../src/data/arenas'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useArenaStore } from '../src/stores/arena'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('arena enemies', () => {
+  it('match coefficient with arena level', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const arena = useArenaStore()
+    const dex = useShlagedexStore()
+    arena.setArena(arena20)
+    const mon = dex.createShlagemon(carapouffe)
+    for (let i = 0; i < arena.selections.length; i++)
+      arena.selectPlayer(i, mon.id)
+
+    const wrapper = mount(ArenaPanel, {
+      global: {
+        plugins: [pinia],
+        stubs: ['ArenaBattleHeader', 'ArenaDuel', 'ArenaEnemyStats', 'Modal', 'ShlagemonImage', 'ShlagemonQuickSelect', 'Button', 'Info'],
+      },
+    })
+
+    wrapper.vm.startBattle()
+
+    const enemy = arena.enemyTeam[0]
+    expect(enemy.base.coefficient).toBe(arena20.level)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- scale enemy coefficient to arena level when starting a battle
- display enemy stats with the same scaling
- test enemy coefficient in arena battles

## Testing
- `pnpm lint` *(fails: Cannot find package '@antfu/eslint-config')*
- `pnpm test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726de9eb34832aabfff8c68748b0ac