### PR TITLE
Add capture cooldown

### DIFF
--- a/src/components/battle/Capture.vue
+++ b/src/components/battle/Capture.vue
@@ -26,11 +26,17 @@ const showCapture = ref(false)
 const captureBall = ref(balls[0])
 const shake = ref(0)
 
+const captureCooldown = ref(false)
+
 const captureButtonDisabled = computed(() =>
-  (inventory.items[ballStore.current] || 0) <= 0 || props.enemyHp <= 0,
+  captureCooldown.value
+  || (inventory.items[ballStore.current] || 0) <= 0
+  || props.enemyHp <= 0,
 )
 
 const captureButtonTooltip = computed(() => {
+  if (captureCooldown.value)
+    return 'Patientez avant de capturer à nouveau'
   if ((inventory.items[ballStore.current] || 0) <= 0)
     return 'Pas de Shlagéball, capture impossible'
   if (props.enemyHp <= 0)
@@ -78,6 +84,10 @@ function finish(success: boolean) {
     dex.captureEnemy(capturedEnemy.value)
   capturedEnemy.value = null
   emit('finished', success)
+  if (success) {
+    captureCooldown.value = true
+    setTimeout(() => (captureCooldown.value = false), 1000)
+  }
 }
 
 defineExpose({ open })


### PR DESCRIPTION
## Summary
- prevent spamming capture button by adding 1s cooldown after a successful capture
- show tooltip while cooldown is active

## Testing
- `pnpm lint`
- `pnpm test` *(fails: multiple failing tests and network errors for fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687624294b58832aa185fdc312ced199