### PR TITLE
Introduce typed item ids

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -379,8 +379,8 @@ declare global {
   export type { ArenaResult } from './stores/arena'
   import('./stores/arena')
   // @ts-ignore
-  export type { BallId } from './stores/ball'
-  import('./stores/ball')
+  export type { BallId } from './data/items/shlageball'
+  import('./data/items/shlageball')
   // @ts-ignore
   export type { AttackResult } from './stores/battle'
   import('./stores/battle')

--- a/src/components/ball/SelectionModal.vue
+++ b/src/components/ball/SelectionModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { BallId } from '~/data/items/shlageball'
 import { balls } from '~/data/items/shlageball'
 import { useBallStore } from '~/stores/ball'
 import { useInventoryStore } from '~/stores/inventory'
@@ -11,8 +12,8 @@ const options = computed(() =>
   balls.map(b => ({ ...b, qty: inventory.items[b.id] || 0 })),
 )
 
-function choose(id: string) {
-  ballStore.setBall(id as any)
+function choose(id: BallId) {
+  ballStore.setBall(id)
 }
 </script>
 

--- a/src/components/inventory/ItemShortcutModal.vue
+++ b/src/components/inventory/ItemShortcutModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ItemId } from '~/data/items/items'
 import UiKeyCapture from '~/components/ui/KeyCapture.vue'
 import { useItemShortcutModalStore } from '~/stores/itemShortcutModal'
 import { useShortcutsStore } from '~/stores/shortcuts'
@@ -15,7 +16,7 @@ watch(() => modal.isVisible, (visible) => {
 function assign(key: string) {
   if (!modal.current)
     return
-  shortcuts.setItemShortcut(modal.current.id, key)
+  shortcuts.setItemShortcut(modal.current.id as ItemId, key)
   modal.close()
 }
 </script>

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { BallId } from '~/data/items/shlageball'
 import type { Item } from '~/type/item'
 import { toast } from 'vue3-toastify'
 import {
@@ -75,7 +76,7 @@ function onUse(item: Item) {
   if (featureLock.isInventoryLocked)
     return
   if ('catchBonus' in item) {
-    ballStore.setBall(item.id as any)
+    ballStore.setBall(item.id as BallId)
     usage.markUsed(item.id)
     toast(`Vous avez équipé la ${item.name}`)
   }

--- a/src/components/settings/ShortcutsTab.vue
+++ b/src/components/settings/ShortcutsTab.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ItemId } from '~/data/items/items'
 import { allItems } from '~/data/items/items'
 import { useShortcutsStore } from '~/stores/shortcuts'
 
@@ -11,7 +12,7 @@ function updateKey(index: number, key: string) {
   store.update(index, entry)
 }
 
-function updateItem(index: number, itemId: string) {
+function updateItem(index: number, itemId: ItemId) {
   const entry = { key: store.shortcuts[index].key, action: { type: 'use-item', itemId } }
   store.update(index, entry)
 }
@@ -42,7 +43,7 @@ function reset() {
         class="flex-1"
         :model-value="sc.action.type === 'use-item' ? sc.action.itemId : ''"
         :options="itemOptions"
-        @update:model-value="val => updateItem(idx, val as string)"
+        @update:model-value="val => updateItem(idx, val as ItemId)"
       />
       <UiButton type="icon" class="h-7 w-7" @click="removeShortcut(idx)">
         <div i-carbon-close />

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -301,7 +301,7 @@ export const ultraSteroid: Item = {
   iconClass: 'text-purple-500 dark:text-purple-300',
 }
 
-export const allItems: Item[] = [
+export const allItems = [
   shlageball,
   superShlageball,
   hyperShlageball,
@@ -329,4 +329,6 @@ export const allItems: Item[] = [
   thunderStone,
   steroids,
   ultraSteroid,
-]
+] as const satisfies Item[]
+
+export type ItemId = typeof allItems[number]['id']

--- a/src/data/items/shlageball.ts
+++ b/src/data/items/shlageball.ts
@@ -42,4 +42,10 @@ export const hyperShlageball: Ball = {
   animation: '/items/shlageball/shlageball.png',
 }
 
-export const balls: Ball[] = [shlageball, superShlageball, hyperShlageball]
+export const balls = [
+  shlageball,
+  superShlageball,
+  hyperShlageball,
+] as const satisfies Ball[]
+
+export type BallId = typeof balls[number]['id']

--- a/src/stores/ball.ts
+++ b/src/stores/ball.ts
@@ -1,7 +1,6 @@
+import type { BallId } from '~/data/items/shlageball'
 import { defineStore } from 'pinia'
 import { balls } from '~/data/items/shlageball'
-
-export type BallId = 'shlageball' | 'super-shlageball' | 'hyper-shlageball'
 
 export const useBallStore = defineStore('ball', () => {
   const current = ref<BallId>('shlageball')

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -1,3 +1,4 @@
+import type { ItemId } from '~/data/items/items'
 import type { Item } from '~/type/item'
 import { defineStore } from 'pinia'
 import { allItems } from '~/data/items/items'
@@ -11,7 +12,7 @@ import { usePlayerStore } from './player'
 import { useShlagedexStore } from './shlagedex'
 
 export const useInventoryStore = defineStore('inventory', () => {
-  const items = ref<Record<string, number>>({})
+  const items = ref<Partial<Record<ItemId, number>>>({})
   const game = useGameStore()
   const dex = useShlagedexStore()
   const featureLock = useFeatureLockStore()
@@ -26,18 +27,18 @@ export const useInventoryStore = defineStore('inventory', () => {
 
   const list = computed(() =>
     Object.entries(items.value).reduce<ListedItem[]>((acc, [id, qty]) => {
-      const item = allItems.find(i => i.id === id)
+      const item = allItems.find(i => i.id === id as ItemId)
       if (item)
         acc.push({ item, qty })
       return acc
     }, []),
   )
 
-  function add(id: string, qty = 1) {
+  function add(id: ItemId, qty = 1) {
     items.value[id] = (items.value[id] || 0) + qty
   }
 
-  function remove(id: string, qty = 1) {
+  function remove(id: ItemId, qty = 1) {
     if (!items.value[id])
       return
     items.value[id] -= qty
@@ -45,7 +46,7 @@ export const useInventoryStore = defineStore('inventory', () => {
       delete items.value[id]
   }
 
-  function buy(id: string, qty = 1) {
+  function buy(id: ItemId, qty = 1) {
     const item = allItems.find(i => i.id === id)
     if (!item)
       return false
@@ -66,7 +67,7 @@ export const useInventoryStore = defineStore('inventory', () => {
     return true
   }
 
-  function sell(id: string) {
+  function sell(id: ItemId) {
     const item = allItems.find(i => i.id === id)
     if (!item || !items.value[id])
       return
@@ -74,7 +75,7 @@ export const useInventoryStore = defineStore('inventory', () => {
     game.addShlagidolar(Math.floor(item.price / 2))
   }
 
-  function useItem(id: string) {
+  function useItem(id: ItemId) {
     if (featureLock.isInventoryLocked || !items.value[id])
       return false
 
@@ -98,7 +99,7 @@ export const useInventoryStore = defineStore('inventory', () => {
       return true
     }
 
-    const handlers: Record<string, () => boolean> = {
+    const handlers: Record<ItemId, () => boolean> = {
       'potion': () => {
         dex.healActive(50)
         remove(id)

--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -1,3 +1,5 @@
+import type { ItemId } from '~/data/items/items'
+import type { BallId } from '~/data/items/shlageball'
 import { defineStore } from 'pinia'
 import { allItems } from '~/data/items/items'
 import { useBallStore } from './ball'
@@ -9,7 +11,7 @@ import { useWearableItemStore } from './wearableItem'
 
 export interface UseItemAction {
   type: 'use-item'
-  itemId: string
+  itemId: ItemId
 }
 
 export type ShortcutAction = UseItemAction
@@ -46,7 +48,7 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
     shortcuts.value = [...defaultShortcuts]
   }
 
-  function setItemShortcut(itemId: string, key: string) {
+  function setItemShortcut(itemId: ItemId, key: string) {
     const idx = shortcuts.value.findIndex(s => s.action.type === 'use-item' && s.action.itemId === itemId)
     const entry: ShortcutEntry = { key, action: { type: 'use-item', itemId } }
     if (idx >= 0)
@@ -73,7 +75,7 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
           continue
 
         if ('catchBonus' in item) {
-          useBallStore().setBall(item.id as any)
+          useBallStore().setBall(item.id as BallId)
           usage.markUsed(item.id)
         }
         else if (item.type === 'evolution') {

--- a/src/utils/ball.ts
+++ b/src/utils/ball.ts
@@ -1,4 +1,6 @@
-export const ballHues: Record<string, string> = {
+import type { BallId } from '~/data/items/shlageball'
+
+export const ballHues: Record<BallId, string> = {
   'shlageball': '0deg',
   'super-shlageball': '120deg',
   'hyper-shlageball': '240deg',


### PR DESCRIPTION
## Summary
- keep literal `id` values when defining balls and items
- expose `BallId` and `ItemId` from data modules
- use these unions in stores and components
- type ball hue map with new `BallId`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: src/utils/shlagedex-serialize.ts:90:11 - Type 'BaseShlagemon' is not assignable to type 'undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68795f270848832ab3abe19f06a34d40