### PR TITLE
Fix dialog component typing

### DIFF
--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,3 +1,4 @@
+import type { Component } from 'vue'
 import { defineStore } from 'pinia'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
 import ArenaDefeatDialog from '~/components/dialog/ArenaDefeatDialog.vue'
@@ -17,7 +18,7 @@ import { useMainPanelStore } from './mainPanel'
 
 interface DialogItem {
   id: string
-  component: any
+  component: Component
   condition: () => boolean
 }
 export interface DialogDone {


### PR DESCRIPTION
## Summary
- type DialogItem components with `Component`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: 'vue-tsc --noEmit')*
- `pnpm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68760f1e4a34832a81400236a64158fd