### PR TITLE
Fix TicTacToe AI moves

### DIFF
--- a/src/components/minigame/TicTacToe.vue
+++ b/src/components/minigame/TicTacToe.vue
@@ -22,12 +22,8 @@ function check(player: 'player' | 'ai') {
 
 function aiMove() {
   const possible = CENTER_CELLS.filter(i => !board.value[i])
-  if (!possible.length) {
-    if (board.value.every(Boolean))
-      return end(false)
-    turn.value = 'player'
-    return
-  }
+  if (!possible.length)
+    return end(false)
   const idx = findBestMove(board.value)
   board.value[idx] = 'ai'
   if (check('ai'))
@@ -38,8 +34,14 @@ function aiMove() {
 }
 
 function play(i: number) {
-  if (finished.value || turn.value !== 'player' || board.value[i])
+  if (
+    finished.value
+    || turn.value !== 'player'
+    || board.value[i]
+    || !isCenter(i)
+  ) {
     return
+  }
   board.value[i] = 'player'
   if (check('player'))
     return end(true)
@@ -68,9 +70,9 @@ onMounted(reset)
         v-for="(_, i) in board"
         :key="i"
         class="h-12 w-12 flex items-center justify-center rounded text-3xl"
-        :class="isCenter(i) ? 'bg-gray-200 dark:bg-gray-700' : 'bg-transparent cursor-default'"
+        :class="isCenter(i) ? 'bg-gray-200 dark:bg-gray-700' : 'bg-transparent cursor-default pointer-events-none'"
         md="h-20 w-20"
-        @click="play(i)"
+        @click="isCenter(i) && play(i)"
       >
         <span v-if="board[i] === 'player'">⭕</span>
         <span v-else-if="board[i] === 'ai'">❌</span>

--- a/src/components/panel/Main.vue
+++ b/src/components/panel/Main.vue
@@ -4,11 +4,10 @@ import { useMainPanelStore } from '~/stores/mainPanel'
 import BattleMain from '../battle/Main.vue'
 import BattleTrainer from '../battle/Trainer.vue'
 import ArenaPanel from './Arena.vue'
+import MiniGamePanel from './MiniGame.vue'
 import PoulaillerPanel from './Poulailler.vue'
 import ShopPanel from './Shop.vue'
 import VillagePanel from './Village.vue'
-import MiniGamePanel from './MiniGame.vue'
-//  from './Shop.vue'
 
 defineOptions({ inheritAttrs: false })
 

--- a/src/composables/useTicTacToe.ts
+++ b/src/composables/useTicTacToe.ts
@@ -42,7 +42,7 @@ export function findBestMove(state: Cell[]): number {
       return 0
     const empty = b
       .map((v, i) => (v ? -1 : i))
-      .filter(i => i >= 0 && (current !== 'ai' || CENTER_CELLS.includes(i)))
+      .filter(i => i >= 0 && CENTER_CELLS.includes(i))
     if (current === 'ai') {
       let best = -Infinity
       for (const idx of empty) {
@@ -100,12 +100,8 @@ export function useTicTacToe() {
 
   function aiMove() {
     const possible = CENTER_CELLS.filter(i => !board.value[i])
-    if (!possible.length) {
-      if (board.value.every(Boolean))
-        return end(false)
-      turn.value = 'player'
-      return
-    }
+    if (!possible.length)
+      return end(false)
     const idx = findBestMove(board.value)
     board.value[idx] = 'ai'
     if (check(board.value, 'ai'))
@@ -116,8 +112,14 @@ export function useTicTacToe() {
   }
 
   function play(i: number) {
-    if (finished.value || turn.value !== 'player' || board.value[i])
+    if (
+      finished.value
+      || turn.value !== 'player'
+      || board.value[i]
+      || !CENTER_CELLS.includes(i)
+    ) {
       return
+    }
     board.value[i] = 'player'
     if (check(board.value, 'player'))
       return end(true)

--- a/src/data/minigames.ts
+++ b/src/data/minigames.ts
@@ -11,7 +11,7 @@ export const ticTacToeMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: "Envie d'une partie de morpion ?",
+        text: 'Envie d\'une partie de morpion ?',
         responses: [
           { label: 'Oui', type: 'primary', action: start },
           { label: 'Non', type: 'danger' },

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -1,7 +1,7 @@
 import type { Arena } from './arena'
 import type { Item } from './item'
-import type { BaseShlagemon } from './shlagemon'
 import type { MiniGameId } from './minigame'
+import type { BaseShlagemon } from './shlagemon'
 
 export type ZoneType = 'village' | 'grotte' | 'sauvage'
 

--- a/test/minigame.test.ts
+++ b/test/minigame.test.ts
@@ -1,8 +1,8 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
+import { getMiniGame } from '../src/data/minigames'
 import { useGameStore } from '../src/stores/game'
 import { useMiniGameStore } from '../src/stores/miniGame'
-import { getMiniGame } from '../src/data/minigames'
 
 describe('mini game store', () => {
   it('rewards player on victory', () => {


### PR DESCRIPTION
## Summary
- make minimax only explore center cells
- stop game when AI has no moves
- restrict player clicks to center cells
- clean up import order and lint errors

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots and other unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a63efe8a8832ab51d10a822b77321