### PR TITLE
Fix rarity 100 coefficient scaling

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -156,7 +156,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       return
     const target = zoneId
       ? { id: zoneId }
-      : accessibleXpZones.value[accessibleXpZones.value.length - 1]
+      : zoneStore.getZoneForLevel(mon.lvl)
     if (!target)
       return
     const rank = zoneStore.getZoneRank(target.id)

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -49,6 +49,11 @@ export const useZoneStore = defineStore('zone', () => {
     return idx >= 0 ? idx + 1 : 1
   }
 
+  function getZoneForLevel(level: number): Zone | undefined {
+    const candidates = xpZones.value.filter(z => level >= z.minLevel)
+    return candidates[candidates.length - 1]
+  }
+
   function completeArena(id: string) {
     const z = zones.value.find(z => z.id === id)
     if (z?.arena)
@@ -93,6 +98,7 @@ export const useZoneStore = defineStore('zone', () => {
     setZone,
     getKing,
     getZoneRank,
+    getZoneForLevel,
     completeArena,
     reset,
   }

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -191,6 +191,33 @@ describe('rarity 100 coefficient update', () => {
     const rank = zone.getZoneRank('bois-de-bouffon')
     expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
   })
+
+  it('keeps coefficient from level bracket when higher zone unlocks', async () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const progress = useZoneProgressStore()
+    const zone = useZoneStore()
+
+    const enemy = createDexShlagemon(carapouffe, false, 1, 27)
+    enemy.rarity = 100
+    applyStats(enemy)
+    const mon = dex.captureEnemy(enemy)
+    await nextTick()
+    const rank = zone.getZoneRank('marais-moudugenou')
+    expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
+
+    ;[
+      'plaine-kekette',
+      'bois-de-bouffon',
+      'chemin-du-slip',
+      'ravin-fesse-molle',
+      'precipice-nanard',
+      'marais-moudugenou',
+    ].forEach(id => progress.defeatKing(id))
+    await nextTick()
+
+    expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
+  })
 })
 
 describe('duplicate capture at max rarity with both methods', () => {


### PR DESCRIPTION
## Summary
- compute stat coefficient from shlagémon level bracket
- expose `getZoneForLevel` in the zone store
- test coefficient stability when higher zones unlock

## Testing
- `pnpm install`
- `pnpm test:unit` *(fails: Failed to resolve some imports)*

------
https://chatgpt.com/codex/tasks/task_e_687816436ce4832a8cb7a465e5e22b23