### PR TITLE
Fix arena music on quick exit

### DIFF
--- a/src/components/dialog/ArenaDefeatDialog.vue
+++ b/src/components/dialog/ArenaDefeatDialog.vue
@@ -1,15 +1,19 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
-import { getArenaTrack } from '~/data/music'
+import { ref } from 'vue'
+import { getArenaTrack, getZoneTrack } from '~/data/music'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useZoneStore } from '~/stores/zone'
 
 const emit = defineEmits(['done'])
 const arena = useArenaStore()
 const dialog = useDialogStore()
 const panel = useMainPanelStore()
+const zone = useZoneStore()
 const preparationMusic = getArenaTrack('preparation') ?? '/audio/musics/arenas/preparation.ogg'
+const exitTrack = ref(preparationMusic)
 
 function retry() {
   const data = arena.arenaData
@@ -24,6 +28,7 @@ function retry() {
 function quit() {
   arena.reset()
   panel.showVillage()
+  exitTrack.value = getZoneTrack(zone.current.id, zone.current.type) ?? preparationMusic
   emit('done', 'arenaDefeat')
 }
 
@@ -44,6 +49,6 @@ const dialogTree: DialogNode[] = [
     :character="arena.arenaData!.character"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
-    :exit-track="preparationMusic"
+    :exit-track="exitTrack"
   />
 </template>

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
+import { ref } from 'vue'
 import { toast } from 'vue3-toastify'
-import { getArenaTrack } from '~/data/music'
+import { getArenaTrack, getZoneTrack } from '~/data/music'
 import { useArenaStore } from '~/stores/arena'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { usePlayerStore } from '~/stores/player'
@@ -16,6 +17,7 @@ const panel = useMainPanelStore()
 const progress = useZoneProgressStore()
 const zone = useZoneStore()
 const preparationMusic = getArenaTrack('preparation') ?? '/audio/musics/arenas/preparation.ogg'
+const exitTrack = ref(preparationMusic)
 
 function collectBadge() {
   if (!arena.arenaData)
@@ -26,6 +28,7 @@ function collectBadge() {
   toast.success(`Badge ${arena.arenaData.badge.name} obtenu !`)
   arena.reset()
   panel.showVillage()
+  exitTrack.value = getZoneTrack(zone.current.id, zone.current.type) ?? preparationMusic
   emit('done', 'arenaVictory')
 }
 
@@ -49,6 +52,6 @@ const dialogTree: DialogNode[] = [
     :character="arena.arenaData!.character"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
-    :exit-track="preparationMusic"
+    :exit-track="exitTrack"
   />
 </template>

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -1,17 +1,22 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
-import { getArenaTrack } from '~/data/music'
+import { ref } from 'vue'
+import { getArenaTrack, getZoneTrack } from '~/data/music'
 import { useArenaStore } from '~/stores/arena'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useZoneStore } from '~/stores/zone'
 
 const emit = defineEmits(['done'])
 const arena = useArenaStore()
 const panel = useMainPanelStore()
+const zone = useZoneStore()
 const preparationMusic = getArenaTrack('preparation') ?? '/audio/musics/arenas/preparation.ogg'
+const exitTrack = ref(preparationMusic)
 
 function quit() {
   arena.reset()
   panel.showVillage()
+  exitTrack.value = getZoneTrack(zone.current.id, zone.current.type) ?? preparationMusic
   emit('done', 'arenaWelcome')
 }
 
@@ -40,6 +45,6 @@ const dialogTree: DialogNode[] = [
     :character="arena.arenaData!.character"
     :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
-    :exit-track="preparationMusic"
+    :exit-track="exitTrack"
   />
 </template>


### PR DESCRIPTION
## Summary
- preserve village music when quitting an arena dialog
- keep same music logic for defeat/victory dialogs

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH during font fetch)*

------
https://chatgpt.com/codex/tasks/task_e_687813f4f3e8832a84b9dcfb8e00251b