### PR TITLE
Improve inventory and shop tab visuals

### DIFF
--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { toast } from 'vue3-toastify'
+import { itemCategoryPanelColors, itemCategoryTabColors } from '~/constants/itemCategory'
 import { useBallStore } from '~/stores/ball'
 import { useEvolutionItemStore } from '~/stores/evolutionItem'
 import { useFeatureLockStore } from '~/stores/featureLock'
@@ -31,6 +32,14 @@ const availableCategories = computed(() =>
     inventory.list.some(entry => entry.item.category === opt.value),
   ),
 )
+
+const panelBgClass = computed(() =>
+  filter.category !== 'all'
+    ? itemCategoryPanelColors[filter.category]
+    : '',
+)
+
+const tabColors = itemCategoryTabColors
 const filteredList = computed(() => {
   let list = inventory.list.slice()
   if (filter.category !== 'all')
@@ -84,7 +93,7 @@ function onUse(item: Item) {
 </script>
 
 <template>
-  <LayoutScrollablePanel v-if="inventory.list.length">
+  <LayoutScrollablePanel v-if="inventory.list.length" :class="panelBgClass">
     <template #header>
       <UiSortControls
         v-model:sort-by="filter.sortBy"
@@ -96,6 +105,7 @@ function onUse(item: Item) {
         v-if="availableCategories.length > 1"
         v-model="filter.category"
         :options="availableCategories"
+        :colors="tabColors"
         class="w-full"
       />
     </template>

--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { toast } from 'vue3-toastify'
+import { itemCategoryPanelColors, itemCategoryTabColors } from '~/constants/itemCategory'
 import { useAudioStore } from '~/stores/audio'
 import { useGameStore } from '~/stores/game'
 import { useInventoryStore } from '~/stores/inventory'
@@ -23,6 +24,14 @@ const categoryOptions = [
 const availableCategories = computed(() =>
   categoryOptions.filter(opt => shopItems.value.some(i => i.category === opt.value)),
 )
+
+const panelBgClass = computed(() =>
+  filter.category !== 'all'
+    ? itemCategoryPanelColors[filter.category]
+    : '',
+)
+
+const tabColors = itemCategoryTabColors
 const filteredShopItems = computed(() =>
   shopItems.value.filter(item =>
     filter.category === 'all' ? true : item.category === filter.category,
@@ -86,7 +95,7 @@ function closeShop() {
 </script>
 
 <template>
-  <div class="flex flex-1 flex-col gap-1 overflow-hidden p-1" v-bind="$attrs">
+  <div class="flex flex-1 flex-col gap-1 overflow-hidden p-1" :class="panelBgClass" v-bind="$attrs">
     <h2 class="text-center font-bold">
       Boutique
     </h2>
@@ -95,6 +104,7 @@ function closeShop() {
         v-if="availableCategories.length > 1"
         v-model="filter.category"
         :options="availableCategories"
+        :colors="tabColors"
         class="mb-1"
       />
       <ShopItemCard

--- a/src/components/ui/TabBar.vue
+++ b/src/components/ui/TabBar.vue
@@ -2,6 +2,7 @@
 const props = defineProps<{
   modelValue?: string | number
   options: { label: string, value: string | number, icon?: string }[]
+  colors?: Record<string | number, string>
 }>()
 const emit = defineEmits<{ (e: 'update:modelValue', value: string | number): void }>()
 function select(val: string | number) {
@@ -14,8 +15,10 @@ function select(val: string | number) {
     <button
       v-for="opt in props.options"
       :key="opt.value"
-      class="flex flex-1 items-center gap-1 border rounded bg-white px-2 py-1 text-sm dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800"
-      :class="props.modelValue === opt.value ? 'font-bold bg-gray-200 dark:bg-gray-700' : ''"
+      class="flex flex-1 items-center gap-1 border rounded-t bg-white px-2 py-1 text-sm dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800"
+      :class="props.modelValue === opt.value
+        ? ['font-bold border-b-transparent', props.colors?.[opt.value] ?? 'bg-gray-200 dark:bg-gray-700']
+        : ''"
       @click="select(opt.value)"
     >
       <div v-if="opt.icon" :class="opt.icon" />

--- a/src/constants/itemCategory.ts
+++ b/src/constants/itemCategory.ts
@@ -1,0 +1,13 @@
+import type { ItemCategory } from '~/type/item'
+
+export const itemCategoryTabColors: Record<ItemCategory, string> = {
+  actif: 'bg-red-200 dark:bg-red-700',
+  passif: 'bg-green-200 dark:bg-green-700',
+  utilitaire: 'bg-yellow-200 dark:bg-yellow-700',
+}
+
+export const itemCategoryPanelColors: Record<ItemCategory, string> = {
+  actif: 'bg-red-50 dark:bg-red-900/20',
+  passif: 'bg-green-50 dark:bg-green-900/20',
+  utilitaire: 'bg-yellow-50 dark:bg-yellow-900/20',
+}


### PR DESCRIPTION
## Summary
- style TabBar so selected tab has no bottom border
- add color mapping for item categories
- colorize inventory and shop panels by category

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import & other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687925826cf4832aa3a2926f97881a92