### PR TITLE
Add auto-select top attack team

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -18,6 +18,17 @@ const showEnemy = ref(false)
 const enemyDetail = ref<BaseShlagemon | null>(null)
 let nextTimer: number | undefined
 
+function autoSelect() {
+  const team = dex.shlagemons
+    .slice()
+    .sort((a, b) => b.attack - a.attack)
+    .slice(0, arena.selections.length)
+
+  team.forEach((mon, i) => {
+    arena.selectPlayer(i, mon.id)
+  })
+}
+
 const playerSelection = computed(() =>
   arena.selections.map(id => dex.shlagemons.find(m => m.id === id) || null),
 )
@@ -140,6 +151,14 @@ onUnmounted(() => {
           <UiInfo color="alert" class="text-center text-xs">
             Le combat est automatique et se déroule sans clics.
           </UiInfo>
+          <UiButton
+            type="valid"
+            variant="outline"
+            class="mx-auto"
+            @click="autoSelect"
+          >
+            Sélection auto
+          </UiButton>
           <UiButton
             type="primary"
             class="mx-auto"


### PR DESCRIPTION
## Summary
- add an `autoSelect` helper in Arena panel to pick strongest mons
- expose a button to fill the team with highest attack Shlagémon

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_687562b80880832abb2d1df88a9aad7c