### PR TITLE
Add evolution sort to Shlagedex

### DIFF
--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -35,6 +35,7 @@ const sortOptions = [
   { label: 'Défense', value: 'defense' },
   { label: 'Nb obtentions', value: 'count' },
   { label: 'Première capture', value: 'date' },
+  { label: 'Proche d\'évoluer', value: 'evolution' },
 ] as const
 
 const displayedMons = computed(() => {
@@ -79,11 +80,27 @@ const displayedMons = computed(() => {
           ),
       )
       break
+    case 'evolution':
+      mons.sort((a, b) => evolutionDistance(a) - evolutionDistance(b))
+      break
   }
   if (!filter.sortAsc)
     mons.reverse()
   return mons
 })
+
+function evolutionDistance(mon: DexShlagemon): number {
+  const evo = mon.base.evolution
+  if (!evo || evo.condition.type !== 'lvl')
+    return Number.POSITIVE_INFINITY
+  const diff = Math.abs(evo.condition.value - mon.lvl)
+  if (mon.lvl >= evo.condition.value) {
+    if (!mon.allowEvolution)
+      return Number.POSITIVE_INFINITY
+    return diff - 1000
+  }
+  return diff
+}
 
 function handleClick(mon: DexShlagemon) {
   if (props.disabledIds.includes(mon.id))

--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -10,6 +10,7 @@ export type DexSort =
   | 'defense'
   | 'count'
   | 'date'
+  | 'evolution'
 
 export const useDexFilterStore = defineStore('dexFilter', () => {
   const search = ref('')

--- a/test/double-click.test.ts
+++ b/test/double-click.test.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
-import Shlagedex from '../src/components/shlagemon/Shlagedex.vue'
+import Shlagedex from '../src/components/panel/Shlagedex.vue'
 import { carapouffe } from '../src/data/shlagemons'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 

--- a/test/sort-evolution.test.ts
+++ b/test/sort-evolution.test.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import Shlagedex from '../src/components/panel/Shlagedex.vue'
+import { jeunebelette } from '../src/data/shlagemons/01-05/jeunebelette'
+import { rouxPasCool } from '../src/data/shlagemons/01-05/rouxPasCool'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useDexFilterStore } from '../src/stores/dexFilter'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { createDexShlagemon } from '../src/utils/dexFactory'
+
+describe('shlagedex sort evolution', () => {
+  it('orders by distance to evolution', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const filter = useDexFilterStore()
+
+    const ready = createDexShlagemon(carapouffe, false, 1, 20)
+    const near = createDexShlagemon(jeunebelette, false, 1, 4)
+    const disabled = createDexShlagemon(rouxPasCool, false, 1, 20)
+    disabled.allowEvolution = false
+
+    dex.addShlagemon(ready)
+    dex.addShlagemon(near)
+    dex.addShlagemon(disabled)
+
+    filter.sortBy = 'evolution'
+    filter.sortAsc = true
+
+    const wrapper = mount(Shlagedex, {
+      global: {
+        plugins: [pinia],
+        stubs: [
+          'ShlagemonImage',
+          'ShlagemonType',
+          'Modal',
+          'SearchInput',
+          'SelectOption',
+          'CheckBox',
+          'MultiExpIcon',
+        ],
+      },
+    })
+
+    const items = wrapper.findAll('div.relative')
+    expect(items.length).toBe(3)
+    expect(items[0].text()).toContain('Carapouffe')
+    expect(items[1].text()).toContain('Jeunebelette')
+    expect(items[2].text()).toContain('Roux pas Cool')
+  })
+})

--- a/test/sort-shiny.test.ts
+++ b/test/sort-shiny.test.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
-import Shlagedex from '../src/components/shlagemon/Shlagedex.vue'
+import Shlagedex from '../src/components/panel/Shlagedex.vue'
 import { carapouffe, sacdepates } from '../src/data/shlagemons'
 import { useDexFilterStore } from '../src/stores/dexFilter'
 import { useShlagedexStore } from '../src/stores/shlagedex'


### PR DESCRIPTION
## Summary
- allow sorting the Shlagedex list by distance to evolution
- expose new `evolution` option in the dex filter store
- fix panel component imports in tests
- test evolution distance ordering

## Testing
- `pnpm vitest run test/sort-evolution.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6876cda139c0832ab953a972b55926a8