### PR TITLE
Fix trainer battle persistence

### DIFF
--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -92,6 +92,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
       const arenaStore = useArenaStore()
       if (store.current === 'arena' && !arenaStore.inBattle)
         store.reset()
+      if (store.current === 'trainerBattle')
+        store.reset()
     },
   },
 })


### PR DESCRIPTION
## Summary
- reset trainer battle panel after hydration so it doesn't default to Bob on reload

## Testing
- `pnpm test` *(fails: Failed to resolve imports and zone data errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877ba9deb50832a9f2afb351fa65b84