### PR TITLE
Add arena defeat dialog

### DIFF
--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
+import ArenaDefeatDialog from '~/components/dialog/ArenaDefeatDialog.vue'
 import ArenaVictoryDialog from '~/components/dialog/ArenaVictoryDialog.vue'
 import ArenaWelcomeDialog from '~/components/dialog/ArenaWelcomeDialog.vue'
 import AttackPotionDialog from '~/components/dialog/AttackPotionDialog.vue'
@@ -69,6 +70,11 @@ export const useDialogStore = defineStore('dialog', () => {
       condition: () => arena.badgeEarned,
     },
     {
+      id: 'arenaDefeat',
+      component: markRaw(ArenaDefeatDialog),
+      condition: () => arena.result === 'lose',
+    },
+    {
       id: 'firstLoss',
       component: markRaw(FirstLossDialog),
       condition: () => stats.losses > 0,
@@ -97,6 +103,7 @@ export const useDialogStore = defineStore('dialog', () => {
   function resetArenaDialogs() {
     done.value.arenaWelcome = false
     done.value.arenaVictory = false
+    done.value.arenaDefeat = false
   }
 
   function reset() {

--- a/test/zone-visit.test.ts
+++ b/test/zone-visit.test.ts
@@ -1,9 +1,9 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useZoneProgressStore } from '../src/stores/zoneProgress'
 import { useZoneVisitStore } from '../src/stores/zoneVisit'
-import { carapouffe } from '../src/data/shlagemons'
 import { xpForLevel } from '../src/utils/dexFactory'
 
 describe('zone visit store', () => {


### PR DESCRIPTION
## Summary
- register `ArenaDefeatDialog` in the dialog store
- reset its state with other arena dialogs
- fix lint in zone-visit test

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ESLint works, but test suite errors and snapshots mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68755a6d5420832aa908149f97982b31