### PR TITLE
Change battle tick speed

### DIFF
--- a/changelog-fr.md
+++ b/changelog-fr.md
@@ -3,6 +3,12 @@
 Toutes les modifications importantes de ce projet seront documentées dans ce fichier.
 Le format s'inspire de [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
+## [0.3.5] - 2025-07-17
+
+### Modifié
+
+- Les combats d'arène s'enchaînent désormais toutes les 250 ms pour plus de rythme.
+
 ## [0.3.4] - 2025-07-06
 
 ### Ajouté

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.7] - 2025-07-17
+
+### Changed
+
+- Arena battles now tick every 250 ms for faster pacing.
+
 ## [0.3.6] - 2025-07-08
 
 ### Changed

--- a/src/components/arena/Duel.vue
+++ b/src/components/arena/Duel.vue
@@ -13,6 +13,7 @@ function onEnd(result: 'win' | 'lose' | 'draw') {
   <BattleRound
     :player="props.player"
     :enemy="props.enemy"
+    :tick-delay="250"
     :click-attack="false"
     :capture-enabled="false"
     :show-xp-bar="false"

--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -14,11 +14,13 @@ const props = withDefaults(defineProps<{
   captureEnabled?: boolean
   showXpBar?: boolean
   showEffects?: boolean
+  tickDelay?: number
 }>(), {
   clickAttack: true,
   captureEnabled: true,
   showXpBar: true,
   showEffects: true,
+  tickDelay: 1000,
 })
 
 const emit = defineEmits<{
@@ -62,6 +64,7 @@ const {
   attack: coreAttack,
 } = useBattleCore({
   createEnemy: () => props.enemy,
+  tickDelay: props.tickDelay,
 })
 
 const showConfetti = ref(false)

--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -6,6 +6,7 @@ import { useBattleEffects } from './battleEngine'
 
 export interface BattleCoreOptions {
   createEnemy: () => DexShlagemon | null
+  tickDelay?: number
 }
 
 export function useBattleCore(options: BattleCoreOptions) {
@@ -34,7 +35,7 @@ export function useBattleCore(options: BattleCoreOptions) {
   const cursorClicked = ref(false)
 
   function startInterval() {
-    battle.startLoop(() => tick(), 1000)
+    battle.startLoop(() => tick(), options.tickDelay ?? 1000)
   }
 
   function stopInterval() {

--- a/test/battle-core.test.ts
+++ b/test/battle-core.test.ts
@@ -9,7 +9,9 @@ function setup() {
   const dex = useShlagedexStore()
   const player = dex.createShlagemon(carapouffe)
   dex.setActiveShlagemon(player)
-  const composable = useBattleCore(() => dex.createShlagemon(carapouffe))
+  const composable = useBattleCore({
+    createEnemy: () => dex.createShlagemon(carapouffe),
+  })
   composable.startBattle()
   return { ...composable, enemy: composable.enemy!, player }
 }


### PR DESCRIPTION
## Summary
- arenas tick every 250ms instead of 1000ms
- keep 1000ms tick rate for other fights

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetching fonts and many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687923ac16c8832a8c7ab5caab0c4227