### PR TITLE
Fix enemy HP not reflecting potion

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -127,7 +127,9 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   }
 
   function maxHp(mon: DexShlagemon): number {
-    return Math.round(mon.hp * (1 + vitalityBonusPercent.value / 100))
+    const isActive = activeShlagemon.value?.id === mon.id
+    const bonus = isActive ? vitalityBonusPercent.value : 0
+    return Math.round(mon.hp * (1 + bonus / 100))
   }
 
   function xpGainForLevel(level: number): number {


### PR DESCRIPTION
## Summary
- ensure HP bonus from vitality potions only applies to the active Shlagémon

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to fetch fonts, missing modules, many failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_6876cd3048c8832a875020e24bd7593a