### PR TITLE
Implement disease reset

### DIFF
--- a/src/stores/disease.ts
+++ b/src/stores/disease.ts
@@ -20,6 +20,11 @@ export const useDiseaseStore = defineStore('disease', () => {
     toast(`Votre Shlagémon n'est plus malade !`)
   }
 
+  function reset() {
+    active.value = false
+    remaining.value = 0
+  }
+
   function onBattleEnd() {
     if (active.value) {
       remaining.value -= 1
@@ -33,7 +38,7 @@ export const useDiseaseStore = defineStore('disease', () => {
 
   events.on('battle:end', onBattleEnd)
 
-  return { active, remaining, start }
+  return { active, remaining, start, reset }
 }, {
   persist: true,
 })

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -5,6 +5,7 @@ import { useBallStore } from './ball'
 import { useBattleStatsStore } from './battleStats'
 import { useDexFilterStore } from './dexFilter'
 import { useDialogStore } from './dialog'
+import { useDiseaseStore } from './disease'
 import { useEquipmentStore } from './equipment'
 import { useGameStore } from './game'
 import { useGameStateStore } from './gameState'
@@ -24,6 +25,7 @@ export const useSaveStore = defineStore('save', () => {
   const battleStats = useBattleStatsStore()
   const inventory = useInventoryStore()
   const dialog = useDialogStore()
+  const disease = useDiseaseStore()
   const zone = useZoneStore()
   const zoneProgress = useZoneProgressStore()
   const zoneVisit = useZoneVisitStore()
@@ -41,6 +43,7 @@ export const useSaveStore = defineStore('save', () => {
     gameState.reset()
     game.reset()
     dialog.reset()
+    disease.reset()
     inventory.reset()
     zone.reset()
     zoneVisit.reset()


### PR DESCRIPTION
## Summary
- add reset function to disease store
- expose the reset API
- include disease store in save reset workflow

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68791216b0bc832abb1f6848b4398197