### PR TITLE
Add Vitality Ring item

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -42,6 +42,7 @@ declare module 'vue' {
     DialogLevel5Dialog: typeof import('./components/dialog/Level5Dialog.vue')['default']
     DialogNewZoneDialog: typeof import('./components/dialog/NewZoneDialog.vue')['default']
     DialogStarter: typeof import('./components/dialog/Starter.vue')['default']
+    DialogVitalityRingDialog: typeof import('./components/dialog/VitalityRingDialog.vue')['default']
     IconBadgeFatAss: typeof import('./components/icon/badge/FatAss.vue')['default']
     IconBadgeShit: typeof import('./components/icon/badge/Shit.vue')['default']
     IconBadgeStench: typeof import('./components/icon/badge/Stench.vue')['default']

--- a/src/components/dialog/VitalityRingDialog.vue
+++ b/src/components/dialog/VitalityRingDialog.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { useInventoryStore } from '~/stores/inventory'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: 'Félicitations ! Tu as capturé au moins 15 Shlagémons.',
+    responses: [
+      { label: 'Continuer', nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: `Voici un objet unique : la Bague Vitalesque.`,
+    responses: [
+      { label: 'Retour', nextId: 'start', type: 'danger' },
+      { label: 'Continuer', nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: 'Fais-la porter à un Shlagémon pour augmenter ses PV maximum de 15%.',
+    responses: [
+      { label: 'Retour', nextId: 'step2', type: 'danger' },
+      { label: 'Continuer', nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: 'Cet effet est cumulable avec les potions de vitalité mais ne concerne qu\'un seul porteur.',
+    responses: [
+      { label: 'Retour', nextId: 'step3', type: 'danger' },
+      { label: 'Continuer', nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: 'Je te la confie, bonne chance pour la suite !',
+    responses: [
+      { label: 'Retour', nextId: 'step4', type: 'danger' },
+      {
+        label: 'Merci !',
+        type: 'valid',
+        action: () => {
+          inventory.add('vitality-ring', 1)
+          emit('done', 'vitalityRing')
+        },
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :dialog-tree="dialogTree"
+    orientation="col"
+  />
+</template>

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -181,6 +181,20 @@ export const multiExp: Item = {
   wearable: true,
 }
 
+export const vitalityRing: Item = {
+  id: 'vitality-ring',
+  name: 'Bague Vitalesque',
+  description: 'Augmente les PV max du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente ses PV maximum de 15%. Effet cumulable avec les potions de vitalité.',
+  price: 20,
+  currency: 'shlagidiamond',
+  icon: 'i-game-icons:ring',
+  iconClass: 'text-red-500 dark:text-red-400',
+  unique: true,
+  wearable: true,
+}
+
 export const thunderStone: Item = {
   id: 'pierre-foutre',
   name: 'Pierre Foutre',
@@ -236,6 +250,7 @@ export const allItems: Item[] = [
   superXpPotion,
   hyperXpPotion,
   multiExp,
+  vitalityRing,
   thunderStone,
   steroids,
   ultraSteroid,

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -12,6 +12,7 @@ import KingUnlockDialog from '~/components/dialog/KingUnlockDialog.vue'
 import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import NewZoneDialog from '~/components/dialog/NewZoneDialog.vue'
 import DialogStarter from '~/components/dialog/Starter.vue'
+import VitalityRingDialog from '~/components/dialog/VitalityRingDialog.vue'
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -68,6 +69,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'attackPotion',
       component: markRaw(AttackPotionDialog),
       condition: () => dex.shlagemons.length >= 10,
+    },
+    {
+      id: 'vitalityRing',
+      component: markRaw(VitalityRingDialog),
+      condition: () => dex.shlagemons.length >= 15,
     },
     {
       id: 'kingUnlock',

--- a/src/stores/equipment.ts
+++ b/src/stores/equipment.ts
@@ -14,16 +14,29 @@ export const useEquipmentStore = defineStore('equipment', () => {
     if (mon.heldItemId) {
       holders.value[mon.heldItemId] = null
       inventory.add(mon.heldItemId)
+      if (mon.heldItemId === 'vitality-ring') {
+        const max = dex.maxHp(mon)
+        if (mon.hpCurrent > max)
+          mon.hpCurrent = max
+      }
     }
     const current = holders.value[itemId]
     if (current) {
       const other = dex.shlagemons.find(m => m.id === current)
-      if (other)
+      if (other) {
         other.heldItemId = null
+        if (itemId === 'vitality-ring') {
+          const max = dex.maxHp(other)
+          if (other.hpCurrent > max)
+            other.hpCurrent = max
+        }
+      }
     }
     mon.heldItemId = itemId
     holders.value[itemId] = monId
     inventory.remove(itemId)
+    if (itemId === 'vitality-ring')
+      mon.hpCurrent = dex.maxHp(mon)
   }
 
   function unequip(monId: string) {
@@ -34,6 +47,11 @@ export const useEquipmentStore = defineStore('equipment', () => {
     mon.heldItemId = null
     holders.value[itemId] = null
     inventory.add(itemId)
+    if (itemId === 'vitality-ring') {
+      const max = dex.maxHp(mon)
+      if (mon.hpCurrent > max)
+        mon.hpCurrent = max
+    }
   }
 
   function unequipItem(itemId: string) {
@@ -41,8 +59,14 @@ export const useEquipmentStore = defineStore('equipment', () => {
     if (!holderId)
       return
     const mon = dex.shlagemons.find(m => m.id === holderId)
-    if (mon)
+    if (mon) {
       mon.heldItemId = null
+      if (itemId === 'vitality-ring') {
+        const max = dex.maxHp(mon)
+        if (mon.hpCurrent > max)
+          mon.hpCurrent = max
+      }
+    }
     holders.value[itemId] = null
     inventory.add(itemId)
   }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -127,7 +127,9 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
 
   function maxHp(mon: DexShlagemon): number {
     const isActive = activeShlagemon.value?.id === mon.id
-    const bonus = isActive ? vitalityBonusPercent.value : 0
+    let bonus = isActive ? vitalityBonusPercent.value : 0
+    if (mon.heldItemId === 'vitality-ring')
+      bonus += 15
     return Math.round(mon.hp * (1 + bonus / 100))
   }
 


### PR DESCRIPTION
## Summary
- add new portable item `vitality-ring`
- boost max HP when the ring is equipped
- distribute item via Professor Merdant after 15 captures
- implement dialog component for the reward

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError ENETUNREACH for fonts, many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6877b2b4d7d4832a9c525205a1521ace