### PR TITLE
Handle max rarity duplicates

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -480,8 +480,12 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
 
   function captureShlagemon(base: BaseShlagemon, shiny = false) {
     const existing = shlagemons.value.find(mon => mon.base.id === base.id)
-    const incoming = createDexShlagemon(base, shiny)
     if (existing) {
+      if (existing.rarity >= 100) {
+        toast('Vous avez déjà ce Shlagémon au maximum de sa rareté')
+        return existing
+      }
+      const incoming = createDexShlagemon(base, shiny)
       existing.captureCount += 1
       let rarityGain = 1
       let levelLoss = 1
@@ -529,6 +533,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       )
       return existing
     }
+    const incoming = createDexShlagemon(base, shiny)
     incoming.captureDate = new Date().toISOString()
     incoming.captureCount = 1
     addShlagemon(incoming)
@@ -541,6 +546,10 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   function captureEnemy(enemy: DexShlagemon) {
     const existing = shlagemons.value.find(mon => mon.base.id === enemy.base.id)
     if (existing) {
+      if (existing.rarity >= 100) {
+        toast('Vous avez déjà ce Shlagémon au maximum de sa rareté')
+        return existing
+      }
       existing.captureCount += 1
       let rarityGain = 1
       let levelLoss = 1

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -69,6 +69,41 @@ describe('shlagedex capture', () => {
     expect(existing.lvl).toBe(4)
     expect(existing.isShiny).toBe(true)
   })
+
+  it('warns when capturing duplicate at max rarity via captureShlagemon', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.rarity = 100
+    mon.lvl = 5
+    toastMock.mockClear()
+    const result = dex.captureShlagemon(carapouffe)
+    expect(result.id).toBe(mon.id)
+    expect(mon.rarity).toBe(100)
+    expect(mon.lvl).toBe(5)
+    expect(toastMock).toHaveBeenCalledWith(
+      'Vous avez déjà ce Shlagémon au maximum de sa rareté',
+    )
+  })
+
+  it('warns when capturing duplicate at max rarity via captureEnemy', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const existing = dex.createShlagemon(carapouffe)
+    existing.rarity = 100
+    existing.lvl = 8
+    const enemy = createDexShlagemon(carapouffe, false, 1, 20)
+    enemy.rarity = 100
+    applyStats(enemy)
+    toastMock.mockClear()
+    const result = dex.captureEnemy(enemy)
+    expect(result.id).toBe(existing.id)
+    expect(existing.rarity).toBe(100)
+    expect(existing.lvl).toBe(8)
+    expect(toastMock).toHaveBeenCalledWith(
+      'Vous avez déjà ce Shlagémon au maximum de sa rareté',
+    )
+  })
 })
 
 describe('shlagedex highest level', () => {


### PR DESCRIPTION
## Summary
- avoid leveling duplicate captures when rarity is already maxed
- guard captureEnemy with the same rarity check
- test preventing capture updates on max rarity

## Testing
- `pnpm test` *(fails: Could not resolve imports, snapshots mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6877da3c6790832ab3c40b73277ba1e5