### PR TITLE
Update PWA snackbar message

### DIFF
--- a/src/components/UpdateSnackbar.vue
+++ b/src/components/UpdateSnackbar.vue
@@ -7,10 +7,10 @@ const store = usePwaUpdateStore()
 <template>
   <Transition name="slide-fade">
     <div v-if="store.needRefresh" class="pointer-events-none fixed inset-x-0 bottom-4 z-100 flex justify-center">
-      <div class="pointer-events-auto flex items-center gap-2 rounded bg-gray-800 px-4 py-2 text-white shadow" dark="bg-gray-200 text-gray-800">
-        <span>Nouvelle version disponible</span>
+      <div class="pointer-events-auto flex items-center gap-2 rounded bg-gray-200 px-4 py-2 text-gray-800 shadow" dark="bg-gray-800 text-white">
+        <span>Mise à jour de l'application disponible</span>
         <UiButton type="primary" variant="solid" @click="store.reload">
-          Mettre à jour
+          Recharger
         </UiButton>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- tweak PWA update snackbar text
- swap light/dark colours for the update alert

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*
- `pnpm typecheck` *(fails: enemy is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_68782013f398832aaf0ce3b7aa24d309