### PR TITLE
Fix battle progression

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -205,7 +205,7 @@ onMounted(() => {
   <div class="w-full flex flex-1 flex-col items-center gap-2">
     <slot name="header" />
     <div class="relative max-w-160 w-full flex flex-1 items-center justify-center gap-4">
-      <Transition name="fade" mode="out-in" @faint-end="onPlayerFaintEnd">
+      <Transition name="fade" mode="out-in">
         <BattleShlagemon
           :key="displayedPlayer?.id"
           :mon="displayedPlayer"
@@ -216,6 +216,7 @@ onMounted(() => {
           :disease="disease.active"
           :disease-remaining="disease.remaining"
           :class="{ flash: flashPlayer }"
+          @faint-end="onPlayerFaintEnd"
         >
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
         </BattleShlagemon>


### PR DESCRIPTION
## Summary
- trigger faintEnd on BattleShlagemon instead of Transition so battles chain properly

## Testing
- `pnpm test:unit` *(fails: 36 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687280e18e14832ab58f7dc5b8f45428