### PR TITLE
Fix import.meta.glob url option

### DIFF
--- a/src/data/music.ts
+++ b/src/data/music.ts
@@ -11,9 +11,21 @@ function createTrackMap(glob: Record<string, string>): TrackMap {
   )
 }
 
-const villageFiles = import.meta.glob('../../public/audio/musics/villages/*.ogg', { eager: true, as: 'url' }) as Record<string, string>
-const battleFiles = import.meta.glob('../../public/audio/musics/battle/*.ogg', { eager: true, as: 'url' }) as Record<string, string>
-const characterFiles = import.meta.glob('../../public/audio/musics/character/*.ogg', { eager: true, as: 'url' }) as Record<string, string>
+const villageFiles = import.meta.glob('../../public/audio/musics/villages/*.ogg', {
+  eager: true,
+  query: '?url',
+  import: 'default',
+}) as Record<string, string>
+const battleFiles = import.meta.glob('../../public/audio/musics/battle/*.ogg', {
+  eager: true,
+  query: '?url',
+  import: 'default',
+}) as Record<string, string>
+const characterFiles = import.meta.glob('../../public/audio/musics/character/*.ogg', {
+  eager: true,
+  query: '?url',
+  import: 'default',
+}) as Record<string, string>
 
 const villageTracks = createTrackMap(villageFiles)
 const battleTracks = createTrackMap(battleFiles)


### PR DESCRIPTION
## Summary
- replace deprecated `as: 'url'` uses in `music.ts` with the new `query` option

## Testing
- `pnpm test` *(fails: Failed to resolve import "../src/components/battle/BattleMain.vue" ...)*

------
https://chatgpt.com/codex/tasks/task_e_6877a84139fc832a9d0b95ced115ac7b