### PR TITLE
Update dialog sound and props

### DIFF
--- a/src/components/arena/ArenaEnemyStats.vue
+++ b/src/components/arena/ArenaEnemyStats.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type/shlagemon'
 import { computed } from 'vue'
-import { useArenaStore } from '~/stores/arena'
 import ShlagemonImage from '~/components/shlagemon/ShlagemonImage.vue'
 import ShlagemonType from '~/components/shlagemon/ShlagemonType.vue'
+import { useArenaStore } from '~/stores/arena'
 import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const props = defineProps<{ mon: BaseShlagemon }>()

--- a/src/components/dialog/AnotherShlagemonDialog.vue
+++ b/src/components/dialog/AnotherShlagemonDialog.vue
@@ -34,9 +34,8 @@ const dialogTree = [
 
 <template>
   <DialogBox
-    :speaker="profMerdant.name"
+    :character="profMerdant"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
-    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaDefeatDialog.vue
+++ b/src/components/dialog/ArenaDefeatDialog.vue
@@ -40,9 +40,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="arena.arenaData?.character.name"
+    :character="arena.arenaData!.character"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
-    :character-id="arena.arenaData?.character.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -45,9 +45,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="arena.arenaData?.character.name"
+    :character="arena.arenaData!.character"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
-    :character-id="arena.arenaData?.character.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -23,9 +23,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="arena.arenaData!.character.name"
+    :character="arena.arenaData!.character"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
-    :character-id="arena.arenaData?.character.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/AttackPotionDialog.vue
+++ b/src/components/dialog/AttackPotionDialog.vue
@@ -51,9 +51,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="profMerdant.name"
+    :character="profMerdant"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
-    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/components/dialog/DialogBox.vue
+++ b/src/components/dialog/DialogBox.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Character } from '~/type/character'
 import type { DialogNode, DialogResponse } from '~/type/dialog'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import Button from '~/components/ui/Button.vue'
@@ -7,12 +8,11 @@ import { useAudioStore } from '~/stores/audio'
 import { useZoneStore } from '~/stores/zone'
 import ImageByBackground from '../ui/ImageByBackground.vue'
 
-const { dialogTree, speaker, avatarUrl, orientation, characterId }
+const { dialogTree, character, avatarUrl, orientation }
   = withDefaults(defineProps<{
     dialogTree: DialogNode[]
-    speaker: string
+    character: Character
     avatarUrl: string
-    characterId: string
     orientation?: 'row' | 'col'
   }>(), {
     orientation: 'row',
@@ -29,11 +29,11 @@ const zone = useZoneStore()
 
 onMounted(() => {
   currentNode.value = dialogTree[0]
-  const track = getCharacterTrack(characterId)
+  const track = getCharacterTrack(character.id)
   if (track)
     audio.fadeToMusic(track)
   else
-    console.warn(`Missing music for character ${characterId}`)
+    console.warn(`Missing music for character ${character.id}`)
 })
 
 onUnmounted(() => {
@@ -43,7 +43,10 @@ onUnmounted(() => {
 })
 
 function choose(r: DialogResponse) {
-  audio.playSfx('/audio/sfx/confirm.ogg')
+  const effect = r.type === 'danger' && r.nextId
+    ? '/audio/sfx/dialog-back.ogg'
+    : '/audio/sfx/confirm.ogg'
+  audio.playSfx(effect)
   if (r.nextId)
     currentNode.value = dialogTree.find(d => d.id === r.nextId)
   else if (r.action)
@@ -57,7 +60,7 @@ function choose(r: DialogResponse) {
       <div class="flex flex-col items-center justify-center">
         <ImageByBackground :src="avatarUrl" alt="avatar" class="w-full flex-1 object-contain" />
         <div class="p-1 text-center font-bold">
-          {{ speaker }}
+          {{ character.name }}
         </div>
       </div>
 

--- a/src/components/dialog/DialogStarter.vue
+++ b/src/components/dialog/DialogStarter.vue
@@ -75,9 +75,8 @@ const dialogTree = [
 
 <template>
   <DialogBox
-    :speaker="profMerdant.name"
+    :character="profMerdant"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
-    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/FirstLossDialog.vue
+++ b/src/components/dialog/FirstLossDialog.vue
@@ -55,9 +55,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="profMerdant.name"
+    :character="profMerdant"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
-    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/HalfDexDialog.vue
+++ b/src/components/dialog/HalfDexDialog.vue
@@ -59,9 +59,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="profSchlag.name"
+    :character="profSchlag"
     avatar-url="/characters/prof-merdant/prof-merdant.png"
-    :character-id="profSchlag.id"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/Level5Dialog.vue
+++ b/src/components/dialog/Level5Dialog.vue
@@ -59,9 +59,8 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :speaker="profMerdant.name"
+    :character="profMerdant"
     :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
-    :character-id="profMerdant.id"
     :dialog-tree="dialogTree"
   />
 </template>


### PR DESCRIPTION
## Summary
- play a new `dialog-back.ogg` SFX when going back in dialogs
- pass a full `Character` object to `DialogBox` and update callers
- fix import order lint issue

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: ... 'z.maxLevel' possibly undefined, etc.)*
- `pnpm test` *(fails: 36 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_687274aa5fb8832a86306de447047f2e