### PR TITLE
Add use/equip button in item modal

### DIFF
--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -119,6 +119,14 @@ watch(showInfo, (val) => {
         <p class="text-center text-sm">
           {{ details }}
         </p>
+        <UiButton
+          class="flex items-center gap-1 text-xs"
+          :disabled="props.disabled"
+          @click.stop="emit('use'); showInfo.value = false"
+        >
+          <div i-carbon-play inline-block />
+          {{ actionLabel }}
+        </UiButton>
       </div>
     </Modal>
   </div>


### PR DESCRIPTION
## Summary
- add a secondary action button inside the inventory item modal to allow using or equipping items directly from the modal

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fonts fetch failure and many unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877f3ae8af4832a8b4ff9ee2f19adb9