### PR TITLE
Fix equipment unequip on release

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -658,6 +658,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const index = shlagemons.value.findIndex(m => m.id === mon.id)
     if (index === -1)
       return
+    equipment.unequip(mon.id)
     shlagemons.value.splice(index, 1)
     if (activeShlagemon.value?.id === mon.id)
       activeShlagemon.value = shlagemons.value[0] || null


### PR DESCRIPTION
## Summary
- ensure releasing a Shlagemon also unequips their item so inventory updates

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 29 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6877ee822b88832a944cb0f22c35c389