### PR TITLE
Add new wearable items

### DIFF
--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -1,5 +1,25 @@
 import type { Item } from '~/type/item'
 import { hyperShlageball, shlageball, superShlageball } from './shlageball'
+import {
+  advancedAttackRing,
+  attackAmulet,
+  attackRing,
+} from './wearables/attackRing'
+import {
+  advancedDefenseRing,
+  defenseAmulet,
+  defenseRing,
+} from './wearables/defenseRing'
+import {
+  advancedVitalityRing,
+  vitalityAmulet,
+  vitalityRing,
+} from './wearables/vitalityRing'
+import {
+  advancedXpRing,
+  xpAmulet,
+  xpRing,
+} from './wearables/xpRing'
 
 // @unocss-include
 export const defensePotion: Item = {
@@ -233,36 +253,6 @@ export const multiExp: Item = {
   wearable: true,
 }
 
-export const vitalityRing: Item = {
-  id: 'vitality-ring',
-  name: 'Bague Vitalesque',
-  description: 'Augmente les PV max du porteur.',
-  details:
-    'Portée par un Shlagémon, elle augmente ses PV maximum de 15%. Effet cumulable avec les potions de vitalité.',
-  price: 20,
-  currency: 'shlagidiamond',
-  category: 'utilitaire',
-  icon: 'i-game-icons:ring',
-  iconClass: 'text-red-500 dark:text-red-400',
-  unique: true,
-  wearable: true,
-}
-
-export const xpRing: Item = {
-  id: 'xp-ring',
-  name: 'Anneau d\'expérience',
-  description: 'Augmente l\'XP du porteur.',
-  details:
-    'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 15%. Effet cumulable avec les potions d\'expérience.',
-  price: 20,
-  currency: 'shlagidiamond',
-  category: 'utilitaire',
-  icon: 'i-game-icons:big-diamond-ring',
-  iconClass: 'text-green-600 dark:text-green-400',
-  unique: true,
-  wearable: true,
-}
-
 export const thunderStone: Item = {
   id: 'pierre-foutre',
   name: 'Pierre Foutre',
@@ -358,7 +348,17 @@ export const allItems = [
   hyperXpPotion,
   multiExp,
   vitalityRing,
+  advancedVitalityRing,
+  vitalityAmulet,
   xpRing,
+  advancedXpRing,
+  xpAmulet,
+  attackRing,
+  advancedAttackRing,
+  attackAmulet,
+  defenseRing,
+  advancedDefenseRing,
+  defenseAmulet,
   thunderStone,
   steroids,
   ultraSteroid,

--- a/src/data/items/wearables/attackRing.ts
+++ b/src/data/items/wearables/attackRing.ts
@@ -1,0 +1,48 @@
+import type { Item } from '~/type/item'
+
+export const attackRing: Item = {
+  id: 'attack-ring',
+  name: 'Bague d\'attaque',
+  description: 'Augmente l\'attaque du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente son attaque de 15%. Effet cumulable avec les potions d\'attaque.',
+  price: 20,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:diamond-ring',
+  iconClass: 'text-orange-500 dark:text-orange-400',
+  unique: true,
+  wearable: true,
+}
+
+export const advancedAttackRing: Item = {
+  id: 'advanced-attack-ring',
+  name: 'Bague d\'attaque avancée',
+  description: 'Augmente fortement l\'attaque du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente son attaque de 25%. Effet cumulable avec les potions d\'attaque.',
+  price: 50,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:big-diamond-ring',
+  iconClass: 'text-orange-600 dark:text-orange-500',
+  unique: true,
+  wearable: true,
+}
+
+export const attackAmulet: Item = {
+  id: 'attack-amulet',
+  name: 'Amulette d\'attaque',
+  description: 'Augmente grandement l\'attaque du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente son attaque de 33%. Effet cumulable avec les potions d\'attaque.',
+  price: 100,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:necklace',
+  iconClass: 'text-orange-700 dark:text-orange-600',
+  unique: true,
+  wearable: true,
+}
+
+export const attackWearables = [attackRing, advancedAttackRing, attackAmulet] as const satisfies Item[]

--- a/src/data/items/wearables/defenseRing.ts
+++ b/src/data/items/wearables/defenseRing.ts
@@ -1,0 +1,48 @@
+import type { Item } from '~/type/item'
+
+export const defenseRing: Item = {
+  id: 'defense-ring',
+  name: 'Bague de défense',
+  description: 'Augmente la défense du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente sa défense de 15%. Effet cumulable avec les potions de défense.',
+  price: 20,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:diamond-ring',
+  iconClass: 'text-blue-500 dark:text-blue-400',
+  unique: true,
+  wearable: true,
+}
+
+export const advancedDefenseRing: Item = {
+  id: 'advanced-defense-ring',
+  name: 'Bague de défense avancée',
+  description: 'Augmente fortement la défense du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente sa défense de 25%. Effet cumulable avec les potions de défense.',
+  price: 50,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:big-diamond-ring',
+  iconClass: 'text-blue-600 dark:text-blue-500',
+  unique: true,
+  wearable: true,
+}
+
+export const defenseAmulet: Item = {
+  id: 'defense-amulet',
+  name: 'Amulette de défense',
+  description: 'Augmente grandement la défense du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente sa défense de 33%. Effet cumulable avec les potions de défense.',
+  price: 100,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:necklace',
+  iconClass: 'text-blue-700 dark:text-blue-600',
+  unique: true,
+  wearable: true,
+}
+
+export const defenseWearables = [defenseRing, advancedDefenseRing, defenseAmulet] as const satisfies Item[]

--- a/src/data/items/wearables/vitalityRing.ts
+++ b/src/data/items/wearables/vitalityRing.ts
@@ -1,0 +1,52 @@
+import type { Item } from '~/type/item'
+
+export const vitalityRing: Item = {
+  id: 'vitality-ring',
+  name: 'Bague Vitalesque',
+  description: 'Augmente les PV max du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente ses PV maximum de 15%. Effet cumulable avec les potions de vitalité.',
+  price: 20,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:diamond-ring',
+  iconClass: 'text-violet-500 dark:text-violet-400',
+  unique: true,
+  wearable: true,
+}
+
+export const advancedVitalityRing: Item = {
+  id: 'advanced-vitality-ring',
+  name: 'Bague Vitalesque avancée',
+  description: 'Augmente fortement les PV max du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente ses PV maximum de 25%. Effet cumulable avec les potions de vitalité.',
+  price: 50,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:big-diamond-ring',
+  iconClass: 'text-violet-600 dark:text-violet-500',
+  unique: true,
+  wearable: true,
+}
+
+export const vitalityAmulet: Item = {
+  id: 'vitality-amulet',
+  name: 'Amulette Vitalesque',
+  description: 'Augmente grandement les PV max du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente ses PV maximum de 33%. Effet cumulable avec les potions de vitalité.',
+  price: 100,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:necklace',
+  iconClass: 'text-violet-700 dark:text-violet-600',
+  unique: true,
+  wearable: true,
+}
+
+export const vitalityWearables = [
+  vitalityRing,
+  advancedVitalityRing,
+  vitalityAmulet,
+] as const satisfies Item[]

--- a/src/data/items/wearables/xpRing.ts
+++ b/src/data/items/wearables/xpRing.ts
@@ -1,0 +1,48 @@
+import type { Item } from '~/type/item'
+
+export const xpRing: Item = {
+  id: 'xp-ring',
+  name: 'Anneau d\'expérience',
+  description: 'Augmente l\'XP du porteur.',
+  details:
+    'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 15%. Effet cumulable avec les potions d\'expérience.',
+  price: 20,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:diamond-ring',
+  iconClass: 'text-green-600 dark:text-green-400',
+  unique: true,
+  wearable: true,
+}
+
+export const advancedXpRing: Item = {
+  id: 'advanced-xp-ring',
+  name: 'Anneau d\'expérience avancé',
+  description: 'Augmente fortement l\'XP du porteur.',
+  details:
+    'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 25%. Effet cumulable avec les potions d\'expérience.',
+  price: 50,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:big-diamond-ring',
+  iconClass: 'text-green-700 dark:text-green-500',
+  unique: true,
+  wearable: true,
+}
+
+export const xpAmulet: Item = {
+  id: 'xp-amulet',
+  name: 'Amulette d\'expérience',
+  description: 'Augmente grandement l\'XP du porteur.',
+  details:
+    'Portée par un Shlagémon, elle augmente l\'expérience gagnée en combat de 33%. Effet cumulable avec les potions d\'expérience.',
+  price: 100,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:necklace',
+  iconClass: 'text-green-800 dark:text-green-600',
+  unique: true,
+  wearable: true,
+}
+
+export const xpWearables = [xpRing, advancedXpRing, xpAmulet] as const satisfies Item[]

--- a/src/stores/equipment.ts
+++ b/src/stores/equipment.ts
@@ -7,6 +7,11 @@ export const useEquipmentStore = defineStore('equipment', () => {
   const dex = useShlagedexStore()
   const inventory = useInventoryStore()
 
+  const vitalityIds = ['vitality-ring', 'advanced-vitality-ring', 'vitality-amulet']
+  function isVitalityItem(id: string) {
+    return vitalityIds.includes(id)
+  }
+
   function equip(monId: string, itemId: string) {
     const mon = dex.shlagemons.find(m => m.id === monId)
     if (!mon)
@@ -14,7 +19,7 @@ export const useEquipmentStore = defineStore('equipment', () => {
     if (mon.heldItemId) {
       holders.value[mon.heldItemId] = null
       inventory.add(mon.heldItemId)
-      if (mon.heldItemId === 'vitality-ring') {
+      if (isVitalityItem(mon.heldItemId)) {
         const max = dex.maxHp(mon)
         if (mon.hpCurrent > max)
           mon.hpCurrent = max
@@ -25,7 +30,7 @@ export const useEquipmentStore = defineStore('equipment', () => {
       const other = dex.shlagemons.find(m => m.id === current)
       if (other) {
         other.heldItemId = null
-        if (itemId === 'vitality-ring') {
+        if (isVitalityItem(itemId)) {
           const max = dex.maxHp(other)
           if (other.hpCurrent > max)
             other.hpCurrent = max
@@ -35,7 +40,7 @@ export const useEquipmentStore = defineStore('equipment', () => {
     mon.heldItemId = itemId
     holders.value[itemId] = monId
     inventory.remove(itemId)
-    if (itemId === 'vitality-ring')
+    if (isVitalityItem(itemId))
       mon.hpCurrent = dex.maxHp(mon)
   }
 
@@ -47,7 +52,7 @@ export const useEquipmentStore = defineStore('equipment', () => {
     mon.heldItemId = null
     holders.value[itemId] = null
     inventory.add(itemId)
-    if (itemId === 'vitality-ring') {
+    if (isVitalityItem(itemId)) {
       const max = dex.maxHp(mon)
       if (mon.hpCurrent > max)
         mon.hpCurrent = max
@@ -61,7 +66,7 @@ export const useEquipmentStore = defineStore('equipment', () => {
     const mon = dex.shlagemons.find(m => m.id === holderId)
     if (mon) {
       mon.heldItemId = null
-      if (itemId === 'vitality-ring') {
+      if (isVitalityItem(itemId)) {
         const max = dex.maxHp(mon)
         if (mon.hpCurrent > max)
           mon.hpCurrent = max
@@ -79,7 +84,7 @@ export const useEquipmentStore = defineStore('equipment', () => {
     holders.value = {}
     for (const mon of dex.shlagemons) {
       if (mon.heldItemId) {
-        if (mon.heldItemId === 'vitality-ring') {
+        if (isVitalityItem(mon.heldItemId)) {
           const max = dex.maxHp(mon)
           if (mon.hpCurrent > max)
             mon.hpCurrent = max

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -95,20 +95,68 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return effect?.percent || 0
   })
 
+  const xpWearableBonus = (id: string | undefined) => {
+    if (!id)
+      return 0
+    if (id === 'xp-ring')
+      return 15
+    if (id === 'advanced-xp-ring')
+      return 25
+    if (id === 'xp-amulet')
+      return 33
+    return 0
+  }
+
   const attackBonusPercent = computed(() => {
     const effect = effects.value.find(e => e.type === 'attack')
     return effect?.percent || 0
   })
+
+  const attackWearableBonus = (id: string | undefined) => {
+    if (!id)
+      return 0
+    if (id === 'attack-ring')
+      return 15
+    if (id === 'advanced-attack-ring')
+      return 25
+    if (id === 'attack-amulet')
+      return 33
+    return 0
+  }
 
   const defenseBonusPercent = computed(() => {
     const effect = effects.value.find(e => e.type === 'defense')
     return effect?.percent || 0
   })
 
+  const defenseWearableBonus = (id: string | undefined) => {
+    if (!id)
+      return 0
+    if (id === 'defense-ring')
+      return 15
+    if (id === 'advanced-defense-ring')
+      return 25
+    if (id === 'defense-amulet')
+      return 33
+    return 0
+  }
+
   const vitalityBonusPercent = computed(() => {
     const effect = effects.value.find(e => e.type === 'vitality')
     return effect?.percent || 0
   })
+
+  const vitalityWearableBonus = (id: string | undefined) => {
+    if (!id)
+      return 0
+    if (id === 'vitality-ring')
+      return 15
+    if (id === 'advanced-vitality-ring')
+      return 25
+    if (id === 'vitality-amulet')
+      return 33
+    return 0
+  }
 
   const captureBonusPercent = computed(() => {
     const effect = effects.value.find(e => e.type === 'capture')
@@ -116,18 +164,19 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   })
 
   function effectiveAttack(mon: DexShlagemon): number {
-    return Math.round(mon.attack * (1 + attackBonusPercent.value / 100))
+    const bonus = attackBonusPercent.value + attackWearableBonus(mon.heldItemId)
+    return Math.round(mon.attack * (1 + bonus / 100))
   }
 
   function effectiveDefense(mon: DexShlagemon): number {
-    return Math.round(mon.defense * (1 + defenseBonusPercent.value / 100))
+    const bonus = defenseBonusPercent.value + defenseWearableBonus(mon.heldItemId)
+    return Math.round(mon.defense * (1 + bonus / 100))
   }
 
   function maxHp(mon: DexShlagemon): number {
     const isActive = activeShlagemon.value?.id === mon.id
     let bonus = isActive ? vitalityBonusPercent.value : 0
-    if (mon.heldItemId === 'vitality-ring')
-      bonus += 15
+    bonus += vitalityWearableBonus(mon.heldItemId)
     return Math.round(mon.hp * (1 + bonus / 100))
   }
 
@@ -469,8 +518,9 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   ) {
     if (mon.lvl >= maxLevel)
       return
-    if (mon.heldItemId === 'xp-ring')
-      amount = Math.round(amount * 1.15)
+    const bonus = xpWearableBonus(mon.heldItemId)
+    if (bonus)
+      amount = Math.round(amount * (1 + bonus / 100))
     mon.xp += amount
     while (mon.lvl < maxLevel && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)


### PR DESCRIPTION
## Summary
- move wearables to separate files under `data/items/wearables`
- introduce advanced ring and amulet variants for vitality, XP, attack and defense
- include new wearables in item list
- update equipment and shlagedex stores for new wearable effects

## Testing
- `npx eslint . --ext .ts,.vue --fix`
- `pnpm test` *(fails: ENETUNREACH for font fetch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687acc52269c832a9d7d641600d394a0