### PR TITLE
Implement equipment reset

### DIFF
--- a/src/stores/equipment.ts
+++ b/src/stores/equipment.ts
@@ -75,7 +75,21 @@ export const useEquipmentStore = defineStore('equipment', () => {
     return holders.value[itemId] || null
   }
 
-  return { holders, equip, unequip, unequipItem, getHolder }
+  function reset() {
+    holders.value = {}
+    for (const mon of dex.shlagemons) {
+      if (mon.heldItemId) {
+        if (mon.heldItemId === 'vitality-ring') {
+          const max = dex.maxHp(mon)
+          if (mon.hpCurrent > max)
+            mon.hpCurrent = max
+        }
+        mon.heldItemId = null
+      }
+    }
+  }
+
+  return { holders, equip, unequip, unequipItem, getHolder, reset }
 }, {
   persist: true,
 })

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -5,6 +5,7 @@ import { useBallStore } from './ball'
 import { useBattleStatsStore } from './battleStats'
 import { useDexFilterStore } from './dexFilter'
 import { useDialogStore } from './dialog'
+import { useEquipmentStore } from './equipment'
 import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
 import { useInventoryStore } from './inventory'
@@ -33,6 +34,7 @@ export const useSaveStore = defineStore('save', () => {
   const mainPanel = useMainPanelStore()
   const player = usePlayerStore()
   const itemUsage = useItemUsageStore()
+  const equipment = useEquipmentStore()
 
   function reset() {
     dex.reset()
@@ -51,6 +53,7 @@ export const useSaveStore = defineStore('save', () => {
     mainPanel.reset()
     player.reset()
     itemUsage.reset()
+    equipment.reset()
   }
 
   return { reset }


### PR DESCRIPTION
## Summary
- add reset functionality to equipment store
- reset held items and health when clearing equipment
- reset equipment state when resetting save data

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 29 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6878fbb039d4832aa2fcd953b6bf62ed