### PR TITLE
Fix zone highlight

### DIFF
--- a/src/stores/zoneVisit.ts
+++ b/src/stores/zoneVisit.ts
@@ -24,7 +24,10 @@ export const useZoneVisitStore = defineStore('zoneVisit', () => {
 
   const accessibleZones = computed(() => zones.filter(z => canAccess(z)))
 
-  const hasNewZone = computed(() => accessibleZones.value.some(z => !visited.value[z.id]))
+  const hasNewZone = computed(
+    () => accessibleZones.value.length > 1
+      && accessibleZones.value.some(z => !visited.value[z.id]),
+  )
 
   function markVisited(id: string) {
     visited.value[id] = true

--- a/test/zone-visit.test.ts
+++ b/test/zone-visit.test.ts
@@ -1,0 +1,28 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useZoneProgressStore } from '../src/stores/zoneProgress'
+import { useZoneVisitStore } from '../src/stores/zoneVisit'
+import { carapouffe } from '../src/data/shlagemons'
+import { xpForLevel } from '../src/utils/dexFactory'
+
+describe('zone visit store', () => {
+  it('does not highlight the first zone', () => {
+    setActivePinia(createPinia())
+    const visit = useZoneVisitStore()
+    expect(visit.hasNewZone).toBe(false)
+  })
+
+  it('highlights when a new zone unlocks', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const progress = useZoneProgressStore()
+    const visit = useZoneVisitStore()
+    const mon = dex.createShlagemon(carapouffe)
+    progress.defeatKing('plaine-kekette')
+    for (let i = 0; i < 4; i++)
+      await dex.gainXp(mon, xpForLevel(mon.lvl))
+    expect(visit.hasNewZone).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- avoid highlighting the very first accessible zone
- add unit tests for zone highlight logic

## Testing
- `pnpm lint` *(fails: cannot find package '@antfu/eslint-config')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687558835da8832ab3125899dbb65ed6