### PR TITLE
Implement dynamic arena lineups

### DIFF
--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -1,6 +1,5 @@
 import type { BaseShlagemon } from '~/type'
 import type { SavageZoneId, Zone } from '~/type/zone'
-import { arena20, arena40 } from './arenas'
 import { villageZones } from './zones/villages'
 
 interface SavageZoneDescription {
@@ -103,31 +102,3 @@ export const zonesData: Zone[] = [
   ...savageZones,
   ...grotteZones,
 ].sort((a, b) => a.minLevel - b.minLevel)
-
-function topShlagemons(zone: Zone, count = 2): BaseShlagemon[] {
-  const unique = (zone.shlagemons ?? [])
-    .flatMap(b => b.evolution?.base ? [b, b.evolution.base] : [b])
-    .reduce<Record<string, BaseShlagemon>>((acc, mon) => {
-      acc[mon.id] = mon
-      return acc
-    }, {})
-
-  return Object.values(unique)
-    .sort((a, b) => b.coefficient - a.coefficient)
-    .slice(0, count)
-}
-
-function generateArenaLineup(zoneId: string): BaseShlagemon[] {
-  const index = zonesData.findIndex(z => z.id === zoneId)
-  const previous: Zone[] = []
-  for (let i = index - 1; i >= 0 && previous.length < 4; i--) {
-    const z = zonesData[i]
-    if (z.type === 'sauvage')
-      previous.push(z)
-  }
-  previous.reverse()
-  return previous.flatMap(z => topShlagemons(z, 2))
-}
-
-arena20.lineup = generateArenaLineup('village-boule')
-arena40.lineup = generateArenaLineup('village-paume')

--- a/src/data/zones.ts
+++ b/src/data/zones.ts
@@ -1,5 +1,6 @@
 import type { BaseShlagemon } from '~/type'
 import type { SavageZoneId, Zone } from '~/type/zone'
+import { arena20, arena40 } from './arenas'
 import { villageZones } from './zones/villages'
 
 interface SavageZoneDescription {
@@ -102,3 +103,31 @@ export const zonesData: Zone[] = [
   ...savageZones,
   ...grotteZones,
 ].sort((a, b) => a.minLevel - b.minLevel)
+
+function topShlagemons(zone: Zone, count = 2): BaseShlagemon[] {
+  const unique = (zone.shlagemons ?? [])
+    .flatMap(b => b.evolution?.base ? [b, b.evolution.base] : [b])
+    .reduce<Record<string, BaseShlagemon>>((acc, mon) => {
+      acc[mon.id] = mon
+      return acc
+    }, {})
+
+  return Object.values(unique)
+    .sort((a, b) => b.coefficient - a.coefficient)
+    .slice(0, count)
+}
+
+function generateArenaLineup(zoneId: string): BaseShlagemon[] {
+  const index = zonesData.findIndex(z => z.id === zoneId)
+  const previous: Zone[] = []
+  for (let i = index - 1; i >= 0 && previous.length < 4; i--) {
+    const z = zonesData[i]
+    if (z.type === 'sauvage')
+      previous.push(z)
+  }
+  previous.reverse()
+  return previous.flatMap(z => topShlagemons(z, 2))
+}
+
+arena20.lineup = generateArenaLineup('village-boule')
+arena40.lineup = generateArenaLineup('village-paume')

--- a/src/data/zones/villages.ts
+++ b/src/data/zones/villages.ts
@@ -1,5 +1,4 @@
 import type { Zone } from '~/type'
-import { arena20, arena40 } from '../arenas'
 
 const village10: Zone = {
   id: 'village-veaux-du-gland',
@@ -17,10 +16,6 @@ const village20: Zone = {
   name: 'Village Sux-Mais-Bouls',
   type: 'village',
   actions: [{ id: 'shop', label: 'Entrer dans le Magasin' }],
-  arena: {
-    arena: arena20,
-    completed: false,
-  },
   minLevel: 20,
 }
 
@@ -29,10 +24,6 @@ const village40: Zone = {
   name: 'Village Paumé du cul',
   type: 'village',
   actions: [{ id: 'shop', label: 'Entrer dans le Magasin' }],
-  arena: {
-    arena: arena40,
-    completed: false,
-  },
   minLevel: 40,
 }
 


### PR DESCRIPTION
## Summary
- generate arena teams from the previous four wild zones

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError: https://fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_68761ef08af4832abfe1b0fa2e11e699