### PR TITLE
Fix potion cleanup when entering arena

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -68,6 +68,7 @@ function quit() {
 }
 
 function startBattle() {
+  dex.clearEffects()
   const team = arena.selections
     .map(id => dex.shlagemons.find(m => m.id === (id || ''))!)
     .map((mon) => {

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -1,19 +1,32 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { useArenaStore } from '~/stores/arena'
+import { useMainPanelStore } from '~/stores/mainPanel'
 
 const emit = defineEmits(['done'])
 const arena = useArenaStore()
+const panel = useMainPanelStore()
+
+function quit() {
+  arena.reset()
+  panel.showVillage()
+  emit('done', 'arenaWelcome')
+}
 
 const dialogTree: DialogNode[] = [
   {
     id: 'start',
-    text: `Bienvenue dans l'ar\u00E8ne, cette ar\u00E8ne te permet de capturer des Shlagémons jusqu'au niveau ${arena.arenaData?.badge.levelCap ?? ''}. Les combats se d\u00E9roulent en un contre un sans potion ni attaque manuelle. Choisis des Shlag\u00E9mons entra\u00EEn\u00E9s et puissants contre les types oppos\u00E9s.`,
+    text: `Bienvenue dans l'ar\u00E8ne, cette ar\u00E8ne te permet de capturer des Shlagémons jusqu'au niveau ${arena.arenaData?.badge.levelCap ?? ''}. Les combats se d\u00E9roulent en un contre un sans potion ni attaque manuelle. Tous tes bonus de potions seront annulés en entrant. Choisis des Shlag\u00E9mons entra\u00EEn\u00E9s et puissants contre les types oppos\u00E9s.`,
     responses: [
       {
         label: 'C\u0027est parti !',
         type: 'valid',
         action: () => emit('done', 'arenaWelcome'),
+      },
+      {
+        label: 'Quitter',
+        type: 'danger',
+        action: quit,
       },
     ],
   },

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -230,6 +230,10 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     })
   }
 
+  function clearEffects() {
+    effects.value.slice().forEach(e => removeEffect(e.id))
+  }
+
   function boostDefense(
     percent: number,
     icon?: string,
@@ -614,6 +618,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     effectiveDefense,
     maxHp,
     xpGainForLevel,
+    clearEffects,
     effects,
     evolveWithItem,
   }


### PR DESCRIPTION
## Summary
- clear active potion bonuses when starting the arena
- tell the player that potion bonuses are removed in the welcome dialog
- allow quitting the arena welcome dialog

## Testing
- `pnpm test:unit` *(fails: Snapshot mismatch and missing data)*

------
https://chatgpt.com/codex/tasks/task_e_6876d055387c832ab2f0952c648993a4