### PR TITLE
Fix potion bonus reset on switch

### DIFF
--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -66,7 +66,7 @@ watch(
   () => dex.activeShlagemon,
   (mon, prev) => {
     if (mon && prev && prev.id !== mon.id)
-      mon.hpCurrent = mon.hp
+      mon.hpCurrent = dex.maxHp(mon)
     if (mon && prev?.id !== mon?.id)
       startBattle()
   },


### PR DESCRIPTION
## Summary
- ensure active shlagemon keeps boosted HP when switching

## Testing
- `npx vitest run --reporter dot --silent` *(fails: Failed to fetch web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68769f10e2c4832aa9b36eb1ecd244e2