### PR TITLE
Add responsive home layout and Schlagedex page

### DIFF
--- a/src/components/layout/HomeFooter.vue
+++ b/src/components/layout/HomeFooter.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <footer class="border-t border-gray-200 bg-gray-100 p-4 text-center text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+    © 2024 Shlagémon. Projet fictif sans lien avec Nintendo.
+  </footer>
+</template>

--- a/src/components/layout/HomeHeader.vue
+++ b/src/components/layout/HomeHeader.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <header class="flex items-center justify-between border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
+    <RouterLink to="/" class="flex items-center gap-2">
+      <img src="/logo.png" alt="Logo Shlagémon" class="h-8 w-auto">
+      <span class="font-bold">Shlagémon</span>
+    </RouterLink>
+    <nav class="hidden gap-4 md:flex">
+      <RouterLink to="/" class="hover:underline">
+        Accueil
+      </RouterLink>
+      <RouterLink to="/schlagedex" class="hover:underline">
+        Shlagédex
+      </RouterLink>
+    </nav>
+    <ThemeToggle />
+  </header>
+</template>

--- a/src/layouts/home.vue
+++ b/src/layouts/home.vue
@@ -1,11 +1,14 @@
+<script setup lang="ts">
+import HomeFooter from '~/components/layout/HomeFooter.vue'
+import HomeHeader from '~/components/layout/HomeHeader.vue'
+</script>
+
 <template>
-  <main
-    px-4 py-10
-    text="center gray-700 dark:gray-200"
-  >
-    <RouterView />
-    <div mx-auto mt-5 text-center text-sm opacity-50>
-      [Home Layout]
-    </div>
-  </main>
+  <div class="min-h-screen flex flex-col">
+    <HomeHeader />
+    <main class="mx-auto max-w-160 w-full flex-1 p-4">
+      <RouterView />
+    </main>
+    <HomeFooter />
+  </div>
 </template>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -2,6 +2,8 @@
 </script>
 
 <route lang="yaml">
+meta:
+  layout: home
 head:
   title: Shlagémon
   meta:
@@ -10,8 +12,14 @@ head:
 </route>
 
 <template>
-  <div class="h-full w-full flex items-center justify-center">
-    <!-- Main content goes here -->
-    <p>Bienvenue dans Shlagémon</p>
+  <div class="mx-auto max-w-160 w-full py-10 text-center">
+    <h1 class="mb-4 text-2xl font-bold">
+      Bienvenue dans Shlagémon
+    </h1>
+    <RouterLink to="/schlagedex">
+      <UiButton type="primary">
+        Voir le Shlagédex
+      </UiButton>
+    </RouterLink>
   </div>
 </template>

--- a/src/pages/schlagedex.vue
+++ b/src/pages/schlagedex.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import PanelShlagedex from '~/components/panel/Shlagedex.vue'
+import UiPanelWrapper from '~/components/ui/PanelWrapper.vue'
+</script>
+
+<route lang="yaml">
+meta:
+  layout: home
+head:
+  title: Shlagédex
+</route>
+
+<template>
+  <div class="mx-auto max-w-160 w-full p-4">
+    <UiPanelWrapper title="Shlagédex" class="overflow-hidden">
+      <PanelShlagedex />
+    </UiPanelWrapper>
+  </div>
+</template>

--- a/src/typed-router.d.ts
+++ b/src/typed-router.d.ts
@@ -21,5 +21,6 @@ declare module 'vue-router/auto-routes' {
     '/': RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>,
     '/player': RouteRecordInfo<'/player', '/player', Record<never, never>, Record<never, never>>,
     '/README': RouteRecordInfo<'/README', '/README', Record<never, never>, Record<never, never>>,
+    '/schlagedex': RouteRecordInfo<'/schlagedex', '/schlagedex', Record<never, never>, Record<never, never>>,
   }
 }


### PR DESCRIPTION
## Summary
- create `HomeHeader` and `HomeFooter` components
- modernize `home` layout with header, footer and responsive container
- update `index.vue` to use the new home layout
- add `/schlagedex` page to display the full Shlagédex
- update typed router definitions

## Testing
- `pnpm lint` *(fails: Irregular whitespace in data files)*
- `pnpm test` *(fails: failing unit tests and network fetch issues)*

------
https://chatgpt.com/codex/tasks/task_e_68789b38e4b0832a95263a5a34cd8a06