### PR TITLE
Colorize village action buttons

### DIFF
--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -90,6 +90,8 @@ function openPoulailler() {
       v-if="zone.current.village?.shop"
       icon="i-carbon:shopping-bag"
       label="Magasin"
+      class="bg-green-600 text-white dark:bg-green-700"
+      hover="bg-green-700 dark:bg-green-800"
       :disabled="arena.inBattle"
       @click="panel.showShop()"
     />
@@ -98,6 +100,8 @@ function openPoulailler() {
       :key="action.id"
       :icon="actionIcon(action.id)"
       :label="action.label"
+      :class="action.id === 'minigame' ? 'bg-violet-600 text-white dark:bg-violet-700' : ''"
+      :hover="action.id === 'minigame' ? 'bg-violet-700 dark:bg-violet-800' : undefined"
       :disabled="arena.inBattle"
       @click="onAction(action.id)"
     />
@@ -105,6 +109,8 @@ function openPoulailler() {
       v-if="hasArena && !arenaCompleted"
       icon="i-mdi:sword-cross"
       label="Arène"
+      class="bg-red-600 text-white dark:bg-red-700"
+      hover="bg-red-700 dark:bg-red-800"
       :disabled="arena.inBattle"
       @click="openArena"
     />


### PR DESCRIPTION
## Summary
- color village shop, arena and minigame buttons

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH when fetching fonts, numerous unit test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687a8040d1ec832a9cf1ec7d83176121