### PR TITLE
Allow lazy arena definitions

### DIFF
--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -48,7 +48,7 @@ function createArena(config: ArenaConfig): Arena {
     get lineup() {
       return generateArenaLineup(config.zoneId)
     },
-  } as unknown as Arena
+  }
 }
 
 export const arena20: Arena = createArena({

--- a/src/data/zones/villages.ts
+++ b/src/data/zones/villages.ts
@@ -45,7 +45,7 @@ const village20: Zone = {
   arena: {
     get arena() { return arena20 },
     completed: false,
-  } as unknown as Zone['arena'],
+  },
   village: {
     shop: {
       items: [
@@ -68,7 +68,7 @@ const village40: Zone = {
   arena: {
     get arena() { return arena40 },
     completed: false,
-  } as unknown as Zone['arena'],
+  },
   village: {
     shop: {
       items: [
@@ -110,7 +110,7 @@ const village60: Zone = {
   arena: {
     get arena() { return arena60 },
     completed: false,
-  } as unknown as Zone['arena'],
+  },
   village: {
     shop: {
       items: [

--- a/src/stores/arena.ts
+++ b/src/stores/arena.ts
@@ -21,7 +21,8 @@ export const useArenaStore = defineStore('arena', () => {
 
   function setArena(arena: Arena) {
     arenaData.value = arena
-    setLineup(arena.lineup)
+    const data = typeof arena.lineup === 'function' ? arena.lineup() : arena.lineup
+    setLineup(data)
   }
 
   function selectPlayer(index: number, id: string | null) {

--- a/src/type/arena.ts
+++ b/src/type/arena.ts
@@ -8,10 +8,12 @@ export interface ArenaBadge {
   image?: string
 }
 
+export type LineupFactory = () => BaseShlagemon[]
+
 export interface Arena {
   id: string
   badge: ArenaBadge
   character: Character
-  lineup: BaseShlagemon[]
+  readonly lineup: BaseShlagemon[] | LineupFactory
   level: number
 }

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -9,6 +9,13 @@ export interface ZoneAction {
   label: string
 }
 
+export type ArenaFactory = () => Arena
+
+export interface ZoneArena {
+  readonly arena: Arena | ArenaFactory
+  completed: boolean
+}
+
 interface BaseZone {
   id: ZoneId
   name: string
@@ -19,10 +26,7 @@ interface BaseZone {
   image?: string
   hasKing?: boolean
   completionAchievement?: string
-  arena?: {
-    arena: Arena
-    completed: boolean
-  }
+  arena?: ZoneArena
   village?: {
     shop?: {
       items: Item[]


### PR DESCRIPTION
## Summary
- update `Zone['arena']` definition to accept a getter or factory
- support lazy `Arena.lineup`
- remove type casts in arena and village data
- handle lineup factory in the arena store

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fonts download error and many failing unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68796ab30908832a8ed2689814bc76fd