### PR TITLE
Audit store persistence

### DIFF
--- a/src/stores/ball.ts
+++ b/src/stores/ball.ts
@@ -30,5 +30,8 @@ export const useBallStore = defineStore('ball', () => {
 
   return { current, currentBall, isVisible, open, close, setBall, reset }
 }, {
-  persist: true,
+  // only keep the current ball across reloads
+  persist: {
+    pick: ['current'],
+  },
 })

--- a/src/stores/miniGame.ts
+++ b/src/stores/miniGame.ts
@@ -49,5 +49,8 @@ export const useMiniGameStore = defineStore('miniGame', () => {
 
   return { level, score, wins, isRunning, timeLeft, start, hit, finish, scoreToWin }
 }, {
-  persist: true,
+  // persist only long term progress
+  persist: {
+    pick: ['level', 'wins'],
+  },
 })


### PR DESCRIPTION
## Summary
- refine ball store persistence to only keep the current ball
- update mini game store to persist long term progress only

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fetch errors and many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68782bac7f6c832ab3f45be3e3aba96f