### PR TITLE
Adjust capture level caps

### DIFF
--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -59,7 +59,7 @@ export const arena20: Arena = createArena({
   badge: {
     id: 'badge-merdant',
     name: 'Badge Merdant',
-    levelCap: 40,
+    levelCap: 39,
     image: '',
   },
 })
@@ -72,7 +72,7 @@ export const arena40: Arena = createArena({
   badge: {
     id: 'badge-suce',
     name: 'Badge Suce',
-    levelCap: 60,
+    levelCap: 59,
     image: '',
   },
 })
@@ -85,7 +85,7 @@ export const arena60: Arena = createArena({
   badge: {
     id: 'badge-fiak',
     name: 'Badge Fiak',
-    levelCap: 80,
+    levelCap: 79,
     image: '',
   },
 })

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -7,7 +7,7 @@ export const usePlayerStore = defineStore('player', () => {
   const realName = ref('')
   const gender = ref<Character['gender']>('unknown')
   const arenaBadges = ref<Record<string, boolean>>({})
-  const captureLevelCap = ref(20)
+  const captureLevelCap = ref(19)
 
   const badgeCount = computed(() =>
     Object.values(arenaBadges.value).filter(v => v).length,
@@ -36,7 +36,7 @@ export const usePlayerStore = defineStore('player', () => {
     realName.value = ''
     gender.value = 'unknown'
     arenaBadges.value = {}
-    captureLevelCap.value = 20
+    captureLevelCap.value = 19
   }
 
   function earnBadge(id: string) {

--- a/test/arena-badge.test.ts
+++ b/test/arena-badge.test.ts
@@ -6,9 +6,9 @@ describe('arena badge', () => {
   it('updates captureLevelCap after earning second arena badge', () => {
     setActivePinia(createPinia())
     const player = usePlayerStore()
-    expect(player.captureLevelCap).toBe(20)
+    expect(player.captureLevelCap).toBe(19)
 
     player.earnBadge('arena40')
-    expect(player.captureLevelCap).toBe(40)
+    expect(player.captureLevelCap).toBe(59)
   })
 })

--- a/test/save-reset.test.ts
+++ b/test/save-reset.test.ts
@@ -42,6 +42,6 @@ describe('useSaveStore.reset', () => {
 
     save.reset()
 
-    expect(player.captureLevelCap).toBe(20)
+    expect(player.captureLevelCap).toBe(19)
   })
 })


### PR DESCRIPTION
## Summary
- lower initial capture level cap
- adjust arena badge level caps accordingly
- update related tests

## Testing
- `pnpm test:unit` *(fails: Failed to fetch web fonts; various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68797c3bbac4832aaf42f2ce9fa1c222