### PR TITLE
Add shlagemons from Onix to Lokhlass

### DIFF
--- a/src/data/shlagemons/70-75/krabbyjaccob.ts
+++ b/src/data/shlagemons/70-75/krabbyjaccob.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import krabbolosse from '../evolutions/krabbolosse'
+
+export const krabbyjaccob: BaseShlagemon = {
+  id: 'krabbyjaccob',
+  name: 'Krabbyjaccob',
+  description: `Ce crustacé porte une petite kippa et danse sans arrêt comme dans le vieux film dont il est fan. Entre deux blagues douteuses, il pince tout ce qui traîne pour vérifier si c'est cashèr.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 73,
+  evolution: {
+    base: krabbolosse,
+    condition: { type: 'lvl', value: 79 },
+  },
+}
+
+export default krabbyjaccob

--- a/src/data/shlagemons/70-75/onixtamere.ts
+++ b/src/data/shlagemons/70-75/onixtamere.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const onixtamere: BaseShlagemon = {
+  id: 'onixtamere',
+  name: 'Onixtamere',
+  description: `Onixtamere est un gigantesque serpent de pierre qui se prend pour le roi des beaux-pères. Il parade au milieu des canyons en vantant ses conquêtes de mamans comme d’autres collectionnent les cailloux. Son corps segmenté résonne à chaque mouvement, histoire d’annoncer son arrivée bien avant qu’il ouvre la bouche.`,
+  types: [shlagemonTypes.sol, shlagemonTypes.roche],
+  coefficient: 71,
+}
+
+export default onixtamere

--- a/src/data/shlagemons/70-75/soporifiak.ts
+++ b/src/data/shlagemons/70-75/soporifiak.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import hypsedentaire from '../evolutions/hypsedentaire'
+
+export const soporifiak: BaseShlagemon = {
+  id: 'soporifiak',
+  name: 'Soporifiak',
+  description: `Soporifiak roupille partout où il passe et son postérieur disproportionné lui sert d’oreiller improvisé. Il charme les passants en promettant des siestes miraculeuses avant de s’endormir lui-même en plein milieu de la conversation.`,
+  types: [shlagemonTypes.psy],
+  coefficient: 72,
+  evolution: {
+    base: hypsedentaire,
+    condition: { type: 'lvl', value: 78 },
+  },
+}
+
+export default soporifiak

--- a/src/data/shlagemons/70-75/voltamere.ts
+++ b/src/data/shlagemons/70-75/voltamere.ts
@@ -1,0 +1,18 @@
+import type { BaseShlagemon } from '~/type'
+import { thunderStone } from '~/data/items/items'
+import { shlagemonTypes } from '../../shlagemons-type'
+import electrobeauf from '../evolutions/electrobeauf'
+
+export const voltamere: BaseShlagemon = {
+  id: 'voltamere',
+  name: 'Voltamère',
+  description: `Voltamère ressemble à une vieille daronne déguisée en boule. Il vole tout ce qui brille pour l'empiler dans son sac à main imaginaire. Gare à la décharge statique quand il te fouille les poches !`,
+  types: [shlagemonTypes.electrique],
+  coefficient: 74,
+  evolution: {
+    base: electrobeauf,
+    condition: { type: 'item', value: thunderStone },
+  },
+}
+
+export default voltamere

--- a/src/data/shlagemons/75-80/chignon.ts
+++ b/src/data/shlagemons/75-80/chignon.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const chignon: BaseShlagemon = {
+  id: 'chignon',
+  name: 'Chignon',
+  description: `Toujours tiré à quatre épingles, Chignon se bat avec des attaques de coiffure redoutables. Il lance ses épingles comme des shurikens et s'arrange pour que tout le monde admire sa queue-de-cheval.`,
+  types: [shlagemonTypes.combat],
+  coefficient: 79,
+}
+
+export default chignon

--- a/src/data/shlagemons/75-80/dentlait.ts
+++ b/src/data/shlagemons/75-80/dentlait.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import hosoltueur from '../evolutions/hosoltueur'
+
+export const dentlait: BaseShlagemon = {
+  id: 'dentlait',
+  name: 'Dentlait',
+  description: `Dentlait n'a qu'une seule dent qui menace de tomber à tout moment. Il la protège jalousement et mord tout ce qui passe pour prouver qu'elle tient encore en place.`,
+  types: [shlagemonTypes.sol],
+  coefficient: 77,
+  evolution: {
+    base: hosoltueur,
+    condition: { type: 'lvl', value: 83 },
+  },
+}
+
+export default dentlait

