### PR TITLE
Fix wearable modal hydration

### DIFF
--- a/src/stores/wearableItem.ts
+++ b/src/stores/wearableItem.ts
@@ -67,6 +67,4 @@ export const useWearableItemStore = defineStore('wearableItem', () => {
     getHolderId,
     getHolder,
   }
-}, {
-  persist: true,
 })


### PR DESCRIPTION
## Summary
- stop persisting wearableItem store so the wearable equip modal does not re-open after refresh

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_687824b17690832a8e16dd36fda4131b