### PR TITLE
Fix evolution sort default order

### DIFF
--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -18,7 +18,7 @@ export const useDexFilterStore = defineStore('dexFilter', () => {
   const sortAsc = ref(false)
 
   watch(sortBy, (val) => {
-    if (val === 'name' || val === 'type' || val === 'date')
+    if (val === 'name' || val === 'type' || val === 'date' || val === 'evolution')
       sortAsc.value = true
     else
       sortAsc.value = false


### PR DESCRIPTION
## Summary
- keep the evolution sorting ascending by default

## Testing
- `pnpm test` *(fails: ENETUNREACH for web fonts, multiple vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876d77087e4832aab2909f3f6339518