### PR TITLE
Fix evolution modal close event

### DIFF
--- a/src/components/shlagemon/EvolutionModal.vue
+++ b/src/components/shlagemon/EvolutionModal.vue
@@ -8,7 +8,11 @@ const store = useEvolutionStore()
   <!-- We only bind the visibility as a prop because `isVisible` is a
        computed value without a setter. Using `v-model` would attempt to
        write to it and trigger an error. -->
-  <Modal :model-value="store.isVisible" :close-on-outside-click="false">
+  <Modal
+    :model-value="store.isVisible"
+    :close-on-outside-click="false"
+    @close="store.reject"
+  >
     <div class="flex flex-col items-center gap-4">
       <h3 class="text-center text-lg font-bold">
         {{ store.pending?.mon.base.name }} évolue


### PR DESCRIPTION
## Summary
- call `store.reject` when closing the evolution confirmation modal

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Failed to fetch web fonts, 29 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_6877f37f4650832a967c1976c4605fba