### PR TITLE
Fix arena active shlagemon restore

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -12,6 +12,7 @@ const dex = useShlagedexStore()
 const arena = useArenaStore()
 const featureLock = useFeatureLockStore()
 const panel = useMainPanelStore()
+const savedActive = ref<DexShlagemon | null>(null)
 
 const enemyTeam = computed(() => arena.lineup)
 const showDex = ref(false)
@@ -107,10 +108,15 @@ function proceedNext() {
   showDuel.value = true
 }
 
-onMounted(featureLock.lockAll)
+onMounted(() => {
+  savedActive.value = dex.activeShlagemon
+  featureLock.lockAll()
+})
 onUnmounted(() => {
   clearTimeout(nextTimer)
   featureLock.unlockAll()
+  if (savedActive.value)
+    dex.setActiveShlagemon(savedActive.value)
 })
 </script>
 


### PR DESCRIPTION
## Summary
- remember the active shlagemon when opening the arena panel
- restore that shlagemon on panel unmount

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch fonts, many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68768d4bc974832a83a843410ff11b44