### PR TITLE
Add rarity-100 SFX

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -374,6 +374,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       existing.captureCount += 1
       if (existing.rarity < 100) {
         existing.rarity += 1
+        if (existing.rarity === 100)
+          audio.playSfx('/audio/sfx/rarity-100.ogg')
         toast(`${existing.base.name} atteint la rareté ${existing.rarity} !`)
       }
       existing.lvl = 1
@@ -497,7 +499,10 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       else if (existing.rarity < 100) {
         existing.rarity += 1
       }
+      const before = existing.rarity
       existing.rarity = Math.min(existing.rarity, 100)
+      if (before < 100 && existing.rarity === 100)
+        audio.playSfx('/audio/sfx/rarity-100.ogg')
       if (incoming.isShiny)
         existing.isShiny = true
       existing.lvl = Math.max(1, existing.lvl - levelLoss)
@@ -539,6 +544,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     addShlagemon(incoming)
     updateHighestLevel(incoming)
     updateCoefficient(incoming)
+    if (incoming.rarity === 100)
+      audio.playSfx('/audio/sfx/rarity-100.ogg')
     toast(`Tu as obtenu ${incoming.base.name} !`)
     return incoming
   }
@@ -561,7 +568,10 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       else if (existing.rarity < 100) {
         existing.rarity += 1
       }
+      const before = existing.rarity
       existing.rarity = Math.min(existing.rarity, 100)
+      if (before < 100 && existing.rarity === 100)
+        audio.playSfx('/audio/sfx/rarity-100.ogg')
       existing.isShiny ||= enemy.isShiny
       existing.lvl = Math.max(1, existing.lvl - levelLoss)
       existing.xp = 0
@@ -590,6 +600,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     addShlagemon(captured)
     updateHighestLevel(captured)
     updateCoefficient(captured)
+    if (captured.rarity === 100)
+      audio.playSfx('/audio/sfx/rarity-100.ogg')
     toast(`Tu as obtenu ${captured.base.name} !`)
     return captured
   }


### PR DESCRIPTION
## Summary
- trigger new rarity-100 sound effect when a Schlagémon's rarity hits 100

## Testing
- `pnpm test` *(fails: failed to fetch google fonts and many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6877e030cf04832aafd7d443cfbb7d60