### PR TITLE
Add defeat dialogs for kings

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -182,7 +182,7 @@ onUnmounted(featureLock.unlockAll)
         {{ trainer.dialogAfter }}
       </div>
       <div v-else class="text-red-600 font-bold dark:text-red-400">
-        Défaite...
+        {{ trainer.dialogDefeat || 'Défaite...' }}
       </div>
       <div v-if="result === 'win'" class="font-bold">
         +{{ trainer.reward }} Shlagédiamonds

--- a/src/data/kings.ts
+++ b/src/data/kings.ts
@@ -10,7 +10,7 @@ import { sachatte } from './characters/sachatte'
 import { siphanus } from './characters/siphanus'
 import { zonesData } from './zones'
 
-function createKing(zoneId: SavageZoneId, character: Character, qteShlagemons: number, dialogBefore: string, dialogAfter: string): Trainer {
+function createKing(zoneId: SavageZoneId, character: Character, qteShlagemons: number, dialogBefore: string, dialogAfter: string, dialogDefeat: string): Trainer {
   const zone = zonesData.find(z => z.id === zoneId)!
   if (!zone) {
     console.warn(`Zone ${zoneId} not found`)
@@ -42,25 +42,26 @@ function createKing(zoneId: SavageZoneId, character: Character, qteShlagemons: n
     character,
     dialogBefore,
     dialogAfter,
+    dialogDefeat,
     reward: zone.maxLevel || 1,
     shlagemons,
   }
 }
 
 export const kings: Trainer[] = [
-  createKing('plaine-kekette', caillou, 2, 'Je protege cette plaine, prepare-toi!', 'Hum, tu m\'as battu, chanceux.'),
-  createKing('bois-de-bouffon', sachatte, 3, 'Ces bois seront ta tombe.', 'Je reviendrai plus fort.'),
-  createKing('chemin-du-slip', norman, 4, 'Entres dans ma grotte si tu l\'oses.', 'Ta victoire ne sera que temporaire.'),
-  createKing('ravin-fesse-molle', marineLahaine, 4, 'Le ravin te verra chuter!', 'Incroyable... tu as gagné.'),
-  createKing('precipice-nanard', marcon, 5, 'Le vieux Nanard t\'attend.', 'Le vieux Nanard te regarde avec degout.'),
-  createKing('marais-moudugenou', siphanus, 5, 'Tu vas couler dans le marais!', 'Tu t\'extirpes du marais victorieux.'),
-  createKing('forteresse-petmoalfiak', profMerdant, 5, 'Ma forteresse est imprenable!', 'Tu as brise ma forteresse...'),
-  createKing('route-du-nawak', caillou, 6, 'Perds-toi sur cette route!', 'Tu t\'en sors, pour l\'instant.'),
-  createKing('mont-dracatombe', norman, 6, 'Le sommet est pour les braves!', 'Le mont te cede la victoire.'),
-  createKing('catacombes-merdifientes', marineLahaine, 6, 'Les catacombes sont ton futur tombeau.', 'Je sombre dans l\'ombre des catacombes.'),
-  createKing('route-aguicheuse', marcon, 6, 'Tentes-tu ta chance ici?', 'Bien joue, voyageur.'),
-  createKing('vallee-des-chieurs', sachatte, 7, 'Personne ne ressort de cette grotte.', 'Tu as dompte la puanteur.'),
-  createKing('trou-du-bide', caillou, 7, 'Mon trou ne te fera pas de cadeau.', 'Je m\'incline... pour cette fois.'),
-  createKing('zone-giga-zob', profMerdant, 7, 'Bienvenue en enfer!', 'Impossible... comment as-tu fait ?'),
-  createKing('route-so-dom', marcon, 8, 'Derniere ligne droite, minus!', 'Tu es vraiment le meilleur.'),
+  createKing('plaine-kekette', caillou, 2, 'Je protege cette plaine, prepare-toi!', 'Hum, tu m\'as battu, chanceux.', 'Hahaha ! J\'t\'ai explosé, retourne jouer dans le bac à sable !'),
+  createKing('bois-de-bouffon', sachatte, 3, 'Ces bois seront ta tombe.', 'Je reviendrai plus fort.', 'Tes griffes sont émoussées, je t\'ai humilié, miaou!'),
+  createKing('chemin-du-slip', norman, 4, 'Entres dans ma grotte si tu l\'oses.', 'Ta victoire ne sera que temporaire.', 'Tu pues la lose, file te laver !'),
+  createKing('ravin-fesse-molle', marineLahaine, 4, 'Le ravin te verra chuter!', 'Incroyable... tu as gagné.', 'Jette-toi dans le ravin et qu\'on en parle plus, naze.'),
+  createKing('precipice-nanard', marcon, 5, 'Le vieux Nanard t\'attend.', 'Le vieux Nanard te regarde avec degout.', 'Le vieux Nanard t\'a roulé dessus, pauvre cloche.'),
+  createKing('marais-moudugenou', siphanus, 5, 'Tu vas couler dans le marais!', 'Tu t\'extirpes du marais victorieux.', 'Je t\'éclabousse de ma boue, retourne barboter ailleurs.'),
+  createKing('forteresse-petmoalfiak', profMerdant, 5, 'Ma forteresse est imprenable!', 'Tu as brise ma forteresse...', 'Boum ! Ma forteresse t\'écrase, petit cancre.'),
+  createKing('route-du-nawak', caillou, 6, 'Perds-toi sur cette route!', 'Tu t\'en sors, pour l\'instant.', 'Complètement paumé ? Je t\'ai laissé sur le bord, tocard.'),
+  createKing('mont-dracatombe', norman, 6, 'Le sommet est pour les braves!', 'Le mont te cede la victoire.', 'T\'es moins drôle que mes vannes foireuses, dégage.'),
+  createKing('catacombes-merdifientes', marineLahaine, 6, 'Les catacombes sont ton futur tombeau.', 'Je sombre dans l\'ombre des catacombes.', 'Remonte donc à la surface, larve.'),
+  createKing('route-aguicheuse', marcon, 6, 'Tentes-tu ta chance ici?', 'Bien joue, voyageur.', 'Président 1 - Toi 0. Allez, file avant que je te taxe.'),
+  createKing('vallee-des-chieurs', sachatte, 7, 'Personne ne ressort de cette grotte.', 'Tu as dompte la puanteur.', 'Même tes pets n\'effraient personne, perdant.'),
+  createKing('trou-du-bide', caillou, 7, 'Mon trou ne te fera pas de cadeau.', 'Je m\'incline... pour cette fois.', 'Même mon trou a plus de talent que toi.'),
+  createKing('zone-giga-zob', profMerdant, 7, 'Bienvenue en enfer!', 'Impossible... comment as-tu fait ?', 'Hop, direction les rattrapages, minus !'),
+  createKing('route-so-dom', marcon, 8, 'Derniere ligne droite, minus!', 'Tu es vraiment le meilleur.', 'J\'avance, toi tu recules, larbin.'),
 ]

--- a/src/type/trainer.ts
+++ b/src/type/trainer.ts
@@ -10,6 +10,7 @@ export interface Trainer {
   character: Character
   dialogBefore: string
   dialogAfter: string
+  dialogDefeat?: string
   reward: number
   shlagemons: TrainerShlagemon[]
 }


### PR DESCRIPTION
## Summary
- add optional `dialogDefeat` field to `Trainer`
- show custom defeat line in battle view
- provide sarcastic defeat lines for every king

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 28 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6877baec26b0832a8946f0b87c1ae3c3