### PR TITLE
Update inventory tab colors

### DIFF
--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { toast } from 'vue3-toastify'
-import { itemCategoryPanelColors, itemCategoryTabColors } from '~/constants/itemCategory'
+import {
+  itemCategoryTabBaseColors,
+  itemCategoryTabColors,
+  itemCategoryTabHoverColors,
+} from '~/constants/itemCategory'
 import { useBallStore } from '~/stores/ball'
 import { useEvolutionItemStore } from '~/stores/evolutionItem'
 import { useFeatureLockStore } from '~/stores/featureLock'
@@ -33,13 +37,9 @@ const availableCategories = computed(() =>
   ),
 )
 
-const panelBgClass = computed(() =>
-  filter.category !== 'all'
-    ? itemCategoryPanelColors[filter.category]
-    : '',
-)
-
-const tabColors = itemCategoryTabColors
+const tabColors = itemCategoryTabBaseColors
+const tabHoverColors = itemCategoryTabHoverColors
+const tabActiveColors = itemCategoryTabColors
 const filteredList = computed(() => {
   let list = inventory.list.slice()
   if (filter.category !== 'all')
@@ -93,7 +93,7 @@ function onUse(item: Item) {
 </script>
 
 <template>
-  <LayoutScrollablePanel v-if="inventory.list.length" :class="panelBgClass">
+  <LayoutScrollablePanel v-if="inventory.list.length">
     <template #header>
       <UiSortControls
         v-model:sort-by="filter.sortBy"
@@ -106,6 +106,8 @@ function onUse(item: Item) {
         v-model="filter.category"
         :options="availableCategories"
         :colors="tabColors"
+        :hover-colors="tabHoverColors"
+        :active-colors="tabActiveColors"
         class="w-full"
       />
     </template>

--- a/src/components/ui/TabBar.vue
+++ b/src/components/ui/TabBar.vue
@@ -3,6 +3,8 @@ const props = defineProps<{
   modelValue?: string | number
   options: { label: string, value: string | number, icon?: string }[]
   colors?: Record<string | number, string>
+  hoverColors?: Record<string | number, string>
+  activeColors?: Record<string | number, string>
 }>()
 const emit = defineEmits<{ (e: 'update:modelValue', value: string | number): void }>()
 function select(val: string | number) {
@@ -15,10 +17,10 @@ function select(val: string | number) {
     <button
       v-for="opt in props.options"
       :key="opt.value"
-      class="flex flex-1 items-center gap-1 border rounded-t bg-white px-2 py-1 text-sm dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800"
+      class="flex flex-1 items-center gap-1 border rounded-t px-2 py-1 text-sm"
       :class="props.modelValue === opt.value
-        ? ['font-bold border-b-transparent', props.colors?.[opt.value] ?? 'bg-gray-200 dark:bg-gray-700']
-        : ''"
+        ? ['font-bold border-b-transparent', props.activeColors?.[opt.value] ?? props.colors?.[opt.value] ?? 'bg-gray-200 dark:bg-gray-700']
+        : [props.colors?.[opt.value] ?? 'bg-white dark:bg-gray-900', props.hoverColors?.[opt.value] ?? 'hover:bg-gray-100 dark:hover:bg-gray-800']"
       @click="select(opt.value)"
     >
       <div v-if="opt.icon" :class="opt.icon" />

--- a/src/constants/itemCategory.ts
+++ b/src/constants/itemCategory.ts
@@ -6,6 +6,18 @@ export const itemCategoryTabColors: Record<ItemCategory, string> = {
   utilitaire: 'bg-yellow-200 dark:bg-yellow-700',
 }
 
+export const itemCategoryTabBaseColors: Record<ItemCategory, string> = {
+  actif: 'bg-red-50 dark:bg-red-900/20',
+  passif: 'bg-green-50 dark:bg-green-900/20',
+  utilitaire: 'bg-yellow-50 dark:bg-yellow-900/20',
+}
+
+export const itemCategoryTabHoverColors: Record<ItemCategory, string> = {
+  actif: 'hover:bg-red-200 dark:hover:bg-red-700',
+  passif: 'hover:bg-green-200 dark:hover:bg-green-700',
+  utilitaire: 'hover:bg-yellow-200 dark:hover:bg-yellow-700',
+}
+
 export const itemCategoryPanelColors: Record<ItemCategory, string> = {
   actif: 'bg-red-50 dark:bg-red-900/20',
   passif: 'bg-green-50 dark:bg-green-900/20',


### PR DESCRIPTION
## Summary
- adjust inventory tab colors
- add hover/active props to `UiTabBar`
- use lighter inventory tab base color

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch fonts, many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687929ae4f6c832a986da9f40416965e