### PR TITLE
Add clickable option to Kbd

### DIFF
--- a/src/components/ui/Kbd.vue
+++ b/src/components/ui/Kbd.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 type Size = 'sm' | 'md' | 'lg' | 'xl'
 
-const props = withDefaults(defineProps<{ keyName: string, size?: Size, waiting?: boolean }>(), {
+const props = withDefaults(defineProps<{ keyName: string, size?: Size, waiting?: boolean, clickable?: boolean }>(), {
   size: 'md',
   waiting: false,
+  clickable: false,
 })
 
 const KEY_LABELS: Record<string, string> = {
@@ -33,6 +34,8 @@ const sizeClass = computed(() => {
       return 'text-sm px-2 py-0.5'
   }
 })
+
+const clickableClass = computed(() => props.clickable ? 'kbd-clickable' : '')
 </script>
 
 <template>
@@ -41,6 +44,7 @@ const sizeClass = computed(() => {
     :class="[
       sizeClass,
       props.waiting ? 'animate-pulse opacity-70' : '',
+      clickableClass,
     ]"
   >
     {{ label }}
@@ -60,5 +64,12 @@ const sizeClass = computed(() => {
     inset 0 -2px 0 rgba(0, 0, 0, 0.5),
     inset 0 2px 0 rgba(255, 255, 255, 0.1),
     0 1px 1px rgba(0, 0, 0, 0.3);
+}
+.kbd-clickable {
+  cursor: pointer;
+  transition: transform 0.05s;
+}
+.kbd-clickable:active {
+  transform: translateY(2px);
 }
 </style>

--- a/src/components/ui/KeyCapture.vue
+++ b/src/components/ui/KeyCapture.vue
@@ -33,6 +33,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
   <UiKbd
     :key-name="waiting ? '?' : props.modelValue || '?'"
     :waiting="waiting"
+    clickable
     @click="startCapture"
   />
 </template>


### PR DESCRIPTION
## Summary
- add optional `clickable` prop on the `Kbd` component
- apply pressed animation and cursor pointer when `clickable`
- set Kbd as clickable in KeyCapture for keyboard shortcut settings

## Testing
- `pnpm lint`
- `pnpm test` *(fails: many tests error due to missing assets and fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6876282e658c832aaf1afefa7117f79e