### PR TITLE
Add new zone unlock dialog

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -39,6 +39,7 @@ declare module 'vue' {
     DialogFirstLossDialog: typeof import('./components/dialog/FirstLossDialog.vue')['default']
     DialogHalfDexDialog: typeof import('./components/dialog/HalfDexDialog.vue')['default']
     DialogLevel5Dialog: typeof import('./components/dialog/Level5Dialog.vue')['default']
+    DialogNewZoneDialog: typeof import('./components/dialog/NewZoneDialog.vue')['default']
     DialogStarter: typeof import('./components/dialog/Starter.vue')['default']
     IconBadgeFatAss: typeof import('./components/icon/badge/FatAss.vue')['default']
     IconBadgeShit: typeof import('./components/icon/badge/Shit.vue')['default']

--- a/src/components/dialog/NewZoneDialog.vue
+++ b/src/components/dialog/NewZoneDialog.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { useInventoryStore } from '~/stores/inventory'
+import { useZoneVisitStore } from '~/stores/zoneVisit'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+const visit = useZoneVisitStore()
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: 'Bien joué ! Tu as dégommé le boss et débloqué une nouvelle zone.',
+    responses: [
+      { label: 'Continuer', nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: 'Pour faire progresser tes Shlagémons et découvrir d\'autres horreurs, balade-toi dans la zone qui vient d\'ouvrir.',
+    responses: [
+      { label: 'Retour', nextId: 'start', type: 'danger' },
+      { label: 'Suite', nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: 'Souviens-toi, un Shlagémon ne peut pas dépasser le niveau maximal de la zone où tu te trouves.',
+    responses: [
+      { label: 'Retour', nextId: 'step2', type: 'danger' },
+      { label: 'Suite', nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: 'Explore d\'autres endroits pour continuer à les faire évoluer. Tiens, prends cette Potion d\'Expérience, j\'en ai qu\'une !',
+    responses: [
+      { label: 'Retour', nextId: 'step3', type: 'danger' },
+      {
+        label: 'Merci Professeur !',
+        type: 'valid',
+        action: () => {
+          inventory.add('xp-potion', 1)
+          visit.markAllAccessibleVisited()
+          emit('done', 'newZone')
+        },
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :dialog-tree="dialogTree"
+    orientation="col"
+  />
+</template>

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -1,5 +1,6 @@
 import type { Component } from 'vue'
 import { defineStore } from 'pinia'
+import { markRaw } from 'vue'
 import AnotherShlagemonDialog from '~/components/dialog/AnotherShlagemonDialog.vue'
 import ArenaDefeatDialog from '~/components/dialog/ArenaDefeatDialog.vue'
 import ArenaVictoryDialog from '~/components/dialog/ArenaVictoryDialog.vue'
@@ -8,6 +9,7 @@ import AttackPotionDialog from '~/components/dialog/AttackPotionDialog.vue'
 import FirstLossDialog from '~/components/dialog/FirstLossDialog.vue'
 import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
 import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
+import NewZoneDialog from '~/components/dialog/NewZoneDialog.vue'
 import DialogStarter from '~/components/dialog/Starter.vue'
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
@@ -15,6 +17,7 @@ import { useShlagedexStore } from '~/stores/shlagedex'
 import { useArenaStore } from './arena'
 import { useBattleStatsStore } from './battleStats'
 import { useMainPanelStore } from './mainPanel'
+import { useZoneVisitStore } from './zoneVisit'
 
 interface DialogItem {
   id: string
@@ -32,6 +35,7 @@ export const useDialogStore = defineStore('dialog', () => {
   const panel = useMainPanelStore()
   const stats = useBattleStatsStore()
   const arena = useArenaStore()
+  const visit = useZoneVisitStore()
 
   const done = ref<DialogDone>({})
   const dialogs: DialogItem[] = [
@@ -59,6 +63,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'attackPotion',
       component: markRaw(AttackPotionDialog),
       condition: () => dex.shlagemons.length >= 10,
+    },
+    {
+      id: 'newZone',
+      component: markRaw(NewZoneDialog),
+      condition: () => visit.hasNewZone,
     },
     {
       id: 'arenaWelcome',


### PR DESCRIPTION
## Summary
- add Professeur Merdant dialog when a new zone unlocks
- register new dialog component in global types
- show this dialog via the dialog store when `hasNewZone` becomes true

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fonts fetch & test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6876e086d91c832aaf88ef808d0abf6b