### PR TITLE
Update Tic Tac Toe reward

### DIFF
--- a/src/data/minigames.ts
+++ b/src/data/minigames.ts
@@ -8,7 +8,7 @@ export const ticTacToeMiniGame: MiniGameDefinition = {
   label: 'Tic Tac Toe',
   character: sachatte,
   component: () => import('~/components/minigame/TicTacToe.vue'),
-  reward: 100,
+  reward: { type: 'item', itemId: 'oeuf-herbe' },
   createIntro(start) {
     const miniGame = useMiniGameStore()
     const panel = useMainPanelStore()
@@ -34,7 +34,7 @@ export const ticTacToeMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'win',
-        text: 'Bien joué ! Tu gagnes 100 Shlagidolars.',
+        text: 'Bien joué ! Tu gagnes un Œuf Herbe.',
         responses: [
           { label: 'Super !', type: 'valid', action: done },
         ],

--- a/src/stores/miniGame.ts
+++ b/src/stores/miniGame.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { getMiniGame } from '~/data/minigames'
 import { notifyAchievement } from './achievements'
 import { useGameStore } from './game'
+import { useInventoryStore } from './inventory'
 
 export const useMiniGameStore = defineStore('miniGame', () => {
   const currentId = ref<MiniGameId | null>(null)
@@ -22,7 +23,11 @@ export const useMiniGameStore = defineStore('miniGame', () => {
     const def = currentId.value ? getMiniGame(currentId.value) : undefined
     if (win && def) {
       const game = useGameStore()
-      game.addShlagidolar(def.reward)
+      const inventory = useInventoryStore()
+      if (def.reward.type === 'money')
+        game.addShlagidolar(def.reward.amount)
+      else if (def.reward.type === 'item')
+        inventory.add(def.reward.itemId)
       wins.value += 1
       notifyAchievement({ type: 'minigame-win' })
     }

--- a/src/type/minigame.ts
+++ b/src/type/minigame.ts
@@ -1,13 +1,26 @@
 import type { Component } from 'vue'
 import type { Character } from './character'
 import type { DialogNode } from './dialog'
+import type { ItemId } from '~/data/items/items'
+
+export interface MoneyReward {
+  type: 'money'
+  amount: number
+}
+
+export interface ItemReward {
+  type: 'item'
+  itemId: ItemId
+}
+
+export type MiniGameReward = MoneyReward | ItemReward
 
 export interface MiniGameDefinition {
   id: MiniGameId
   label: string
   character: Character
   component: () => Promise<{ default: Component }>
-  reward: number
+  reward: MiniGameReward
   createIntro: (start: () => void) => DialogNode[]
   createSuccess: (done: () => void) => DialogNode[]
   createFailure: (done: () => void) => DialogNode[]

--- a/test/minigame.test.ts
+++ b/test/minigame.test.ts
@@ -1,7 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
-import { getMiniGame } from '../src/data/minigames'
 import { useGameStore } from '../src/stores/game'
+import { useInventoryStore } from '../src/stores/inventory'
 import { useMiniGameStore } from '../src/stores/miniGame'
 
 describe('mini game store', () => {
@@ -9,17 +9,21 @@ describe('mini game store', () => {
     setActivePinia(createPinia())
     const mini = useMiniGameStore()
     const game = useGameStore()
+    const inventory = useInventoryStore()
     mini.select('tictactoe')
     mini.finish(true)
-    expect(game.shlagidolar).toBe(getMiniGame('tictactoe')!.reward)
+    expect(inventory.items['oeuf-herbe']).toBe(1)
+    expect(game.shlagidolar).toBe(0)
     expect(mini.wins).toBe(1)
   })
 
   it('no reward on defeat', () => {
     setActivePinia(createPinia())
     const mini = useMiniGameStore()
+    const inventory = useInventoryStore()
     mini.select('tictactoe')
     mini.finish(false)
+    expect(inventory.items['oeuf-herbe']).toBeUndefined()
     expect(mini.wins).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- reward player with a Grass Egg for the Tic Tac Toe minigame
- handle item or money rewards in the minigame store
- extend minigame types with reward union
- adjust minigame store tests for new reward

## Testing
- `pnpm test` *(fails: Zone vallee-des-chieurs not found, snapshot mismatches, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687accfb0a14832ab601de57dafde939