### PR TITLE
Add item sort option

### DIFF
--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -29,6 +29,7 @@ const sortOptions = [
   { label: 'Niveau', value: 'level' },
   { label: 'Rareté', value: 'rarity' },
   { label: 'Shiny', value: 'shiny' },
+  { label: 'Objet équipé', value: 'item' },
   { label: 'Nom', value: 'name' },
   { label: 'Type', value: 'type' },
   { label: 'Attaque', value: 'attack' },
@@ -53,6 +54,9 @@ const displayedMons = computed(() => {
       break
     case 'shiny':
       mons.sort((a, b) => Number(a.isShiny) - Number(b.isShiny))
+      break
+    case 'item':
+      mons.sort((a, b) => Number(Boolean(a.heldItemId)) - Number(Boolean(b.heldItemId)))
       break
     case 'attack':
       mons.sort((a, b) => a.attack - b.attack)

--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -6,6 +6,7 @@ export type DexSort =
   | 'name'
   | 'type'
   | 'shiny'
+  | 'item'
   | 'attack'
   | 'defense'
   | 'count'

--- a/test/sort-item.test.ts
+++ b/test/sort-item.test.ts
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import Shlagedex from '../src/components/panel/Shlagedex.vue'
+import { carapouffe, sacdepates } from '../src/data/shlagemons'
+import { useDexFilterStore } from '../src/stores/dexFilter'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('shlagedex sort item', () => {
+  it('displays shlagemons with items first', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const filter = useDexFilterStore()
+    const withoutItem = dex.createShlagemon(carapouffe, false)
+    const withItem = dex.createShlagemon(sacdepates, false)
+    withItem.heldItemId = 'potion'
+    filter.sortBy = 'item'
+    const wrapper = mount(Shlagedex, {
+      global: {
+        plugins: [pinia],
+        stubs: [
+          'ShlagemonImage',
+          'ShlagemonType',
+          'Modal',
+          'SearchInput',
+          'SelectOption',
+          'CheckBox',
+          'MultiExpIcon',
+        ],
+      },
+    })
+
+    const items = wrapper.findAll('div.relative')
+    expect(items.length).toBe(2)
+    expect(items[0].text()).toContain(withItem.base.name)
+    expect(items[1].text()).toContain(withoutItem.base.name)
+  })
+})


### PR DESCRIPTION
## Summary
- add new `item` sort option in Shlagedex filter store
- allow sorting shlagemons by held item in the list
- test new sort logic

## Testing
- `pnpm lint`
- `pnpm test -t sort-item.test.ts` *(fails: FetchError ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6877c3eea560832a850091d630144d64