### PR TITLE
Add equipment evolution and release tests

### DIFF
--- a/test/equipment-evolution.test.ts
+++ b/test/equipment-evolution.test.ts
@@ -1,0 +1,34 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { multiExp, thunderStone } from '../src/data/items/items'
+import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
+import raichiotte from '../src/data/shlagemons/evolutions/raichiotte'
+import { useEquipmentStore } from '../src/stores/equipment'
+import { useEvolutionStore } from '../src/stores/evolution'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('equipment on evolution', () => {
+  it('keeps unique item on evolved species', async () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const inventory = useInventoryStore()
+    const equipment = useEquipmentStore()
+    const evo = useEvolutionStore()
+    vi.spyOn(evo, 'requestEvolution').mockResolvedValue(true)
+
+    inventory.add(multiExp.id)
+    const target = dex.createShlagemon(raichiotte)
+    const mon = dex.createShlagemon(pikachiant)
+
+    equipment.equip(mon.id, multiExp.id)
+
+    const result = await dex.evolveWithItem(mon, thunderStone)
+    expect(result).toBe(true)
+
+    expect(mon.heldItemId).toBeNull()
+    const holder = equipment.getHolder(multiExp.id)
+    const qty = inventory.items[multiExp.id] || 0
+    expect(holder === target.id || qty === 1).toBe(true)
+  })
+})

--- a/test/equipment-release.test.ts
+++ b/test/equipment-release.test.ts
@@ -1,0 +1,25 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { multiExp } from '../src/data/items/items'
+import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
+import { useEquipmentStore } from '../src/stores/equipment'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('equipment on release', () => {
+  it('returns held item to inventory when releasing a shlagemon', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const inventory = useInventoryStore()
+    const equipment = useEquipmentStore()
+
+    inventory.add(multiExp.id)
+    const mon = dex.createShlagemon(pikachiant)
+    equipment.equip(mon.id, multiExp.id)
+
+    dex.releaseShlagemon(mon)
+
+    expect(inventory.items[multiExp.id]).toBe(1)
+    expect(equipment.getHolder(multiExp.id)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for item transfer when a Shlagémon evolves into an already owned species
- add tests for item transfer when releasing a Shlagémon

## Testing
- `pnpm test:unit` *(fails: Failed to fetch web fonts, zone errors, failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6877f61827c8832a8b8d30607552a5d5