### PR TITLE
Fix evolution prompt for item-based evolutions

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -483,8 +483,6 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const evo = mon.base.evolution
     if (!evo || evo.condition.type !== 'item' || evo.condition.value.id !== item.id)
       return false
-    if (!mon.allowEvolution)
-      return false
     const accepted = await evolutionStore.requestEvolution(mon, evo.base)
     if (!accepted)
       return false

--- a/test/evolution-item.test.ts
+++ b/test/evolution-item.test.ts
@@ -1,0 +1,21 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { thunderStone } from '../src/data/items/items'
+import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
+import { useEvolutionStore } from '../src/stores/evolution'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('item evolution', () => {
+  it('prompts even when evolution is disabled', async () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const evo = useEvolutionStore()
+    const spy = vi.spyOn(evo, 'requestEvolution').mockResolvedValue(true)
+    const mon = dex.createShlagemon(pikachiant)
+    mon.allowEvolution = false
+    const result = await dex.evolveWithItem(mon, thunderStone)
+    expect(result).toBe(true)
+    expect(spy).toHaveBeenCalled()
+    expect(mon.base.id).toBe('raichiotte')
+  })
+})


### PR DESCRIPTION
## Summary
- allow evolution items to trigger the confirmation popup even if the `allowEvolution` flag is disabled
- add unit test covering this behaviour

## Testing
- `pnpm test:unit` *(fails: Failed to resolve imports and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877f01042a0832a8eb5be30b67f69f1