### PR TITLE
Persist mobile tab state

### DIFF
--- a/src/stores/mobileTab.ts
+++ b/src/stores/mobileTab.ts
@@ -17,4 +17,6 @@ export const useMobileTabStore = defineStore('mobileTab', () => {
     current.value = current.value === tab ? 'game' : tab
   }
   return { current, set, toggle }
+}, {
+  persist: true,
 })

--- a/test/mobile-tab-persist.test.ts
+++ b/test/mobile-tab-persist.test.ts
@@ -1,0 +1,18 @@
+import { createPinia, setActivePinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { describe, expect, it } from 'vitest'
+import { useMobileTabStore } from '../src/stores/mobileTab'
+
+describe('mobile tab persistence', () => {
+  it('restores current tab from storage', () => {
+    const pinia = createPinia()
+    pinia.use(piniaPluginPersistedstate)
+    setActivePinia(pinia)
+
+    // simulate previously saved tab
+    window.localStorage.setItem('mobileTab', JSON.stringify({ current: 'dex' }))
+
+    const tab = useMobileTabStore()
+    expect(tab.current).toBe('dex')
+  })
+})


### PR DESCRIPTION
## Summary
- store currently active mobile panel in the mobileTab store and persist it
- test that the mobile tab is restored from storage

## Testing
- `pnpm test:unit` *(fails: Could not fetch fonts; data errors, audio errors, etc.)*
- `pnpm test:e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874f9198390832aab0f5c87360d8744