### PR TITLE
Add random buy sfx

### DIFF
--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { toast } from 'vue3-toastify'
+import { useAudioStore } from '~/stores/audio'
 import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
 import { useMainPanelStore } from '~/stores/mainPanel'
@@ -10,6 +11,7 @@ const panel = useMainPanelStore()
 const zone = useZoneStore()
 const game = useGameStore()
 const inventory = useInventoryStore()
+const audio = useAudioStore()
 const shopItems = computed(() => zone.current.village?.shop?.items || [])
 const selectedItem = ref<Item | null>(null)
 const selectedQty = ref(1)
@@ -52,6 +54,7 @@ function buy() {
     return
   const success = inventory.buy(selectedItem.value.id, selectedQty.value)
   if (success) {
+    audio.playBuySfx()
     const cost = selectedItem.value.price * selectedQty.value
     const currency = selectedItem.value.currency === 'shlagidiamond'
       ? 'Shlagédiamant'

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -32,6 +32,15 @@ export const useAudioStore = defineStore('audio', () => {
     ],
   } as const
 
+  const buySfx = [
+    '/audio/sfx/buy/buy-a.ogg',
+    '/audio/sfx/buy/buy-b.ogg',
+    '/audio/sfx/buy/buy-c.ogg',
+    '/audio/sfx/buy/buy-d.ogg',
+    '/audio/sfx/buy/buy-e.ogg',
+  ] as const
+  let lastBuyIndex = -1
+
   function randomTrack(category: keyof typeof tracks) {
     const list = tracks[category]
     return list[Math.floor(Math.random() * list.length)]
@@ -116,6 +125,14 @@ export const useAudioStore = defineStore('audio', () => {
     sfx.play()
   }
 
+  function playBuySfx() {
+    let index = Math.floor(Math.random() * buySfx.length)
+    if (index === lastBuyIndex)
+      index = (index + 1) % buySfx.length
+    lastBuyIndex = index
+    playSfx(buySfx[index])
+  }
+
   watch(musicVolume, (v) => {
     if (currentMusic.value)
       currentMusic.value.volume(v)
@@ -142,6 +159,7 @@ export const useAudioStore = defineStore('audio', () => {
     fadeToRandomMusic,
     stopMusic,
     playSfx,
+    playBuySfx,
   }
 }, {
   persist: {


### PR DESCRIPTION
## Summary
- play one of five `buy` SFX at random when purchasing an item
- avoid repeating the same buy sound twice in a row

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH while fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6877bfaba16c832a9064a4e6a11caaa4