### PR TITLE
Fix equipping Shlagéball via shortcut

### DIFF
--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -1,6 +1,11 @@
 import { defineStore } from 'pinia'
+import { allItems } from '~/data/items/items'
+import { useBallStore } from './ball'
+import { useEvolutionItemStore } from './evolutionItem'
 import { useFeatureLockStore } from './featureLock'
 import { useInventoryStore } from './inventory'
+import { useItemUsageStore } from './itemUsage'
+import { useWearableItemStore } from './wearableItem'
 
 export interface UseItemAction {
   type: 'use-item'
@@ -57,7 +62,27 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
     if (entry.action.type === 'use-item') {
       if (lock.isInventoryLocked)
         return
-      useInventoryStore().useItem(entry.action.itemId)
+
+      const item = allItems.find(i => i.id === entry.action.itemId)
+      if (!item)
+        return
+
+      const inventory = useInventoryStore()
+      const usage = useItemUsageStore()
+      if ('catchBonus' in item) {
+        useBallStore().setBall(item.id as any)
+        usage.markUsed(item.id)
+      }
+      else if (item.type === 'evolution') {
+        useEvolutionItemStore().open(item)
+      }
+      else if (item.wearable) {
+        useWearableItemStore().open(item)
+      }
+      else {
+        if (inventory.useItem(item.id))
+          usage.markUsed(item.id)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- handle Shlagéball shortcuts as equipment instead of item usage

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6876d91b303c832a9340181ffd1a17fc