### PR TITLE
Refactor zone access into shared helper

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -338,6 +338,7 @@ declare global {
   const useWindowFocus: typeof import('@vueuse/core')['useWindowFocus']
   const useWindowScroll: typeof import('@vueuse/core')['useWindowScroll']
   const useWindowSize: typeof import('@vueuse/core')['useWindowSize']
+  const useZoneAccess: typeof import('./stores/zoneAccess')['useZoneAccess']
   const useZoneMonsModalStore: typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']
   const useZoneProgressStore: typeof import('./stores/zoneProgress')['useZoneProgressStore']
   const useZoneStore: typeof import('./stores/zone')['useZoneStore']
@@ -734,6 +735,7 @@ declare module 'vue' {
     readonly useWindowFocus: UnwrapRef<typeof import('@vueuse/core')['useWindowFocus']>
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
+    readonly useZoneAccess: UnwrapRef<typeof import('./stores/zoneAccess')['useZoneAccess']>
     readonly useZoneMonsModalStore: UnwrapRef<typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']>
     readonly useZoneProgressStore: UnwrapRef<typeof import('./stores/zoneProgress')['useZoneProgressStore']>
     readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>

--- a/src/stores/zoneAccess.ts
+++ b/src/stores/zoneAccess.ts
@@ -1,0 +1,32 @@
+import type { Ref } from 'vue'
+import type { Zone } from '~/type/zone'
+import { computed, unref } from 'vue'
+import { zonesData } from '~/data/zones'
+import { useZoneProgressStore } from './zoneProgress'
+
+export function useZoneAccess(highestLevel: Ref<number>) {
+  const progress = useZoneProgressStore()
+  const zones = zonesData
+  const xpZones = computed(() => zones.filter(z => z.maxLevel > 0))
+
+  function canAccess(z: Zone) {
+    if (z.type === 'village')
+      return z.minLevel <= unref(highestLevel)
+    const idx = xpZones.value.findIndex(x => x.id === z.id)
+    if (idx === 0)
+      return true
+    const prev = xpZones.value[idx - 1]
+    return progress.isKingDefeated(prev.id)
+  }
+
+  const accessibleZones = computed(() => zones.filter(z => canAccess(z)))
+  const accessibleXpZones = computed(() =>
+    accessibleZones.value.filter(z => z.maxLevel > 0),
+  )
+
+  return {
+    canAccess,
+    accessibleZones,
+    accessibleXpZones,
+  }
+}

--- a/src/stores/zoneVisit.ts
+++ b/src/stores/zoneVisit.ts
@@ -1,28 +1,12 @@
-import type { Zone } from '~/type/zone'
 import { defineStore } from 'pinia'
-import { zonesData } from '~/data/zones'
 import { useShlagedexStore } from './shlagedex'
-import { useZoneProgressStore } from './zoneProgress'
+import { useZoneAccess } from './zoneAccess'
 
 export const useZoneVisitStore = defineStore('zoneVisit', () => {
   const visited = ref<Record<string, boolean>>({})
   const dex = useShlagedexStore()
-  const progress = useZoneProgressStore()
 
-  const zones = zonesData
-  const xpZones = computed(() => zones.filter(z => z.maxLevel > 0))
-
-  function canAccess(z: Zone) {
-    if (z.type === 'village')
-      return z.minLevel <= dex.highestLevel
-    const idx = xpZones.value.findIndex(x => x.id === z.id)
-    if (idx === 0)
-      return true
-    const prev = xpZones.value[idx - 1]
-    return progress.isKingDefeated(prev.id)
-  }
-
-  const accessibleZones = computed(() => zones.filter(z => canAccess(z)))
+  const { accessibleZones } = useZoneAccess(dex.highestLevel)
 
   const hasNewZone = computed(
     () => accessibleZones.value.length > 1


### PR DESCRIPTION
## Summary
- add a `useZoneAccess` helper with zone accessibility logic
- use the new helper in shlagedex and zoneVisit stores
- update auto-import declarations

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch errors and many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687918bce158832abc65def2bf2fddb3