### PR TITLE
Add auto disable evolution when rejecting

### DIFF
--- a/src/stores/evolution.ts
+++ b/src/stores/evolution.ts
@@ -29,6 +29,7 @@ export const useEvolutionStore = defineStore('evolution', () => {
 
   function reject() {
     if (pending.value) {
+      pending.value.mon.allowEvolution = false
       pending.value.resolve(false)
       pending.value = null
     }

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -31,4 +31,15 @@ describe('evolution', () => {
     expect(mon.base.id).toBe(abraquemar.id)
     expect(mon.lvl).toBe(3)
   })
+
+  it('disables future evolutions when user rejects', async () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const evo = useEvolutionStore()
+    const mon = dex.createShlagemon(abraquemar)
+    const promise = evo.requestEvolution(mon, alakalbar)
+    evo.reject()
+    await promise
+    expect(mon.allowEvolution).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- disable Schlagemon evolution when player refuses
- test rejecting an evolution disables the next prompts

## Testing
- `pnpm lint`
- `pnpm test` *(fails: failed to fetch web fonts and other snapshot mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6876256edef4832aaa9e62258a1b214e