--- a/src/data/shlagemons/75-80/huithuit.ts
+++ b/src/data/shlagemons/75-80/huithuit.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import noadcajou from '../evolutions/noadcajou'
+
+export const huithuit: BaseShlagemon = {
+  id: 'huithuit',
+  name: 'Huithuit',
+  description: `Formé de deux chiffres huit tout collés, Huithuit adore faire des blagues sur les œufs. Il se dandine maladroitement et déclenche parfois des visions psychédéliques chez ceux qui le regardent trop longtemps.`,
+  types: [shlagemonTypes.plante, shlagemonTypes.psy],
+  coefficient: 76,
+  evolution: {
+    base: noadcajou,
+    condition: { type: 'lvl', value: 82 },
+  },
+}
+
+export default huithuit

--- a/src/data/shlagemons/75-80/kistlee.ts
+++ b/src/data/shlagemons/75-80/kistlee.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const kistlee: BaseShlagemon = {
+  id: 'kistlee',
+  name: 'Kistlee',
+  description: `Kistlee possède un énorme kyste qui sert autant d'arme que de chaise. Il frappe ses ennemis à coups de pied tout en se plaignant que ça tire un peu.`,
+  types: [shlagemonTypes.combat],
+  coefficient: 78,
+}
+
+export default kistlee

--- a/src/data/shlagemons/80-85/languedepute.ts
+++ b/src/data/shlagemons/80-85/languedepute.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const languedepute: BaseShlagemon = {
+  id: 'languedepute',
+  name: 'Languedepute',
+  description: `Sa langue interminable traîne partout et sert principalement à médire. Il aime critiquer ses adversaires jusqu'à ce qu'ils abandonnent par lassitude.`,
+  types: [shlagemonTypes.normal],
+  coefficient: 81,
+}
+
+export default languedepute

--- a/src/data/shlagemons/80-85/lecocu.ts
+++ b/src/data/shlagemons/80-85/lecocu.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const lecocu: BaseShlagemon = {
+  id: 'lecocu',
+  name: 'Lecocu',
+  description: `Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.`,
+  types: [shlagemonTypes.normal],
+  coefficient: 84,
+}
+
+export default lecocu

--- a/src/data/shlagemons/80-85/rhinofaringite.ts
+++ b/src/data/shlagemons/80-85/rhinofaringite.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import rhinoplastie from '../evolutions/rhinoplastie'
+
+export const rhinofaringite: BaseShlagemon = {
+  id: 'rhinofaringite',
+  name: 'Rhinofaringite',
+  description: `Ce rhinocéros enrhumé éternue des rochers sur ses ennemis. Son nez coule en permanence, ce qui le rend aussi glissant qu'imprévisible.`,
+  types: [shlagemonTypes.sol, shlagemonTypes.roche],
+  coefficient: 83,
+  evolution: {
+    base: rhinoplastie,
+    condition: { type: 'lvl', value: 89 },
+  },
+}
+
+export default rhinofaringite

--- a/src/data/shlagemons/80-85/smongol.ts
+++ b/src/data/shlagemons/80-85/smongol.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import smongogol from '../evolutions/smongogol'
+
+export const smongol: BaseShlagemon = {
+  id: 'smongol',
+  name: 'Smongol',
+  description: `Smongol flotte dans une brume toxique et regarde le vide d'un air hébété. Il ne comprend pas grand-chose, mais il adore exploser quand on le secoue trop.`,
+  types: [shlagemonTypes.poison],
+  coefficient: 82,
+  evolution: {
+    base: smongogol,
+    condition: { type: 'lvl', value: 88 },
+  },
+}
+
+export default smongol

--- a/src/data/shlagemons/85-90/hypotrompe.ts
+++ b/src/data/shlagemons/85-90/hypotrompe.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import hyporuisseau from '../evolutions/hyporuisseau'
+
+export const hypotrompe: BaseShlagemon = {
+  id: 'hypotrompe',
+  name: 'Hypotrompe',
+  description: `Petit hippocampe distrait, Hypotrompe se trompe constamment de direction. Sa trompe démesurée lui sert à aspirer tout ce qui passe, y compris des objets qui n'auraient jamais dû finir dans un estomac.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 87,
+  evolution: {
+    base: hyporuisseau,
+    condition: { type: 'lvl', value: 92 },
+  },
+}
+
+export default hypotrompe

--- a/src/data/shlagemons/85-90/kandurex.ts
+++ b/src/data/shlagemons/85-90/kandurex.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const kandurex: BaseShlagemon = {
+  id: 'kandurex',
+  name: 'Kandurex',
+  description: `Toujours équipé de préservatifs fluo, Kandurex vante ses prouesses au lit à qui veut l'entendre. Il distribue des conseils douteux sur la reproduction entre deux uppercuts.`,
+  types: [shlagemonTypes.normal],
+  coefficient: 86,
+}
+
+export default kandurex

