### PR TITLE
Handle duplicate shortcuts

### DIFF
--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -51,13 +51,15 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    const entry = shortcuts.value.find(s => s.key === e.key)
-    if (!entry)
+    const entries = shortcuts.value.filter(s => s.key === e.key)
+    if (!entries.length)
       return
-    if (entry.action.type === 'use-item') {
-      if (lock.isInventoryLocked)
-        return
-      useInventoryStore().useItem(entry.action.itemId)
+    for (const entry of entries) {
+      if (entry.action.type === 'use-item') {
+        if (lock.isInventoryLocked)
+          continue
+        useInventoryStore().useItem(entry.action.itemId)
+      }
     }
   }
 

--- a/test/shortcuts.test.ts
+++ b/test/shortcuts.test.ts
@@ -1,0 +1,29 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useShortcutsStore } from '../src/stores/shortcuts'
+
+// Ensure multiple shortcuts using the same key all trigger
+
+describe('shortcuts', () => {
+  it('triggers all actions bound to the same key', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const inventory = useInventoryStore()
+    const shortcuts = useShortcutsStore()
+    // need an active shlagemon for potions to work
+    const mon = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(mon)
+    inventory.add('potion')
+    inventory.add('super-potion')
+    shortcuts.shortcuts = [
+      { key: 'a', action: { type: 'use-item', itemId: 'potion' } },
+      { key: 'a', action: { type: 'use-item', itemId: 'super-potion' } },
+    ]
+    shortcuts.handleKeydown(new KeyboardEvent('keydown', { key: 'a' }))
+    expect(inventory.items.potion).toBeUndefined()
+    expect(inventory.items['super-potion']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- execute every shortcut bound to the same key
- add test ensuring that all shortcuts trigger

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876d7f290b4832a81557a89a152c4c4