### PR TITLE
Fix mobile panel state and zone modal

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -7,6 +7,7 @@ import { useBattleStatsStore } from '~/stores/battleStats'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useGameStore } from '~/stores/game'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMobileTabStore } from '~/stores/mobileTab'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
@@ -21,6 +22,7 @@ const progress = useZoneProgressStore()
 const panel = useMainPanelStore()
 const featureLock = useFeatureLockStore()
 const game = useGameStore()
+const mobile = useMobileTabStore()
 
 const trainer = computed(() => trainerStore.current)
 const isZoneKing = computed(() => trainer.value?.id.startsWith('king-'))
@@ -118,6 +120,8 @@ function finish() {
     trainerStore.next()
     zone.setZone(zone.current.id)
     panel.showBattle()
+    if (trainer.value?.id.startsWith('king-'))
+      mobile.set('zones')
   }
   else if (result.value === 'lose') {
     stage.value = 'before'

--- a/src/components/dialog/NewZoneDialog.vue
+++ b/src/components/dialog/NewZoneDialog.vue
@@ -2,11 +2,13 @@
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
 import { useInventoryStore } from '~/stores/inventory'
+import { useMobileTabStore } from '~/stores/mobileTab'
 import { useZoneVisitStore } from '~/stores/zoneVisit'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
 const visit = useZoneVisitStore()
+const mobile = useMobileTabStore()
 
 const dialogTree: DialogNode[] = [
   {
@@ -43,6 +45,7 @@ const dialogTree: DialogNode[] = [
         action: () => {
           inventory.add('xp-potion', 1)
           visit.markAllAccessibleVisited()
+          mobile.set('zones')
           emit('done', 'newZone')
         },
       },

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import { allItems } from '~/data/items/items'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useShlagedexStore } from '~/stores/shlagedex'
-import { allItems } from '~/data/items/items'
 
 interface Props {
   mons: DexShlagemon[]

--- a/src/stores/captureLimitModal.ts
+++ b/src/stores/captureLimitModal.ts
@@ -2,7 +2,8 @@ import { defineStore } from 'pinia'
 import { createModalStore } from './helpers'
 
 export const useCaptureLimitModalStore = defineStore('captureLimitModal', () => {
-  const { isVisible, open: openModal, close } = createModalStore('game')
+  // Do not change mobile tab when showing this modal
+  const { isVisible, open: openModal, close } = createModalStore()
   const requiredLevel = ref(0)
 
   function open(level: number) {

--- a/src/stores/wearableEquipModal.ts
+++ b/src/stores/wearableEquipModal.ts
@@ -1,11 +1,11 @@
+import type { DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import type { DexShlagemon } from '~/type/shlagemon'
 import { allItems } from '~/data/items/items'
 import { useEquipmentStore } from './equipment'
+import { createModalStore } from './helpers'
 import { useInventoryStore } from './inventory'
 import { useItemUsageStore } from './itemUsage'
-import { createModalStore } from './helpers'
 
 export const useWearableEquipModalStore = defineStore('wearableEquipModal', () => {
   const { isVisible, open: openModal, close } = createModalStore('game')

--- a/src/stores/zoneMonsModal.ts
+++ b/src/stores/zoneMonsModal.ts
@@ -2,7 +2,9 @@ import { defineStore } from 'pinia'
 import { createModalStore } from './helpers'
 
 export const useZoneMonsModalStore = defineStore('zoneMonsModal', () => {
-  const { isVisible, open, close } = createModalStore('game')
+  // Keep the current mobile tab when opening this modal so the secondary panel
+  // stays visible on mobile
+  const { isVisible, open, close } = createModalStore()
 
   return { isVisible, open, close }
 })


### PR DESCRIPTION
## Summary
- keep secondary panel open when viewing zone mons
- prevent capture limit modal from switching tabs
- highlight newly unlocked zones in dialog
- open zone panel after defeating a king
- clean up import orders

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH fetch fonts, vitest suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877ae68fee0832ab71357f739d46732