### PR TITLE
Remove redundant battle start on mount

### DIFF
--- a/src/components/battle/BattleRound.vue
+++ b/src/components/battle/BattleRound.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import AttackCursor from '~/components/battle/AttackCursor.vue'
 import BattleCapture from '~/components/battle/BattleCapture.vue'
 import BattleShlagemon from '~/components/battle/BattleShlagemon.vue'
@@ -50,7 +50,6 @@ const enemyOwned = computed(() => {
 })
 
 const {
-  enemy: currentEnemy,
   playerHp,
   enemyHp,
   flashPlayer,
@@ -197,11 +196,6 @@ function onClick(_e: MouseEvent) {
   if (props.clickAttack)
     attack()
 }
-
-onMounted(() => {
-  currentEnemy.value = props.enemy
-  startBattle()
-})
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- remove `onMounted` handler in `BattleRound` that duplicated battle initialization
- rely on existing watchers for initializing battles

## Testing
- `pnpm test` *(fails: 36 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6873a570cd34832a836e1f39c3ecedd3