### PR TITLE
Add inventory hotkey reassignment

### DIFF
--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
+import { storeToRefs } from 'pinia'
 import { useItemUsageStore } from '~/stores/itemUsage'
 import { useShortcutsStore } from '~/stores/shortcuts'
 import { useUIStore } from '~/stores/ui'
-import { storeToRefs } from 'pinia'
 import { ballHues } from '~/utils/ball'
 
 const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
@@ -33,13 +33,18 @@ const actionLabel = computed(() => {
 
 const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
 
-const { shortcuts } = storeToRefs(useShortcutsStore())
+const shortcutStore = useShortcutsStore()
+const { shortcuts } = storeToRefs(shortcutStore)
 const { isMobile } = storeToRefs(useUIStore())
 
 const shortcutKey = computed(() => {
   const entry = shortcuts.value.find(s => s.action.type === 'use-item' && s.action.itemId === props.item.id)
   return entry?.key || '?'
 })
+
+function assignShortcut(key: string) {
+  shortcutStore.setItemShortcut(props.item.id, key)
+}
 
 watch(showInfo, (val) => {
   if (val) {
@@ -71,7 +76,13 @@ watch(showInfo, (val) => {
         >
         <span class="font-bold">{{ props.item.name }}</span>
       </div>
-      <UiKbd v-if="!isMobile" size="sm" :key-name="shortcutKey" />
+      <UiKeyCapture
+        v-if="!isMobile"
+        size="sm"
+        :model-value="shortcutKey"
+        @update:model-value="assignShortcut"
+        @click.stop
+      />
     </div>
     <div class="mt-1 flex items-center justify-end gap-1">
       <span class="font-bold">x{{ props.qty }}</span>

--- a/src/components/ui/KeyCapture.vue
+++ b/src/components/ui/KeyCapture.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useKeyboardCaptureStore } from '~/stores/keyboardCapture'
 
-const props = defineProps<{ modelValue: string }>()
+const props = withDefaults(defineProps<{ modelValue: string, size?: 'sm' | 'md' | 'lg' | 'xl' }>(), {
+  size: 'md',
+})
 const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
 
 const captureStore = useKeyboardCaptureStore()
@@ -32,6 +34,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
 <template>
   <UiKbd
     :key-name="waiting ? '?' : props.modelValue || '?'"
+    :size="props.size"
     :waiting="waiting"
     clickable
     @click="startCapture"

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -3,21 +3,17 @@ import { defineStore } from 'pinia'
 import { allItems } from '~/data/items/items'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from './achievements'
-import { useArenaStore } from './arena'
 import { useCaptureLimitModalStore } from './captureLimitModal'
 import { useFeatureLockStore } from './featureLock'
 import { useGameStore } from './game'
 import { useItemUsageStore } from './itemUsage'
 import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
-import { useTrainerBattleStore } from './trainerBattle'
 
 export const useInventoryStore = defineStore('inventory', () => {
   const items = ref<Record<string, number>>({})
   const game = useGameStore()
   const dex = useShlagedexStore()
-  const arena = useArenaStore()
-  const trainerBattle = useTrainerBattleStore()
   const featureLock = useFeatureLockStore()
   const player = usePlayerStore()
   const captureLimitModal = useCaptureLimitModalStore()

--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -41,6 +41,15 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
     shortcuts.value = [...defaultShortcuts]
   }
 
+  function setItemShortcut(itemId: string, key: string) {
+    const idx = shortcuts.value.findIndex(s => s.action.type === 'use-item' && s.action.itemId === itemId)
+    const entry: ShortcutEntry = { key, action: { type: 'use-item', itemId } }
+    if (idx >= 0)
+      shortcuts.value[idx] = entry
+    else
+      shortcuts.value.push(entry)
+  }
+
   function handleKeydown(e: KeyboardEvent) {
     const entry = shortcuts.value.find(s => s.key === e.key)
     if (!entry)
@@ -52,7 +61,7 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
     }
   }
 
-  return { shortcuts, add, update, remove, reset, handleKeydown }
+  return { shortcuts, add, update, remove, reset, setItemShortcut, handleKeydown }
 }, {
   persist: true,
 })


### PR DESCRIPTION
## Summary
- allow customizing item shortcuts directly from item cards
- support sizing for KeyCapture component
- clean unused arena imports

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Failed to fetch web fonts; 26 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876d553174c832abdda9f84d1b97f0e