### PR TITLE
Fix wearable modal on mobile

### DIFF
--- a/src/stores/wearableItem.ts
+++ b/src/stores/wearableItem.ts
@@ -2,7 +2,6 @@ import type { Item } from '~/type/item'
 import { defineStore } from 'pinia'
 import { useEquipmentStore } from './equipment'
 import { useItemUsageStore } from './itemUsage'
-import { useMobileTabStore } from './mobileTab'
 import { useShlagedexStore } from './shlagedex'
 
 export const useWearableItemStore = defineStore('wearableItem', () => {
@@ -11,7 +10,6 @@ export const useWearableItemStore = defineStore('wearableItem', () => {
   const selectedId = ref<string | null>(null)
   const dex = useShlagedexStore()
   const equipment = useEquipmentStore()
-  const mobile = useMobileTabStore()
   const usage = useItemUsageStore()
 
   const holderId = computed(() =>
@@ -34,7 +32,6 @@ export const useWearableItemStore = defineStore('wearableItem', () => {
       return
     current.value = item
     selectedId.value = holderId.value
-    mobile.set('game')
     isVisible.value = true
   }
 


### PR DESCRIPTION
## Summary
- keep inventory tab when equipping wearable items on mobile

## Testing
- `pnpm test:unit` *(fails: Failed to resolve import `../src/components/battle/BattleMain.vue`)*

------
https://chatgpt.com/codex/tasks/task_e_68780c2beff8832a856946c9fc84dfc0