### PR TITLE
Enable fade transition on player's shlagemon

### DIFF
--- a/src/components/arena/ArenaEnemyStats.vue
+++ b/src/components/arena/ArenaEnemyStats.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type/shlagemon'
 import { computed } from 'vue'
-import { useArenaStore } from '~/stores/arena'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
+import { useArenaStore } from '~/stores/arena'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const props = defineProps<{ mon: BaseShlagemon }>()

--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -203,19 +203,22 @@ onMounted(() => {
   <div class="w-full flex flex-1 flex-col items-center gap-2">
     <slot name="header" />
     <div class="relative max-w-160 w-full flex flex-1 items-center justify-center gap-4">
-      <BattleShlagemon
-        :mon="displayedPlayer"
-        :hp="playerHp"
-        :fainted="playerFainted"
-        flipped
-        :effects="props.showEffects ? dex.effects : []"
-        :disease="disease.active"
-        :disease-remaining="disease.remaining"
-        :class="{ flash: flashPlayer }"
-        @faint-end="onPlayerFaintEnd"
-      >
-        <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
-      </BattleShlagemon>
+      <Transition name="fade" mode="out-in">
+        <BattleShlagemon
+          :key="displayedPlayer?.id"
+          :mon="displayedPlayer"
+          :hp="playerHp"
+          :fainted="playerFainted"
+          flipped
+          :effects="props.showEffects ? dex.effects : []"
+          :disease="disease.active"
+          :disease-remaining="disease.remaining"
+          :class="{ flash: flashPlayer }"
+          @faint-end="onPlayerFaintEnd"
+        >
+          <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
+        </BattleShlagemon>
+      </Transition>
       <div class="vs font-bold">
         VS
       </div>


### PR DESCRIPTION
## Summary
- add fade transition when the active player shlagemon changes
- fix import order in `ArenaEnemyStats.vue`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: 'z.maxLevel' possibly undefined, missing types)*
- `pnpm test` *(fails: many tests fail with TypeErrors and unimplemented HTMLMediaElement methods)*

------
https://chatgpt.com/codex/tasks/task_e_68726fd0df1c832aada0f47c025fb47a