### PR TITLE
Implement new evolution and death SFX

### DIFF
--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -1,4 +1,5 @@
 import type { DexShlagemon } from '~/type/shlagemon'
+import { useAudioStore } from '~/stores/audio'
 import { useBattleStore } from '~/stores/battle'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useBattleEffects } from './battleEngine'
@@ -10,6 +11,7 @@ export interface BattleCoreOptions {
 export function useBattleCore(options: BattleCoreOptions) {
   const battle = useBattleStore()
   const dex = useShlagedexStore()
+  const audio = useAudioStore()
   const {
     playerEffect,
     enemyEffect,
@@ -92,6 +94,8 @@ export function useBattleCore(options: BattleCoreOptions) {
 
   function checkEnd() {
     if (enemyHp.value <= 0 || playerHp.value <= 0) {
+      if (playerHp.value <= 0 && !playerFainted.value)
+        audio.playSfx('/audio/sfx/die.ogg')
       stopBattle()
       playerFainted.value = playerHp.value <= 0
       enemyFainted.value = enemyHp.value <= 0

--- a/src/stores/evolution.ts
+++ b/src/stores/evolution.ts
@@ -22,6 +22,7 @@ export const useEvolutionStore = defineStore('evolution', () => {
 
   function accept() {
     if (pending.value) {
+      audio.playSfx('/audio/sfx/evolued.ogg')
       pending.value.resolve(true)
       pending.value = null
     }


### PR DESCRIPTION
## Summary
- play new `evolued.ogg` when confirming evolution
- play new `die.ogg` when the player’s monster faints

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots mismatched and assets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876db6a6380832a843252eb9efdaffb