### PR TITLE
Watch theme changes for toastify

### DIFF
--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { storeToRefs } from 'pinia'
+import { useItemShortcutModalStore } from '~/stores/itemShortcutModal'
 import { useItemUsageStore } from '~/stores/itemUsage'
 import { useShortcutsStore } from '~/stores/shortcuts'
 import { useUIStore } from '~/stores/ui'
-import { useItemShortcutModalStore } from '~/stores/itemShortcutModal'
 import { ballHues } from '~/utils/ball'
 
 const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()

--- a/src/modules/toastify.ts
+++ b/src/modules/toastify.ts
@@ -1,12 +1,14 @@
 import type { ToastContainerOptions } from 'vue3-toastify'
 
 import type { UserModule } from '~/types'
-import Vue3Toastify from 'vue3-toastify'
+import Vue3Toastify, { updateGlobalOptions } from 'vue3-toastify'
 
-export const install: UserModule = ({ app }) => {
+export const install: UserModule = ({ app, isClient }) => {
   const isDark = useDark()
   app.use(Vue3Toastify, {
     autoClose: 5000,
     theme: isDark.value ? 'dark' : 'light',
   } as ToastContainerOptions)
+  if (isClient)
+    watch(isDark, val => updateGlobalOptions({ theme: val ? 'dark' : 'light' }))
 }


### PR DESCRIPTION
## Summary
- watch dark mode state in toastify module
- fix item card import ordering

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots mismatch and missing files)*

------
https://chatgpt.com/codex/tasks/task_e_6877e00535c8832a92912c4364b65668