### PR TITLE
Add shortcut delete and assign modal

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -223,6 +223,7 @@ declare global {
   const useInventoryModalStore: typeof import('./stores/inventoryModal')['useInventoryModalStore']
   const useInventoryStore: typeof import('./stores/inventory')['useInventoryStore']
   const useItemUsageStore: typeof import('./stores/itemUsage')['useItemUsageStore']
+  const useItemShortcutModalStore: typeof import('./stores/itemShortcutModal')['useItemShortcutModalStore']
   const useKeyModifier: typeof import('@vueuse/core')['useKeyModifier']
   const useKeyboardCaptureStore: typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']
   const useLastChanged: typeof import('@vueuse/core')['useLastChanged']
@@ -620,6 +621,7 @@ declare module 'vue' {
     readonly useInventoryFilterStore: UnwrapRef<typeof import('./stores/inventoryFilter')['useInventoryFilterStore']>
     readonly useInventoryStore: UnwrapRef<typeof import('./stores/inventory')['useInventoryStore']>
     readonly useItemUsageStore: UnwrapRef<typeof import('./stores/itemUsage')['useItemUsageStore']>
+    readonly useItemShortcutModalStore: UnwrapRef<typeof import('./stores/itemShortcutModal')['useItemShortcutModalStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
     readonly useKeyboardCaptureStore: UnwrapRef<typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']>
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -58,6 +58,7 @@ declare module 'vue' {
     InventoryEvolutionItemModal: typeof import('./components/inventory/EvolutionItemModal.vue')['default']
     InventoryItemCard: typeof import('./components/inventory/ItemCard.vue')['default']
     InventoryWearableItemModal: typeof import('./components/inventory/WearableItemModal.vue')['default']
+    InventoryItemShortcutModal: typeof import('./components/inventory/ItemShortcutModal.vue')['default']
     LayoutGameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     LayoutHeader: typeof import('./components/layout/Header.vue')['default']
     LayoutMobileMenu: typeof import('./components/layout/MobileMenu.vue')['default']

--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import { useItemUsageStore } from '~/stores/itemUsage'
 import { useShortcutsStore } from '~/stores/shortcuts'
 import { useUIStore } from '~/stores/ui'
+import { useItemShortcutModalStore } from '~/stores/itemShortcutModal'
 import { ballHues } from '~/utils/ball'
 
 const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
@@ -36,6 +37,7 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
 const shortcutStore = useShortcutsStore()
 const { shortcuts } = storeToRefs(shortcutStore)
 const { isMobile } = storeToRefs(useUIStore())
+const shortcutModal = useItemShortcutModalStore()
 
 const shortcutKey = computed(() => {
   const entry = shortcuts.value.find(s => s.action.type === 'use-item' && s.action.itemId === props.item.id)
@@ -44,6 +46,10 @@ const shortcutKey = computed(() => {
 
 function assignShortcut(key: string) {
   shortcutStore.setItemShortcut(props.item.id, key)
+}
+
+function openShortcutModal() {
+  shortcutModal.open(props.item)
 }
 
 watch(showInfo, (val) => {
@@ -117,6 +123,10 @@ watch(showInfo, (val) => {
         <p class="text-center text-sm">
           {{ details }}
         </p>
+        <UiButton class="mt-2 flex items-center gap-1 text-sm" @click="openShortcutModal">
+          <div i-carbon-keyboard />
+          Ajouter un raccourci
+        </UiButton>
       </div>
     </Modal>
   </div>

--- a/src/components/inventory/ItemShortcutModal.vue
+++ b/src/components/inventory/ItemShortcutModal.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { useItemShortcutModalStore } from '~/stores/itemShortcutModal'
+import { useShortcutsStore } from '~/stores/shortcuts'
+
+const modal = useItemShortcutModalStore()
+const shortcuts = useShortcutsStore()
+
+const details = computed(() => modal.current?.details || modal.current?.description)
+
+function assign(key: string) {
+  if (!modal.current)
+    return
+  shortcuts.setItemShortcut(modal.current.id, key)
+  modal.close()
+}
+</script>
+
+<template>
+  <Modal v-model="modal.isVisible" :close-on-outside-click="false">
+    <div class="flex flex-col items-center gap-2">
+      <div
+        v-if="modal.current?.icon"
+        class="h-10 w-10"
+        :class="[modal.current.iconClass, modal.current.icon]"
+      />
+      <img
+        v-else-if="modal.current?.image"
+        :src="modal.current.image"
+        :alt="modal.current?.name"
+        class="h-10 w-10 object-contain"
+      >
+      <h3 class="text-lg font-bold text-center">
+        {{ modal.current?.name }}
+      </h3>
+      <p class="text-center text-sm">
+        {{ details }}
+      </p>
+      <p class="text-center text-sm">
+        Appuyez sur une touche pour assigner un raccourci à cet objet.
+      </p>
+      <UiKeyCapture auto-start size="lg" model-value="" @update:model-value="assign" />
+    </div>
+  </Modal>
+</template>

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -96,4 +96,5 @@ function onUse(item: Item) {
   </LayoutScrollablePanel>
   <InventoryEvolutionItemModal />
   <InventoryWearableItemModal />
+  <InventoryItemShortcutModal />
 </template>

--- a/src/components/settings/ShortcutsTab.vue
+++ b/src/components/settings/ShortcutsTab.vue
@@ -21,6 +21,10 @@ function addShortcut() {
   store.add({ key: '', action: { type: 'use-item', itemId: firstItem.id } })
 }
 
+function removeShortcut(index: number) {
+  store.remove(index)
+}
+
 function reset() {
   store.reset()
 }
@@ -40,6 +44,9 @@ function reset() {
         :options="itemOptions"
         @update:model-value="val => updateItem(idx, val as string)"
       />
+      <UiButton type="icon" class="h-7 w-7" @click="removeShortcut(idx)">
+        <div i-carbon-close />
+      </UiButton>
     </div>
     <div class="mt-2 flex gap-2">
       <UiButton class="flex-1" @click="addShortcut">

--- a/src/components/ui/KeyCapture.vue
+++ b/src/components/ui/KeyCapture.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { useKeyboardCaptureStore } from '~/stores/keyboardCapture'
 
-const props = withDefaults(defineProps<{ modelValue: string, size?: 'sm' | 'md' | 'lg' | 'xl' }>(), {
+const props = withDefaults(defineProps<{ modelValue: string, size?: 'sm' | 'md' | 'lg' | 'xl', autoStart?: boolean }>(), {
   size: 'md',
+  autoStart: false,
 })
 const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
 
@@ -32,7 +33,18 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 onMounted(() => window.addEventListener('keydown', onKeydown))
-onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+  stopCapture()
+})
+onMounted(() => {
+  if (props.autoStart)
+    startCapture()
+})
+watch(() => props.autoStart, (v) => {
+  if (v && !waiting.value)
+    startCapture()
+})
 </script>
 
 <template>

--- a/src/stores/itemShortcutModal.ts
+++ b/src/stores/itemShortcutModal.ts
@@ -1,0 +1,15 @@
+import type { Item } from '~/type/item'
+import { defineStore } from 'pinia'
+import { createModalStore } from './helpers'
+
+export const useItemShortcutModalStore = defineStore('itemShortcutModal', () => {
+  const { isVisible, open: openModal, close } = createModalStore()
+  const current = ref<Item | null>(null)
+
+  function open(item: Item) {
+    current.value = item
+    openModal()
+  }
+
+  return { isVisible, current, open, close }
+})


### PR DESCRIPTION
## Summary
- add remove button for each shortcut in settings
- start key capture automatically with new `autoStart` option
- create item shortcut modal to assign keys from inventory
- open shortcut modal from item details and panel

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_6877dd9529a4832abe15fbba504865c8