### PR TITLE
Add notifications for new zones and items

### DIFF
--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import Modal from '~/components/modal/Modal.vue'
 import Button from '~/components/ui/Button.vue'
 import { ballHues } from '~/utils/ball'
+import { useItemUsageStore } from '~/stores/itemUsage'
 
 const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
 const emit = defineEmits<{
@@ -13,6 +14,8 @@ const emit = defineEmits<{
 
 const showInfo = ref(false)
 const opened = ref(false)
+const usage = useItemUsageStore()
+const isUnused = computed(() => !usage.used[props.item.id])
 function toggle() {
   opened.value = !opened.value
 }
@@ -29,7 +32,8 @@ const actionLabel = computed(() => {
 </script>
 
 <template>
-  <div class="relative flex flex-col gap-1 border rounded bg-white p-2 dark:bg-gray-900">
+  <div class="relative flex flex-col gap-1 border rounded bg-white p-2 dark:bg-gray-900"
+    :class="isUnused ? 'animate-pulse ring-2 ring-blue-500 dark:ring-blue-400' : ''">
     <div class="flex cursor-pointer items-center justify-between gap-2" @click="toggle">
       <div class="flex items-center gap-2">
         <div

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -6,6 +6,7 @@ import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useInventoryStore } from '~/stores/inventory'
+import { useItemUsageStore } from '~/stores/itemUsage'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -14,6 +15,7 @@ import { useZoneVisitStore } from '~/stores/zoneVisit'
 const mobile = useMobileTabStore()
 const dialog = useDialogStore()
 const inventory = useInventoryStore()
+const usage = useItemUsageStore()
 const arena = useArenaStore()
 const achievements = useAchievementsStore()
 const shlagedex = useShlagedexStore()
@@ -22,6 +24,7 @@ const lockStore = useFeatureLockStore()
 const visit = useZoneVisitStore()
 
 const highlightMap = computed(() => visit.hasNewZone)
+const highlightInventory = computed(() => usage.hasUnusedItem)
 
 const menuDisabled = computed(() => dialog.isDialogVisible || panel.current === 'arena')
 const zoneDisabled = menuDisabled
@@ -44,8 +47,6 @@ function toggleInventory() {
 function onSecondButton() {
   const opening = mobile.current !== 'zones'
   mobile.toggle('zones')
-  if (opening)
-    visit.markAllAccessibleVisited()
 }
 </script>
 
@@ -77,7 +78,7 @@ function onSecondButton() {
     </button>
     <button
       class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"
-      :class="mobile.current === 'inventory' ? 'active' : ''"
+      :class="[mobile.current === 'inventory' ? 'active' : '', highlightInventory ? 'animate-pulse' : '']"
       :disabled="inventoryDisabled"
       @click="toggleInventory"
     >

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -12,6 +12,7 @@ import { useFeatureLockStore } from '~/stores/featureLock'
 import { useInventoryStore } from '~/stores/inventory'
 import { useInventoryFilterStore } from '~/stores/inventoryFilter'
 import { useWearableItemStore } from '~/stores/wearableItem'
+import { useItemUsageStore } from '~/stores/itemUsage'
 
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
@@ -19,6 +20,7 @@ const evoItemStore = useEvolutionItemStore()
 const wearableStore = useWearableItemStore()
 const filter = useInventoryFilterStore()
 const featureLock = useFeatureLockStore()
+const usage = useItemUsageStore()
 const sortOptions = [
   { label: 'Type', value: 'type' },
   { label: 'Nom', value: 'name' },
@@ -58,6 +60,7 @@ function onUse(item: Item) {
     return
   if ('catchBonus' in item) {
     ballStore.setBall(item.id as any)
+    usage.markUsed(item.id)
     toast(`Vous avez équipé la ${item.name}`)
   }
   else if (item.type === 'evolution') {
@@ -67,7 +70,8 @@ function onUse(item: Item) {
     wearableStore.open(item)
   }
   else {
-    inventory.useItem(item.id)
+    if (inventory.useItem(item.id))
+      usage.markUsed(item.id)
   }
 }
 </script>

--- a/src/components/panels/ZonePanel.vue
+++ b/src/components/panels/ZonePanel.vue
@@ -9,6 +9,7 @@ import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
+import { useZoneVisitStore } from '~/stores/zoneVisit'
 
 const zone = useZoneStore()
 const dex = useShlagedexStore()
@@ -17,6 +18,7 @@ const arena = useArenaStore()
 const progress = useZoneProgressStore()
 const dialog = useDialogStore()
 const featureLock = useFeatureLockStore()
+const visit = useZoneVisitStore()
 
 const zoneButtonsDisabled = computed(
   () =>
@@ -101,6 +103,10 @@ function kingDefeated(z: Zone) {
 function arenaDefeated(z: Zone) {
   return !!z.arena && progress.isArenaCompleted(z.id)
 }
+
+function isNew(z: Zone) {
+  return !visit.visited[z.id]
+}
 </script>
 
 <template>
@@ -119,7 +125,11 @@ function arenaDefeated(z: Zone) {
         v-for="z in accessibleZones"
         :key="z.id"
         class="relative grid grid-rows-2 max-h-[120px] gap-1 rounded px-2 py-1 text-xs"
-        :class="`${classes(z)} ${buttonDisabled(z) ? 'opacity-50 cursor-not-allowed' : ''}`"
+        :class="[
+          classes(z),
+          buttonDisabled(z) ? 'opacity-50 cursor-not-allowed' : '',
+          isNew(z) ? 'animate-pulse ring-2 ring-blue-500 dark:ring-blue-400' : '',
+        ]"
         :disabled="buttonDisabled(z)"
         @click="selectZone(z.id)"
       >

--- a/src/stores/evolutionItem.ts
+++ b/src/stores/evolutionItem.ts
@@ -4,11 +4,13 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useInventoryStore } from './inventory'
 import { useShlagedexStore } from './shlagedex'
+import { useItemUsageStore } from './itemUsage'
 
 export const useEvolutionItemStore = defineStore('evolutionItem', () => {
   const current = ref<Item | null>(null)
   const dex = useShlagedexStore()
   const inventory = useInventoryStore()
+  const usage = useItemUsageStore()
 
   // modal visibility is controlled by this ref
   const isVisible = ref(false)
@@ -44,6 +46,7 @@ export const useEvolutionItemStore = defineStore('evolutionItem', () => {
     const success = await dex.evolveWithItem(mon, current.value)
     if (success) {
       inventory.remove(current.value.id)
+      usage.markUsed(current.value.id)
       close()
     }
     return success

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -9,6 +9,7 @@ import { useCaptureLimitModalStore } from './captureLimitModal'
 import { useGameStore } from './game'
 import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
+import { useItemUsageStore } from './itemUsage'
 
 export const useInventoryStore = defineStore('inventory', () => {
   const items = ref<Record<string, number>>({})
@@ -17,6 +18,7 @@ export const useInventoryStore = defineStore('inventory', () => {
   const arena = useArenaStore()
   const player = usePlayerStore()
   const captureLimitModal = useCaptureLimitModalStore()
+  const itemUsage = useItemUsageStore()
 
   interface ListedItem {
     item: Item
@@ -149,7 +151,10 @@ export const useInventoryStore = defineStore('inventory', () => {
     }
 
     const handler = handlers[id]
-    return handler ? handler() : false
+    const result = handler ? handler() : false
+    if (result)
+      itemUsage.markUsed(id)
+    return result
   }
 
   function reset() {

--- a/src/stores/itemUsage.ts
+++ b/src/stores/itemUsage.ts
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { useInventoryStore } from './inventory'
+
+export const useItemUsageStore = defineStore('itemUsage', () => {
+  const used = ref<Record<string, boolean>>({})
+  const inventory = useInventoryStore()
+
+  const hasUnusedItem = computed(() =>
+    Object.entries(inventory.items).some(([id, qty]) => qty > 0 && !used.value[id]),
+  )
+
+  function markUsed(id: string) {
+    used.value[id] = true
+  }
+
+  function reset() {
+    used.value = {}
+  }
+
+  return { used, hasUnusedItem, markUsed, reset }
+}, {
+  persist: true,
+})

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -12,6 +12,7 @@ import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 import { useZoneProgressStore } from './zoneProgress'
+import { useItemUsageStore } from './itemUsage'
 
 export const useSaveStore = defineStore('save', () => {
   const dex = useShlagedexStore()
@@ -27,6 +28,7 @@ export const useSaveStore = defineStore('save', () => {
   const dexFilter = useDexFilterStore()
   const mainPanel = useMainPanelStore()
   const player = usePlayerStore()
+  const itemUsage = useItemUsageStore()
 
   function reset() {
     dex.reset()
@@ -42,6 +44,7 @@ export const useSaveStore = defineStore('save', () => {
     dexFilter.reset()
     mainPanel.reset()
     player.reset()
+    itemUsage.reset()
   }
 
   return { reset }

--- a/src/stores/wearableItem.ts
+++ b/src/stores/wearableItem.ts
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import { useEquipmentStore } from './equipment'
 import { useMobileTabStore } from './mobileTab'
 import { useShlagedexStore } from './shlagedex'
+import { useItemUsageStore } from './itemUsage'
 
 export const useWearableItemStore = defineStore('wearableItem', () => {
   const current = ref<Item | null>(null)
@@ -12,6 +13,7 @@ export const useWearableItemStore = defineStore('wearableItem', () => {
   const dex = useShlagedexStore()
   const equipment = useEquipmentStore()
   const mobile = useMobileTabStore()
+  const usage = useItemUsageStore()
 
   const holderId = computed(() =>
     current.value ? equipment.getHolder(current.value.id) : null,
@@ -48,6 +50,7 @@ export const useWearableItemStore = defineStore('wearableItem', () => {
       return
     selectedId.value = monId
     equipment.equip(monId, current.value.id)
+    usage.markUsed(current.value.id)
     close()
   }
 


### PR DESCRIPTION
## Summary
- store item usage to know when items are still unused
- reset new store when resetting a save
- highlight new items in inventory
- pulse inventory and zone buttons when something new is available
- show new zones inside the zone panel

## Testing
- `pnpm lint` *(fails: cannot find @antfu/eslint-config)*
- `pnpm test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874333d5978832a839769e68c0306a8