### PR TITLE
Update mobile panel toggling

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -38,12 +38,14 @@ watch(
 )
 
 function toggleInventory() {
-  mobile.set('inventory')
+  mobile.toggle('inventory')
 }
 
 function onSecondButton() {
-  mobile.set('zones')
-  visit.markAllAccessibleVisited()
+  const opening = mobile.current !== 'zones'
+  mobile.toggle('zones')
+  if (opening)
+    visit.markAllAccessibleVisited()
 }
 </script>
 
@@ -53,7 +55,7 @@ function onSecondButton() {
       class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"
       :class="mobile.current === 'achievements' ? 'active' : ''"
       :disabled="achievementsDisabled"
-      @click="mobile.set('achievements')"
+      @click="mobile.toggle('achievements')"
     >
       <div class="i-carbon-trophy" />
     </button>
@@ -69,7 +71,7 @@ function onSecondButton() {
       class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"
       :class="mobile.current === 'dex' ? 'active' : ''"
       :disabled="dexDisabled"
-      @click="mobile.set('dex')"
+      @click="mobile.toggle('dex')"
     >
       <SchlagedexIcon class="h-5 w-5" />
     </button>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -6,7 +6,6 @@ import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
-import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
@@ -17,7 +16,6 @@ const panel = useMainPanelStore()
 const arena = useArenaStore()
 const progress = useZoneProgressStore()
 const dialog = useDialogStore()
-const mobile = useMobileTabStore()
 const featureLock = useFeatureLockStore()
 
 const zoneButtonsDisabled = computed(
@@ -54,7 +52,6 @@ function selectZone(id: string) {
   if (!z || buttonDisabled(z))
     return
   zone.setZone(id)
-  mobile.set('game')
 }
 
 function icon(z: Zone) {

--- a/src/components/shlagemon/Shlagedex.vue
+++ b/src/components/shlagemon/Shlagedex.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { storeToRefs } from 'pinia'
 import Modal from '~/components/modal/Modal.vue'
 import { useFeatureLockStore } from '~/stores/featureLock'
-import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { useUIStore } from '~/stores/ui'
 import ShlagemonDetail from './ShlagemonDetail.vue'
 import ShlagemonList from './ShlagemonList.vue'
 
@@ -13,8 +10,6 @@ const dex = useShlagedexStore()
 const featureLock = useFeatureLockStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
-const mobile = useMobileTabStore()
-const { isMobile } = storeToRefs(useUIStore())
 
 const clickTimer = ref<number | null>(null)
 
@@ -29,8 +24,6 @@ function changeActive(mon: DexShlagemon) {
   if (featureLock.isShlagedexLocked)
     return
   dex.setActiveShlagemon(mon)
-  if (isMobile.value)
-    mobile.set('game')
 }
 
 function onItemClick(mon: DexShlagemon) {

--- a/src/components/shlagemon/ShlagemonList.vue
+++ b/src/components/shlagemon/ShlagemonList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
-import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import MultiExpIcon from '~/components/icons/multi-exp.vue'
 import CheckBox from '~/components/ui/CheckBox.vue'
@@ -8,9 +7,7 @@ import SearchInput from '~/components/ui/SearchInput.vue'
 import SortControls from '~/components/ui/SortControls.vue'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useFeatureLockStore } from '~/stores/featureLock'
-import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { useUIStore } from '~/stores/ui'
 import { useWearableItemStore } from '~/stores/wearableItem'
 import ShlagemonImage from './ShlagemonImage.vue'
 import ShlagemonType from './ShlagemonType.vue'
@@ -32,8 +29,6 @@ const props = withDefaults(defineProps<Props>(), {
 const filter = useDexFilterStore()
 const dex = useShlagedexStore()
 const wearableItemStore = useWearableItemStore()
-const mobile = useMobileTabStore()
-const { isMobile } = storeToRefs(useUIStore())
 const featureLock = useFeatureLockStore()
 const isLocked = featureLock.isShlagedexLocked
 
@@ -115,8 +110,6 @@ function changeActive(mon: DexShlagemon) {
   if (isLocked.value)
     return
   dex.setActiveShlagemon(mon)
-  if (isMobile.value)
-    mobile.set('game')
 }
 </script>
 

--- a/src/stores/mobileTab.ts
+++ b/src/stores/mobileTab.ts
@@ -13,5 +13,8 @@ export const useMobileTabStore = defineStore('mobileTab', () => {
   function set(tab: MobileTab) {
     current.value = tab
   }
-  return { current, set }
+  function toggle(tab: MobileTab) {
+    current.value = current.value === tab ? 'game' : tab
+  }
+  return { current, set, toggle }
 })


### PR DESCRIPTION
## Summary
- add `toggle` to mobile tab store
- use `mobile.toggle` in the mobile menu
- keep panels open when selecting zones or shlagemons
- clean up unused mobile imports

## Testing
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_6873c91f34a8832aa49f8cb86fef6229