### PR TITLE
Fix shiny evolution

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -394,6 +394,8 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       }
       applyStats(existing)
       existing.hpCurrent = maxHp(existing)
+      if (mon.isShiny)
+        existing.isShiny = true
       const index = shlagemons.value.findIndex(m => m.id === mon.id)
       if (index !== -1)
         shlagemons.value.splice(index, 1)

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -2,8 +2,10 @@ import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import abraquemar from '../src/data/shlagemons/10-15/abraquemar'
 import alakalbar from '../src/data/shlagemons/evolutions/alakalbar'
+import kadavrebras from '../src/data/shlagemons/evolutions/kadavrebras'
 import { useEvolutionStore } from '../src/stores/evolution'
 import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useZoneStore } from '../src/stores/zone'
 import { xpForLevel } from '../src/utils/dexFactory'
 
 describe('evolution', () => {
@@ -41,5 +43,21 @@ describe('evolution', () => {
     evo.reject()
     await promise
     expect(mon.allowEvolution).toBe(false)
+  })
+
+  it('turns existing evolution shiny when evolving from a shiny mon', async () => {
+    setActivePinia(createPinia())
+    const zone = useZoneStore()
+    const dex = useShlagedexStore()
+    const evo = useEvolutionStore()
+    vi.spyOn(evo, 'requestEvolution').mockResolvedValue(true)
+    zone.setZone('plaine-kekette')
+    const existing = dex.createShlagemon(kadavrebras)
+    existing.isShiny = false
+    const mon = dex.createShlagemon(abraquemar)
+    mon.isShiny = true
+    mon.lvl = 45
+    await dex.gainXp(mon, xpForLevel(mon.lvl))
+    expect(existing.isShiny).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- keep shiny state when evolving into existing mon
- add regression test for shiny evolution merge

## Testing
- `pnpm lint`
- `pnpm test` *(fails: failed to fetch fonts; many failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_6877e9099fbc832aa5a85bbb6035cffb