### PR TITLE
Add XP Ring wearable item

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -721,6 +721,7 @@ declare module 'vue' {
     readonly useVibrate: UnwrapRef<typeof import('@vueuse/core')['useVibrate']>
     readonly useVirtualList: UnwrapRef<typeof import('@vueuse/core')['useVirtualList']>
     readonly useWakeLock: UnwrapRef<typeof import('@vueuse/core')['useWakeLock']>
+    readonly useWearableEquipModalStore: UnwrapRef<typeof import('./stores/wearableEquipModal')['useWearableEquipModalStore']>
     readonly useWearableItemStore: UnwrapRef<typeof import('./stores/wearableItem')['useWearableItemStore']>
     readonly useWebNotification: UnwrapRef<typeof import('@vueuse/core')['useWebNotification']>
     readonly useWebSocket: UnwrapRef<typeof import('@vueuse/core')['useWebSocket']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -43,6 +43,7 @@ declare module 'vue' {
     DialogNewZoneDialog: typeof import('./components/dialog/NewZoneDialog.vue')['default']
     DialogStarter: typeof import('./components/dialog/Starter.vue')['default']
     DialogVitalityRingDialog: typeof import('./components/dialog/VitalityRingDialog.vue')['default']
+    DialogXpRingDialog: typeof import('./components/dialog/XpRingDialog.vue')['default']
     IconBadgeFatAss: typeof import('./components/icon/badge/FatAss.vue')['default']
     IconBadgeShit: typeof import('./components/icon/badge/Shit.vue')['default']
     IconBadgeStench: typeof import('./components/icon/badge/Stench.vue')['default']

--- a/src/components/dialog/XpRingDialog.vue
+++ b/src/components/dialog/XpRingDialog.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { useInventoryStore } from '~/stores/inventory'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+
+const dialogTree: DialogNode[] = [
+  {
+    id: 'start',
+    text: 'Incroyable ! Tu as capturé au moins 20 Shlagémons.',
+    responses: [
+      { label: 'Continuer', nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: 'Voici un objet unique : l\'Anneau d\'expérience.',
+    responses: [
+      { label: 'Retour', nextId: 'start', type: 'danger' },
+      { label: 'Continuer', nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: 'Fais-le tenir à un Shlagémon pour qu\'il gagne 15% d\'expérience supplémentaire à la fin des combats.',
+    responses: [
+      { label: 'Retour', nextId: 'step2', type: 'danger' },
+      { label: 'Continuer', nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: 'Son effet se cumule avec celui des potions d\'expérience, mais il n\'affecte que le porteur.',
+    responses: [
+      { label: 'Retour', nextId: 'step3', type: 'danger' },
+      { label: 'Continuer', nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: 'Je te le confie, bonne chance pour la suite !',
+    responses: [
+      { label: 'Retour', nextId: 'step4', type: 'danger' },
+      {
+        label: 'Merci !',
+        type: 'valid',
+        action: () => {
+          inventory.add('xp-ring', 1)
+          emit('done', 'xpRing')
+        },
+      },
+    ],
+  },
+]
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
+    :dialog-tree="dialogTree"
+    orientation="col"
+  />
+</template>

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -195,6 +195,20 @@ export const vitalityRing: Item = {
   wearable: true,
 }
 
+export const xpRing: Item = {
+  id: 'xp-ring',
+  name: 'Anneau d\'expérience',
+  description: 'Augmente l\'XP du porteur.',
+  details:
+    'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 15%. Effet cumulable avec les potions d\'expérience.',
+  price: 20,
+  currency: 'shlagidiamond',
+  icon: 'i-game-icons:big-diamond-ring',
+  iconClass: 'text-green-600 dark:text-green-400',
+  unique: true,
+  wearable: true,
+}
+
 export const thunderStone: Item = {
   id: 'pierre-foutre',
   name: 'Pierre Foutre',
@@ -251,6 +265,7 @@ export const allItems: Item[] = [
   hyperXpPotion,
   multiExp,
   vitalityRing,
+  xpRing,
   thunderStone,
   steroids,
   ultraSteroid,

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -13,6 +13,7 @@ import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import NewZoneDialog from '~/components/dialog/NewZoneDialog.vue'
 import DialogStarter from '~/components/dialog/Starter.vue'
 import VitalityRingDialog from '~/components/dialog/VitalityRingDialog.vue'
+import XpRingDialog from '~/components/dialog/XpRingDialog.vue'
 import { useGameStore } from '~/stores/game'
 import { useGameStateStore } from '~/stores/gameState'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -74,6 +75,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'vitalityRing',
       component: markRaw(VitalityRingDialog),
       condition: () => dex.shlagemons.length >= 15,
+    },
+    {
+      id: 'xpRing',
+      component: markRaw(XpRingDialog),
+      condition: () => dex.shlagemons.length >= 20,
     },
     {
       id: 'kingUnlock',

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -446,6 +446,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   ) {
     if (mon.lvl >= maxLevel)
       return
+    if (mon.heldItemId === 'xp-ring')
+      amount = Math.round(amount * 1.15)
     mon.xp += amount
     while (mon.lvl < maxLevel && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)


### PR DESCRIPTION
## Summary
- create unique wearable `xp-ring` item with same color as XP potions
- apply 15% XP bonus when a monster holding the ring gains XP
- introduce `XpRingDialog` for Professeur Merdant
- trigger dialog when the player owns 20 Shlagémons

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fonts unreachable and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877c5200344832aa0735c1b2619514f