### PR TITLE
Expand Tic-Tac-Toe board

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -6,9 +6,13 @@
 // biome-ignore lint: disable
 export {}
 declare global {
+  const CENTER_CELLS: typeof import('./composables/useTicTacToe')['CENTER_CELLS']
   const EffectScope: typeof import('vue')['EffectScope']
+  const SIZE: typeof import('./composables/useTicTacToe')['SIZE']
   const asyncComputed: typeof import('@vueuse/core')['asyncComputed']
   const autoResetRef: typeof import('@vueuse/core')['autoResetRef']
+  const check: typeof import('./composables/useTicTacToe')['check']
+  const combos: typeof import('./composables/useTicTacToe')['combos']
   const computed: typeof import('vue')['computed']
   const computedAsync: typeof import('@vueuse/core')['computedAsync']
   const computedEager: typeof import('@vueuse/core')['computedEager']
@@ -37,6 +41,7 @@ declare global {
   const eagerComputed: typeof import('@vueuse/core')['eagerComputed']
   const effectScope: typeof import('vue')['effectScope']
   const extendRef: typeof import('@vueuse/core')['extendRef']
+  const findBestMove: typeof import('./composables/useTicTacToe')['findBestMove']
   const getActiveHead: typeof import('@unhead/vue')['getActiveHead']
   const getCurrentInstance: typeof import('vue')['getCurrentInstance']
   const getCurrentScope: typeof import('vue')['getCurrentScope']
@@ -310,6 +315,7 @@ declare global {
   const useThrottle: typeof import('@vueuse/core')['useThrottle']
   const useThrottleFn: typeof import('@vueuse/core')['useThrottleFn']
   const useThrottledRefHistory: typeof import('@vueuse/core')['useThrottledRefHistory']
+  const useTicTacToe: typeof import('./composables/useTicTacToe')['useTicTacToe']
   const useTimeAgo: typeof import('@vueuse/core')['useTimeAgo']
   const useTimeout: typeof import('@vueuse/core')['useTimeout']
   const useTimeoutFn: typeof import('@vueuse/core')['useTimeoutFn']
@@ -389,6 +395,9 @@ declare global {
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
   // @ts-ignore
+  export type { EggType, Egg } from './stores/egg'
+  import('./stores/egg')
+  // @ts-ignore
   export type { EventMap, EventCallback } from './stores/event'
   import('./stores/event')
   // @ts-ignore
@@ -410,9 +419,13 @@ import { UnwrapRef } from 'vue'
 declare module 'vue' {
   interface GlobalComponents {}
   interface ComponentCustomProperties {
+    readonly CENTER_CELLS: UnwrapRef<typeof import('./composables/useTicTacToe')['CENTER_CELLS']>
     readonly EffectScope: UnwrapRef<typeof import('vue')['EffectScope']>
+    readonly SIZE: UnwrapRef<typeof import('./composables/useTicTacToe')['SIZE']>
     readonly asyncComputed: UnwrapRef<typeof import('@vueuse/core')['asyncComputed']>
     readonly autoResetRef: UnwrapRef<typeof import('@vueuse/core')['autoResetRef']>
+    readonly check: UnwrapRef<typeof import('./composables/useTicTacToe')['check']>
+    readonly combos: UnwrapRef<typeof import('./composables/useTicTacToe')['combos']>
     readonly computed: UnwrapRef<typeof import('vue')['computed']>
     readonly computedAsync: UnwrapRef<typeof import('@vueuse/core')['computedAsync']>
     readonly computedEager: UnwrapRef<typeof import('@vueuse/core')['computedEager']>
@@ -439,6 +452,7 @@ declare module 'vue' {
     readonly eagerComputed: UnwrapRef<typeof import('@vueuse/core')['eagerComputed']>
     readonly effectScope: UnwrapRef<typeof import('vue')['effectScope']>
     readonly extendRef: UnwrapRef<typeof import('@vueuse/core')['extendRef']>
+    readonly findBestMove: UnwrapRef<typeof import('./composables/useTicTacToe')['findBestMove']>
     readonly getCurrentInstance: UnwrapRef<typeof import('vue')['getCurrentInstance']>
     readonly getCurrentScope: UnwrapRef<typeof import('vue')['getCurrentScope']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
@@ -583,6 +597,7 @@ declare module 'vue' {
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>
     readonly useDropZone: UnwrapRef<typeof import('@vueuse/core')['useDropZone']>
+    readonly useEggStore: UnwrapRef<typeof import('./stores/egg')['useEggStore']>
     readonly useElementBounding: UnwrapRef<typeof import('@vueuse/core')['useElementBounding']>
     readonly useElementByPoint: UnwrapRef<typeof import('@vueuse/core')['useElementByPoint']>
     readonly useElementHover: UnwrapRef<typeof import('@vueuse/core')['useElementHover']>
@@ -706,6 +721,7 @@ declare module 'vue' {
     readonly useThrottle: UnwrapRef<typeof import('@vueuse/core')['useThrottle']>
     readonly useThrottleFn: UnwrapRef<typeof import('@vueuse/core')['useThrottleFn']>
     readonly useThrottledRefHistory: UnwrapRef<typeof import('@vueuse/core')['useThrottledRefHistory']>
+    readonly useTicTacToe: UnwrapRef<typeof import('./composables/useTicTacToe')['useTicTacToe']>
     readonly useTimeAgo: UnwrapRef<typeof import('@vueuse/core')['useTimeAgo']>
     readonly useTimeout: UnwrapRef<typeof import('@vueuse/core')['useTimeout']>
     readonly useTimeoutFn: UnwrapRef<typeof import('@vueuse/core')['useTimeoutFn']>

--- a/src/components/minigame/TicTacToe.vue
+++ b/src/components/minigame/TicTacToe.vue
@@ -1,22 +1,17 @@
 <script setup lang="ts">
+import { CENTER_CELLS, combos, findBestMove, SIZE } from '~/composables/useTicTacToe'
+
 const emit = defineEmits(['win', 'lose'])
-const board = ref<(null | 'player' | 'ai')[]>(Array.from({ length: 9 }).fill(null))
+const board = ref<(null | 'player' | 'ai')[]>(Array.from({ length: SIZE * SIZE }).fill(null))
 const turn = ref<'player' | 'ai'>('player')
 const finished = ref(false)
 
-const combos = [
-  [0, 1, 2],
-  [3, 4, 5],
-  [6, 7, 8],
-  [0, 3, 6],
-  [1, 4, 7],
-  [2, 5, 8],
-  [0, 4, 8],
-  [2, 4, 6],
-]
+function isCenter(i: number) {
+  return CENTER_CELLS.includes(i)
+}
 
 function reset() {
-  board.value = Array.from({ length: 9 }).fill(null)
+  board.value = Array.from({ length: SIZE * SIZE }).fill(null)
   turn.value = 'player'
   finished.value = false
 }
@@ -25,64 +20,15 @@ function check(player: 'player' | 'ai') {
   return combos.some(c => c.every(i => board.value[i] === player))
 }
 
-function findBestMove(state: (null | 'player' | 'ai')[] = board.value) {
-  function checkLocal(b: (null | 'player' | 'ai')[], p: 'player' | 'ai') {
-    return combos.some(c => c.every(i => b[i] === p))
-  }
-
-  function minimax(
-    b: (null | 'player' | 'ai')[],
-    current: 'player' | 'ai',
-  ): number {
-    if (checkLocal(b, 'ai'))
-      return 1
-    if (checkLocal(b, 'player'))
-      return -1
-    if (b.every(Boolean))
-      return 0
-    const empty = b.map((v, i) => (v ? -1 : i)).filter(i => i >= 0)
-    if (current === 'ai') {
-      let best = -Infinity
-      for (const idx of empty) {
-        b[idx] = 'ai'
-        const score = minimax(b, 'player')
-        b[idx] = null
-        best = Math.max(best, score)
-      }
-      return best
-    }
-    else {
-      let best = Infinity
-      for (const idx of empty) {
-        b[idx] = 'player'
-        const score = minimax(b, 'ai')
-        b[idx] = null
-        best = Math.min(best, score)
-      }
-      return best
-    }
-  }
-
-  let bestScore = -Infinity
-  let bestIdx = -1
-  const empty = state.map((v, i) => (v ? -1 : i)).filter(i => i >= 0)
-  for (const idx of empty) {
-    const copy = [...state]
-    copy[idx] = 'ai'
-    const score = minimax(copy, 'player')
-    if (score > bestScore) {
-      bestScore = score
-      bestIdx = idx
-    }
-  }
-  return bestIdx
-}
-
 function aiMove() {
-  const empty = board.value.some(v => !v)
-  if (!empty)
-    return end(false)
-  const idx = findBestMove()
+  const possible = CENTER_CELLS.filter(i => !board.value[i])
+  if (!possible.length) {
+    if (board.value.every(Boolean))
+      return end(false)
+    turn.value = 'player'
+    return
+  }
+  const idx = findBestMove(board.value)
   board.value[idx] = 'ai'
   if (check('ai'))
     return end(false)
@@ -117,12 +63,13 @@ onMounted(reset)
 
 <template>
   <div class="flex flex-col items-center gap-2">
-    <div class="grid grid-cols-3 gap-1" md="gap-2">
+    <div class="grid grid-cols-5 gap-1" md="gap-2">
       <button
         v-for="(_, i) in board"
         :key="i"
-        class="h-20 w-20 flex items-center justify-center rounded bg-gray-200 text-3xl dark:bg-gray-700"
-        md="h-24 w-24"
+        class="h-12 w-12 flex items-center justify-center rounded text-3xl"
+        :class="isCenter(i) ? 'bg-gray-200 dark:bg-gray-700' : 'bg-transparent cursor-default'"
+        md="h-20 w-20"
         @click="play(i)"
       >
         <span v-if="board[i] === 'player'">⭕</span>

--- a/test/tictactoe-ai.test.ts
+++ b/test/tictactoe-ai.test.ts
@@ -1,16 +1,28 @@
 import { describe, expect, it } from 'vitest'
-import { findBestMove } from '../src/composables/useTicTacToe'
+import { CENTER_CELLS, findBestMove, SIZE } from '../src/composables/useTicTacToe'
 
-const combos = [
-  [0, 1, 2],
-  [3, 4, 5],
-  [6, 7, 8],
-  [0, 3, 6],
-  [1, 4, 7],
-  [2, 5, 8],
-  [0, 4, 8],
-  [2, 4, 6],
-]
+function generateCombos() {
+  const res: number[][] = []
+  for (let r = 0; r < SIZE; r++) {
+    for (let c = 0; c <= SIZE - 3; c++)
+      res.push([r * SIZE + c, r * SIZE + c + 1, r * SIZE + c + 2])
+  }
+
+  for (let c = 0; c < SIZE; c++) {
+    for (let r = 0; r <= SIZE - 3; r++)
+      res.push([r * SIZE + c, (r + 1) * SIZE + c, (r + 2) * SIZE + c])
+  }
+
+  for (let r = 0; r <= SIZE - 3; r++) {
+    for (let c = 0; c <= SIZE - 3; c++)
+      res.push([r * SIZE + c, (r + 1) * SIZE + c + 1, (r + 2) * SIZE + c + 2])
+    for (let c = 2; c < SIZE; c++)
+      res.push([r * SIZE + c, (r + 1) * SIZE + c - 1, (r + 2) * SIZE + c - 2])
+  }
+  return res
+}
+
+const combos = generateCombos()
 
 function check(b: (null | 'player' | 'ai')[], p: 'player' | 'ai') {
   return combos.some(c => c.every(i => b[i] === p))
@@ -35,6 +47,9 @@ function search(board: (null | 'player' | 'ai')[], playerTurn: boolean): 'ai' | 
     return 'draw'
   }
   else {
+    const possible = CENTER_CELLS.filter(i => !board[i])
+    if (!possible.length)
+      return search(board, true)
     const idx = findBestMove(board)
     board[idx] = 'ai'
     const res = search(board, true)
@@ -45,8 +60,8 @@ function search(board: (null | 'player' | 'ai')[], playerTurn: boolean): 'ai' | 
 
 describe('tic tac toe ai', () => {
   it('never loses after any first move', () => {
-    for (let i = 0; i < 9; i++) {
-      const board = Array.from({ length: 9 }).fill(null) as (null | 'player' | 'ai')[]
+    for (const i of CENTER_CELLS) {
+      const board = Array.from({ length: SIZE * SIZE }).fill(null) as (null | 'player' | 'ai')[]
       board[i] = 'player'
       const result = search(board, false)
       expect(result).not.toBe('player')


### PR DESCRIPTION
## Summary
- reimplement Tic-Tac-Toe logic for a 5x5 board
- restrict AI to the center cells only
- hide outer cells visually in the minigame UI
- update unit tests for the new board

## Testing
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_687a5ebc7d94832aad5468312f3977aa