### PR TITLE
Fix PWA background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="apple-touch-icon" href="/pwa-192x192.png" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0d9488" />
     <meta name="msapplication-TileColor" content="#0d9488" />
+    <meta name="theme-color" content="#0d9488" />
     <script>
       ;(function () {
         const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -110,6 +110,7 @@ export default defineConfig({
         name: 'Shlagémon',
         short_name: 'Shlagémon',
         theme_color: '#0d9488',
+        background_color: '#0d9488',
         icons: [
           {
             src: '/pwa-192x192.png',


### PR DESCRIPTION
## Summary
- improve meta theme color on initial load
- set PWA background color so splash screen matches brand

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: background network errors and failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68777139b820832aa9a0f5a65e4ef202