### PR TITLE
Fix missing faint event after transition

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -203,7 +203,7 @@ onMounted(() => {
   <div class="w-full flex flex-1 flex-col items-center gap-2">
     <slot name="header" />
     <div class="relative max-w-160 w-full flex flex-1 items-center justify-center gap-4">
-      <Transition name="fade" mode="out-in">
+      <Transition name="fade" mode="out-in" @faint-end="onPlayerFaintEnd">
         <BattleShlagemon
           :key="displayedPlayer?.id"
           :mon="displayedPlayer"
@@ -214,7 +214,6 @@ onMounted(() => {
           :disease="disease.active"
           :disease-remaining="disease.remaining"
           :class="{ flash: flashPlayer }"
-          @faint-end="onPlayerFaintEnd"
         >
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
         </BattleShlagemon>
@@ -229,7 +228,7 @@ onMounted(() => {
         @mouseenter="onMouseEnter"
         @mouseleave="onMouseLeave"
       >
-        <Transition name="fade" mode="out-in">
+        <Transition name="fade" mode="out-in" @faint-end="onEnemyFaintEnd">
           <BattleShlagemon
             :key="displayedEnemy?.id"
             :mon="displayedEnemy"
@@ -239,7 +238,6 @@ onMounted(() => {
             :show-ball="showOwnedBall"
             :owned="enemyOwned"
             :class="{ flash: flashEnemy }"
-            @faint-end="onEnemyFaintEnd"
           >
             <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
           </BattleShlagemon>


### PR DESCRIPTION
## Summary
- handle `faint-end` events on the `<Transition>` wrapper so the next battle starts correctly

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH fetching fonts and failing assertions)*

------
https://chatgpt.com/codex/tasks/task_e_687275cf0c48832aaa16ddcb61d535af