### PR TITLE
Enable Type chart modal on type click

### DIFF
--- a/src/components/shlagemon/ShlagemonDetail.vue
+++ b/src/components/shlagemon/ShlagemonDetail.vue
@@ -99,7 +99,12 @@ const captureInfo = computed(() => {
       </h2>
       <div class="relative h-40 w-full">
         <div class="absolute flex gap-2">
-          <ShlagemonType v-for="type in mon.base.types" :key="type.id" :value="type" />
+          <ShlagemonType
+            v-for="type in mon.base.types"
+            :key="type.id"
+            :value="type"
+            open-on-click
+          />
         </div>
         <ShlagemonImage
           :id="mon.base.id"

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -172,6 +172,7 @@ function changeActive(mon: DexShlagemon) {
                 :key="t.id"
                 :value="t"
                 size="xs"
+                open-on-click
               />
             </div>
           </div>

--- a/src/components/shlagemon/ShlagemonType.vue
+++ b/src/components/shlagemon/ShlagemonType.vue
@@ -4,9 +4,15 @@ import type { ShlagemonType } from '~/type'
 interface Props {
   value: ShlagemonType
   size?: 'xs' | 'sm' | 'base' | 'lg'
+  openOnClick?: boolean
 }
 
-const { value, size } = withDefaults(defineProps<Props>(), { size: 'xs' })
+const { value, size, openOnClick } = withDefaults(defineProps<Props>(), {
+  size: 'xs',
+  openOnClick: false,
+})
+
+const typeChart = useTypeChartModalStore()
 
 const sizeClass = computed(() => {
   switch (size) {
@@ -22,6 +28,11 @@ const sizeClass = computed(() => {
 })
 
 const textColor = computed(() => getAdjustedTextColor())
+
+function handleClick() {
+  if (openOnClick)
+    typeChart.open(value.id)
+}
 
 function getAdjustedTextColor(amount = 60) {
   const hex = value.color.replace('#', '')
@@ -41,9 +52,10 @@ function getAdjustedTextColor(amount = 60) {
 <template>
   <span
     class="type overflow-hidden text-ellipsis rounded px-1.5 py-1 text-center leading-none"
-    :class="sizeClass"
+    :class="[sizeClass, openOnClick ? 'cursor-pointer hover:opacity-80' : '']"
     :name="value.name"
     :style="{ backgroundColor: value.color, color: textColor }"
+    @click="handleClick"
   >
     {{ value.name }}
   </span>


### PR DESCRIPTION
## Summary
- add `openOnClick` prop to `ShlagemonType`
- open the type chart modal when clicking a type badge
- enable the feature in the Shlagédex list and detail views

## Testing
- `pnpm test` *(fails: Zone tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_68728a619f24832aba9be4ebbc86ebd4