### PR TITLE
Fix enemy faint callback

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -216,7 +216,7 @@ onMounted(() => {
           :disease="disease.active"
           :disease-remaining="disease.remaining"
           :class="{ flash: flashPlayer }"
-          @faint-end="onPlayerFaintEnd"
+          @fainted="onPlayerFaintEnd"
         >
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
         </BattleShlagemon>
@@ -231,7 +231,7 @@ onMounted(() => {
         @mouseenter="onMouseEnter"
         @mouseleave="onMouseLeave"
       >
-        <Transition name="fade" mode="out-in" @after-leave="onEnemyFaintEnd">
+        <Transition name="fade" mode="out-in">
           <BattleShlagemon
             :key="displayedEnemy?.id"
             :mon="displayedEnemy"
@@ -241,6 +241,7 @@ onMounted(() => {
             :show-ball="showOwnedBall"
             :owned="enemyOwned"
             :class="{ flash: flashEnemy }"
+            @fainted="onEnemyFaintEnd"
           >
             <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />
           </BattleShlagemon>

--- a/src/components/battle/BattleShlagemon.vue
+++ b/src/components/battle/BattleShlagemon.vue
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<Props>(), {
   diseaseRemaining: 0,
 })
 
-const emit = defineEmits<{ (e: 'faintEnd'): void }>()
+const emit = defineEmits<{ (e: 'fainted'): void }>()
 const typeChart = useTypeChartModalStore()
 
 const now = ref(Date.now())
@@ -43,9 +43,8 @@ const timer = window.setInterval(() => {
 }, 1000)
 onUnmounted(() => window.clearInterval(timer))
 
-function onAnimationEnd() {
-  if (props.fainted)
-    emit('faintEnd')
+function onAfterLeave() {
+  emit('fainted')
 }
 
 function showTypeChart() {
@@ -71,14 +70,16 @@ function showTypeChart() {
       />
       <DiseaseBadge v-if="props.disease" :remaining="props.diseaseRemaining" />
     </div>
-    <ShlagemonImage
-      :id="props.mon.base.id"
-      :alt="props.mon.base.name"
-      :shiny="props.mon.isShiny"
-      class="min-h-25 flex-1"
-      :class="[props.flipped ? '-scale-x-100' : '', { faint: props.fainted }]"
-      @animationend="onAnimationEnd"
-    />
+    <Transition name="faint" @after-leave="onAfterLeave">
+      <ShlagemonImage
+        v-if="!props.fainted"
+        :id="props.mon.base.id"
+        :alt="props.mon.base.name"
+        :shiny="props.mon.isShiny"
+        class="min-h-25 flex-1"
+        :class="props.flipped ? '-scale-x-100' : ''"
+      />
+    </Transition>
     <div class="absolute left-0 text-sm font-bold" :class="props.levelPosition === 'top' ? 'top-0' : 'bottom-0'">
       lvl {{ props.mon.lvl }}
     </div>
@@ -101,14 +102,15 @@ function showTypeChart() {
 </template>
 
 <style scoped>
-.faint {
-  animation: faint 0.6s ease forwards;
+.faint-enter-active,
+.faint-leave-active {
+  transition:
+    transform 0.6s ease,
+    opacity 0.6s ease;
 }
-
-@keyframes faint {
-  to {
-    transform: scale(0);
-    opacity: 0;
-  }
+.faint-enter-from,
+.faint-leave-to {
+  transform: scale(0);
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- wire up the enemy faint-end event directly on `BattleShlagemon`
- handle the fade-out transition inside `BattleShlagemon`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch fonts, 36 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68729a635104832a94a3825607ce8e9e