### PR TITLE
Implement single item toggle

### DIFF
--- a/src/components/achievements/AchievementItem.vue
+++ b/src/components/achievements/AchievementItem.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import type { Achievement } from '~/stores/achievements'
 
-const props = defineProps<{ achievement: Achievement & { achieved: boolean } }>()
-const opened = ref(false)
+const props = withDefaults(defineProps<{ achievement: Achievement & { achieved: boolean }, opened?: boolean }>(), {
+  opened: false,
+})
+const emit = defineEmits(['toggle'])
+
 function toggle() {
-  opened.value = !opened.value
+  emit('toggle')
 }
 </script>
 
@@ -20,9 +23,9 @@ function toggle() {
         <div :class="props.achievement.icon" class="inline-block text-lg" />
         <span class="font-bold">{{ props.achievement.title }}</span>
       </div>
-      <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
+      <div class="i-carbon-chevron-down transition-transform" :class="props.opened ? '' : 'rotate-90'" />
     </div>
-    <div v-show="opened" class="mt-1 text-xs">
+    <div v-show="props.opened" class="mt-1 text-xs">
       <p>{{ props.achievement.description }}</p>
     </div>
   </div>

--- a/src/components/achievements/AchievementsPanel.vue
+++ b/src/components/achievements/AchievementsPanel.vue
@@ -3,6 +3,8 @@ import { useAchievementsStore } from '~/stores/achievements'
 import { useAchievementsFilterStore } from '~/stores/achievementsFilter'
 import AchievementItem from './AchievementItem.vue'
 
+const openedId = ref<string | null>(null)
+
 const store = useAchievementsStore()
 const filter = useAchievementsFilterStore()
 
@@ -25,6 +27,10 @@ const filteredList = computed(() => {
   const q = filter.search.toLowerCase()
   return list.value.filter(a => a.title.toLowerCase().includes(q))
 })
+
+function toggleItem(id: string) {
+  openedId.value = openedId.value === id ? null : id
+}
 </script>
 
 <template>
@@ -43,6 +49,8 @@ const filteredList = computed(() => {
         v-for="a in filteredList"
         :key="a.id"
         :achievement="a"
+        :opened="openedId === a.id"
+        @toggle="toggleItem(a.id)"
       />
     </template>
   </LayoutScrollablePanel>

--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -2,22 +2,23 @@
 import type { Item } from '~/type/item'
 import { computed, ref } from 'vue'
 import Modal from '~/components/modal/Modal.vue'
-import Button from '~/components/ui/Button.vue'
 import { useItemUsageStore } from '~/stores/itemUsage'
 import { ballHues } from '~/utils/ball'
 
-const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
+const props = withDefaults(defineProps<{ item: Item, qty: number, disabled?: boolean, opened?: boolean }>(), {
+  opened: false,
+})
 const emit = defineEmits<{
   (e: 'use'): void
   (e: 'sell'): void
+  (e: 'toggle'): void
 }>()
 
 const showInfo = ref(false)
-const opened = ref(false)
 const usage = useItemUsageStore()
 const isUnused = computed(() => !usage.used[props.item.id])
 function onCardClick() {
-  opened.value = !opened.value
+  emit('toggle')
   usage.markUsed(props.item.id)
 }
 const details = computed(() => props.item.details || props.item.description)
@@ -56,9 +57,9 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
         >
         <span class="font-bold">{{ props.item.name }}</span>
       </div>
-      <div class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />
+      <div class="i-carbon-chevron-down transition-transform" :class="props.opened ? '' : 'rotate-90'" />
     </div>
-    <span v-show="opened" class="text-xs">{{ props.item.description }}</span>
+    <span v-show="props.opened" class="text-xs">{{ props.item.description }}</span>
     <div class="mt-1 flex items-center justify-end gap-1">
       <span class="font-bold">x{{ props.qty }}</span>
       <UiButton

--- a/src/components/panels/InventoryPanel.vue
+++ b/src/components/panels/InventoryPanel.vue
@@ -16,6 +16,7 @@ const wearableStore = useWearableItemStore()
 const filter = useInventoryFilterStore()
 const featureLock = useFeatureLockStore()
 const usage = useItemUsageStore()
+const openedId = ref<string | null>(null)
 const sortOptions = [
   { label: 'Type', value: 'type' },
   { label: 'Nom', value: 'name' },
@@ -41,6 +42,10 @@ const filteredList = computed(() => {
     list.reverse()
   return list
 })
+
+function toggleItem(id: string) {
+  openedId.value = openedId.value === id ? null : id
+}
 
 function isDisabled(item: Item) {
   if (featureLock.isInventoryLocked)
@@ -89,6 +94,8 @@ function onUse(item: Item) {
         :item="entry.item"
         :qty="entry.qty"
         :disabled="isDisabled(entry.item)"
+        :opened="openedId === entry.item.id"
+        @toggle="toggleItem(entry.item.id)"
         @use="onUse(entry.item)"
         @sell="inventory.sell(entry.item.id)"
       />


### PR DESCRIPTION
## Summary
- close previously opened item/success when opening a new one
- manage open state in InventoryPanel and AchievementsPanel
- propagate `opened` state to item components

## Testing
- `pnpm lint`
- `pnpm test` *(fails: many errors about zones and media elements)*

------
https://chatgpt.com/codex/tasks/task_e_6874fe33cea8832abb9a3af6fa6a8d96