### PR TITLE
Implement item evolution sorting

### DIFF
--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -91,14 +91,19 @@ const displayedMons = computed(() => {
 
 function evolutionDistance(mon: DexShlagemon): number {
   const evo = mon.base.evolution
-  if (!evo || evo.condition.type !== 'lvl')
+  if (!evo)
     return Number.POSITIVE_INFINITY
   if (!mon.allowEvolution)
     return Number.POSITIVE_INFINITY
-  const diff = Math.abs(evo.condition.value - mon.lvl)
-  if (mon.lvl >= evo.condition.value)
-    return diff - 1000
-  return diff
+  if (evo.condition.type === 'item')
+    return -2000
+  if (evo.condition.type === 'lvl') {
+    const diff = Math.abs(evo.condition.value - mon.lvl)
+    if (mon.lvl >= evo.condition.value)
+      return diff - 1000
+    return diff
+  }
+  return Number.POSITIVE_INFINITY
 }
 
 function handleClick(mon: DexShlagemon) {

--- a/test/sort-evolution.test.ts
+++ b/test/sort-evolution.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import Shlagedex from '../src/components/panel/Shlagedex.vue'
 import { jeunebelette } from '../src/data/shlagemons/01-05/jeunebelette'
 import { rouxPasCool } from '../src/data/shlagemons/01-05/rouxPasCool'
+import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useDexFilterStore } from '../src/stores/dexFilter'
 import { useShlagedexStore } from '../src/stores/shlagedex'
@@ -16,11 +17,13 @@ describe('shlagedex sort evolution', () => {
     const dex = useShlagedexStore()
     const filter = useDexFilterStore()
 
+    const item = createDexShlagemon(pikachiant, false, 1, 10)
     const ready = createDexShlagemon(carapouffe, false, 1, 20)
     const near = createDexShlagemon(jeunebelette, false, 1, 4)
     const disabled = createDexShlagemon(rouxPasCool, false, 1, 20)
     disabled.allowEvolution = false
 
+    dex.addShlagemon(item)
     dex.addShlagemon(ready)
     dex.addShlagemon(near)
     dex.addShlagemon(disabled)
@@ -44,9 +47,10 @@ describe('shlagedex sort evolution', () => {
     })
 
     const items = wrapper.findAll('div.relative')
-    expect(items.length).toBe(3)
-    expect(items[0].text()).toContain('Carapouffe')
-    expect(items[1].text()).toContain('Jeunebelette')
-    expect(items[2].text()).toContain('Roux pas Cool')
+    expect(items.length).toBe(4)
+    expect(items[0].text()).toContain('Pikachiant')
+    expect(items[1].text()).toContain('Carapouffe')
+    expect(items[2].text()).toContain('Jeunebelette')
+    expect(items[3].text()).toContain('Roux pas Cool')
   })
 })


### PR DESCRIPTION
## Summary
- support item-based evolutions in shlagémon list sort
- test that item evolutions appear first

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68775c113b98832aa5f8175903ddf702