### PR TITLE
Fix auto start capture for item shortcut modal

### DIFF
--- a/src/components/inventory/ItemShortcutModal.vue
+++ b/src/components/inventory/ItemShortcutModal.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
+import UiKeyCapture from '~/components/ui/KeyCapture.vue'
 import { useItemShortcutModalStore } from '~/stores/itemShortcutModal'
 import { useShortcutsStore } from '~/stores/shortcuts'
 
 const modal = useItemShortcutModalStore()
 const shortcuts = useShortcutsStore()
+const capture = ref<InstanceType<typeof UiKeyCapture> | null>(null)
+
+watch(() => modal.isVisible, (visible) => {
+  if (!visible)
+    capture.value?.stopCapture()
+})
 
 function assign(key: string) {
   if (!modal.current)
@@ -14,7 +21,7 @@ function assign(key: string) {
 </script>
 
 <template>
-  <Modal v-model="modal.isVisible" :close-on-outside-click="false">
+  <Modal v-model="modal.isVisible" :close-on-outside-click="false" @close="capture?.stopCapture()">
     <div class="flex flex-col items-center gap-4">
       <h3 class="text-center text-lg font-bold">
         Assigner un raccourci clavier pour cet objet
@@ -37,7 +44,13 @@ function assign(key: string) {
         <p class="text-center text-sm">
           Appuyez sur une touche pour assigner le raccourci clavier
         </p>
-        <UiKeyCapture auto-start size="lg" model-value="" @update:model-value="assign" />
+        <UiKeyCapture
+          ref="capture"
+          :auto-start="modal.isVisible"
+          size="lg"
+          model-value=""
+          @update:model-value="assign"
+        />
       </div>
     </div>
   </Modal>

--- a/src/components/ui/KeyCapture.vue
+++ b/src/components/ui/KeyCapture.vue
@@ -45,6 +45,7 @@ watch(() => props.autoStart, (v) => {
   if (v && !waiting.value)
     startCapture()
 })
+defineExpose({ startCapture, stopCapture })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- start keyboard capture automatically when shortcut modal opens
- allow key capture to expose start/stop methods

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH during font fetch and multiple failing unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877f3dcabf0832a931c742a1e35c6fd