### PR TITLE
Add king unlock dialog

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -38,6 +38,7 @@ declare module 'vue' {
     DialogBox: typeof import('./components/dialog/Box.vue')['default']
     DialogFirstLossDialog: typeof import('./components/dialog/FirstLossDialog.vue')['default']
     DialogHalfDexDialog: typeof import('./components/dialog/HalfDexDialog.vue')['default']
+    DialogKingUnlockDialog: typeof import('./components/dialog/KingUnlockDialog.vue')['default']
     DialogLevel5Dialog: typeof import('./components/dialog/Level5Dialog.vue')['default']
     DialogStarter: typeof import('./components/dialog/Starter.vue')['default']
     IconBadgeFatAss: typeof import('./components/icon/badge/FatAss.vue')['default']

--- a/src/components/dialog/KingUnlockDialog.vue
+++ b/src/components/dialog/KingUnlockDialog.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { useInventoryStore } from '~/stores/inventory'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: 'Félicitations ! Tes victoires ont débloqué l\'accès au combat contre le roi.',
+    responses: [
+      { label: 'Continuer', nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: 'Pour progresser, tu devras vaincre ce boss redoutable.',
+    responses: [
+      { label: 'Retour', nextId: 'start', type: 'danger' },
+      { label: 'Continuer', nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: 'Je t\'offre une Potion de Défense. Elle s\'utilise dans ton inventaire et booste toute ton équipe.',
+    responses: [
+      { label: 'Retour', nextId: 'step2', type: 'danger' },
+      { label: 'Continuer', nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: 'Attention, son effet dure 10 minutes et ne fonctionne qu\'une seule fois, quel que soit ton Schlagémon actif.',
+    responses: [
+      { label: 'Retour', nextId: 'step3', type: 'danger' },
+      { label: 'Continuer', nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: 'Bonne chance pour le combat contre le roi !',
+    responses: [
+      { label: 'Retour', nextId: 'step4', type: 'danger' },
+      {
+        label: 'Merci Prof !',
+        type: 'valid',
+        action: () => {
+          inventory.add('defense-potion', 1)
+          emit('done', 'kingUnlock')
+        },
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :dialog-tree="dialogTree"
+    orientation="col"
+  />
+</template>

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -7,6 +7,7 @@ import ArenaWelcomeDialog from '~/components/dialog/ArenaWelcomeDialog.vue'
 import AttackPotionDialog from '~/components/dialog/AttackPotionDialog.vue'
 import FirstLossDialog from '~/components/dialog/FirstLossDialog.vue'
 import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
+import KingUnlockDialog from '~/components/dialog/KingUnlockDialog.vue'
 import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import DialogStarter from '~/components/dialog/Starter.vue'
 import { useGameStore } from '~/stores/game'
@@ -15,6 +16,8 @@ import { useShlagedexStore } from '~/stores/shlagedex'
 import { useArenaStore } from './arena'
 import { useBattleStatsStore } from './battleStats'
 import { useMainPanelStore } from './mainPanel'
+import { useZoneStore } from './zone'
+import { useZoneProgressStore } from './zoneProgress'
 
 interface DialogItem {
   id: string
@@ -32,6 +35,8 @@ export const useDialogStore = defineStore('dialog', () => {
   const panel = useMainPanelStore()
   const stats = useBattleStatsStore()
   const arena = useArenaStore()
+  const progress = useZoneProgressStore()
+  const zone = useZoneStore()
 
   const done = ref<DialogDone>({})
   const dialogs: DialogItem[] = [
@@ -59,6 +64,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'attackPotion',
       component: markRaw(AttackPotionDialog),
       condition: () => dex.shlagemons.length >= 10,
+    },
+    {
+      id: 'kingUnlock',
+      component: markRaw(KingUnlockDialog),
+      condition: () => progress.canFightKing(zone.current.id) && !progress.isKingDefeated(zone.current.id),
     },
     {
       id: 'arenaWelcome',


### PR DESCRIPTION
## Summary
- introduce `KingUnlockDialog` for when the king battle unlocks
- register dialog in the dialog store
- update component typings

## Testing
- `pnpm test:unit` *(fails: mobile tab persistence, component snapshot and others)*

------
https://chatgpt.com/codex/tasks/task_e_6876e100a6ec832a8f0a8018bade2c07