### PR TITLE
Fix coefficient scaling bug

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -163,7 +163,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const rank = zoneStore.getZoneRank(target.id)
     const baseCoef = baseMap[mon.base.id].coefficient
     const newCoef = baseCoef * rank
-    mon.base.coefficient = newCoef
+    mon.coefficient = newCoef
     applyCurrentStats(mon)
     if (heal)
       mon.hpCurrent = maxHp(mon)

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -20,6 +20,12 @@ export interface BaseShlagemon {
 export interface DexShlagemon extends Stats {
   id: string
   base: BaseShlagemon
+  /**
+   * Current coefficient used to compute battle stats.
+   * The original coefficient from the base definition
+   * remains unchanged in `base.coefficient`.
+   */
+  coefficient: number
   baseStats: Stats
   /**
    * ISO string representing the first time this Shlagémon was obtained.

--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -4,7 +4,7 @@ import { useShlagedexStore } from '~/stores/shlagedex'
 
 export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
   const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
-  const coefMod = 1 / Math.cbrt(enemy.base.coefficient)
+  const coefMod = 1 / Math.cbrt(enemy.coefficient)
   const levelMod = 1 / (1 + enemy.lvl / 40)
   // Slightly increase the global capture rate to make encounters less frustrating
   const difficultyMod = 1.3
@@ -15,7 +15,7 @@ export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
   if (dev.debug) {
     console.warn(
       `Capture chance: ${chance.toFixed(2)}%`,
-      { level: enemy.lvl, coef: enemy.base.coefficient, ballBonus: ball.catchBonus, hpChance, coefMod, levelMod, captureMod },
+      { level: enemy.lvl, coef: enemy.coefficient, ballBonus: ball.catchBonus, hpChance, coefMod, levelMod, captureMod },
     )
   }
   return Math.random() * 100 < chance

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -32,7 +32,7 @@ export function applyStats(mon: DexShlagemon) {
 
 export function applyCurrentStats(mon: DexShlagemon) {
   const levelBoost = 1 + (mon.lvl - 1) * 0.02
-  const coefficientBoost = 1 + 2.5 * (mon.base.coefficient - 1) / 999
+  const coefficientBoost = 1 + 2.5 * (mon.coefficient - 1) / 999
 
   const hpBase = Math.floor(mon.baseStats.hp * coefficientBoost / 5) * 5
   mon.hp = Math.floor((hpBase + (mon.lvl - 1) * 5) * levelBoost)
@@ -49,13 +49,10 @@ export function createDexShlagemon(
   level = 1,
 ): DexShlagemon {
   const rarity = generateRarity()
-  const adjustedBase: BaseShlagemon = {
-    ...base,
-    coefficient: base.coefficient * coefficientMultiplier,
-  }
   const mon: DexShlagemon = {
     id: crypto.randomUUID(),
-    base: adjustedBase,
+    base,
+    coefficient: base.coefficient * coefficientMultiplier,
     baseStats: {
       hp: statWithRarityAndCoefficient(baseStats.hp, 1, rarity),
       attack: statWithRarityAndCoefficient(baseStats.attack, 1, rarity),

--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -43,6 +43,7 @@ export const shlagedexSerializer = {
           ...mon,
           base,
           baseId: mon.baseId ?? base.id,
+          coefficient: mon.coefficient ?? base.coefficient,
           baseStats: mon.baseStats ?? {
             hp: statWithRarityAndCoefficient(baseStats.hp, base.coefficient, mon.rarity ?? 1),
             attack: statWithRarityAndCoefficient(baseStats.attack, base.coefficient, mon.rarity ?? 1),
@@ -66,6 +67,7 @@ export const shlagedexSerializer = {
           ...active,
           base,
           baseId: active.baseId ?? base.id,
+          coefficient: active.coefficient ?? base.coefficient,
           baseStats: active.baseStats ?? {
             hp: statWithRarityAndCoefficient(baseStats.hp, base.coefficient, active.rarity ?? 1),
             attack: statWithRarityAndCoefficient(baseStats.attack, base.coefficient, active.rarity ?? 1),

--- a/test/arena-enemy-coefficient.test.ts
+++ b/test/arena-enemy-coefficient.test.ts
@@ -28,7 +28,7 @@ describe('arena enemies', () => {
     wrapper.vm.startBattle()
 
     const enemy = arena.enemyTeam[0]
-    expect(enemy.base.coefficient).toBe(arena20.level)
+    expect(enemy.coefficient).toBe(arena20.level)
     wrapper.unmount()
   })
 })

--- a/test/battle-zone-rank.test.ts
+++ b/test/battle-zone-rank.test.ts
@@ -32,7 +32,7 @@ describe('zone rank scaling', () => {
     vi.runOnlyPendingTimers()
 
     const enemy = (wrapper.vm as any).enemy
-    expect(enemy.base.coefficient).toBe(carapouffe.coefficient * rank * EQUILIBRE_RANK)
+    expect(enemy.coefficient).toBe(carapouffe.coefficient * rank * EQUILIBRE_RANK)
 
     wrapper.unmount()
     pickSpy.mockRestore()
@@ -56,6 +56,6 @@ describe('zone rank scaling', () => {
     dex.captureShlagemon(carapouffe)
     await Promise.resolve()
     expect(mon.rarity).toBe(100)
-    expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
   })
 })

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -27,11 +27,11 @@ describe('capture mechanics', () => {
 
   it('hyper ball versus strong foe gives around 10% chance', () => {
     const mon = createDexShlagemon(carapouffe, false, 1, 100)
-    mon.base.coefficient = 1000
+    mon.coefficient = 1000
     mon.hp = 100
     mon.hpCurrent = 10
     const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
-    const coefMod = 1 / Math.cbrt(mon.base.coefficient)
+    const coefMod = 1 / Math.cbrt(mon.coefficient)
     const levelMod = 1 / (1 + mon.lvl / 40)
     const difficultyMod = 1.3
     const chance = Math.min(100, hpChance * coefMod * levelMod * balls[2].catchBonus * difficultyMod)
@@ -40,10 +40,10 @@ describe('capture mechanics', () => {
 
   it('regular ball against lvl1 coefficient1 foe at full HP is almost guaranteed', () => {
     const mon = createDexShlagemon(carapouffe, false, 1, 1)
-    mon.base.coefficient = 1
+    mon.coefficient = 1
     mon.hpCurrent = mon.hp
     const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
-    const coefMod = 1 / Math.cbrt(mon.base.coefficient)
+    const coefMod = 1 / Math.cbrt(mon.coefficient)
     const levelMod = 1 / (1 + mon.lvl / 40)
     const difficultyMod = 1.3
     const chance = Math.min(100, hpChance * coefMod * levelMod * balls[0].catchBonus * difficultyMod)

--- a/test/evolution-coefficient.test.ts
+++ b/test/evolution-coefficient.test.ts
@@ -21,6 +21,6 @@ describe('evolution coefficient bonus', () => {
     mon.rarity = 100
     await dex.gainXp(mon, xpForLevel(1) + xpForLevel(2))
     expect(mon.base.id).toBe(alakalbar.id)
-    expect(mon.base.coefficient).toBe(alakalbar.coefficient * rank)
+    expect(mon.coefficient).toBe(alakalbar.coefficient * rank)
   })
 })

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -176,7 +176,7 @@ describe('rarity 100 coefficient update', () => {
     await nextTick()
     const rank = zone.getZoneRank('bois-de-bouffon')
     expect(mon.rarity).toBe(100)
-    expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
   })
 
   it('recalculates stats when a new zone unlocks', async () => {
@@ -190,13 +190,13 @@ describe('rarity 100 coefficient update', () => {
     applyStats(mon)
     applyCurrentStats(mon)
     await nextTick()
-    expect(mon.base.coefficient).toBe(carapouffe.coefficient * zone.getZoneRank('plaine-kekette'))
+    expect(mon.coefficient).toBe(carapouffe.coefficient * zone.getZoneRank('plaine-kekette'))
     for (let i = 0; i < 4; i++)
       await dex.gainXp(mon, xpForLevel(mon.lvl))
     progress.defeatKing('plaine-kekette')
     await nextTick()
     const rank = zone.getZoneRank('bois-de-bouffon')
-    expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
   })
 
   it('keeps coefficient from level bracket when higher zone unlocks', async () => {
@@ -212,7 +212,7 @@ describe('rarity 100 coefficient update', () => {
     const mon = dex.captureEnemy(enemy)
     await nextTick()
     const rank = zone.getZoneRank('marais-moudugenou')
-    expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
 
     ;[
       'plaine-kekette',
@@ -224,7 +224,7 @@ describe('rarity 100 coefficient update', () => {
     ].forEach(id => progress.defeatKing(id))
     await nextTick()
 
-    expect(mon.base.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
   })
 })
 


### PR DESCRIPTION
## Summary
- keep base stats unchanged by storing dynamic coefficient separately
- compute stats with the new `coefficient` field
- persist coefficient in serializer
- update related unit tests

## Testing
- `pnpm test` *(fails: ENETUNREACH fetch errors and many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68788f86bfac832aa10108174089c74e