### PR TITLE
Fix Howl serialization issue

### DIFF
--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -1,6 +1,6 @@
 import type { AudioSettings } from '~/type'
 import { Howl } from 'howler'
-import { defineStore } from 'pinia'
+import { defineStore, skipHydrate } from 'pinia'
 
 export const useAudioStore = defineStore('audio', () => {
   const settings = reactive<AudioSettings>({
@@ -152,7 +152,7 @@ export const useAudioStore = defineStore('audio', () => {
     sfxVolume,
     isMusicEnabled,
     isSfxEnabled,
-    currentMusic,
+    currentMusic: import.meta.env.SSR ? skipHydrate(currentMusic) : currentMusic,
     playMusic,
     fadeToMusic,
     playRandomMusic,


### PR DESCRIPTION
## Summary
- avoid serializing `Howl` instance in Pinia state

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot read properties of undefined)*
- `pnpm test:e2e` *(fails: Missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68790eba0e08832a8cba8a135279c0e0