### PR TITLE
feat(detail): highlight modal for rarity 100

### DIFF
--- a/src/components/modal/index.vue
+++ b/src/components/modal/index.vue
@@ -4,10 +4,12 @@ const props = withDefaults(defineProps<{
   closeOnOutsideClick?: boolean
   footerClose?: boolean
   dialogAutofocus?: boolean
+  goldenBorder?: boolean
 }>(), {
   closeOnOutsideClick: true,
   footerClose: false,
   dialogAutofocus: false,
+  goldenBorder: false,
 })
 const emit = defineEmits(['update:modelValue', 'close'])
 const dialogRef = ref<HTMLDialogElement | null>(null)
@@ -59,7 +61,10 @@ function close() {
       @click="onDialogClick"
       @close="emit('update:modelValue', false); emit('close')"
     >
-      <div class="modal-content relative flex flex-col overflow-hidden">
+      <div
+        class="modal-content relative flex flex-col overflow-hidden"
+        :class="props.goldenBorder ? 'border-2 border-yellow-500 dark:border-yellow-400' : ''"
+      >
         <button
           v-if="!props.footerClose"
           type="button"

--- a/src/components/panel/Shlagedex.vue
+++ b/src/components/panel/Shlagedex.vue
@@ -44,7 +44,12 @@ function onItemClick(mon: DexShlagemon) {
     show-checkbox
     :on-item-click="onItemClick"
   />
-  <Modal v-model="showDetail" footer-close @close="showDetail = false">
+  <Modal
+    v-model="showDetail"
+    footer-close
+    @close="showDetail = false"
+    :golden-border="detailMon?.rarity === 100"
+  >
     <ShlagemonDetail
       :mon="detailMon"
       @release="showDetail = false"

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -109,7 +109,6 @@ const captureInfo = computed(() => {
     <div
       v-if="mon"
       class="max-w-xl w-full flex flex-col gap-2 rounded bg-white dark:bg-gray-900"
-      :class="mon.rarity === 100 ? 'border-2 border-yellow-500 dark:border-yellow-400' : ''"
     >
       <h2 class="flex items-center justify-between text-lg font-bold">
         <div class="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- add optional `goldenBorder` prop to Modal
- apply modal outline when a Shlagémon reaches rarity 100
- remove border from detail view

## Testing
- `pnpm lint` *(fails: cannot find package '@antfu/eslint-config')*
- `pnpm test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e63e6e28832a8ad651203caafa82