--- a/src/data/shlagemons/85-90/poissocisse.ts
+++ b/src/data/shlagemons/85-90/poissocisse.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import poissomerguez from '../evolutions/poissomerguez'
+
+export const poissocisse: BaseShlagemon = {
+  id: 'poissocisse',
+  name: 'Poissocisse',
+  description: `Poissocisse se nourrit exclusivement de saucisses. Son odeur charcutière attire chiens et dresseurs affamés, ce qui le rend paradoxalement difficile à pêcher.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 88,
+  evolution: {
+    base: poissomerguez,
+    condition: { type: 'lvl', value: 94 },
+  },
+}
+
+export default poissocisse

--- a/src/data/shlagemons/85-90/strabisme.ts
+++ b/src/data/shlagemons/85-90/strabisme.ts
@@ -1,0 +1,18 @@
+import type { BaseShlagemon } from '~/type'
+import { thunderStone } from '~/data/items/items'
+import { shlagemonTypes } from '../../shlagemons-type'
+import stabiscarosse from '../evolutions/stabiscarosse'
+
+export const strabisme: BaseShlagemon = {
+  id: 'strabisme',
+  name: 'Strabisme',
+  description: `Ses yeux partent chacun dans une direction différente, ce qui déstabilise ses adversaires. Il brille d'une lueur aquatique quand on lui parle de vacances au bord de la mer.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 89,
+  evolution: {
+    base: stabiscarosse,
+    condition: { type: 'item', value: thunderStone },
+  },
+}
+
+export default strabisme

--- a/src/data/shlagemons/90-95/elektektonik.ts
+++ b/src/data/shlagemons/90-95/elektektonik.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const elektektonik: BaseShlagemon = {
+  id: 'elektektonik',
+  name: 'Elektektonik',
+  description: `Toujours en train de danser la tecktonik, il électrise l'air autour de lui. Ses mouvements saccadés déclenchent de petites décharges qui font sauter les plombs partout où il passe.`,
+  types: [shlagemonTypes.electrique],
+  coefficient: 94,
+}
+
+export default elektektonik

--- a/src/data/shlagemons/90-95/insinerateur.ts
+++ b/src/data/shlagemons/90-95/insinerateur.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const insinerateur: BaseShlagemon = {
+  id: 'insinerateur',
+  name: 'Insinérateur',
+  description: `Armé de lames insectes, il a surtout envie de mettre le feu à tout ce qui bouge. Sa passion pour la combustion le rend particulièrement dangereux dans les forêts.`,
+  types: [shlagemonTypes.insecte],
+  coefficient: 92,
+}
+
+export default insinerateur

--- a/src/data/shlagemons/90-95/lipposucsion.ts
+++ b/src/data/shlagemons/90-95/lipposucsion.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const lipposucsion: BaseShlagemon = {
+  id: 'lipposucsion',
+  name: 'Lipposucsion',
+  description: `Après une liposuccion ratée, ce Shlagémon a la peau toute fripée et un tempérament glacial. Il embrasse ses ennemis pour les geler sur place avant de se plaindre de ses kilos en trop.`,
+  types: [shlagemonTypes.glace, shlagemonTypes.psy],
+  coefficient: 93,
+}
+
+export default lipposucsion

--- a/src/data/shlagemons/90-95/m-ventriloque.ts
+++ b/src/data/shlagemons/90-95/m-ventriloque.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const mVentriloque: BaseShlagemon = {
+  id: 'm-ventriloque',
+  name: 'M. Ventriloque',
+  description: `C'est le sosie raté d'un célèbre humoriste et il passe son temps à discuter avec sa propre main. Ses tours de ventriloquie mettent mal à l'aise plus qu'ils ne font rire.`,
+  types: [shlagemonTypes.psy],
+  coefficient: 91,
+}
+
+export default mVentriloque

