### PR TITLE
Reset player store via save

### DIFF
--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -8,6 +8,7 @@ import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
 import { useInventoryStore } from './inventory'
 import { useMainPanelStore } from './mainPanel'
+import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 import { useZoneProgressStore } from './zoneProgress'
@@ -25,6 +26,7 @@ export const useSaveStore = defineStore('save', () => {
   const ball = useBallStore()
   const dexFilter = useDexFilterStore()
   const mainPanel = useMainPanelStore()
+  const player = usePlayerStore()
 
   function reset() {
     dex.reset()
@@ -39,6 +41,7 @@ export const useSaveStore = defineStore('save', () => {
     ball.reset()
     dexFilter.reset()
     mainPanel.reset()
+    player.reset()
   }
 
   return { reset }

--- a/test/save-reset.test.ts
+++ b/test/save-reset.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import { useDialogStore } from '../src/stores/dialog'
+import { usePlayerStore } from '../src/stores/player'
 import { useSaveStore } from '../src/stores/save'
 import { useZoneProgressStore } from '../src/stores/zoneProgress'
 
@@ -29,5 +30,18 @@ describe('useSaveStore.reset', () => {
     save.reset()
 
     expect(progress.getWins('foo')).toBe(0)
+  })
+
+  it('should reset player capture level cap', () => {
+    setActivePinia(createPinia())
+    const player = usePlayerStore()
+    const save = useSaveStore()
+
+    player.captureLevelCap = 50
+    expect(player.captureLevelCap).toBe(50)
+
+    save.reset()
+
+    expect(player.captureLevelCap).toBe(20)
   })
 })


### PR DESCRIPTION
## Summary
- reset player store from save store
- verify capture level cap reset in tests

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch errors, zone data missing, HTMLMediaElement methods not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_687274bbe900832a8059df2cb4a2571e