### PR TITLE
Add evolution modal link

### DIFF
--- a/src/components/deck/DeckDetail.vue
+++ b/src/components/deck/DeckDetail.vue
@@ -2,6 +2,9 @@
 import type { BaseShlagemon } from '~/type/shlagemon'
 
 const props = defineProps<{ mon: BaseShlagemon | null }>()
+const emit = defineEmits<{
+  (e: 'openMon', mon: BaseShlagemon): void
+}>()
 </script>
 
 <template>
@@ -25,15 +28,17 @@ const props = defineProps<{ mon: BaseShlagemon | null }>()
     </p>
     <div v-if="props.mon.evolution" class="flex flex-col items-center text-sm font-medium">
       <span>Évolution :</span>
-      <span>
-        {{ props.mon.evolution.base.name }}
-        <template v-if="props.mon.evolution.condition.type === 'lvl'">
+      <div class="mt-1 flex items-center gap-1">
+        <UiButton variant="outline" @click="emit('openMon', props.mon.evolution.base)">
+          {{ props.mon.evolution.base.name }}
+        </UiButton>
+        <span v-if="props.mon.evolution.condition.type === 'lvl'">
           - lvl {{ props.mon.evolution.condition.value }}
-        </template>
-        <template v-else>
+        </span>
+        <span v-else>
           - {{ props.mon.evolution.condition.value.name }}
-        </template>
-      </span>
+        </span>
+      </div>
     </div>
   </div>
 </template>

--- a/src/pages/shlagedex.vue
+++ b/src/pages/shlagedex.vue
@@ -24,7 +24,7 @@ head:
   <div class="mx-auto max-w-160 w-full p-4">
     <DeckList :mons="allShlagemons" :on-item-click="open" />
     <Modal v-model="showDetail" footer-close @close="showDetail = false">
-      <DeckDetail :mon="selected" />
+      <DeckDetail :mon="selected" @open-mon="open" />
     </Modal>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- make `DeckDetail` emit an event when clicking on the evolution
- update Schlagedex page to open another mon when the event fires

## Testing
- `pnpm lint`
- `pnpm test` *(fails: cannot fetch fonts; many failing unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_6878f44ac344832abf7fc4907c015f55