### PR TITLE
Add vitality potions

### DIFF
--- a/src/components/battle/EffectBadge.vue
+++ b/src/components/battle/EffectBadge.vue
@@ -15,6 +15,8 @@ const tooltipText = computed(() => {
       return `Votre défense est boostée pour encore ${remaining.value}`
     case 'xp':
       return `Vos gains d'XP sont augmentés pour encore ${remaining.value}`
+    case 'vitality':
+      return `Votre vitalité est augmentée pour encore ${remaining.value}`
     default:
       return ''
   }
@@ -28,6 +30,8 @@ const colorClasses = computed(() => {
       return 'text-blue-500 dark:text-blue-400 bg-blue-500/15 outline-blue-500 dark:border-blue-700'
     case 'xp':
       return 'text-green-500 dark:text-green-400 bg-green-500/15 outline-green-500 dark:border-green-700'
+    case 'vitality':
+      return 'text-violet-500 dark:text-violet-400 bg-violet-500/15 outline-violet-500 dark:border-violet-700'
     default:
       return ''
   }

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -79,6 +79,39 @@ export const hyperAttackPotion: Item = {
   iconClass: 'text-orange-700 dark:text-orange-600',
 }
 
+export const vitalityPotion: Item = {
+  id: 'vitality-potion',
+  name: 'Potion de Vitalité',
+  description: 'Augmente temporairement les PV.',
+  details: 'Augmente les PV de votre Shlagémon actif de 10% pendant quelques minutes.',
+  price: 7,
+  currency: 'shlagidolar',
+  icon: 'i-game-icons:magic-potion',
+  iconClass: 'text-violet-500 dark:text-violet-400',
+}
+
+export const superVitalityPotion: Item = {
+  id: 'super-vitality-potion',
+  name: 'Super Potion de Vitalité',
+  description: 'Augmente beaucoup les PV.',
+  details: 'Augmente les PV de votre Shlagémon actif de 25% pendant quelques minutes.',
+  price: 15,
+  currency: 'shlagidolar',
+  icon: 'i-game-icons:round-potion',
+  iconClass: 'text-violet-600 dark:text-violet-500',
+}
+
+export const hyperVitalityPotion: Item = {
+  id: 'hyper-vitality-potion',
+  name: 'Hyper Potion de Vitalité',
+  description: 'Maximise temporairement les PV.',
+  details: 'Augmente les PV de votre Shlagémon actif de 50% pendant quelques minutes.',
+  price: 25,
+  currency: 'shlagidolar',
+  icon: 'i-game-icons:standing-potion',
+  iconClass: 'text-violet-700 dark:text-violet-600',
+}
+
 export const xpPotion: Item = {
   id: 'xp-potion',
   name: 'Potion d\'Expérience',
@@ -181,6 +214,9 @@ export const allItems: Item[] = [
   attackPotion,
   superAttackPotion,
   hyperAttackPotion,
+  vitalityPotion,
+  superVitalityPotion,
+  hyperVitalityPotion,
   superPotion,
   hyperPotion,
   xpPotion,

--- a/src/data/shops.ts
+++ b/src/data/shops.ts
@@ -5,12 +5,15 @@ import {
   hyperAttackPotion,
   hyperDefensePotion,
   hyperPotion,
+  hyperVitalityPotion,
   multiExp,
   potion,
   superAttackPotion,
   superDefensePotion,
   superPotion,
+  superVitalityPotion,
   thunderStone,
+  vitalityPotion,
   xpPotion,
 } from './items/items'
 import { hyperShlageball, shlageball, superShlageball } from './items/shlageball'
@@ -19,17 +22,17 @@ export const shops: Shop[] = [
   {
     id: 'village-veaux-du-gland',
     level: 10,
-    items: [potion, defensePotion, attackPotion, shlageball],
+    items: [potion, defensePotion, attackPotion, vitalityPotion, shlageball],
   },
   {
     id: 'village-boule',
     level: 25,
-    items: [potion, xpPotion, superPotion, superDefensePotion, superAttackPotion, superShlageball, shlageball, thunderStone],
+    items: [potion, xpPotion, superPotion, superDefensePotion, superAttackPotion, superVitalityPotion, superShlageball, shlageball, thunderStone],
   },
   {
     id: 'village-paume',
     level: 50,
-    items: [hyperPotion, hyperDefensePotion, hyperAttackPotion, hyperShlageball, multiExp],
+    items: [hyperPotion, hyperDefensePotion, hyperAttackPotion, hyperVitalityPotion, hyperShlageball, multiExp],
   },
 ]
 

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -134,6 +134,21 @@ export const useInventoryStore = defineStore('inventory', () => {
         remove(id)
         return true
       },
+      'vitality-potion': () => {
+        dex.boostVitality(10, icon, iconClass)
+        remove(id)
+        return true
+      },
+      'super-vitality-potion': () => {
+        dex.boostVitality(25, icon, iconClass)
+        remove(id)
+        return true
+      },
+      'hyper-vitality-potion': () => {
+        dex.boostVitality(50, icon, iconClass)
+        remove(id)
+        return true
+      },
       'xp-potion': () => {
         dex.boostXp(10, icon, iconClass)
         remove(id)

--- a/src/type/effect.ts
+++ b/src/type/effect.ts
@@ -1,6 +1,6 @@
 export interface ActiveEffect {
   id: number
-  type: 'attack' | 'defense' | 'xp'
+  type: 'attack' | 'defense' | 'xp' | 'vitality'
   percent: number
   icon?: string
   iconClass?: string


### PR DESCRIPTION
## Summary
- create vitality potion items and include them in the item list
- allow buying vitality potions in shops
- handle using vitality potions in inventory
- support vitality effects in battle and store
- display vitality effect badges in combat

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetching fonts and various test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68768371a598832a9dc367402229fd0e