### PR TITLE
Add egg incubation feature

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -182,6 +182,7 @@ declare global {
   const useDocumentVisibility: typeof import('@vueuse/core')['useDocumentVisibility']
   const useDraggable: typeof import('@vueuse/core')['useDraggable']
   const useDropZone: typeof import('@vueuse/core')['useDropZone']
+  const useEggStore: typeof import('./stores/egg')['useEggStore']
   const useElementBounding: typeof import('@vueuse/core')['useElementBounding']
   const useElementByPoint: typeof import('@vueuse/core')['useElementByPoint']
   const useElementHover: typeof import('@vueuse/core')['useElementHover']
@@ -388,6 +389,9 @@ declare global {
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
   // @ts-ignore
+  export type { EggType, Egg } from './stores/egg'
+  import('./stores/egg')
+  // @ts-ignore
   export type { EventMap, EventCallback } from './stores/event'
   import('./stores/event')
   // @ts-ignore
@@ -582,6 +586,7 @@ declare module 'vue' {
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>
     readonly useDropZone: UnwrapRef<typeof import('@vueuse/core')['useDropZone']>
+    readonly useEggStore: UnwrapRef<typeof import('./stores/egg')['useEggStore']>
     readonly useElementBounding: UnwrapRef<typeof import('@vueuse/core')['useElementBounding']>
     readonly useElementByPoint: UnwrapRef<typeof import('@vueuse/core')['useElementByPoint']>
     readonly useElementHover: UnwrapRef<typeof import('@vueuse/core')['useElementHover']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -78,6 +78,7 @@ declare module 'vue' {
     PanelInventory: typeof import('./components/panel/Inventory.vue')['default']
     PanelMain: typeof import('./components/panel/Main.vue')['default']
     PanelPlayerInfos: typeof import('./components/panel/PlayerInfos.vue')['default']
+    PanelPoulailler: typeof import('./components/panel/Poulailler.vue')['default']
     PanelSelectedShlagemon: typeof import('./components/panel/SelectedShlagemon.vue')['default']
     PanelShlagedex: typeof import('./components/panel/Shlagedex.vue')['default']
     PanelShop: typeof import('./components/panel/Shop.vue')['default']

--- a/src/components/panel/Main.vue
+++ b/src/components/panel/Main.vue
@@ -4,6 +4,7 @@ import { useMainPanelStore } from '~/stores/mainPanel'
 import BattleMain from '../battle/Main.vue'
 import BattleTrainer from '../battle/Trainer.vue'
 import ArenaPanel from './Arena.vue'
+import PoulaillerPanel from './Poulailler.vue'
 import ShopPanel from './Shop.vue'
 import VillagePanel from './Village.vue'
 //  from './Shop.vue'
@@ -25,6 +26,8 @@ const currentComponent = computed(() => {
       // return 'WhackAShlag'
     case 'arena':
       return ArenaPanel
+    case 'poulailler':
+      return PoulaillerPanel
     case 'village':
       return VillagePanel
     default:

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useEggStore } from '~/stores/egg'
+
+const eggs = useEggStore()
+const now = ref(Date.now())
+setInterval(() => now.value = Date.now(), 1000)
+
+function remaining(egg: { hatchesAt: number }) {
+  return Math.max(0, Math.ceil((egg.hatchesAt - now.value) / 1000))
+}
+</script>
+
+<template>
+  <LayoutScrollablePanel>
+    <template #header>
+      <h3 class="font-bold">
+        Poulailler
+      </h3>
+    </template>
+    <template #content>
+      <div v-if="!eggs.eggs.length" class="text-center text-sm">
+        Aucun œuf en incubation
+      </div>
+      <div
+        v-for="egg in eggs.eggs"
+        :key="egg.id"
+        class="flex items-center justify-between border-b p-1"
+      >
+        <div class="flex items-center gap-1">
+          <div
+            class="i-game-icons:egg-eye h-6 w-6"
+            :class="{
+              'text-orange-500 dark:text-orange-400': egg.type === 'feu',
+              'text-blue-500 dark:text-blue-400': egg.type === 'eau',
+              'text-green-500 dark:text-green-400': egg.type === 'herbe',
+            }"
+          />
+          <span class="text-sm capitalize">{{ egg.type }}</span>
+        </div>
+        <span class="text-xs">{{ remaining(egg) }}s</span>
+      </div>
+    </template>
+  </LayoutScrollablePanel>
+</template>

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -17,6 +17,7 @@ const hasKing = computed(() =>
   zone.current.hasKing ?? zone.current.type === 'sauvage',
 )
 const hasArena = computed(() => !!zone.current.arena)
+const hasPoulailler = computed(() => !!zone.current.village?.poulailler)
 const arenaCompleted = computed(() => progress.isArenaCompleted(zone.current.id))
 const currentKing = computed(() =>
   hasKing.value ? zone.getKing(zone.current.id) : undefined,
@@ -71,6 +72,12 @@ function fightKing() {
   trainerBattle.setQueue([trainer])
   panel.showTrainerBattle()
 }
+
+function openPoulailler() {
+  if (arena.inBattle)
+    return
+  panel.showPoulailler()
+}
 </script>
 
 <template>
@@ -96,6 +103,13 @@ function fightKing() {
       label="Arène"
       :disabled="arena.inBattle"
       @click="openArena"
+    />
+    <UiNavigationButton
+      v-if="hasPoulailler"
+      icon="i-game-icons:bird-house"
+      label="Poulailler"
+      :disabled="arena.inBattle"
+      @click="openPoulailler"
     />
     <UiNavigationButton
       v-if="hasKing && !progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -301,6 +301,39 @@ export const ultraSteroid: Item = {
   iconClass: 'text-purple-500 dark:text-purple-300',
 }
 
+export const fireEgg: Item = {
+  id: 'oeuf-feu',
+  name: 'Œuf Feu',
+  description: 'Un œuf chaud bouillant.',
+  price: 30,
+  currency: 'shlagidolar',
+  category: 'utilitaire',
+  icon: 'i-game-icons:egg-eye',
+  iconClass: 'text-orange-500 dark:text-orange-400',
+}
+
+export const waterEgg: Item = {
+  id: 'oeuf-eau',
+  name: 'Œuf Eau',
+  description: 'Un œuf qui ruisselle.',
+  price: 30,
+  currency: 'shlagidolar',
+  category: 'utilitaire',
+  icon: 'i-game-icons:egg-eye',
+  iconClass: 'text-blue-500 dark:text-blue-400',
+}
+
+export const grassEgg: Item = {
+  id: 'oeuf-herbe',
+  name: 'Œuf Herbe',
+  description: 'Un œuf qui sent la pelouse.',
+  price: 30,
+  currency: 'shlagidolar',
+  category: 'utilitaire',
+  icon: 'i-game-icons:egg-eye',
+  iconClass: 'text-green-500 dark:text-green-400',
+}
+
 export const allItems = [
   shlageball,
   superShlageball,
@@ -329,6 +362,9 @@ export const allItems = [
   thunderStone,
   steroids,
   ultraSteroid,
+  fireEgg,
+  waterEgg,
+  grassEgg,
 ] as const satisfies Item[]
 
 export type ItemId = typeof allItems[number]['id']

--- a/src/data/zones/villages.ts
+++ b/src/data/zones/villages.ts
@@ -98,6 +98,9 @@ const village50: Zone = {
         steroids,
       ],
     },
+    poulailler: {
+      icon: 'i-game-icons:bird-house',
+    },
   },
 }
 

--- a/src/stores/egg.ts
+++ b/src/stores/egg.ts
@@ -1,0 +1,55 @@
+import { defineStore } from 'pinia'
+import { bulgrosboule } from '~/data/shlagemons/bulgrosboule'
+import { carapouffe } from '~/data/shlagemons/carapouffe'
+import { salamiches } from '~/data/shlagemons/salamiches'
+import { useShlagedexStore } from './shlagedex'
+
+export type EggType = 'feu' | 'eau' | 'herbe'
+
+export interface Egg {
+  id: number
+  type: EggType
+  hatchesAt: number
+}
+
+export const useEggStore = defineStore('egg', () => {
+  const eggs = ref<Egg[]>([])
+  const dex = useShlagedexStore()
+
+  function addEgg(type: EggType, duration = 60_000) {
+    const id = Date.now() + Math.random()
+    eggs.value.push({ id, type, hatchesAt: Date.now() + duration })
+  }
+
+  function hatchEgg(id: number) {
+    const idx = eggs.value.findIndex(e => e.id === id)
+    if (idx === -1)
+      return
+    const egg = eggs.value[idx]
+    eggs.value.splice(idx, 1)
+    switch (egg.type) {
+      case 'feu':
+        dex.createShlagemon(salamiches)
+        break
+      case 'eau':
+        dex.createShlagemon(carapouffe)
+        break
+      case 'herbe':
+        dex.createShlagemon(bulgrosboule)
+        break
+    }
+  }
+
+  setInterval(() => {
+    const now = Date.now()
+    eggs.value.filter(e => e.hatchesAt <= now).forEach(e => hatchEgg(e.id))
+  }, 1000)
+
+  function reset() {
+    eggs.value = []
+  }
+
+  return { eggs, addEgg, hatchEgg, reset }
+}, {
+  persist: true,
+})

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -5,6 +5,7 @@ import { allItems } from '~/data/items/items'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from './achievements'
 import { useCaptureLimitModalStore } from './captureLimitModal'
+import { useEggStore } from './egg'
 import { useFeatureLockStore } from './featureLock'
 import { useGameStore } from './game'
 import { useItemUsageStore } from './itemUsage'
@@ -193,6 +194,24 @@ export const useInventoryStore = defineStore('inventory', () => {
       'shlageball': capture,
       'super-shlageball': capture,
       'hyper-shlageball': capture,
+      'oeuf-feu': () => {
+        const eggs = useEggStore()
+        eggs.addEgg('feu')
+        remove(id)
+        return true
+      },
+      'oeuf-eau': () => {
+        const eggs = useEggStore()
+        eggs.addEgg('eau')
+        remove(id)
+        return true
+      },
+      'oeuf-herbe': () => {
+        const eggs = useEggStore()
+        eggs.addEgg('herbe')
+        remove(id)
+        return true
+      },
     }
 
     const handler = handlers[id]

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -5,7 +5,7 @@ import { useBattleStore } from './battle'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 
-export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop' | 'miniGame' | 'arena'
+export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop' | 'miniGame' | 'arena' | 'poulailler'
 
 export const useMainPanelStore = defineStore('mainPanel', () => {
   const zone = useZoneStore()
@@ -59,6 +59,12 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     current.value = 'miniGame'
   }
 
+  function showPoulailler() {
+    if (arena.inBattle)
+      return
+    current.value = 'poulailler'
+  }
+
   function showArena() {
     if (arena.inBattle)
       return
@@ -81,6 +87,7 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     showBattle,
     showTrainerBattle,
     showMiniGame,
+    showPoulailler,
     showArena,
     showVillage,
     reset,
@@ -94,7 +101,7 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
       const arenaStore = useArenaStore()
       if (store.current === 'arena' && !arenaStore.inBattle)
         store.reset()
-      if (store.current === 'trainerBattle')
+      if (store.current === 'trainerBattle' || store.current === 'poulailler')
         store.reset()
     },
   },

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -31,6 +31,9 @@ interface BaseZone {
     shop?: {
       items: Item[]
     }
+    poulailler?: {
+      icon: string
+    }
   }
 }
 

--- a/test/egg.test.ts
+++ b/test/egg.test.ts
@@ -1,0 +1,25 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { useEggStore } from '../src/stores/egg'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('egg workflow', () => {
+  it('acquires and hatches eggs', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const inventory = useInventoryStore()
+    const eggs = useEggStore()
+    const dex = useShlagedexStore()
+
+    inventory.add('oeuf-feu')
+    expect(inventory.useItem('oeuf-feu')).toBe(true)
+    expect(eggs.eggs.length).toBe(1)
+
+    vi.advanceTimersByTime(61_000)
+    vi.runOnlyPendingTimers()
+    expect(eggs.eggs.length).toBe(0)
+    expect(dex.shlagemons.length).toBe(1)
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- add fire/water/grass eggs to utilitaire items
- add poulailler feature to zones
- allow using eggs via inventory to start incubation
- implement egg store with hatching logic
- show poulailler panel in village actions
- support new panel in main panel component
- tests for egg incubation workflow

## Testing
- `npm test` *(fails: Failed to fetch web fonts and other errors)*
- `npx tsc -p tsconfig.json --noEmit` *(errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879fc045d5c832a9b71f5679ce4a06d