### PR TITLE
Fix wearable equip modal on mobile

### DIFF
--- a/src/stores/wearableEquipModal.ts
+++ b/src/stores/wearableEquipModal.ts
@@ -8,7 +8,9 @@ import { useInventoryStore } from './inventory'
 import { useItemUsageStore } from './itemUsage'
 
 export const useWearableEquipModalStore = defineStore('wearableEquipModal', () => {
-  const { isVisible, open: openModal, close } = createModalStore('game')
+  // Keep the current mobile tab when opening this modal so the secondary panel
+  // and any open dialogs remain visible on mobile
+  const { isVisible, open: openModal, close } = createModalStore()
   const currentMon = ref<DexShlagemon | null>(null)
   const inventory = useInventoryStore()
   const equipment = useEquipmentStore()


### PR DESCRIPTION
## Summary
- keep current mobile tab when opening Wearable Equip modal so it doesn't close the Shlagédex detail

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: 29 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68797e086bbc832a96f2f1e619f99e0d