### PR TITLE
Adjust legendary coefficient

### DIFF
--- a/src/data/shlagemons/40-45/chetibranle.ts
+++ b/src/data/shlagemons/40-45/chetibranle.ts
@@ -18,7 +18,7 @@ On ne sait jamais vraiment ce qu’il absorbe, ni ce qu’il fait pousser, mais 
       type: 'lvl',
       value: 48,
     },
-  }
+  },
 }
 
 export default chetibranle

--- a/src/data/shlagemons/evolutions/boustiflemme.ts
+++ b/src/data/shlagemons/evolutions/boustiflemme.ts
@@ -5,13 +5,13 @@ import empifouette from './empifouette'
 export const boustiflemme: BaseShlagemon = {
   id: 'boustiflemme',
   name: 'Boustiflemme',
-  description: `Boustiflemme est le Shlagémon ultime du laisser-aller. Doté d’une apathie légendaire, il passe le plus clair de ses journées à s’étaler de tout son long, cherchant l’endroit le plus mou et le moins dérangeant possible. On raconte qu’il a développé un sixième sens pour repérer la moindre parcelle d’ombre ou de confort, n’hésitant jamais à s’y abandonner pour des siestes interminables.
+  description: `Boustiflemme est le Shlagémon ultime du laisser-aller. Doté d'une apathie légendaire, il passe le plus clair de ses journées à s'étaler de tout son long, cherchant l'endroit le plus mou et le moins dérangeant possible. On raconte qu'il a développé un sixième sens pour repérer la moindre parcelle d'ombre ou de confort, n'hésitant jamais à s'y abandonner pour des siestes interminables.
 
-Sa technique signature, *Soupir Universel*, consiste à expirer si fort qu’il peut assommer d’ennui tout adversaire ambitieux. Capable de repousser toute initiative, Boustiflemme préfère attendre que les occasions viennent littéralement à lui, quitte à rater tout le reste.
+Sa technique signature, *Soupir Universel*, consiste à expirer si fort qu'il peut assommer d'ennui tout adversaire ambitieux. Capable de repousser toute initiative, Boustiflemme préfère attendre que les occasions viennent littéralement à lui, quitte à rater tout le reste.
 
-Même la nourriture, il ne la chasse pas : il attend qu’elle lui tombe dessus. On dit que certains Boustiflemme restent plusieurs jours sans bouger, se contentant d’observer le monde d’un regard vide mais profondément satisfait. Sa présence dégage une aura soporifique capable de neutraliser même les plus dynamiques des Shlagémons.
+Même la nourriture, il ne la chasse pas: il attend qu'elle lui tombe dessus. On dit que certains Boustiflemme restent plusieurs jours sans bouger, se contentant d'observer le monde d'un regard vide mais profondément satisfait. Sa présence dégage une aura soporifique capable de neutraliser même les plus dynamiques des Shlagémons.
 
-En résumé, Boustiflemme ne fait jamais rien… et il le fait très bien.`,
+En résumé, Boustiflemme ne fait jamais rien... et il le fait très bien.`,
   types: [shlagemonTypes.normal],
   coefficient: 52,
   evolution: {
@@ -20,7 +20,7 @@ En résumé, Boustiflemme ne fait jamais rien… et il le fait très bien.`,
       type: 'lvl',
       value: 62,
     },
-  }
+  },
 }
 
 export default boustiflemme

--- a/src/data/shlagemons/evolutions/empifouette.ts
+++ b/src/data/shlagemons/evolutions/empifouette.ts
@@ -4,11 +4,11 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const empifouette: BaseShlagemon = {
   id: 'empifouette',
   name: 'Empifouette',
-  description: `Empifouette est un Shlagémon tristement célèbre pour son parfum… inoubliable. Mais ce n’est pas tout : il est aussi doté d’un fouet végétal particulièrement sournois. Sa présence ne passe jamais inaperçue : même les plus téméraires préfèrent garder leurs distances tant son odeur est capable de terrasser un troupeau de Tauros à plusieurs kilomètres.
+  description: `Empifouette est un Shlagémon tristement célèbre pour son parfum… inoubliable. Mais ce n’est pas tout : il est aussi doté d’un fouet végétal particulièrement sournois. Sa présence ne passe jamais inaperçue : même les plus téméraires préfèrent garder leurs distances tant son odeur est capable de terrasser un troupeau de Tauros à plusieurs kilomètres.
 
 Sa technique signature, *Fouet Puant*, consiste à agiter frénétiquement son appendice végétal pour répandre autour de lui un nuage pestilentiel, tout en infligeant des coups bien placés à ceux qui oseraient s’approcher. Les rares Shlagémons à s’être laissés tromper par son attitude nonchalante parlent d’un véritable cauchemar olfactif et tactique.
 
-Empifouette s’en sert aussi comme d’un leurre : attirant l’ennemi avec un faux air pataud, il profite de la confusion (et du désespoir nasal) pour frapper par surprise. Sa réputation de Shlagémon le plus repoussant du coin est solidement ancrée, et on raconte que même les corbeaux n’osent pas s’en approcher après une attaque de ce spécimen.
+Empifouette s’en sert aussi comme d’un leurre : attirant l’ennemi avec un faux air pataud, il profite de la confusion (et du désespoir nasal) pour frapper par surprise. Sa réputation de Shlagémon le plus repoussant du coin est solidement ancrée, et on raconte que même les corbeaux n’osent pas s’en approcher après une attaque de ce spécimen.
 
 Si vous croisez un Empifouette, courez… ou retenez votre souffle, et espérez qu’il n’a pas décidé de sortir le grand jeu.`,
   types: [shlagemonTypes.poison, shlagemonTypes.plante],

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -161,7 +161,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     if (!target)
       return
     const rank = zoneStore.getZoneRank(target.id)
-    const baseCoef = baseMap[mon.base.id].coefficient
+    const baseCoef = mon.lvl + 1
     const newCoef = baseCoef * rank
     mon.coefficient = newCoef
     applyCurrentStats(mon)

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -176,7 +176,7 @@ describe('rarity 100 coefficient update', () => {
     await nextTick()
     const rank = zone.getZoneRank('bois-de-bouffon')
     expect(mon.rarity).toBe(100)
-    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe((mon.lvl + 1) * rank)
   })
 
   it('recalculates stats when a new zone unlocks', async () => {
@@ -190,13 +190,13 @@ describe('rarity 100 coefficient update', () => {
     applyStats(mon)
     applyCurrentStats(mon)
     await nextTick()
-    expect(mon.coefficient).toBe(carapouffe.coefficient * zone.getZoneRank('plaine-kekette'))
+    expect(mon.coefficient).toBe((mon.lvl + 1) * zone.getZoneRank('plaine-kekette'))
     for (let i = 0; i < 4; i++)
       await dex.gainXp(mon, xpForLevel(mon.lvl))
     progress.defeatKing('plaine-kekette')
     await nextTick()
     const rank = zone.getZoneRank('bois-de-bouffon')
-    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe((mon.lvl + 1) * rank)
   })
 
   it('keeps coefficient from level bracket when higher zone unlocks', async () => {
@@ -212,7 +212,7 @@ describe('rarity 100 coefficient update', () => {
     const mon = dex.captureEnemy(enemy)
     await nextTick()
     const rank = zone.getZoneRank('marais-moudugenou')
-    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe((mon.lvl + 1) * rank)
 
     ;[
       'plaine-kekette',
@@ -224,7 +224,7 @@ describe('rarity 100 coefficient update', () => {
     ].forEach(id => progress.defeatKing(id))
     await nextTick()
 
-    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
+    expect(mon.coefficient).toBe((mon.lvl + 1) * rank)
   })
 })
 


### PR DESCRIPTION
## Summary
- boost coefficient of rarity-100 shlagémons dynamically
- expect new coefficient logic in shlagedex tests
- fix lint issues in shlagémon data files

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined; network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878999671e4832ab42bbdef3faf4bb5