### PR TITLE
Fix sorting for evolution-disabled monsters

### DIFF
--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -93,12 +93,11 @@ function evolutionDistance(mon: DexShlagemon): number {
   const evo = mon.base.evolution
   if (!evo || evo.condition.type !== 'lvl')
     return Number.POSITIVE_INFINITY
+  if (!mon.allowEvolution)
+    return Number.POSITIVE_INFINITY
   const diff = Math.abs(evo.condition.value - mon.lvl)
-  if (mon.lvl >= evo.condition.value) {
-    if (!mon.allowEvolution)
-      return Number.POSITIVE_INFINITY
+  if (mon.lvl >= evo.condition.value)
     return diff - 1000
-  }
   return diff
 }
 


### PR DESCRIPTION
## Summary
- ensure monsters with evolution disabled sort last when sorting by evolution distance

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876d993d7f4832aa65a4e908e77cef7