### PR TITLE
Disable shop tab switching while viewing item detail

### DIFF
--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -106,6 +106,7 @@ function closeShop() {
       :colors="tabColors"
       :hover-colors="tabHoverColors"
       :active-colors="tabActiveColors"
+      :disabled="!!selectedItem"
       class="-mb-1"
     />
     <div v-if="!selectedItem" class="tiny-scrollbar flex flex-col gap-2 overflow-auto">

--- a/src/components/ui/TabBar.vue
+++ b/src/components/ui/TabBar.vue
@@ -6,9 +6,12 @@ const props = defineProps<{
   hoverColors?: Record<string | number, string>
   activeColors?: Record<string | number, string>
   highlightClasses?: string
+  disabled?: boolean
 }>()
 const emit = defineEmits<{ (e: 'update:modelValue', value: string | number): void }>()
 function select(val: string | number) {
+  if (props.disabled)
+    return
   emit('update:modelValue', val)
 }
 </script>
@@ -19,13 +22,17 @@ function select(val: string | number) {
       v-for="opt in props.options"
       :key="opt.value"
       class="flex items-center gap-1 rounded-t px-1 py-1 text-sm"
-      :class="props.modelValue === opt.value
-        ? ['font-bold', props.activeColors?.[opt.value] ?? props.colors?.[opt.value] ?? 'bg-gray-200 dark:bg-gray-700']
-        : [
-          props.colors?.[opt.value] ?? 'bg-white dark:bg-gray-900',
-          props.hoverColors?.[opt.value] ?? 'hover:bg-gray-100 dark:hover:bg-gray-800',
-          opt.highlight ? props.highlightClasses ?? 'animate-pulse-alt animate-count-infinite' : '',
-        ]"
+      :class="[
+        props.modelValue === opt.value
+          ? ['font-bold', props.activeColors?.[opt.value] ?? props.colors?.[opt.value] ?? 'bg-gray-200 dark:bg-gray-700']
+          : [
+            props.colors?.[opt.value] ?? 'bg-white dark:bg-gray-900',
+            props.disabled ? '' : props.hoverColors?.[opt.value] ?? 'hover:bg-gray-100 dark:hover:bg-gray-800',
+            opt.highlight && !props.disabled ? props.highlightClasses ?? 'animate-pulse-alt animate-count-infinite' : '',
+          ],
+        props.disabled ? 'pointer-events-none opacity-50' : '',
+      ]"
+      :disabled="props.disabled"
       @click="select(opt.value)"
     >
       <div v-if="opt.icon" :class="opt.icon" />


### PR DESCRIPTION
## Summary
- prevent interaction with `UiTabBar` when an item is selected
- apply the new prop in the shop panel so tabs don't react while viewing details

## Testing
- `pnpm lint`
- `pnpm test` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68797d88a124832aa325d910ce1d00fc