### PR TITLE
Fix duplicate exports in itemCategory constants

### DIFF
--- a/src/constants/itemCategory.ts
+++ b/src/constants/itemCategory.ts
@@ -18,18 +18,6 @@ export const itemCategoryTabHoverColors: Record<ItemCategory, string> = {
   utilitaire: 'hover:bg-yellow-200 dark:hover:bg-yellow-700',
 }
 
-export const itemCategoryTabBaseColors: Record<ItemCategory, string> = {
-  actif: 'bg-red-50 dark:bg-red-900/20',
-  passif: 'bg-green-50 dark:bg-green-900/20',
-  utilitaire: 'bg-yellow-50 dark:bg-yellow-900/20',
-}
-
-export const itemCategoryTabHoverColors: Record<ItemCategory, string> = {
-  actif: 'hover:bg-red-200 dark:hover:bg-red-700',
-  passif: 'hover:bg-green-200 dark:hover:bg-green-700',
-  utilitaire: 'hover:bg-yellow-200 dark:hover:bg-yellow-700',
-}
-
 export const itemCategoryPanelColors: Record<ItemCategory, string> = {
   actif: 'bg-red-50 dark:bg-red-900/20',
   passif: 'bg-green-50 dark:bg-green-900/20',


### PR DESCRIPTION
## Summary
- remove duplicate color map exports in `itemCategory.ts`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots and many store tests)*

------
https://chatgpt.com/codex/tasks/task_e_6879366470fc832a9438dce94e1c779e