### PR TITLE
Fix structuredClone error in arena

### DIFF
--- a/src/components/arena/ArenaPanel.vue
+++ b/src/components/arena/ArenaPanel.vue
@@ -14,6 +14,7 @@ import { useDialogStore } from '~/stores/dialog'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
+import { cloneDexShlagemon } from '~/utils/clone'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
@@ -67,7 +68,7 @@ function startBattle() {
   const team = arena.selections
     .map(id => dex.shlagemons.find(m => m.id === (id || ''))!)
     .map((mon) => {
-      const clone = structuredClone(toRaw(mon))
+      const clone = cloneDexShlagemon(toRaw(mon))
       applyStats(clone)
       clone.hpCurrent = clone.hp
       return clone

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -1,0 +1,9 @@
+import type { DexShlagemon } from '~/type'
+
+export function cloneDexShlagemon(mon: DexShlagemon): DexShlagemon {
+  return {
+    ...mon,
+    base: mon.base,
+    baseStats: { ...mon.baseStats },
+  }
+}

--- a/test/cloneDexShlagemon.test.ts
+++ b/test/cloneDexShlagemon.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { cloneDexShlagemon } from '../src/utils/clone'
+
+const base = { id: 'base', name: 'Base', description: '', types: [], coefficient: 1 }
+const mon = { id: 'id', base, baseStats: { hp: 1, attack: 1, defense: 1, smelling: 1 }, captureDate: '', captureCount: 1, lvl: 1, xp: 0, rarity: 1, sex: 'male', isShiny: false, hpCurrent: 1, allowEvolution: true, heldItemId: null }
+
+describe('cloneDexShlagemon', () => {
+  it('creates a copy', () => {
+    const clone = cloneDexShlagemon(mon)
+    expect(clone).not.toBe(mon)
+    expect(clone.base).toBe(mon.base)
+    expect(clone).toMatchObject(mon)
+  })
+})


### PR DESCRIPTION
## Summary
- add a helper to copy DexShlagemon without structuredClone
- use the new helper in ArenaPanel
- test the clone helper

## Testing
- `pnpm test:unit` *(fails: ENETUNREACH errors and many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68727043fc94832ab8d20216ebba0368