### PR TITLE
Simplify inventory item card behavior

### DIFF
--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -3,20 +3,17 @@ import type { Item } from '~/type/item'
 import { useItemUsageStore } from '~/stores/itemUsage'
 import { ballHues } from '~/utils/ball'
 
-const props = withDefaults(defineProps<{ item: Item, qty: number, disabled?: boolean, opened?: boolean }>(), {
-  opened: false,
-})
+const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
 const emit = defineEmits<{
   (e: 'use'): void
   (e: 'sell'): void
-  (e: 'toggle'): void
 }>()
 
 const showInfo = ref(false)
 const usage = useItemUsageStore()
 const isUnused = computed(() => !usage.used[props.item.id])
 function onCardClick() {
-  emit('toggle')
+  showInfo.value = true
   usage.markUsed(props.item.id)
 }
 const details = computed(() => props.item.details || props.item.description)
@@ -55,9 +52,7 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
         >
         <span class="font-bold">{{ props.item.name }}</span>
       </div>
-      <div class="i-carbon-chevron-down absolute right-1 top-1 text-xs transition-transform" :class="props.opened ? '' : 'rotate-90'" />
     </div>
-    <span v-show="props.opened" class="text-xs">{{ props.item.description }}</span>
     <div class="mt-1 flex items-center justify-end gap-1">
       <span class="font-bold">x{{ props.qty }}</span>
       <UiButton

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -16,7 +16,6 @@ const wearableStore = useWearableItemStore()
 const filter = useInventoryFilterStore()
 const featureLock = useFeatureLockStore()
 const usage = useItemUsageStore()
-const openedId = ref<string | null>(null)
 const sortOptions = [
   { label: 'Type', value: 'type' },
   { label: 'Nom', value: 'name' },
@@ -42,10 +41,6 @@ const filteredList = computed(() => {
     list.reverse()
   return list
 })
-
-function toggleItem(id: string) {
-  openedId.value = openedId.value === id ? null : id
-}
 
 function isDisabled(item: Item) {
   if (featureLock.isInventoryLocked)
@@ -94,8 +89,6 @@ function onUse(item: Item) {
         :item="entry.item"
         :qty="entry.qty"
         :disabled="isDisabled(entry.item)"
-        :opened="openedId === entry.item.id"
-        @toggle="toggleItem(entry.item.id)"
         @use="onUse(entry.item)"
         @sell="inventory.sell(entry.item.id)"
       />


### PR DESCRIPTION
## Summary
- remove collapsible state from `InventoryItemCard`
- open item info modal when clicking anywhere on the card
- update inventory panel to use simplified card

## Testing
- `pnpm test` *(fails: unable to resolve imports & other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68752351eb0c832a9895e9c9d53fb0f7