### PR TITLE
Fix xp reward function import

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -13,6 +13,7 @@ import {
   createDexShlagemon,
   statWithRarityAndCoefficient,
   xpForLevel,
+  xpRewardForLevel,
 } from '~/utils/dexFactory'
 import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
 import { useAudioStore } from './audio'


### PR DESCRIPTION
## Summary
- fix reference error in shlagedex store by importing `xpRewardForLevel`

## Testing
- `pnpm lint` *(fails: Unexpected token 'with')*
- `pnpm test` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_687631b0efcc832a992aea560652dbce