### PR TITLE
Use QuickSelect in WearableItemModal

### DIFF
--- a/src/components/inventory/WearableItemModal.vue
+++ b/src/components/inventory/WearableItemModal.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { useWearableItemStore } from '~/stores/wearableItem'
 
 const store = useWearableItemStore()
 const dex = useShlagedexStore()
 
-function select(monId: string) {
-  store.setHolder(monId)
+function select(mon: DexShlagemon) {
+  store.setHolder(mon.id)
 }
 </script>
 
@@ -16,23 +17,12 @@ function select(monId: string) {
       <h3 class="text-center text-lg font-bold">
         Choisir le porteur de {{ store.current?.name }}
       </h3>
-      <div v-if="dex.shlagemons.length" class="flex flex-col gap-2">
-        <div
-          v-for="mon in dex.shlagemons"
-          :key="mon.id"
-          class="flex items-center justify-between border rounded p-2"
-          :class="store.holderId === mon.id ? 'bg-orange-100 dark:bg-orange-900' : ''"
-        >
-          <div class="flex items-center gap-2">
-            <ShlagemonImage :id="mon.base.id" :alt="mon.base.name" class="h-6 w-6" />
-            <span>{{ mon.base.name }} (lvl {{ mon.lvl }})</span>
-          </div>
-          <UiButton class="text-xs" @click="select(mon.id)">
-            <span v-if="store.holderId === mon.id">Équipé</span>
-            <span v-else>Choisir</span>
-          </UiButton>
-        </div>
-      </div>
+      <ShlagemonQuickSelect
+        v-if="dex.shlagemons.length"
+        class="max-h-60vh"
+        :selected="store.holderId ? [store.holderId] : []"
+        @select="select"
+      />
       <p v-else class="text-center text-sm">
         Aucun Shlagémon disponible.
       </p>


### PR DESCRIPTION
## Summary
- use `<ShlagemonQuickSelect>` to show monsters in WearableItemModal
- highlight the current holder ID
- keep existing behaviour to equip when a monster is selected
- allow scrolling when list is long

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: FetchError ENETUNREACH for fonts, many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687828d1fb44832a9f4488b63d255f78