--- a/src/data/shlagemons/95-100/lokhlash.ts
+++ b/src/data/shlagemons/95-100/lokhlash.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const lokhlash: BaseShlagemon = {
+  id: 'lokhlash',
+  name: 'Lokhlash',
+  description: `Lokhlash adore participer à des battles de rap improvisées sur son dos. Il navigue de scène en scène, lâchant des punchlines glaciales qui font frissonner l'auditoire.`,
+  types: [shlagemonTypes.eau, shlagemonTypes.glace],
+  coefficient: 100,
+}
+
+export default lokhlash

--- a/src/data/shlagemons/95-100/magmaretfred.ts
+++ b/src/data/shlagemons/95-100/magmaretfred.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const magmaretfred: BaseShlagemon = {
+  id: 'magmaretfred',
+  name: 'Magmaretfred',
+  description: `Toujours en duo imaginaire avec son compère absent, Magmaretfred crache des flammes en récitant des blagues douteuses. Il chauffe l'ambiance mais finit souvent seul sur scène.`,
+  types: [shlagemonTypes.feu],
+  coefficient: 96,
+}
+
+export default magmaretfred

--- a/src/data/shlagemons/95-100/marginal.ts
+++ b/src/data/shlagemons/95-100/marginal.ts
@@ -1,0 +1,17 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+import leviaraison from '../evolutions/leviaraison'
+
+export const marginal: BaseShlagemon = {
+  id: 'marginal',
+  name: 'Marginal',
+  description: `Marginal passe son temps à jongler sur une corde raide tout en jouant du diabolo. Il fait la manche dans les ports en espérant qu'on lui lance autre chose que des tomates.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 99,
+  evolution: {
+    base: leviaraison,
+    condition: { type: 'lvl', value: 100 },
+  },
+}
+
+export default marginal

--- a/src/data/shlagemons/95-100/scarapute.ts
+++ b/src/data/shlagemons/95-100/scarapute.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const scarapute: BaseShlagemon = {
+  id: 'scarapute',
+  name: 'Scarapute',
+  description: `Cet insecte adore sucer le sang des voyageurs imprudents. On le voit souvent roder près des campings à la recherche d'un mollet juteux.`,
+  types: [shlagemonTypes.insecte],
+  coefficient: 97,
+}
+
+export default scarapute

--- a/src/data/shlagemons/95-100/taurus.ts
+++ b/src/data/shlagemons/95-100/taurus.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const taurus: BaseShlagemon = {
+  id: 'taurus',
+  name: 'Taurus',
+  description: `Taurus est littéralement un taureau géométrique. Ses angles parfaits le rendent difficile à approcher sans se prendre une arrête dans les côtes.`,
+  types: [shlagemonTypes.normal],
+  coefficient: 98,
+}
+
+export default taurus

--- a/src/data/shlagemons/evolutions/electrobeauf.ts
+++ b/src/data/shlagemons/evolutions/electrobeauf.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const electrobeauf: BaseShlagemon = {
+  id: 'electrobeauf',
+  name: 'Électrobeauf',
+  description: `DJ de soirée miteuse, Électrobeauf fait exploser les watts et les tympans à coups de beats ringards. Il se prend pour la star des discothèques de camping.`,
+  types: [shlagemonTypes.electrique],
+  coefficient: 83,
+}
+
+export default electrobeauf

--- a/src/data/shlagemons/evolutions/hosoltueur.ts
+++ b/src/data/shlagemons/evolutions/hosoltueur.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const hosoltueur: BaseShlagemon = {
+  id: 'hosoltueur',
+  name: 'Hosoltueur',
+  description: `Armé d'un os gigantesque, Hosoltueur règle ses comptes en une seule frappe. Il garde pourtant un air mélancolique en pensant à son enfance perdue.`,
+  types: [shlagemonTypes.sol],
+  coefficient: 85,
+}
+
+export default hosoltueur

--- a/src/data/shlagemons/evolutions/hyporuisseau.ts
+++ b/src/data/shlagemons/evolutions/hyporuisseau.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const hyporuisseau: BaseShlagemon = {
+  id: 'hyporuisseau',
+  name: 'Hyporuisseau',
+  description: `Hyporuisseau ne nage que dans les petits ruisseaux par peur des grandes eaux. Son courage grandit à mesure que le débit augmente, mais pas trop quand même.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 92,
+}
+
+export default hyporuisseau

--- a/src/data/shlagemons/evolutions/hypsedentaire.ts
+++ b/src/data/shlagemons/evolutions/hypsedentaire.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const hypsedentaire: BaseShlagemon = {
+  id: 'hypsedentaire',
+  name: 'Hypsedentaire',
+  description: `Hypsedentaire a développé un pouvoir hypnotique tellement fort qu'il préfère rester affalé chez lui. Il endort ses ennemis à distance pour ne jamais avoir à se lever.`,
+  types: [shlagemonTypes.psy],
+  coefficient: 80,
+}
+
+export default hypsedentaire

