### PR TITLE
Add XP potions and bonus

### DIFF
--- a/src/components/battle/EffectBadge.vue
+++ b/src/components/battle/EffectBadge.vue
@@ -7,11 +7,18 @@ const emit = defineEmits<{ (e: 'click'): void }>()
 
 const remaining = computed(() => formatDuration(props.effect.expiresAt - props.now))
 
-const tooltipText = computed(() =>
-  props.effect.type === 'attack'
-    ? `Votre attaque est boostée pour encore ${remaining.value}`
-    : `Votre défense est boostée pour encore ${remaining.value}`,
-)
+const tooltipText = computed(() => {
+  switch (props.effect.type) {
+    case 'attack':
+      return `Votre attaque est boostée pour encore ${remaining.value}`
+    case 'defense':
+      return `Votre défense est boostée pour encore ${remaining.value}`
+    case 'xp':
+      return `Vos gains d'XP sont augmentés pour encore ${remaining.value}`
+    default:
+      return ''
+  }
+})
 
 const colorClasses = computed(() => {
   switch (props.effect.type) {
@@ -19,6 +26,8 @@ const colorClasses = computed(() => {
       return 'text-red-500 dark:text-red-400 bg-red-500/15 outline-red-500 dark:border-red-700'
     case 'defense':
       return 'text-blue-500 dark:text-blue-400 bg-blue-500/15 outline-blue-500 dark:border-blue-700'
+    case 'xp':
+      return 'text-green-500 dark:text-green-400 bg-green-500/15 outline-green-500 dark:border-green-700'
     default:
       return ''
   }

--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -12,7 +12,7 @@ import { useWearableItemStore } from '~/stores/wearableItem'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneMonsModalStore } from '~/stores/zoneMonsModal'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
-import { createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
+import { createDexShlagemon } from '~/utils/dexFactory'
 import { pickRandomByCoefficient } from '~/utils/spawn'
 
 const dex = useShlagedexStore()
@@ -115,7 +115,7 @@ async function handleEnd(result: 'win' | 'lose' | 'draw') {
     game.addShlagidolar(zone.rewardMultiplier)
     notifyAchievement({ type: 'battle-win', stronger })
     if (dex.activeShlagemon) {
-      const xp = xpRewardForLevel(defeated.lvl)
+      const xp = dex.xpGainForLevel(defeated.lvl)
       await dex.gainXp(dex.activeShlagemon, xp, zone.current.maxLevel)
       const holder = wearableItemStore.getHolder('multi-exp')
       if (holder)

--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -6,7 +6,6 @@ import { useDiseaseStore } from '~/stores/disease'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useWearableItemStore } from '~/stores/wearableItem'
 import { useZoneStore } from '~/stores/zone'
-import { xpRewardForLevel } from '~/utils/dexFactory'
 
 const props = withDefaults(defineProps<{
   player: DexShlagemon
@@ -91,7 +90,7 @@ async function onCaptureEnd(success: boolean) {
   if (success && props.enemy) {
     notifyAchievement({ type: 'capture', shiny: props.enemy.isShiny })
     if (dex.activeShlagemon) {
-      const xp = xpRewardForLevel(props.enemy.lvl)
+      const xp = dex.xpGainForLevel(props.enemy.lvl)
       await dex.gainXp(dex.activeShlagemon, xp, zone.current.maxLevel)
       const holder = wearableItemStore.getHolder('multi-exp')
       if (holder)

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -12,7 +12,7 @@ import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useWearableItemStore } from '~/stores/wearableItem'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
-import { createDexShlagemon, xpRewardForLevel } from '~/utils/dexFactory'
+import { createDexShlagemon } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
 const trainerStore = useTrainerBattleStore()
@@ -84,7 +84,7 @@ async function onEnd(type: 'capture' | 'win' | 'lose' | 'draw') {
   }
   if (type === 'win') {
     if (dex.activeShlagemon) {
-      const xp = xpRewardForLevel(defeated.lvl)
+      const xp = dex.xpGainForLevel(defeated.lvl)
       await dex.gainXp(dex.activeShlagemon, xp, undefined, trainerStore.levelUpHealPercent)
       const holder = wearableItemStore.getHolder('multi-exp')
       if (holder)

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -79,6 +79,39 @@ export const hyperAttackPotion: Item = {
   iconClass: 'text-orange-700 dark:text-orange-600',
 }
 
+export const xpPotion: Item = {
+  id: 'xp-potion',
+  name: 'Potion d\'Expérience',
+  description: 'Augmente temporairement les gains d\'XP.',
+  details: 'Améliore l\'XP gagnée de 10% pendant quelques minutes.',
+  price: 7,
+  currency: 'shlagidolar',
+  icon: 'i-game-icons:magic-potion',
+  iconClass: 'text-green-600 dark:text-green-400',
+}
+
+export const superXpPotion: Item = {
+  id: 'super-xp-potion',
+  name: 'Super Potion d\'Expérience',
+  description: 'Augmente beaucoup les gains d\'XP.',
+  details: 'Améliore l\'XP gagnée de 25% pendant quelques minutes.',
+  price: 15,
+  currency: 'shlagidolar',
+  icon: 'i-game-icons:round-potion',
+  iconClass: 'text-green-700 dark:text-green-500',
+}
+
+export const hyperXpPotion: Item = {
+  id: 'hyper-xp-potion',
+  name: 'Hyper Potion d\'Expérience',
+  description: 'Maximise temporairement les gains d\'XP.',
+  details: 'Améliore l\'XP gagnée de 50% pendant quelques minutes.',
+  price: 25,
+  currency: 'shlagidolar',
+  icon: 'i-game-icons:standing-potion',
+  iconClass: 'text-green-800 dark:text-green-600',
+}
+
 export const superPotion: Item = {
   id: 'super-potion',
   name: 'Super Potion',
@@ -150,6 +183,9 @@ export const allItems: Item[] = [
   hyperAttackPotion,
   superPotion,
   hyperPotion,
+  xpPotion,
+  superXpPotion,
+  hyperXpPotion,
   multiExp,
   thunderStone,
 ]

--- a/src/data/shops.ts
+++ b/src/data/shops.ts
@@ -11,6 +11,7 @@ import {
   superDefensePotion,
   superPotion,
   thunderStone,
+  xpPotion,
 } from './items/items'
 import { hyperShlageball, shlageball, superShlageball } from './items/shlageball'
 
@@ -23,7 +24,7 @@ export const shops: Shop[] = [
   {
     id: 'village-boule',
     level: 25,
-    items: [potion, superPotion, superDefensePotion, superAttackPotion, superShlageball, shlageball, thunderStone],
+    items: [potion, xpPotion, superPotion, superDefensePotion, superAttackPotion, superShlageball, shlageball, thunderStone],
   },
   {
     id: 'village-paume',

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -134,6 +134,21 @@ export const useInventoryStore = defineStore('inventory', () => {
         remove(id)
         return true
       },
+      'xp-potion': () => {
+        dex.boostXp(10, icon, iconClass)
+        remove(id)
+        return true
+      },
+      'super-xp-potion': () => {
+        dex.boostXp(25, icon, iconClass)
+        remove(id)
+        return true
+      },
+      'hyper-xp-potion': () => {
+        dex.boostXp(50, icon, iconClass)
+        remove(id)
+        return true
+      },
       'super-potion': () => {
         dex.healActive(100)
         remove(id)

--- a/src/type/effect.ts
+++ b/src/type/effect.ts
@@ -1,6 +1,6 @@
 export interface ActiveEffect {
   id: number
-  type: 'attack' | 'defense'
+  type: 'attack' | 'defense' | 'xp'
   percent: number
   icon?: string
   iconClass?: string


### PR DESCRIPTION
## Summary
- introduce new XP potions and shop entry
- allow using XP potions via inventory
- show active XP potion badge during battles
- centralize XP gain calculation

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH while fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6876265794a4832a96609d22af856c50