### PR TITLE
Reset main panel when changing zone

### DIFF
--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -17,8 +17,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
 
   // Update the panel when the zone changes
   watch(
-    () => zone.current.type,
-    (type) => {
+    () => [zone.current.type, zone.current.id],
+    ([type]) => {
       current.value = type === 'village' ? 'village' : 'battle'
     },
     { immediate: true },


### PR DESCRIPTION
## Summary
- reset main panel to default when switching zones

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: unable to fetch fonts and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876271d4b7c832a8c5886fa08caa119