### PR TITLE
Add trainer duel healing

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -9,7 +9,6 @@ import { useGameStore } from '~/stores/game'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
-import { useWearableItemStore } from '~/stores/wearableItem'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
 import { createDexShlagemon } from '~/utils/dexFactory'
@@ -17,7 +16,6 @@ import { createDexShlagemon } from '~/utils/dexFactory'
 const dex = useShlagedexStore()
 const trainerStore = useTrainerBattleStore()
 const battleStats = useBattleStatsStore()
-const wearableItemStore = useWearableItemStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
 const panel = useMainPanelStore()
@@ -84,11 +82,11 @@ async function onEnd(type: 'capture' | 'win' | 'lose' | 'draw') {
   }
   if (type === 'win') {
     if (dex.activeShlagemon) {
-      const xp = dex.xpGainForLevel(defeated.lvl)
-      await dex.gainXp(dex.activeShlagemon, xp, undefined, trainerStore.levelUpHealPercent)
-      const holder = wearableItemStore.getHolder('multi-exp')
-      if (holder)
-        await dex.gainXp(holder, Math.round(xp * 0.5), undefined, trainerStore.levelUpHealPercent)
+      const missing = dex.activeShlagemon.hp - dex.activeShlagemon.hpCurrent
+      if (missing > 0) {
+        const heal = Math.round(missing * trainerStore.winHealPercent / 100)
+        dex.healActive(heal)
+      }
     }
     const finished = nextBattle()
     if (finished) {

--- a/src/stores/trainerBattle.ts
+++ b/src/stores/trainerBattle.ts
@@ -6,6 +6,7 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   const queue = ref<Trainer[]>([])
   const currentIndex = ref(0)
   const levelUpHealPercent = ref(15)
+  const winHealPercent = ref(15)
 
   function setQueue(list: Trainer[]) {
     queue.value = list
@@ -40,5 +41,6 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
     setQueue,
     reset,
     levelUpHealPercent,
+    winHealPercent,
   }
 })

--- a/test/trainer-battle-heal.test.ts
+++ b/test/trainer-battle-heal.test.ts
@@ -9,10 +9,10 @@ import { useTrainerBattleStore } from '../src/stores/trainerBattle'
 import { useZoneStore } from '../src/stores/zone'
 import { useZoneProgressStore } from '../src/stores/zoneProgress'
 
-// Ensure player shlagemon is not healed between trainer battles
+// Ensure player shlagemon heals a portion of lost hp between trainer battles
 
 describe('trainer battle healing', () => {
-  it('keeps player hp between fights', async () => {
+  it('heals player and grants no xp between fights', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     expect(EQUILIBRE_RANK).toBe(2)
@@ -48,9 +48,12 @@ describe('trainer battle healing', () => {
     })
 
     wrapper.vm.startFight()
-    player.hpCurrent -= 1
+    player.hpCurrent -= 10
     const hpBefore = player.hpCurrent
+    const xpBefore = player.xp
     await wrapper.vm.onEnd('win')
-    expect(player.hpCurrent).toBe(hpBefore)
+    const expected = hpBefore + Math.round((player.hp - hpBefore) * 0.15)
+    expect(player.hpCurrent).toBe(expected)
+    expect(player.xp).toBe(xpBefore)
   })
 })

--- a/test/trainer-store.test.ts
+++ b/test/trainer-store.test.ts
@@ -7,6 +7,7 @@ describe('trainer battle store', () => {
     setActivePinia(createPinia())
     const store = useTrainerBattleStore()
     expect(store.levelUpHealPercent).toBe(15)
+    expect(store.winHealPercent).toBe(15)
   })
 
   it('isActive reflects queue state', () => {


### PR DESCRIPTION
## Summary
- heal 15% of missing HP after each trainer duel win and remove XP gain
- expose a `winHealPercent` from the trainer battle store
- update trainer store tests for new field
- adjust trainer battle heal test for HP recovery and no XP gain

## Testing
- `npm test --silent` *(fails: cannot read properties of undefined / Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_687686f1416c832a92e26ff3fb414745