### PR TITLE
Fix enemy watcher

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -43,10 +43,6 @@ const nextPlayer = ref<DexShlagemon | null>(null)
 const displayedEnemy = ref(props.enemy)
 const nextEnemy = ref<DexShlagemon | null>(null)
 
-watch(() => props.enemy, () => {
-  console.log(props.enemy.id)
-})
-
 const showOwnedBall = computed(() => zone.current.type === 'sauvage')
 const enemyOwned = computed(() => {
   const id = displayedEnemy.value?.base.id
@@ -114,9 +110,12 @@ async function onCaptureEnd(success: boolean) {
 }
 
 watch(
-  () => props.enemy,
-  (val, old) => {
-    if (!old) {
+  () => props.enemy.id,
+  (id, oldId) => {
+    if (id === oldId)
+      return
+    const val = props.enemy
+    if (!oldId) {
       displayedEnemy.value = val
       startBattle()
       return


### PR DESCRIPTION
## Summary
- watch enemy ID for BattleRound
- clean up extra spacing

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6873a3ab640c832a897269a215d648e8