### PR TITLE
Fix enemy stats preview

### DIFF
--- a/src/components/arena/EnemyStats.vue
+++ b/src/components/arena/EnemyStats.vue
@@ -1,42 +1,28 @@
 <script setup lang="ts">
-import type { BaseShlagemon } from '~/type/shlagemon'
-import { useArenaStore } from '~/stores/arena'
-import { createDexShlagemon } from '~/utils/dexFactory'
+import type { DexShlagemon } from '~/type/shlagemon'
+import ShlagemonStats from '~/components/shlagemon/Stats.vue'
 
-const props = defineProps<{ mon: BaseShlagemon }>()
-
-const arena = useArenaStore()
-
-const dexMon = computed(() => {
-  const lvl = arena.arenaData?.level ?? 1
-  const coefficientMultiplier = lvl / props.mon.coefficient
-  return createDexShlagemon(props.mon, false, coefficientMultiplier, lvl)
-})
+const props = defineProps<{ mon: DexShlagemon }>()
 
 const stats = computed(() => [
-  { label: 'HP', value: dexMon.value.hp },
-  { label: 'Attaque', value: dexMon.value.attack },
-  { label: 'Défense', value: dexMon.value.defense },
-  { label: 'Puanteur', value: dexMon.value.smelling },
+  { label: 'HP', value: props.mon.hp },
+  { label: 'Attaque', value: props.mon.attack },
+  { label: 'Défense', value: props.mon.defense },
+  { label: 'Puanteur', value: props.mon.smelling },
 ])
 </script>
 
 <template>
   <div class="flex flex-col items-center gap-2">
     <h3 class="text-center text-lg font-bold">
-      {{ props.mon.name }}
+      {{ props.mon.base.name }}
     </h3>
     <div class="h-24 w-24">
-      <ShlagemonImage :id="props.mon.id" :alt="props.mon.name" class="object-contain" />
+      <ShlagemonImage :id="props.mon.base.id" :alt="props.mon.base.name" class="object-contain" />
     </div>
     <div class="flex gap-1">
-      <ShlagemonType v-for="t in props.mon.types" :key="t.id" :value="t" />
+      <ShlagemonType v-for="t in props.mon.base.types" :key="t.id" :value="t" open-on-click />
     </div>
-    <div class="grid grid-cols-2 gap-2 text-sm">
-      <div v-for="s in stats" :key="s.label" class="flex flex-col items-center">
-        <span class="font-semibold">{{ s.label }}</span>
-        <span>{{ s.value }}</span>
-      </div>
-    </div>
+    <ShlagemonStats :stats="stats" />
   </div>
 </template>

--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
+import type { DexShlagemon } from '~/type/shlagemon'
 import { useArenaStore } from '~/stores/arena'
 import { useFeatureLockStore } from '~/stores/featureLock'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useShlagedexStore } from '~/stores/shlagedex'
 import { cloneDexShlagemon } from '~/utils/clone'
 import { delay } from '~/utils/delay'
-import { applyCurrentStats, applyStats, createDexShlagemon } from '~/utils/dexFactory'
+import { applyCurrentStats, applyStats } from '~/utils/dexFactory'
 
 const dex = useShlagedexStore()
 const arena = useArenaStore()
@@ -15,11 +15,12 @@ const panel = useMainPanelStore()
 const savedActive = ref<DexShlagemon | null>(null)
 
 const enemyTeam = computed(() => arena.lineup)
+const enemyDexTeam = computed(() => arena.lineupDex)
 const showDex = ref(false)
 const activeSlot = ref<number | null>(null)
 const showDuel = ref(false)
 const showEnemy = ref(false)
