### PR TITLE
Add placeholder icon for empty arena slots

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -156,6 +156,11 @@ onUnmounted(() => {
             class="h-full w-full object-contain"
           />
         </template>
+        <template v-else>
+          <div class="h-full w-full flex-center">
+            <div class="i-carbon:touch-1 text-3xl color-blue-600 dark:color-blue-300" />
+          </div>
+        </template>
       </button>
 
       <div class="col-span-6 flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- show a `touch-1` icon in empty team slots during arena selection

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to fetch web fonts and missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68797b91478c832a8bcce414b13be7ca