### PR TITLE
Fix trainer battle shortcuts

### DIFF
--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -5,16 +5,20 @@ import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from './achievements'
 import { useArenaStore } from './arena'
 import { useCaptureLimitModalStore } from './captureLimitModal'
+import { useFeatureLockStore } from './featureLock'
 import { useGameStore } from './game'
 import { useItemUsageStore } from './itemUsage'
 import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
+import { useTrainerBattleStore } from './trainerBattle'
 
 export const useInventoryStore = defineStore('inventory', () => {
   const items = ref<Record<string, number>>({})
   const game = useGameStore()
   const dex = useShlagedexStore()
   const arena = useArenaStore()
+  const trainerBattle = useTrainerBattleStore()
+  const featureLock = useFeatureLockStore()
   const player = usePlayerStore()
   const captureLimitModal = useCaptureLimitModalStore()
   const itemUsage = useItemUsageStore()
@@ -75,7 +79,7 @@ export const useInventoryStore = defineStore('inventory', () => {
   }
 
   function useItem(id: string) {
-    if (arena.inBattle || !items.value[id])
+    if (arena.inBattle || trainerBattle.isActive || featureLock.isInventoryLocked || !items.value[id])
       return false
 
     notifyAchievement({ type: 'item-used' })

--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { useFeatureLockStore } from './featureLock'
 import { useInventoryStore } from './inventory'
 
 export interface UseItemAction {
@@ -21,6 +22,7 @@ const defaultShortcuts: ShortcutEntry[] = [
 
 export const useShortcutsStore = defineStore('shortcuts', () => {
   const shortcuts = ref<ShortcutEntry[]>([...defaultShortcuts])
+  const lock = useFeatureLockStore()
 
   function add(entry: ShortcutEntry) {
     shortcuts.value.push(entry)
@@ -43,8 +45,11 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
     const entry = shortcuts.value.find(s => s.key === e.key)
     if (!entry)
       return
-    if (entry.action.type === 'use-item')
+    if (entry.action.type === 'use-item') {
+      if (lock.isInventoryLocked)
+        return
       useInventoryStore().useItem(entry.action.itemId)
+    }
   }
 
   return { shortcuts, add, update, remove, reset, handleKeydown }


### PR DESCRIPTION
## Summary
- prevent item use via shortcuts when inventory is locked
- lock keyboard shortcuts during trainer battles

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: 'z.maxLevel' possibly undefined)*
- `pnpm test` *(fails to resolve imports and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68768e0d7c24832ab328bc7c0e245323