### PR TITLE
Handle item transfer during evolution merge

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -17,6 +17,7 @@ import {
 import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
 import { useAudioStore } from './audio'
 import { useDiseaseStore } from './disease'
+import { useEquipmentStore } from './equipment'
 import { useEvolutionStore } from './evolution'
 import { useZoneProgressStore } from './zoneProgress'
 
@@ -29,6 +30,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const zoneStore = useZoneStore()
   const audio = useAudioStore()
   const disease = useDiseaseStore()
+  const equipment = useEquipmentStore()
   const baseMap = Object.fromEntries(allShlagemons.map(b => [b.id, b]))
   cleanupEffects()
   watchEffect(cleanupEffects)
@@ -394,6 +396,11 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       }
       applyStats(existing)
       existing.hpCurrent = maxHp(existing)
+      if (mon.heldItemId) {
+        const itemId = mon.heldItemId
+        equipment.unequip(mon.id)
+        equipment.equip(existing.id, itemId)
+      }
       const index = shlagemons.value.findIndex(m => m.id === mon.id)
       if (index !== -1)
         shlagemons.value.splice(index, 1)


### PR DESCRIPTION
## Summary
- inject `useEquipmentStore` into `useShlagedexStore`
- transfer held item to existing mon when merging evolutions

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fonts fetch and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877eb3b5534832aa77aed60fd61da29