### PR TITLE
Add golden frame for max rarity Schlagemon

### DIFF
--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -106,7 +106,11 @@ const captureInfo = computed(() => {
 
 <template>
   <div class="tiny-scrollbar h-full w-full overflow-y-auto">
-    <div v-if="mon" class="max-w-xl w-full flex flex-col gap-2 rounded bg-white dark:bg-gray-900">
+    <div
+      v-if="mon"
+      class="max-w-xl w-full flex flex-col gap-2 rounded bg-white dark:bg-gray-900"
+      :class="mon.rarity === 100 ? 'border-2 border-yellow-500 dark:border-yellow-400' : ''"
+    >
       <h2 class="flex items-center justify-between text-lg font-bold">
         <div class="flex items-center gap-1">
           <span :class="mon.isShiny ? 'shiny-text' : ''">{{ mon.base.name }}</span>

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -155,6 +155,9 @@ function changeActive(mon: DexShlagemon) {
           isHighlighted(mon) && !isActive(mon)
             ? 'bg-blue-500/10 dark:bg-blue-500/20 ring-2 ring-blue-500 dark:ring-blue-400'
             : '',
+          mon.rarity === 100
+            ? 'border-yellow-500 dark:border-yellow-400'
+            : '',
         ]"
         @click.stop="handleClick(mon)"
       >


### PR DESCRIPTION
## Summary
- highlight Schlagemon with rarity 100 in the list
- show a golden border on the detail view of max rarity Schlagemon

## Testing
- `pnpm lint` *(fails: Expected "~/stores/itemShortcutModal" to come before "~/stores/ui")*
- `pnpm test` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877e0b1af48832abb23a731f22ca6b9