### PR TITLE
Implement wearable item system

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -89,6 +89,7 @@ declare module 'vue' {
     ShlagemonType: typeof import('./components/shlagemon/Type.vue')['default']
     ShlagemonTypeChart: typeof import('./components/shlagemon/TypeChart.vue')['default']
     ShlagemonTypeChartModal: typeof import('./components/shlagemon/TypeChartModal.vue')['default']
+    ShlagemonWearableEquipModal: typeof import('./components/shlagemon/WearableEquipModal.vue')['default']
     ShlagemonXpBar: typeof import('./components/shlagemon/XpBar.vue')['default']
     ShopItemCard: typeof import('./components/shop/ItemCard.vue')['default']
     ShopItemDetail: typeof import('./components/shop/ItemDetail.vue')['default']

--- a/src/components/dialog/HalfDexDialog.vue
+++ b/src/components/dialog/HalfDexDialog.vue
@@ -1,22 +1,22 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
-import { profShlag } from '~/data/characters/prof-shlag'
-import { useGameStore } from '~/stores/game'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { useInventoryStore } from '~/stores/inventory'
 
 const emit = defineEmits(['done'])
-const game = useGameStore()
+const inventory = useInventoryStore()
 
 const dialogTree: DialogNode[] = [
   {
     id: 'step1',
-    text: `Oh ! Salut dresseur ! Je suis ${profShlag.name}. Tu as rempli 50% du Shlagedex !`,
+    text: 'Félicitations ! Tu as déjà complété la moitié du Shlagedex.',
     responses: [
       { label: 'Continuer', nextId: 'step2', type: 'primary' },
     ],
   },
   {
     id: 'step2',
-    text: 'Je dois avouer que je ne m\'attendais pas à sentir ta persévérance aussi longtemps.',
+    text: `Je suis ${profMerdant.name}. Pour t\'aider, je vais te remettre un objet très spécial : le Multi-UXP.`,
     responses: [
       { label: 'Retour', nextId: 'step1', type: 'danger' },
       { label: 'Continuer', nextId: 'step3', type: 'primary' },
@@ -24,7 +24,7 @@ const dialogTree: DialogNode[] = [
   },
   {
     id: 'step3',
-    text: 'Pour célébrer, je t\'offre 10 Shlagédiamants. Ils brillent presque autant que toi.',
+    text: 'Fais-le tenir par un Shlagémon et il recevra la moitié de l\'expérience gagnée en combat.',
     responses: [
       { label: 'Retour', nextId: 'step2', type: 'danger' },
       { label: 'Continuer', nextId: 'step4', type: 'primary' },
@@ -32,22 +32,14 @@ const dialogTree: DialogNode[] = [
   },
   {
     id: 'step4',
-    text: 'Ne les dépense pas tous au même endroit... sauf si c\'est pour m\'acheter des parfums.',
+    text: 'Un seul Shlagémon peut le porter, alors choisis bien son porteur !',
     responses: [
       { label: 'Retour', nextId: 'step3', type: 'danger' },
-      { label: 'Continuer', nextId: 'step5', type: 'primary' },
-    ],
-  },
-  {
-    id: 'step5',
-    text: 'Allez, file. Le Shlagedex n\'attend que toi pour être complété.',
-    responses: [
-      { label: 'Retour', nextId: 'step4', type: 'danger' },
       {
-        label: 'Merci, Professeur !',
+        label: 'Merci !',
         type: 'valid',
         action: () => {
-          game.addShlagidiamond(10)
+          inventory.add('multi-exp', 1)
           emit('done', 'halfDex')
         },
       },
@@ -58,7 +50,7 @@ const dialogTree: DialogNode[] = [
 
 <template>
   <DialogBox
-    :character="profShlag"
+    :character="profMerdant"
     avatar-url="/characters/prof-merdant/prof-merdant.png"
     :dialog-tree="dialogTree"
   />

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -138,6 +138,7 @@ const bottomLocked = computed(() => {
 
       <ShlagemonEvolutionModal />
       <ShlagemonTypeChartModal />
+      <ShlagemonWearableEquipModal />
     </div>
   </div>
 </template>

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -3,6 +3,8 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { useDiseaseStore } from '~/stores/disease'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useWearableItemStore } from '~/stores/wearableItem'
+import { useWearableEquipModalStore } from '~/stores/wearableEquipModal'
+import { allItems } from '~/data/items/items'
 
 const props = defineProps<{ mon: DexShlagemon | null }>()
 const emit = defineEmits<{
@@ -41,8 +43,15 @@ const allowEvolution = computed({
 
 const store = useShlagedexStore()
 const wearableItemStore = useWearableItemStore()
+const equipModal = useWearableEquipModalStore()
 const disease = useDiseaseStore()
 const showConfirm = ref(false)
+
+const heldItem = computed(() => {
+  if (!props.mon?.heldItemId)
+    return null
+  return allItems.find(i => i.id === props.mon!.heldItemId) || null
+})
 
 const evolutionInfo = computed(() => {
   if (!props.mon?.base.evolution)
@@ -82,6 +91,11 @@ function confirmRelease() {
 function cancelRelease() {
   showConfirm.value = false
 }
+
+function openEquip() {
+  if (props.mon)
+    equipModal.open(props.mon)
+}
 const captureInfo = computed(() => {
   if (!props.mon)
     return { date: '', count: 0 }
@@ -117,17 +131,35 @@ const captureInfo = computed(() => {
           :shiny="mon.isShiny"
           class="w-full object-contain"
         />
-        <div
-          v-if="wearableItemStore.getHolderId('multi-exp') === mon.id"
-          class="absolute right-0 top-0 flex items-center gap-1"
-        >
-          <IconMultiExp class="h-5 w-5" />
+        <div class="absolute right-0 top-0 flex items-center gap-1">
+          <template v-if="heldItem">
+            <div
+              v-if="heldItem.icon"
+              class="h-5 w-5"
+              :class="[heldItem.icon, heldItem.iconClass]"
+            />
+            <img
+              v-else-if="heldItem.image"
+              :src="heldItem.image"
+              :alt="heldItem.name"
+              class="h-5 w-5 object-contain"
+            >
+            <UiButton
+              type="icon"
+              class="h-5 w-5"
+              @click="wearableItemStore.removeHolder(heldItem.id)"
+            >
+              <div i-carbon-trash-can />
+            </UiButton>
+          </template>
           <UiButton
+            v-else
             type="icon"
             class="h-5 w-5"
-            @click="wearableItemStore.removeHolder('multi-exp')"
+            title="Équiper un objet"
+            @click="openEquip"
           >
-            <div i-carbon-trash-can />
+            <div i-carbon-add />
           </UiButton>
         </div>
       </div>

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -3,7 +3,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { useWearableItemStore } from '~/stores/wearableItem'
+import { allItems } from '~/data/items/items'
 
 interface Props {
   mons: DexShlagemon[]
@@ -21,9 +21,9 @@ const props = withDefaults(defineProps<Props>(), {
 
 const filter = useDexFilterStore()
 const dex = useShlagedexStore()
-const wearableItemStore = useWearableItemStore()
 const featureLock = useFeatureLockStore()
 const isLocked = featureLock.isShlagedexLocked
+const items = Object.fromEntries(allItems.map(i => [i.id, i])) as Record<string, typeof allItems[number]>
 
 const sortOptions = [
   { label: 'Niveau', value: 'level' },
@@ -154,10 +154,19 @@ function changeActive(mon: DexShlagemon) {
         ]"
         @click.stop="handleClick(mon)"
       >
-        <IconMultiExp
-          v-if="wearableItemStore.getHolderId('multi-exp') === mon.id"
-          class="absolute right-1 top-1 h-4 w-4"
-        />
+        <div v-if="mon.heldItemId" class="absolute right-1 top-1 h-4 w-4">
+          <div
+            v-if="items[mon.heldItemId]?.icon"
+            class="h-4 w-4"
+            :class="[items[mon.heldItemId].icon, items[mon.heldItemId].iconClass]"
+          />
+          <img
+            v-else-if="items[mon.heldItemId]?.image"
+            :src="items[mon.heldItemId].image"
+            :alt="items[mon.heldItemId].name"
+            class="h-4 w-4 object-contain"
+          >
+        </div>
         <div class="absolute bottom-0 right-2 text-xs">
           lvl {{ mon.lvl }}
         </div>

--- a/src/components/shlagemon/WearableEquipModal.vue
+++ b/src/components/shlagemon/WearableEquipModal.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { useWearableEquipModalStore } from '~/stores/wearableEquipModal'
+
+const store = useWearableEquipModalStore()
+</script>
+
+<template>
+  <Modal v-model="store.isVisible" footer-close>
+    <div class="flex flex-col items-center gap-2">
+      <h3 class="text-center text-lg font-bold">
+        Choisir un objet à équiper
+      </h3>
+      <div v-if="store.options.length" class="flex flex-col gap-2 w-full">
+        <UiButton
+          v-for="o in store.options"
+          :key="o.item.id"
+          class="flex items-center justify-between gap-2"
+          :disabled="o.qty <= 0"
+          @click="store.equip(o.item.id)"
+        >
+          <div class="flex items-center gap-2">
+            <div v-if="o.item.icon" class="h-6 w-6" :class="[o.item.icon, o.item.iconClass]" />
+            <img v-else-if="o.item.image" :src="o.item.image" :alt="o.item.name" class="h-6 w-6 object-contain" />
+            <span>{{ o.item.name }}</span>
+          </div>
+          <span class="text-xs font-bold">x{{ o.qty }}</span>
+        </UiButton>
+      </div>
+      <p v-else class="text-center text-sm">Aucun objet disponible.</p>
+    </div>
+  </Modal>
+</template>

--- a/src/stores/wearableEquipModal.ts
+++ b/src/stores/wearableEquipModal.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import type { DexShlagemon } from '~/type/shlagemon'
+import { allItems } from '~/data/items/items'
+import { useEquipmentStore } from './equipment'
+import { useInventoryStore } from './inventory'
+import { useItemUsageStore } from './itemUsage'
+import { createModalStore } from './helpers'
+
+export const useWearableEquipModalStore = defineStore('wearableEquipModal', () => {
+  const { isVisible, open: openModal, close } = createModalStore('game')
+  const currentMon = ref<DexShlagemon | null>(null)
+  const inventory = useInventoryStore()
+  const equipment = useEquipmentStore()
+  const usage = useItemUsageStore()
+
+  const options = computed(() =>
+    allItems
+      .filter(i => i.wearable && (inventory.items[i.id] || 0) > 0)
+      .map(i => ({ item: i, qty: inventory.items[i.id] || 0 })),
+  )
+
+  function open(mon: DexShlagemon) {
+    currentMon.value = mon
+    openModal()
+  }
+
+  function equip(itemId: string) {
+    if (!currentMon.value)
+      return
+    equipment.equip(currentMon.value.id, itemId)
+    usage.markUsed(itemId)
+    close()
+  }
+
+  return { isVisible, currentMon, options, open, close, equip }
+})


### PR DESCRIPTION
## Summary
- add `wearableEquipModal` store for equipping items on a Shlagémon
- allow selecting a wearable item through `WearableEquipModal`
- display any held item on Shlagémon detail and list views
- trigger a new HalfDex dialog that grants the Multi‑UXP item
- register new modal in `GameGrid`

## Testing
- `pnpm lint` *(fails: Cannot find package '@antfu/eslint-config')*
- `pnpm test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877940f4d38832ab00356ffe4c9055a