--- a/src/data/shlagemons/evolutions/krabbolosse.ts
+++ b/src/data/shlagemons/evolutions/krabbolosse.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const krabbolosse: BaseShlagemon = {
+  id: 'krabbolosse',
+  name: 'Krabbolosse',
+  description: `Krabbolosse est un crabe massif mais un peu benêt. Il écrase tout sur son passage en bredouillant des prières en vieux dialecte.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 82,
+}
+
+export default krabbolosse

--- a/src/data/shlagemons/evolutions/leviaraison.ts
+++ b/src/data/shlagemons/evolutions/leviaraison.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const leviaraison: BaseShlagemon = {
+  id: 'leviaraison',
+  name: 'Léviaraison',
+  description: `Toujours persuadé d'avoir raison, ce serpent de mer géant fulmine dès qu'on le contredit. Ses colères déclenchent des tempêtes monumentales.`,
+  types: [shlagemonTypes.eau, shlagemonTypes.vol],
+  coefficient: 101,
+}
+
+export default leviaraison

--- a/src/data/shlagemons/evolutions/noadcajou.ts
+++ b/src/data/shlagemons/evolutions/noadcajou.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const noadcajou: BaseShlagemon = {
+  id: 'noadcajou',
+  name: 'Noadcajou',
+  description: `Cet arbre sur pattes produit des noix de cajou grillées à chaque attaque. Il préfère le climat tropical et se moque des régimes alimentaires de ses adversaires.`,
+  types: [shlagemonTypes.plante, shlagemonTypes.psy],
+  coefficient: 84,
+}
+
+export default noadcajou

--- a/src/data/shlagemons/evolutions/poissomerguez.ts
+++ b/src/data/shlagemons/evolutions/poissomerguez.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const poissomerguez: BaseShlagemon = {
+  id: 'poissomerguez',
+  name: 'Poissomerguez',
+  description: `Poissomerguez dégage une forte odeur de barbecue. Il fait frire l'eau autour de lui et provoque des fringales incontrôlables chez ses adversaires.`,
+  types: [shlagemonTypes.eau],
+  coefficient: 93,
+}
+
+export default poissomerguez

--- a/src/data/shlagemons/evolutions/rhinoplastie.ts
+++ b/src/data/shlagemons/evolutions/rhinoplastie.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const rhinoplastie: BaseShlagemon = {
+  id: 'rhinoplastie',
+  name: 'Rhinoplastie',
+  description: `Après une chirurgie esthétique ratée, Rhinoplastie a la face entièrement remodelée. Il fait peur à tout le monde mais se trouve magnifique.`,
+  types: [shlagemonTypes.sol, shlagemonTypes.roche],
+  coefficient: 91,
+}
+
+export default rhinoplastie

--- a/src/data/shlagemons/evolutions/smongogol.ts
+++ b/src/data/shlagemons/evolutions/smongogol.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const smongogol: BaseShlagemon = {
+  id: 'smongogol',
+  name: 'Smongogol',
+  description: `Toujours plus imbécile et plus toxique que Smongol, Smongogol libère un nuage épais qui empeste la débilité. On le confond souvent avec un vieux pneu en feu.`,
+  types: [shlagemonTypes.poison],
+  coefficient: 90,
+}
+
+export default smongogol

--- a/src/data/shlagemons/evolutions/stabiscarosse.ts
+++ b/src/data/shlagemons/evolutions/stabiscarosse.ts
@@ -1,0 +1,12 @@
+import type { BaseShlagemon } from '~/type'
+import { shlagemonTypes } from '../../shlagemons-type'
+
+export const stabiscarosse: BaseShlagemon = {
+  id: 'stabiscarosse',
+  name: 'Stabiscarosse',
+  description: `Parti s'installer à Biscarrosse pour profiter des vagues, ce Shlagémon se pavane désormais avec une planche de surf sous chaque bras.`,
+  types: [shlagemonTypes.eau, shlagemonTypes.psy],
+  coefficient: 94,
+}
+
+export default stabiscarosse


### PR DESCRIPTION
## Summary
- add new level folders 70-75 to 90-95
- create shlagemons from Onixtamere to Lokhlash
- include evolutions like Hypsedentaire and Léviaraison

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Zone catacombes-merdifientes not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879284bf1d4832ab93d0fc6275afcf6