### PR TITLE
Improve generic typing for watchers and utils

### DIFF
--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -359,7 +359,8 @@ export const useAchievementsStore = defineStore('achievements', () => {
     { immediate: true },
   )
   watch(level100Count, v => checkThresholds(v, 'lvl100', lvl100Thresholds))
-  watch(
+  // Use explicit tuple typing when watching multiple sources
+  watch<[number, number, number]>(
     [() => dex.potentialCompletionPercent, level100Count, () => dex.shlagemons.length],
     () => {
       if (

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -1,3 +1,4 @@
+import type { ZoneId, ZoneType } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { useArenaStore } from './arena'
 import { useBattleStore } from './battle'
@@ -16,7 +17,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
   const isBattle = computed(() => current.value === 'battle' || current.value === 'trainerBattle')
 
   // Update the panel when the zone changes
-  watch(
+  // Keep watch sources typed with a tuple for clarity
+  watch<[ZoneType, ZoneId]>(
     () => [zone.current.type, zone.current.id],
     ([type]) => {
       current.value = type === 'village' ? 'village' : 'battle'

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -52,6 +52,7 @@ export const useUIStore = defineStore('ui', () => {
     return classes.join(' ')
   })
 
+  // Explicit tuple typing keeps arguments in sync when adding new sources
   watch<[MainPanel, ZoneId, string | undefined, ZoneType, boolean], true>(
     () => [
       mainPanel.current,

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,3 +1,6 @@
-export function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
+/**
+ * Promise-based timeout that optionally resolves with a value.
+ */
+export function delay<T = void>(ms: number, value?: T): Promise<T> {
+  return new Promise(resolve => setTimeout(() => resolve(value as T), ms))
 }

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -1,6 +1,10 @@
 import type { BaseShlagemon } from '~/type'
 
-export function pickRandomByCoefficient(list: BaseShlagemon[]): BaseShlagemon {
+/**
+ * Pick a random Shlagemon based on its coefficient while preserving the
+ * original item type.
+ */
+export function pickRandomByCoefficient<T extends BaseShlagemon>(list: T[]): T {
   const total = list.reduce((sum, mon) => sum + 1 / mon.coefficient, 0)
   const r = Math.random() * total
   let acc = 0
@@ -9,5 +13,6 @@ export function pickRandomByCoefficient(list: BaseShlagemon[]): BaseShlagemon {
     if (r < acc)
       return mon
   }
+  // Fallback should never happen but keeps typing consistent
   return list[list.length - 1]
 }


### PR DESCRIPTION
## Summary
- use tuple generics in mainPanel store watch
- clarify multi-source watch in achievements
- document tuple typing example in ui store
- allow returning values from delay helper
- generic pickRandomByCoefficient utility

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot and network related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68796d982318832a8305bbbeb5f98993