### PR TITLE
Fix rarity toast singular case

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -35,6 +35,12 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   // Vérifie chaque seconde si les effets ont expiré pour retirer icône et bonus
   setInterval(cleanupEffects, 1000)
 
+  function rarityToastMessage(name: string, rarityGain: number, levelLoss: number) {
+    const point = rarityGain > 1 ? 'points' : 'point'
+    const level = levelLoss > 1 ? 'niveaux' : 'niveau'
+    return `${name} gagne ${rarityGain} ${point} de rareté et perd ${levelLoss} ${level} !`
+  }
+
   const xpZones = computed(() => zonesData.filter(z => z.maxLevel > 0))
 
   function canAccess(z: Zone) {
@@ -533,9 +539,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       existing.hpCurrent = maxHp(existing)
       updateHighestLevel(existing)
       updateCoefficient(existing)
-      toast(
-        `${existing.base.name} gagne ${rarityGain} points de rareté et perd ${levelLoss} niveaux !`,
-      )
+      toast(rarityToastMessage(existing.base.name, rarityGain, levelLoss))
       return existing
     }
     const incoming = createDexShlagemon(base, shiny)
@@ -585,9 +589,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       existing.hpCurrent = maxHp(existing)
       updateHighestLevel(existing)
       updateCoefficient(existing)
-      toast(
-        `${existing.base.name} gagne ${rarityGain} points de rareté et perd ${levelLoss} niveaux !`,
-      )
+      toast(rarityToastMessage(existing.base.name, rarityGain, levelLoss))
       return existing
     }
     const captured: DexShlagemon = {

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -31,6 +31,24 @@ describe('shlagedex capture', () => {
     )
   })
 
+  it('uses singular when only one point and one level are gained', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.rarity = 1
+    mon.lvl = 5
+    toastMock.mockClear()
+    const enemy = createDexShlagemon(carapouffe, false, 1, 4)
+    enemy.rarity = 2
+    applyStats(enemy)
+    dex.captureEnemy(enemy)
+    expect(mon.rarity).toBe(2)
+    expect(mon.lvl).toBe(4)
+    expect(toastMock).toHaveBeenCalledWith(
+      `${mon.base.name} gagne 1 point de rareté et perd 1 niveau !`,
+    )
+  })
+
   it('turns existing mon shiny if duplicate is shiny', () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()


### PR DESCRIPTION
## Summary
- handle singular/plural for rarity toast
- add regression test for singular toast

## Testing
- `pnpm test` *(fails: Failed to fetch fonts from https://fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6877e3af9568832a8328f070ed7c8ff2