### PR TITLE
Add achievement filter options

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -119,6 +119,7 @@ declare global {
   const unref: typeof import('vue')['unref']
   const unrefElement: typeof import('@vueuse/core')['unrefElement']
   const until: typeof import('@vueuse/core')['until']
+  const useAchievementsFilterStore: typeof import('./stores/achievementsFilter')['useAchievementsFilterStore']
   const useAchievementsStore: typeof import('./stores/achievements')['useAchievementsStore']
   const useActiveElement: typeof import('@vueuse/core')['useActiveElement']
   const useAnimate: typeof import('@vueuse/core')['useAnimate']
@@ -219,6 +220,7 @@ declare global {
   const useIntervalFn: typeof import('@vueuse/core')['useIntervalFn']
   const useInventoryFilterStore: typeof import('./stores/inventoryFilter')['useInventoryFilterStore']
   const useInventoryStore: typeof import('./stores/inventory')['useInventoryStore']
+  const useItemUsageStore: typeof import('./stores/itemUsage')['useItemUsageStore']
   const useKeyModifier: typeof import('@vueuse/core')['useKeyModifier']
   const useKeyboardCaptureStore: typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']
   const useLastChanged: typeof import('@vueuse/core')['useLastChanged']
@@ -363,6 +365,9 @@ declare global {
   // @ts-ignore
   export type { Achievement, AchievementEvent } from './stores/achievements'
   import('./stores/achievements')
+  // @ts-ignore
+  export type { AchievementFilterStatus } from './stores/achievementsFilter'
+  import('./stores/achievementsFilter')
   // @ts-ignore
   export type { ArenaResult } from './stores/arena'
   import('./stores/arena')
@@ -510,6 +515,7 @@ declare module 'vue' {
     readonly unref: UnwrapRef<typeof import('vue')['unref']>
     readonly unrefElement: UnwrapRef<typeof import('@vueuse/core')['unrefElement']>
     readonly until: UnwrapRef<typeof import('@vueuse/core')['until']>
+    readonly useAchievementsFilterStore: UnwrapRef<typeof import('./stores/achievementsFilter')['useAchievementsFilterStore']>
     readonly useAchievementsStore: UnwrapRef<typeof import('./stores/achievements')['useAchievementsStore']>
     readonly useActiveElement: UnwrapRef<typeof import('@vueuse/core')['useActiveElement']>
     readonly useAnimate: UnwrapRef<typeof import('@vueuse/core')['useAnimate']>
@@ -610,6 +616,7 @@ declare module 'vue' {
     readonly useIntervalFn: UnwrapRef<typeof import('@vueuse/core')['useIntervalFn']>
     readonly useInventoryFilterStore: UnwrapRef<typeof import('./stores/inventoryFilter')['useInventoryFilterStore']>
     readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
+    readonly useItemUsageStore: UnwrapRef<typeof import('./stores/itemUsage')['useItemUsageStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
     readonly useKeyboardCaptureStore: UnwrapRef<typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']>
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -1,18 +1,30 @@
 <script setup lang="ts">
-import Button from '~/components/ui/Button.vue'
-import CheckBox from '~/components/ui/CheckBox.vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
+import SelectOption from '~/components/ui/SelectOption.vue'
 import { useAchievementsStore } from '~/stores/achievements'
+import { useAchievementsFilterStore } from '~/stores/achievementsFilter'
 import AchievementItem from './AchievementItem.vue'
 
 const store = useAchievementsStore()
-const showLocked = ref(false)
-const search = ref('')
-const list = computed(() => showLocked.value ? store.list : store.unlockedList)
+const filter = useAchievementsFilterStore()
+
+const statusOptions = [
+  { label: 'Tous', value: 'all' },
+  { label: 'Débloqués', value: 'unlocked' },
+  { label: 'À débloquer', value: 'locked' },
+]
+
+const list = computed(() => {
+  if (filter.status === 'all')
+    return store.list
+  if (filter.status === 'unlocked')
+    return store.unlockedList
+  return store.list.filter(a => !a.achieved)
+})
 const filteredList = computed(() => {
-  if (!search.value.trim())
+  if (!filter.search.trim())
     return list.value
-  const q = search.value.toLowerCase()
+  const q = filter.search.toLowerCase()
   return list.value.filter(a => a.title.toLowerCase().includes(q))
 })
 </script>
@@ -20,11 +32,12 @@ const filteredList = computed(() => {
 <template>
   <ScrollablePanel>
     <template #header>
-      <Button class="flex flex-1 items-center justify-between gap-2 text-sm" @click="showLocked = !showLocked">
-        <span class="whitespace-nowrap" md="whitespace-normal">{{ showLocked ? 'Masquer' : 'Afficher' }} les succès verrouillés</span>
-        <CheckBox :model-value="showLocked" @update:model-value="showLocked = $event" @click.stop />
-      </Button>
-      <SearchInput v-model="search" class="flex-1" />
+      <SelectOption
+        v-model="filter.status"
+        :options="statusOptions"
+        class="min-w-28"
+      />
+      <SearchInput v-model="filter.search" class="flex-1" />
     </template>
 
     <template #content>

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -45,7 +45,6 @@ function toggleInventory() {
 }
 
 function onSecondButton() {
-  const opening = mobile.current !== 'zones'
   mobile.toggle('zones')
 }
 

--- a/src/stores/achievementsFilter.ts
+++ b/src/stores/achievementsFilter.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type AchievementFilterStatus = 'unlocked' | 'locked' | 'all'
+
+export const useAchievementsFilterStore = defineStore('achievementsFilter', () => {
+  const search = ref('')
+  const status = ref<AchievementFilterStatus>('unlocked')
+
+  function reset() {
+    search.value = ''
+    status.value = 'unlocked'
+  }
+
+  return { search, status, reset }
+}, {
+  persist: true,
+})

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { useAchievementsStore } from './achievements'
+import { useAchievementsFilterStore } from './achievementsFilter'
 import { useBallStore } from './ball'
 import { useBattleStatsStore } from './battleStats'
 import { useDexFilterStore } from './dexFilter'
@@ -7,12 +8,12 @@ import { useDialogStore } from './dialog'
 import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
 import { useInventoryStore } from './inventory'
+import { useItemUsageStore } from './itemUsage'
 import { useMainPanelStore } from './mainPanel'
 import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 import { useZoneProgressStore } from './zoneProgress'
-import { useItemUsageStore } from './itemUsage'
 
 export const useSaveStore = defineStore('save', () => {
   const dex = useShlagedexStore()
@@ -24,6 +25,7 @@ export const useSaveStore = defineStore('save', () => {
   const zone = useZoneStore()
   const zoneProgress = useZoneProgressStore()
   const achievements = useAchievementsStore()
+  const achievementsFilter = useAchievementsFilterStore()
   const ball = useBallStore()
   const dexFilter = useDexFilterStore()
   const mainPanel = useMainPanelStore()
@@ -39,6 +41,7 @@ export const useSaveStore = defineStore('save', () => {
     zone.reset()
     zoneProgress.reset()
     achievements.reset()
+    achievementsFilter.reset()
     battleStats.reset()
     ball.reset()
     dexFilter.reset()


### PR DESCRIPTION
## Summary
- add achievementsFilter store to persist search and status
- use SelectOption in AchievementsPanel for filtering
- reset filter in SaveStore
- clean unused variable in MobileMenu

## Testing
- `pnpm exec eslint src/components/achievements/AchievementsPanel.vue src/components/layout/MobileMenu.vue src/stores/save.ts src/stores/achievementsFilter.ts`
- `pnpm test` *(fails: fetch errors & ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6874f2b938b0832ab79f8c625438287a