### PR TITLE
Fix enemy faint transition

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -231,7 +231,7 @@ onMounted(() => {
         @mouseenter="onMouseEnter"
         @mouseleave="onMouseLeave"
       >
-        <Transition name="fade" mode="out-in">
+        <Transition name="fade" mode="out-in" @after-leave="onEnemyFaintEnd">
           <BattleShlagemon
             :key="displayedEnemy?.id"
             :mon="displayedEnemy"
@@ -241,7 +241,6 @@ onMounted(() => {
             :show-ball="showOwnedBall"
             :owned="enemyOwned"
             :class="{ flash: flashEnemy }"
-            @faint-end="onEnemyFaintEnd"
           >
             <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
           </BattleShlagemon>


### PR DESCRIPTION
## Summary
- handle enemy faint with `@after-leave` on `Transition`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined; also network fetch to fonts.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68728997f56c832a95eeebdc1d5290ec