### PR TITLE
Fix tic tac toe UX

### DIFF
--- a/src/data/minigames.ts
+++ b/src/data/minigames.ts
@@ -1,4 +1,6 @@
 import type { MiniGameDefinition } from '~/type/minigame'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMiniGameStore } from '~/stores/miniGame'
 import { sachatte } from './characters/sachatte'
 
 export const ticTacToeMiniGame: MiniGameDefinition = {
@@ -8,13 +10,22 @@ export const ticTacToeMiniGame: MiniGameDefinition = {
   component: () => import('~/components/minigame/TicTacToe.vue'),
   reward: 100,
   createIntro(start) {
+    const miniGame = useMiniGameStore()
+    const panel = useMainPanelStore()
     return [
       {
         id: 'start',
         text: 'Envie d\'une partie de morpion ?',
         responses: [
           { label: 'Oui', type: 'primary', action: start },
-          { label: 'Non', type: 'danger' },
+          {
+            label: 'Non',
+            type: 'danger',
+            action: () => {
+              miniGame.quit()
+              panel.showVillage()
+            },
+          },
         ],
       },
     ]

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -2,6 +2,7 @@ import type { ZoneId, ZoneType } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { useArenaStore } from './arena'
 import { useBattleStore } from './battle'
+import { useMiniGameStore } from './miniGame'
 import { useShlagedexStore } from './shlagedex'
 import { useZoneStore } from './zone'
 
@@ -99,9 +100,12 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     afterHydrate(ctx) {
       const store = ctx.store as ReturnType<typeof useMainPanelStore>
       const arenaStore = useArenaStore()
+      const miniGameStore = useMiniGameStore()
       if (store.current === 'arena' && !arenaStore.inBattle)
         store.reset()
       if (store.current === 'trainerBattle' || store.current === 'poulailler')
+        store.reset()
+      if (store.current === 'miniGame' && !miniGameStore.currentId)
         store.reset()
     },
   },

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -67,6 +67,11 @@ export const useUIStore = defineStore('ui', () => {
         return
       }
 
+      if (panel === 'miniGame') {
+        audio.fadeToMusic('/audio/musics/games/mini-game.ogg')
+        return
+      }
+
       if (panel === 'battle') {
         const track = getZoneBattleTrack(zoneId)
         if (track)


### PR DESCRIPTION
## Summary
- reset panel when reloading on a minigame
- handle negative answer in tic tac toe intro
- refactor tic tac toe board layout
- color win animation and play area
- play dedicated music during minigames

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_687a805c5dd4832aaa3e92e124d5b176