### PR TITLE
Fix component name prefixes

### DIFF
--- a/scripts/check-components.cjs
+++ b/scripts/check-components.cjs
@@ -1,0 +1,44 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const componentsDefs = fs.readFileSync('src/components.d.ts', 'utf8')
+const componentRegex = /\s(\w+):/g
+const components = new Set()
+for (const match of componentsDefs.matchAll(componentRegex)) {
+  components.add(match[1])
+}
+const builtIns = new Set(['Transition', 'TransitionGroup', 'KeepAlive', 'Teleport', 'Suspense'])
+
+function extractComponentsFromTemplate(content) {
+  const templateMatch = content.match(/<template>([\s\S]*?)<\/template>/)
+  if (!templateMatch)
+    return []
+  const template = templateMatch[1]
+  const tagRegex = /<([A-Z][\w-]*)/g
+  const tags = new Set()
+  for (const m of template.matchAll(tagRegex)) {
+    tags.add(m[1])
+  }
+  return Array.from(tags)
+}
+
+function walk(dir) {
+  const files = fs.readdirSync(dir)
+  for (const file of files) {
+    const full = path.join(dir, file)
+    const stat = fs.statSync(full)
+    if (stat.isDirectory()) {
+      walk(full)
+    }
+    else if (file.endsWith('.vue')) {
+      const content = fs.readFileSync(full, 'utf8')
+      const used = extractComponentsFromTemplate(content)
+      const missing = used.filter(u => !components.has(u) && !builtIns.has(u))
+      if (missing.length) {
+        console.log(full, '-> missing', missing.join(', '))
+      }
+    }
+  }
+}
+
+walk('src')

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -75,7 +75,7 @@ const highlightClasses = 'animate-jello animate-count-infinite color-blue-500 da
       :disabled="dexDisabled"
       @click="mobile.toggle('dex')"
     >
-      <SchlagedexIcon class="h-5 w-5" />
+      <IconsSchlagedexIcon class="h-5 w-5" />
     </button>
     <button
       class="button button-rectangle disabled:cursor-not-allowed disabled:opacity-50"

--- a/src/components/panels/ArenaPanel.vue
+++ b/src/components/panels/ArenaPanel.vue
@@ -2,5 +2,5 @@
 </script>
 
 <template>
-  <ArenaPanelInner class="h-full p-2" />
+  <ArenaArenaPanel class="h-full p-2" />
 </template>

--- a/src/components/panels/BonusDetails.vue
+++ b/src/components/panels/BonusDetails.vue
@@ -19,15 +19,15 @@ const dex = useShlagedexStore()
     </p>
     <div class="mt-2 flex flex-col gap-1">
       <div class="flex items-center gap-2">
-        <SchlagedexIcon class="h-5 w-5" />
+        <IconsSchlagedexIcon class="h-5 w-5" />
         <span>Complétion : {{ Math.round(dex.potentialCompletionPercent) }}%</span>
       </div>
       <div class="flex items-center gap-2">
-        <XpIcon class="h-5 w-5" />
+        <IconsXpIcon class="h-5 w-5" />
         <span>Niveau moyen : {{ dex.averageLevel.toFixed(1) }}</span>
       </div>
       <div class="flex items-center gap-2">
-        <BonusIcon class="h-5 w-5" />
+        <IconsBonusIcon class="h-5 w-5" />
         <span>Bonus actuel : +{{ Math.round(dex.bonusPercent) }}%</span>
       </div>
     </div>

--- a/src/components/panels/PlayerInfos.vue
+++ b/src/components/panels/PlayerInfos.vue
@@ -36,13 +36,13 @@ const totalInDex = allShlagemons.length
     <CurrencyAmount :amount="game.shlagidiamond" currency="shlagidiamond" />
     <UiTooltip text="SchlagéDex">
       <div class="min-w-0 flex items-center gap-1">
-        <SchlagedexIcon class="h-4 w-4" />
+        <IconsSchlagedexIcon class="h-4 w-4" />
         <span class="shrink-0 font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
       </div>
     </UiTooltip>
     <UiTooltip text="Niveau moyen">
       <div class="min-w-0 flex items-center gap-1">
-        <XpIcon class="h-4 w-4" />
+        <IconsXpIcon class="h-4 w-4" />
         <span class="shrink-0 font-bold">{{ dex.averageLevel.toFixed(1) }}</span>
       </div>
     </UiTooltip>
@@ -51,7 +51,7 @@ const totalInDex = allShlagemons.length
         class="min-w-0 flex cursor-pointer items-center gap-1"
         @click="showBonus = true"
       >
-        <BonusIcon class="h-4 w-4" />
+        <IconsBonusIcon class="h-4 w-4" />
         <span class="shrink-0 font-bold">+{{ Math.round(dex.bonusPercent) }}%</span>
       </div>
     </UiTooltip>

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -121,7 +121,7 @@ const captureInfo = computed(() => {
           v-if="wearableItemStore.getHolderId('multi-exp') === mon.id"
           class="absolute right-0 top-0 flex items-center gap-1"
         >
-          <MultiExpIcon class="h-5 w-5" />
+          <IconsMultiExpIcon class="h-5 w-5" />
           <UiButton
             type="icon"
             class="h-5 w-5"

--- a/src/components/ui/NavigationButton.vue
+++ b/src/components/ui/NavigationButton.vue
@@ -7,7 +7,7 @@ const emit = defineEmits(['click'])
 
 <template>
   <button
-    class="grid grid-rows-2 max-h-[120px] gap-1 rounded px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 flex-shrink-0"
+    class="grid grid-rows-2 max-h-[120px] flex-shrink-0 gap-1 rounded bg-gray-200 px-2 py-1 text-xs dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
     :class="props.disabled ? 'opacity-50 cursor-not-allowed' : ''"
     :disabled="props.disabled"
     @click="emit('click')"

--- a/src/layouts/home.vue
+++ b/src/layouts/home.vue
@@ -4,7 +4,6 @@
     text="center gray-700 dark:gray-200"
   >
     <RouterView />
-    <TheFooter />
     <div mx-auto mt-5 text-center text-sm opacity-50>
       [Home Layout]
     </div>


### PR DESCRIPTION
## Summary
- update icon component names after enabling parent folder prefixes
- rename Arena panel reference
- drop obsolete footer
- format NavigationButton per linter
- add helper script to check missing components

## Testing
- `pnpm lint --fix`
- `pnpm test` *(fails: Test Files 20 failed | 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68750b4a95ac832a8d8f1fd4e7715fba