### PR TITLE
Add level parameter to createDexShlagemon

### DIFF
--- a/src/components/arena/EnemyStats.vue
+++ b/src/components/arena/EnemyStats.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type/shlagemon'
 import { useArenaStore } from '~/stores/arena'
-import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
+import { createDexShlagemon } from '~/utils/dexFactory'
 
 const props = defineProps<{ mon: BaseShlagemon }>()
 
@@ -10,10 +10,7 @@ const arena = useArenaStore()
 const dexMon = computed(() => {
   const lvl = arena.arenaData?.level ?? 1
   const coefficientMultiplier = lvl / props.mon.coefficient
-  const m = createDexShlagemon(props.mon, false, coefficientMultiplier)
-  m.lvl = lvl
-  applyStats(m)
-  return m
+  return createDexShlagemon(props.mon, false, coefficientMultiplier, lvl)
 })
 
 const stats = computed(() => [

--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -78,10 +78,7 @@ function startBattle() {
   const enemies = enemyTeam.value.map((b) => {
     const lvl = arena.arenaData?.level ?? 1
     const coefficientMultiplier = lvl / b.coefficient
-    const m = createDexShlagemon(b, false, coefficientMultiplier)
-    m.lvl = lvl
-    applyStats(m)
-    return m
+    return createDexShlagemon(b, false, coefficientMultiplier, lvl)
   })
   arena.start(team, enemies)
   arena.currentIndex = 0

--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -12,7 +12,7 @@ import { useWearableItemStore } from '~/stores/wearableItem'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneMonsModalStore } from '~/stores/zoneMonsModal'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
-import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
+import { createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
 import { pickRandomByCoefficient } from '~/utils/spawn'
 
 const dex = useShlagedexStore()
@@ -39,13 +39,11 @@ function createEnemy(): DexShlagemon | null {
   const base = pickRandomByCoefficient(pool)
   progress.registerEncounter(zone.current.id, base.id)
   const rank = zone.getZoneRank(zone.current.id) * EQUILIBRE_RANK
-  const created = createDexShlagemon(base, false, rank)
   const min = Number(zone.current.minLevel ?? 1)
   const zoneMax = Number(zone.current.maxLevel ?? (min + 1))
   const max = Math.max(zoneMax - 1, min)
   const lvl = Math.floor(Math.random() * (max - min + 1)) + min
-  created.lvl = lvl
-  applyStats(created)
+  const created = createDexShlagemon(base, false, rank, lvl)
   if (created.isShiny) {
     audio.playSfx('/audio/sfx/shiny.ogg')
   }

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -12,7 +12,7 @@ import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useWearableItemStore } from '~/stores/wearableItem'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
-import { applyStats, createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
+import { createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
 const trainerStore = useTrainerBattleStore()
@@ -44,10 +44,7 @@ function createEnemy(): DexShlagemon | null {
   if (!base)
     return null
   const rank = t.id.startsWith('king-') ? zone.getZoneRank(zone.current.id) : 1
-  const mon = createDexShlagemon(base, false, rank * EQUILIBRE_RANK)
-  mon.lvl = spec.level
-  applyStats(mon)
-  return mon
+  return createDexShlagemon(base, false, rank * EQUILIBRE_RANK, spec.level)
 }
 
 function startFight() {

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -37,6 +37,7 @@ export function createDexShlagemon(
   base: BaseShlagemon,
   shiny = false,
   coefficientMultiplier = 1,
+  level = 1,
 ): DexShlagemon {
   const rarity = generateRarity()
   const adjustedBase: BaseShlagemon = {
@@ -54,7 +55,7 @@ export function createDexShlagemon(
     },
     captureDate: new Date().toISOString(),
     captureCount: 1,
-    lvl: 1,
+    lvl: level,
     xp: 0,
     rarity,
     hp: 0,

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -26,9 +26,8 @@ describe('capture mechanics', () => {
   })
 
   it('hyper ball versus strong foe gives around 10% chance', () => {
-    const mon = createDexShlagemon(carapouffe)
+    const mon = createDexShlagemon(carapouffe, false, 1, 100)
     mon.base.coefficient = 1000
-    mon.lvl = 100
     mon.hp = 100
     mon.hpCurrent = 10
     const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
@@ -40,9 +39,8 @@ describe('capture mechanics', () => {
   })
 
   it('regular ball against lvl1 coefficient1 foe at full HP is almost guaranteed', () => {
-    const mon = createDexShlagemon(carapouffe)
+    const mon = createDexShlagemon(carapouffe, false, 1, 1)
     mon.base.coefficient = 1
-    mon.lvl = 1
     mon.hpCurrent = mon.hp
     const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
     const coefMod = 1 / Math.cbrt(mon.base.coefficient)

--- a/test/save-dedup.test.ts
+++ b/test/save-dedup.test.ts
@@ -4,18 +4,15 @@ import { createDexShlagemon } from '../src/utils/dexFactory'
 import { shlagedexSerializer } from '../src/utils/shlagedex-serialize'
 
 function prepare() {
-  const m1 = createDexShlagemon(carapouffe)
+  const m1 = createDexShlagemon(carapouffe, false, 1, 1)
   m1.isShiny = false
   m1.rarity = 1
-  m1.lvl = 1
-  const m2 = createDexShlagemon(carapouffe)
+  const m2 = createDexShlagemon(carapouffe, false, 1, 10)
   m2.isShiny = false
   m2.rarity = 5
-  m2.lvl = 10
-  const m3 = createDexShlagemon(carapouffe)
+  const m3 = createDexShlagemon(carapouffe, false, 1, 2)
   m3.isShiny = true
   m3.rarity = 3
-  m3.lvl = 2
   const raw = shlagedexSerializer.serialize({
     shlagemons: [m1, m2, m3],
     activeShlagemon: m1,

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -20,9 +20,8 @@ describe('shlagedex capture', () => {
     mon.rarity = 1
     mon.lvl = 10
     toastMock.mockClear()
-    const enemy = createDexShlagemon(carapouffe)
+    const enemy = createDexShlagemon(carapouffe, false, 1, 3)
     enemy.rarity = 5
-    enemy.lvl = 3
     applyStats(enemy)
     dex.captureEnemy(enemy)
     expect(mon.rarity).toBe(5)
@@ -45,8 +44,7 @@ describe('shlagedex capture', () => {
   it('captures new enemy with same level and rarity', () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
-    const enemy = createDexShlagemon(carapouffe)
-    enemy.lvl = 17
+    const enemy = createDexShlagemon(carapouffe, false, 1, 17)
     enemy.rarity = 42
     applyStats(enemy)
     const captured = dex.captureEnemy(enemy)
@@ -61,10 +59,9 @@ describe('shlagedex capture', () => {
     existing.rarity = 3
     existing.lvl = 5
     applyStats(existing)
-    const enemy = createDexShlagemon(carapouffe)
+    const enemy = createDexShlagemon(carapouffe, false, 1, 10)
     enemy.isShiny = true
     enemy.rarity = 1
-    enemy.lvl = 10
     applyStats(enemy)
     const captured = dex.captureEnemy(enemy)
     expect(captured.id).toBe(existing.id)


### PR DESCRIPTION
## Summary
- allow specifying level when creating dex shlagemon
- use new level parameter when creating arena enemies and trainers
- simplify enemy creation in battles
- adjust tests to use new helper signature

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6876174b6764832aa6bd1463c6866ead