### PR TITLE
Ensure single expanded item

### DIFF
--- a/src/components/achievements/AchievementItem.vue
+++ b/src/components/achievements/AchievementItem.vue
@@ -1,10 +1,20 @@
 <script setup lang="ts">
 import type { Achievement } from '~/stores/achievements'
+import { withDefaults } from 'vue'
 
-const props = defineProps<{ achievement: Achievement & { achieved: boolean } }>()
-const opened = ref(false)
+const props = withDefaults(defineProps<{
+  achievement: Achievement & { achieved: boolean }
+  opened?: boolean
+}>(), {
+  opened: false,
+})
+
+const emit = defineEmits<{
+  (e: 'toggle'): void
+}>()
+
 function toggle() {
-  opened.value = !opened.value
+  emit('toggle')
 }
 </script>
 
@@ -20,9 +30,9 @@ function toggle() {
         <div :class="props.achievement.icon" class="inline-block text-lg" />
         <span class="font-bold">{{ props.achievement.title }}</span>
       </div>
-      <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
+      <div class="i-carbon-chevron-down transition-transform" :class="props.opened ? '' : 'rotate-90'" />
     </div>
-    <div v-show="opened" class="mt-1 text-xs">
+    <div v-show="props.opened" class="mt-1 text-xs">
       <p>{{ props.achievement.description }}</p>
     </div>
   </div>

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import SearchInput from '~/components/ui/SearchInput.vue'
 import SelectOption from '~/components/ui/SelectOption.vue'
 import { useAchievementsStore } from '~/stores/achievements'
@@ -7,6 +8,11 @@ import AchievementItem from './AchievementItem.vue'
 
 const store = useAchievementsStore()
 const filter = useAchievementsFilterStore()
+const opened = ref<string | null>(null)
+
+function toggle(id: string) {
+  opened.value = opened.value === id ? null : id
+}
 
 const statusOptions = [
   { label: 'Tous', value: 'all' },
@@ -45,6 +51,8 @@ const filteredList = computed(() => {
         v-for="a in filteredList"
         :key="a.id"
         :achievement="a"
+        :opened="opened === a.id"
+        @toggle="toggle(a.id)"
       />
     </template>
   </ScrollablePanel>

--- a/src/components/inventory/InventoryItemCard.vue
+++ b/src/components/inventory/InventoryItemCard.vue
@@ -1,23 +1,31 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
-import { computed, ref } from 'vue'
+import { computed, ref, withDefaults } from 'vue'
 import Modal from '~/components/modal/Modal.vue'
 import Button from '~/components/ui/Button.vue'
 import { useItemUsageStore } from '~/stores/itemUsage'
 import { ballHues } from '~/utils/ball'
 
-const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
+const props = withDefaults(defineProps<{
+  item: Item
+  qty: number
+  disabled?: boolean
+  opened?: boolean
+}>(), {
+  opened: false,
+})
+
 const emit = defineEmits<{
   (e: 'use'): void
   (e: 'sell'): void
+  (e: 'toggle'): void
 }>()
 
 const showInfo = ref(false)
-const opened = ref(false)
 const usage = useItemUsageStore()
 const isUnused = computed(() => !usage.used[props.item.id])
 function onCardClick() {
-  opened.value = !opened.value
+  emit('toggle')
   usage.markUsed(props.item.id)
 }
 const details = computed(() => props.item.details || props.item.description)
@@ -56,9 +64,9 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
         >
         <span class="font-bold">{{ props.item.name }}</span>
       </div>
-      <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
+      <div class="i-carbon-chevron-down transition-transform" :class="props.opened ? '' : 'rotate-90'" />
     </div>
-    <span v-show="opened" class="text-xs">{{ props.item.description }}</span>
+    <span v-show="props.opened" class="text-xs">{{ props.item.description }}</span>
     <div class="mt-1 flex items-center justify-end gap-1">
       <span class="font-bold">x{{ props.qty }}</span>
       <Button

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -21,6 +21,7 @@ const wearableStore = useWearableItemStore()
 const filter = useInventoryFilterStore()
 const featureLock = useFeatureLockStore()
 const usage = useItemUsageStore()
+const opened = ref<string | null>(null)
 const sortOptions = [
   { label: 'Type', value: 'type' },
   { label: 'Nom', value: 'name' },
@@ -53,6 +54,10 @@ function isDisabled(item: Item) {
   if ('catchBonus' in item)
     return ballStore.current === item.id
   return item.type === 'evolution' && !evoItemStore.canUse(item)
+}
+
+function toggle(id: string) {
+  opened.value = opened.value === id ? null : id
 }
 
 function onUse(item: Item) {
@@ -94,8 +99,10 @@ function onUse(item: Item) {
         :item="entry.item"
         :qty="entry.qty"
         :disabled="isDisabled(entry.item)"
+        :opened="opened === entry.item.id"
         @use="onUse(entry.item)"
         @sell="inventory.sell(entry.item.id)"
+        @toggle="toggle(entry.item.id)"
       />
     </template>
   </ScrollablePanel>


### PR DESCRIPTION
## Summary
- track opened item in inventory and achievements panels
- keep only one achievement expanded at a time
- keep only one inventory item expanded at a time

## Testing
- `pnpm test` *(fails: Test timed out in 5000ms, 36 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6874f9817a78832a9c399b44526f3100