### PR TITLE
Split stat computation for monsters

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -6,7 +6,7 @@ import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { cloneDexShlagemon } from '~/utils/clone'
 import { delay } from '~/utils/delay'
-import { applyStats, createDexShlagemon } from '~/utils/dexFactory'
+import { applyCurrentStats, applyStats, createDexShlagemon } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
 const arena = useArenaStore()
@@ -74,6 +74,7 @@ function startBattle() {
     .map((mon) => {
       const clone = cloneDexShlagemon(toRaw(mon))
       applyStats(clone)
+      applyCurrentStats(clone)
       clone.hpCurrent = clone.hp
       return clone
     })

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -7,6 +7,7 @@ import { toast } from 'vue3-toastify'
 import { allShlagemons } from '~/data/shlagemons'
 import { zonesData } from '~/data/zones'
 import {
+  applyCurrentStats,
   applyStats,
   createDexShlagemon,
   xpForLevel,
@@ -163,7 +164,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const baseCoef = baseMap[mon.base.id].coefficient
     const newCoef = baseCoef * rank
     mon.base.coefficient = newCoef
-    applyStats(mon)
+    applyCurrentStats(mon)
     if (heal)
       mon.hpCurrent = maxHp(mon)
   }
@@ -419,6 +420,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       existing.lvl = 1
       existing.xp = 0
       applyStats(existing)
+      applyCurrentStats(existing)
       existing.hpCurrent = maxHp(existing)
       if (mon.heldItemId) {
         const itemId = mon.heldItemId
@@ -438,6 +440,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     else {
       mon.base = to
       applyStats(mon)
+      applyCurrentStats(mon)
       mon.hpCurrent = maxHp(mon)
       mon.captureDate = new Date().toISOString()
       mon.captureCount = 1
@@ -489,8 +492,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       const prevHp = mon.hpCurrent
       if (mon.rarity === 100)
         updateCoefficient(mon, undefined, false)
-      else
-        applyStats(mon)
+      applyCurrentStats(mon)
       const healAmount = Math.round((mon.hp * healPercent) / 100)
       mon.hpCurrent = Math.min(mon.hp, prevHp + healAmount)
       updateHighestLevel(mon)
@@ -542,6 +544,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       existing.lvl = Math.max(1, existing.lvl - levelLoss)
       existing.xp = 0
       applyStats(existing)
+      applyCurrentStats(existing)
       existing.hpCurrent = maxHp(existing)
       updateHighestLevel(existing)
       updateCoefficient(existing)
@@ -586,6 +589,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       existing.lvl = Math.max(1, existing.lvl - levelLoss)
       existing.xp = 0
       applyStats(existing)
+      applyCurrentStats(existing)
       existing.hpCurrent = maxHp(existing)
       updateHighestLevel(existing)
       updateCoefficient(existing)


### PR DESCRIPTION
## Summary
- refactor stat handling in `dexFactory` to separate base and current stats
- update store logic to recalc only current stats for coefficient changes
- adjust arena panel cloning to use new current stat function
- revise tests and add coverage for base stat persistence at rarity 100

## Testing
- `npm test` *(fails: FetchError from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_687831316d68832aba33acbcc3dff63a