### PR TITLE
Add PWA update snackbar

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -268,6 +268,7 @@ declare global {
   const usePreferredReducedMotion: typeof import('@vueuse/core')['usePreferredReducedMotion']
   const usePreferredReducedTransparency: typeof import('@vueuse/core')['usePreferredReducedTransparency']
   const usePrevious: typeof import('@vueuse/core')['usePrevious']
+  const usePwaUpdateStore: typeof import('./stores/pwaUpdate')['usePwaUpdateStore']
   const useRafFn: typeof import('@vueuse/core')['useRafFn']
   const useRefHistory: typeof import('@vueuse/core')['useRefHistory']
   const useResizeObserver: typeof import('@vueuse/core')['useResizeObserver']
@@ -664,6 +665,7 @@ declare module 'vue' {
     readonly usePreferredReducedMotion: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedMotion']>
     readonly usePreferredReducedTransparency: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedTransparency']>
     readonly usePrevious: UnwrapRef<typeof import('@vueuse/core')['usePrevious']>
+    readonly usePwaUpdateStore: UnwrapRef<typeof import('./stores/pwaUpdate')['usePwaUpdateStore']>
     readonly useRafFn: UnwrapRef<typeof import('@vueuse/core')['useRafFn']>
     readonly useRefHistory: UnwrapRef<typeof import('@vueuse/core')['useRefHistory']>
     readonly useResizeObserver: UnwrapRef<typeof import('@vueuse/core')['useResizeObserver']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -115,6 +115,7 @@ declare module 'vue' {
     UiSelectOption: typeof import('./components/ui/SelectOption.vue')['default']
     UiSortControls: typeof import('./components/ui/SortControls.vue')['default']
     UiTooltip: typeof import('./components/ui/Tooltip.vue')['default']
+    UpdateSnackbar: typeof import('./components/UpdateSnackbar.vue')['default']
     VillageZoneActions: typeof import('./components/village/ZoneActions.vue')['default']
     ZoneMonsModal: typeof import('./components/zone/MonsModal.vue')['default']
   }

--- a/src/components/UpdateSnackbar.vue
+++ b/src/components/UpdateSnackbar.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { usePwaUpdateStore } from '~/stores/pwaUpdate'
+
+const store = usePwaUpdateStore()
+</script>
+
+<template>
+  <Transition name="slide-fade">
+    <div v-if="store.needRefresh" class="pointer-events-none fixed inset-x-0 bottom-4 z-100 flex justify-center">
+      <div class="pointer-events-auto flex items-center gap-2 rounded bg-gray-800 px-4 py-2 text-white shadow" dark="bg-gray-200 text-gray-800">
+        <span>Nouvelle version disponible</span>
+        <UiButton type="primary" variant="solid" @click="store.reload">
+          Mettre à jour
+        </UiButton>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition: all 0.3s ease;
+}
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  opacity: 0;
+  transform: translateY(10px);
+}
+</style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -3,5 +3,6 @@
     <LayoutHeader />
     <LayoutGameGrid class="flex-1" />
     <LayoutMobileMenu />
+    <UpdateSnackbar />
   </div>
 </template>

--- a/src/modules/pwa.ts
+++ b/src/modules/pwa.ts
@@ -1,4 +1,5 @@
 import type { UserModule } from '~/types'
+import { usePwaUpdateStore } from '~/stores/pwaUpdate'
 
 // https://github.com/antfu/vite-plugin-pwa#automatic-reload-when-new-content-available
 export const install: UserModule = ({ isClient, router }) => {
@@ -8,7 +9,14 @@ export const install: UserModule = ({ isClient, router }) => {
   router.isReady()
     .then(async () => {
       const { registerSW } = await import('virtual:pwa-register')
-      registerSW({ immediate: true })
+      const store = usePwaUpdateStore()
+      const updateSW = registerSW({
+        immediate: true,
+        onNeedRefresh() {
+          store.showUpdate()
+        },
+      })
+      store.registerUpdate(updateSW)
     })
     .catch(() => {})
 }

--- a/src/stores/pwaUpdate.ts
+++ b/src/stores/pwaUpdate.ts
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia'
+
+export const usePwaUpdateStore = defineStore('pwaUpdate', () => {
+  const needRefresh = ref(false)
+  let updateFn: (() => Promise<void>) | null = null
+
+  function registerUpdate(swUpdate: () => Promise<void>) {
+    updateFn = swUpdate
+  }
+
+  function showUpdate() {
+    needRefresh.value = true
+  }
+
+  async function reload() {
+    if (updateFn)
+      await updateFn()
+    window.location.reload()
+  }
+
+  return { needRefresh, registerUpdate, showUpdate, reload }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -104,7 +104,7 @@ export default defineConfig({
 
     // https://github.com/antfu/vite-plugin-pwa
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       includeAssets: ['favicon.svg', 'safari-pinned-tab.svg'],
       manifest: {
         name: 'Shlagémon',


### PR DESCRIPTION
## Summary
- show snackbar when a new PWA version is available
- allow user to activate the new service worker and reload
- register update store and fix PWA config

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6877f5c493f0832a9826f88ea9b384d1