### PR TITLE
Fix arena lineup to use six best Shlagemons

### DIFF
--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -25,7 +25,7 @@ function generateArenaLineup(zoneId: string): BaseShlagemon[] {
       previous.push(z)
   }
   previous.reverse()
-  return previous.flatMap(z => topShlagemons(z, 2))
+  return previous.flatMap((z, i) => topShlagemons(z, i < 2 ? 1 : 2))
 }
 
 interface ArenaConfig {


### PR DESCRIPTION
## Summary
- adjust arena lineup generation to only use six Shlagemons

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Failed to fetch web fonts & multiple unit test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687639a41278832a901735b3b3b62fca