### PR TITLE
Implement wild zone unlock logic

### DIFF
--- a/src/components/panel/Zone.vue
+++ b/src/components/panel/Zone.vue
@@ -42,9 +42,9 @@ function canAccess(z: Zone) {
     return z.minLevel <= dex.highestLevel
   const idx = xpZones.value.findIndex(x => x.id === z.id)
   if (idx === 0)
-    return dex.highestLevel >= z.minLevel
+    return true
   const prev = xpZones.value[idx - 1]
-  return dex.highestLevel >= z.minLevel && progress.isKingDefeated(prev.id)
+  return progress.isKingDefeated(prev.id)
 }
 
 function selectZone(id: string) {

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -43,9 +43,9 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       return z.minLevel <= highestLevel.value
     const idx = xpZones.value.findIndex(x => x.id === z.id)
     if (idx === 0)
-      return highestLevel.value >= z.minLevel
+      return true
     const prev = xpZones.value[idx - 1]
-    return highestLevel.value >= z.minLevel && progress.isKingDefeated(prev.id)
+    return progress.isKingDefeated(prev.id)
   }
 
   const accessibleZones = computed(() => zonesData.filter(z => canAccess(z)))

--- a/src/stores/zoneVisit.ts
+++ b/src/stores/zoneVisit.ts
@@ -17,9 +17,9 @@ export const useZoneVisitStore = defineStore('zoneVisit', () => {
       return z.minLevel <= dex.highestLevel
     const idx = xpZones.value.findIndex(x => x.id === z.id)
     if (idx === 0)
-      return dex.highestLevel >= z.minLevel
+      return true
     const prev = xpZones.value[idx - 1]
-    return dex.highestLevel >= z.minLevel && progress.isKingDefeated(prev.id)
+    return progress.isKingDefeated(prev.id)
   }
 
   const accessibleZones = computed(() => zones.filter(z => canAccess(z)))


### PR DESCRIPTION
## Summary
- loosen wild zone access logic so defeating the previous king alone unlocks the next
- apply same logic in UI zone list and Dex store

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'base'))*

------
https://chatgpt.com/codex/tasks/task_e_687760e43244832abecf233aa5ebc252