### PR TITLE
docs: shrink README images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Shlagémon
 
-![Logo](public/logo.png)
+<p align="center">
+  <img src="public/logo.png" alt="Logo" width="180" />
+</p>
 
 Plongez dans un univers délirant peuplé de Shlagémons totalement barrés. Capturez-les, faites-les combattre et remplissez votre Shlagedex pour devenir le dresseur ultime et rafler les précieux _Shlagidolar_. Le projet utilise les dernières versions de **Vue&nbsp;3** et suit les meilleures pratiques de la doc officielle pour une expérience fluide, que ce soit sur mobile ou sur grand écran.
 
-![Carapouffe](public/shlagemons/carapouffe/carapouffe.png)
-![Sachatte](public/characters/sachatte/sachatte.png)
-![Prof Merdant](public/characters/prof-merdant/prof-merdant.png)
+<p align="center">
+  <img src="public/shlagemons/carapouffe/carapouffe.png" alt="Carapouffe" width="160" />
+  <img src="public/characters/sachatte/sachatte.png" alt="Sachatte" width="160" />
+  <img src="public/characters/prof-merdant/prof-merdant.png" alt="Prof Merdant" width="160" />
+</p>
 
 ## Concept
 


### PR DESCRIPTION
## Summary
- reduce size of README intro images so they display on one line

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots mismatched and network errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a69a3fb0c832ab900cf72e8e34a15