### PR TITLE
Fix TicTacToe panel bug

### DIFF
--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -2,12 +2,14 @@
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
 import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMiniGameStore } from '~/stores/miniGame'
 import { useTrainerBattleStore } from '~/stores/trainerBattle'
 import { useZoneStore } from '~/stores/zone'
 import { useZoneProgressStore } from '~/stores/zoneProgress'
 
 const zone = useZoneStore()
 const panel = useMainPanelStore()
+const mini = useMiniGameStore()
 const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
 const arena = useArenaStore()
@@ -49,6 +51,8 @@ function onAction(id: string) {
     panel.showTrainerBattle()
   }
   else if (id === 'minigame') {
+    if (zone.current.miniGame)
+      mini.select(zone.current.miniGame)
     panel.showMiniGame()
   }
 }


### PR DESCRIPTION
## Summary
- load the current zone's mini game before showing the panel so TicTacToe appears

## Testing
- `pnpm test:unit` *(fails: snapshots mismatched and other tests fail)*
- `pnpm lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687a34425a7c832aada884d5d6a5393f