### PR TITLE
Remove unused store references from inventory

### DIFF
--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -14,8 +14,6 @@ export const useInventoryStore = defineStore('inventory', () => {
   const items = ref<Record<string, number>>({})
   const game = useGameStore()
   const dex = useShlagedexStore()
-  const _arena = useArenaStore()
-  const _trainerBattle = useTrainerBattleStore()
   const featureLock = useFeatureLockStore()
   const player = usePlayerStore()
   const captureLimitModal = useCaptureLimitModalStore()


### PR DESCRIPTION
## Summary
- clean up inventory store by removing unused arena and trainer battle references

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 29 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878f9349b88832a898a4c4b798ff673