### PR TITLE
Link arenas to villages

### DIFF
--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -45,8 +45,10 @@ function createArena(config: ArenaConfig): Arena {
     character: config.character,
     level: config.level,
     badge: config.badge,
-    lineup: generateArenaLineup(config.zoneId),
-  }
+    get lineup() {
+      return generateArenaLineup(config.zoneId)
+    },
+  } as unknown as Arena
 }
 
 export const arena20: Arena = createArena({
@@ -88,17 +90,10 @@ export const arena60: Arena = createArena({
   },
 })
 
-const zone20 = zonesData.find(z => z.id === 'village-boule')
-if (zone20)
-  zone20.arena = { arena: arena20, completed: false }
-
-const zone40 = zonesData.find(z => z.id === 'village-paume')
-if (zone40)
-  zone40.arena = { arena: arena40, completed: false }
-
 export const arenas: Arena[] = [
   arena20,
   arena40,
+  arena60,
 ]
 
 export function getArena(id: string): Arena | undefined {

--- a/src/data/zones/villages.ts
+++ b/src/data/zones/villages.ts
@@ -1,4 +1,5 @@
 import type { Zone } from '~/type'
+import { arena20, arena40, arena60 } from '../arenas'
 import {
   attackPotion,
   capturePotion,
@@ -41,6 +42,10 @@ const village20: Zone = {
   type: 'village',
   actions: [],
   minLevel: 20,
+  arena: {
+    get arena() { return arena20 },
+    completed: false,
+  } as unknown as Zone['arena'],
   village: {
     shop: {
       items: [
@@ -60,6 +65,10 @@ const village40: Zone = {
   type: 'village',
   actions: [],
   minLevel: 40,
+  arena: {
+    get arena() { return arena40 },
+    completed: false,
+  } as unknown as Zone['arena'],
   village: {
     shop: {
       items: [
@@ -98,6 +107,10 @@ const village60: Zone = {
   type: 'village',
   actions: [],
   minLevel: 60,
+  arena: {
+    get arena() { return arena60 },
+    completed: false,
+  } as unknown as Zone['arena'],
   village: {
     shop: {
       items: [


### PR DESCRIPTION
## Summary
- reference arenas from village definitions instead of mutating after
- include arena60 when exporting all arenas

## Testing
- `pnpm test` *(fails: ENETUNREACH for fonts and many failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_6877ef4daab8832aae717c14e0ce5873