### PR TITLE
Fix zone highlight on new game

### DIFF
--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -7,12 +7,13 @@ import { useDialogStore } from './dialog'
 import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
 import { useInventoryStore } from './inventory'
+import { useItemUsageStore } from './itemUsage'
 import { useMainPanelStore } from './mainPanel'
 import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 import { useZoneProgressStore } from './zoneProgress'
-import { useItemUsageStore } from './itemUsage'
+import { useZoneVisitStore } from './zoneVisit'
 
 export const useSaveStore = defineStore('save', () => {
   const dex = useShlagedexStore()
@@ -23,6 +24,7 @@ export const useSaveStore = defineStore('save', () => {
   const dialog = useDialogStore()
   const zone = useZoneStore()
   const zoneProgress = useZoneProgressStore()
+  const zoneVisit = useZoneVisitStore()
   const achievements = useAchievementsStore()
   const ball = useBallStore()
   const dexFilter = useDexFilterStore()
@@ -37,6 +39,7 @@ export const useSaveStore = defineStore('save', () => {
     dialog.reset()
     inventory.reset()
     zone.reset()
+    zoneVisit.reset()
     zoneProgress.reset()
     achievements.reset()
     battleStats.reset()

--- a/src/stores/zoneVisit.ts
+++ b/src/stores/zoneVisit.ts
@@ -35,11 +35,16 @@ export const useZoneVisitStore = defineStore('zoneVisit', () => {
     accessibleZones.value.forEach(z => markVisited(z.id))
   }
 
+  function reset() {
+    visited.value = {}
+  }
+
   return {
     visited,
     hasNewZone,
     markVisited,
     markAllAccessibleVisited,
+    reset,
   }
 }, {
   persist: true,


### PR DESCRIPTION
## Summary
- add reset function to zoneVisit store
- clear zone visit data when save is reset

## Testing
- `pnpm test:unit` *(fails: Cannot read properties of undefined, timed out)*
- `pnpm lint` *(fails: import order errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874f238d9d8832a88d2b12b8ef51f3a