### PR TITLE
Use KeepAlive for tab content

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
+// eslint-disable-next-line unused-imports/no-unused-imports
+import { KeepAlive } from 'vue'
 import AchievementsPanel from '~/components/achievements/AchievementsPanel.vue'
 import SchlagedexIcon from '~/components/icons/schlagedex.vue'
 import InventoryPanel from '~/components/panels/InventoryPanel.vue'
@@ -132,7 +134,9 @@ const bottomLocked = computed(() => {
             <SchlagedexIcon v-else-if="activeTab === 'dex'" class="h-4 w-4" />
             <div v-else-if="activeTab === 'inventory'" class="i-carbon-inventory-management" />
           </template>
-          <component :is="bottomComponent" />
+          <KeepAlive>
+            <component :is="bottomComponent" :key="activeTab" />
+          </KeepAlive>
         </PanelWrapper>
       </div>
 


### PR DESCRIPTION
## Summary
- import KeepAlive in `GameGrid.vue`
- keep each tab content alive when switching

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fetch errors for fonts, plus many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6873c304da08832ab32d0588a9bb69ae