-const enemyDetail = ref<BaseShlagemon | null>(null)
+const enemyDetail = ref<DexShlagemon | null>(null)
 let nextTimer: number | undefined
 
 async function autoSelect() {
@@ -43,8 +44,8 @@ function openDex(i: number) {
   showDex.value = true
 }
 
-function openEnemy(mon: BaseShlagemon) {
-  enemyDetail.value = mon
+function openEnemy(index: number) {
+  enemyDetail.value = enemyDexTeam.value[index]
   showEnemy.value = true
 }
 
@@ -78,10 +79,10 @@ function startBattle() {
       clone.hpCurrent = clone.hp
       return clone
     })
-  const enemies = enemyTeam.value.map((b) => {
-    const lvl = arena.arenaData?.level ?? 1
-    const coefficientMultiplier = Math.floor(lvl / 2) - 1
-    return createDexShlagemon(b, false, coefficientMultiplier, lvl)
+  const enemies = enemyDexTeam.value.map((m) => {
+    const clone = cloneDexShlagemon(toRaw(m))
+    clone.hpCurrent = clone.hp
+    return clone
   })
   arena.start(team, enemies)
   arena.currentIndex = 0
@@ -126,10 +127,10 @@ onUnmounted(() => {
   <div class="tiny-scrollbar relative h-full flex flex-col items-center overflow-auto">
     <div v-show="!showDuel" class="grid grid-rows-[auto_auto_auto_auto] grid-cols-6 max-w-120 w-full gap-2">
       <button
-        v-for="enemy in enemyTeam"
+        v-for="(enemy, i) in enemyTeam"
         :key="enemy.id"
         class="aspect-square border-red-600 rounded-full bg-red-500/40"
-        @click="openEnemy(enemy)"
+        @click="openEnemy(i)"
       >
         <ShlagemonImage :id="enemy.id" :alt="enemy.name" class="h-full w-full object-contain" />
       </button>

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import ShlagemonStats from '~/components/shlagemon/Stats.vue'
 import { allItems } from '~/data/items/items'
 import { useDiseaseStore } from '~/stores/disease'
 import { useShlagedexStore } from '~/stores/shlagedex'
@@ -11,15 +12,6 @@ const emit = defineEmits<{
   (e: 'release'): void
   (e: 'active'): void
 }>()
-
-const statColors = [
-  'bg-red-200 dark:bg-red-700',
-  'bg-emerald-200 dark:bg-emerald-700',
-  'bg-blue-200 dark:bg-blue-700',
-  'bg-amber-200 dark:bg-amber-700',
-  'bg-violet-200 dark:bg-violet-700',
-  'bg-pink-200 dark:bg-pink-700',
-]
 
 const stats = computed(() => {
   if (!props.mon)
@@ -177,18 +169,7 @@ const captureInfo = computed(() => {
       <p class="tiny-scrollbar max-h-25 overflow-auto text-sm italic">
         {{ mon.base.description }}
       </p>
-      <div class="grid grid-cols-2 gap-2 text-sm">
-        <div
-          v-for="(stat, i) in stats"
-          :key="stat.label"
-          class="flex flex-col items-center rounded p-2 text-gray-900 transition-colors dark:text-white"
-          :class="statColors[i % statColors.length]"
-          hover="opacity-80"
-        >
-          <span class="font-semibold">{{ stat.label }}</span>
-          <span class="text-base">{{ stat.value.toLocaleString() }}</span>
-        </div>
-      </div>
+      <ShlagemonStats :stats="stats" />
       <ShlagemonXpBar :mon="mon" />
       <div class="w-full flex items-center justify-center gap-2 text-xs">
         <p class="">

--- a/src/components/shlagemon/Stats.vue
+++ b/src/components/shlagemon/Stats.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+interface Stat {
+  label: string
+  value: number
+}
+const props = defineProps<{ stats: Stat[] }>()
+
+const statColors = [
+  'bg-red-200 dark:bg-red-700',
+  'bg-emerald-200 dark:bg-emerald-700',
+  'bg-blue-200 dark:bg-blue-700',
+  'bg-amber-200 dark:bg-amber-700',
+  'bg-violet-200 dark:bg-violet-700',
+  'bg-pink-200 dark:bg-pink-700',
+]
+</script>
+
+<template>
+  <div class="grid grid-cols-2 gap-2 text-sm">
+    <div
+      v-for="(stat, i) in props.stats"
+      :key="stat.label"
+      class="flex flex-col items-center rounded p-2 text-gray-900 transition-colors dark:text-white"
+      :class="statColors[i % statColors.length]"
+      hover="opacity-80"
+    >
+      <span class="font-semibold">{{ stat.label }}</span>
+      <span class="text-base">{{ stat.value.toLocaleString() }}</span>
+    </div>
+  </div>
+</template>

--- a/src/stores/arena.ts
+++ b/src/stores/arena.ts
@@ -1,5 +1,6 @@
 import type { Arena, BaseShlagemon, DexShlagemon } from '~/type'
 import { defineStore } from 'pinia'
+import { createDexShlagemon } from '~/utils/dexFactory'
 
 export type ArenaResult = 'none' | 'win' | 'lose'
 
@@ -7,6 +8,7 @@ export const useArenaStore = defineStore('arena', () => {
   const team = ref<DexShlagemon[]>([])
   const enemyTeam = ref<DexShlagemon[]>([])
   const lineup = ref<BaseShlagemon[]>([])
+  const lineupDex = ref<DexShlagemon[]>([])
   const arenaData = ref<Arena | null>(null)
   const selections = ref<(string | null)[]>([])
   const currentIndex = ref(0)
@@ -14,15 +16,19 @@ export const useArenaStore = defineStore('arena', () => {
   const badgeEarned = ref(false)
   const inBattle = ref(false)
 
-  function setLineup(enemies: BaseShlagemon[]) {
+  function setLineup(enemies: BaseShlagemon[], level: number) {
     lineup.value = enemies
+    const coefficientMultiplier = Math.floor(level / 2) - 1
+    lineupDex.value = enemies.map(m =>
+      createDexShlagemon(m, false, coefficientMultiplier, level),
+    )
     selections.value = Array.from({ length: enemies.length }).fill(null)
   }
 
   function setArena(arena: Arena) {
     arenaData.value = arena
     const data = typeof arena.lineup === 'function' ? arena.lineup() : arena.lineup
-    setLineup(data)
+    setLineup(data, arena.level)
   }
 
   function selectPlayer(index: number, id: string | null) {
@@ -54,6 +60,7 @@ export const useArenaStore = defineStore('arena', () => {
     team.value = []
     enemyTeam.value = []
     lineup.value = []
+    lineupDex.value = []
     arenaData.value = null
     selections.value = []
     currentIndex.value = 0
@@ -66,6 +73,7 @@ export const useArenaStore = defineStore('arena', () => {
     team,
     enemyTeam,
     lineup,
+    lineupDex,
     arenaData,
     selections,
     currentIndex,


### PR DESCRIPTION
## Summary
- compute enemy stats once when setting up the arena
- share those stats between preview and battle
- add reusable `<ShlagemonStats>` component
- reuse it in enemy and player detail views

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: TS errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6879766983a4832abb0d02dcb369a87e