### PR TITLE
Refactor minigame data into separate files

### DIFF
--- a/src/data/Minigame/Battleship.ts
+++ b/src/data/Minigame/Battleship.ts
@@ -1,0 +1,56 @@
+import type { MiniGameDefinition } from '~/type/minigame'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMiniGameStore } from '~/stores/miniGame'
+import { sachatte } from '../characters/sachatte'
+import { waterEgg } from '../items/items'
+
+export const battleshipMiniGame: MiniGameDefinition = {
+  id: 'battleship',
+  label: 'Bataille Navale',
+  character: sachatte,
+  component: () => import('~/components/minigame/Battleship.vue'),
+  reward: { type: 'item', itemId: waterEgg.id },
+  createIntro(start) {
+    const miniGame = useMiniGameStore()
+    const panel = useMainPanelStore()
+    return [
+      {
+        id: 'start',
+        text: 'Une partie de bataille navale ?',
+        responses: [
+          { label: 'Oui', type: 'primary', action: start },
+          {
+            label: 'Non',
+            type: 'danger',
+            action: () => {
+              miniGame.quit()
+              panel.showVillage()
+            },
+          },
+        ],
+      },
+    ]
+  },
+  createSuccess(done) {
+    return [
+      {
+        id: 'win',
+        text: 'Victoire ! Tu gagnes un \u0153uf Eau.',
+        responses: [
+          { label: 'Super !', type: 'valid', action: done },
+        ],
+      },
+    ]
+  },
+  createFailure(done) {
+    return [
+      {
+        id: 'fail',
+        text: 'Perdu ! Recommence quand tu veux.',
+        responses: [
+          { label: 'Retour', type: 'danger', action: done },
+        ],
+      },
+    ]
+  },
+}

--- a/src/data/Minigame/TicTacToe.ts
+++ b/src/data/Minigame/TicTacToe.ts
@@ -1,0 +1,56 @@
+import type { MiniGameDefinition } from '~/type/minigame'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMiniGameStore } from '~/stores/miniGame'
+import { sachatte } from '../characters/sachatte'
+import { grassEgg } from '../items/items'
+
+export const ticTacToeMiniGame: MiniGameDefinition = {
+  id: 'tictactoe',
+  label: 'Tic Tac Toe',
+  character: sachatte,
+  component: () => import('~/components/minigame/TicTacToe.vue'),
+  reward: { type: 'item', itemId: grassEgg.id },
+  createIntro(start) {
+    const miniGame = useMiniGameStore()
+    const panel = useMainPanelStore()
+    return [
+      {
+        id: 'start',
+        text: 'Envie d\'une partie de morpion ?',
+        responses: [
+          { label: 'Oui', type: 'primary', action: start },
+          {
+            label: 'Non',
+            type: 'danger',
+            action: () => {
+              miniGame.quit()
+              panel.showVillage()
+            },
+          },
+        ],
+      },
+    ]
+  },
+  createSuccess(done) {
+    return [
+      {
+        id: 'win',
+        text: 'Bien joué ! Tu gagnes un Œuf Herbe.',
+        responses: [
+          { label: 'Super !', type: 'valid', action: done },
+        ],
+      },
+    ]
+  },
+  createFailure(done) {
+    return [
+      {
+        id: 'fail',
+        text: 'Perdu ! Recommence quand tu veux.',
+        responses: [
+          { label: 'Retour', type: 'danger', action: done },
+        ],
+      },
+    ]
+  },
+}

--- a/src/data/minigames.ts
+++ b/src/data/minigames.ts
@@ -1,111 +1,11 @@
 import type { MiniGameDefinition } from '~/type/minigame'
-import { useMainPanelStore } from '~/stores/mainPanel'
-import { useMiniGameStore } from '~/stores/miniGame'
-import { sachatte } from './characters/sachatte'
+import { battleshipMiniGame } from './Minigame/Battleship'
+import { ticTacToeMiniGame } from './Minigame/TicTacToe'
 
-export const ticTacToeMiniGame: MiniGameDefinition = {
-  id: 'tictactoe',
-  label: 'Tic Tac Toe',
-  character: sachatte,
-  component: () => import('~/components/minigame/TicTacToe.vue'),
-  reward: { type: 'item', itemId: 'oeuf-herbe' },
-  createIntro(start) {
-    const miniGame = useMiniGameStore()
-    const panel = useMainPanelStore()
-    return [
-      {
-        id: 'start',
-        text: 'Envie d\'une partie de morpion ?',
-        responses: [
-          { label: 'Oui', type: 'primary', action: start },
-          {
-            label: 'Non',
-            type: 'danger',
-            action: () => {
-              miniGame.quit()
-              panel.showVillage()
-            },
-          },
-        ],
-      },
-    ]
-  },
-  createSuccess(done) {
-    return [
-      {
-        id: 'win',
-        text: 'Bien joué ! Tu gagnes un Œuf Herbe.',
-        responses: [
-          { label: 'Super !', type: 'valid', action: done },
-        ],
-      },
-    ]
-  },
-  createFailure(done) {
-    return [
-      {
-        id: 'fail',
-        text: 'Perdu ! Recommence quand tu veux.',
-        responses: [
-          { label: 'Retour', type: 'danger', action: done },
-        ],
-      },
-    ]
-  },
-}
-
-export const battleshipMiniGame: MiniGameDefinition = {
-  id: 'battleship',
-  label: 'Bataille Navale',
-  character: sachatte,
-  component: () => import('~/components/minigame/Battleship.vue'),
-  reward: 'oeuf-eau',
-  createIntro(start) {
-    const miniGame = useMiniGameStore()
-    const panel = useMainPanelStore()
-    return [
-      {
-        id: 'start',
-        text: 'Une partie de bataille navale ?',
-        responses: [
-          { label: 'Oui', type: 'primary', action: start },
-          {
-            label: 'Non',
-            type: 'danger',
-            action: () => {
-              miniGame.quit()
-              panel.showVillage()
-            },
-          },
-        ],
-      },
-    ]
-  },
-  createSuccess(done) {
-    return [
-      {
-        id: 'win',
-        text: 'Victoire ! Tu gagnes un \u0153uf Eau.',
-        responses: [
-          { label: 'Super !', type: 'valid', action: done },
-        ],
-      },
-    ]
-  },
-  createFailure(done) {
-    return [
-      {
-        id: 'fail',
-        text: 'Perdu ! Recommence quand tu veux.',
-        responses: [
-          { label: 'Retour', type: 'danger', action: done },
-        ],
-      },
-    ]
-  },
-}
-
-export const miniGames: MiniGameDefinition[] = [ticTacToeMiniGame, battleshipMiniGame]
+export const miniGames: MiniGameDefinition[] = [
+  ticTacToeMiniGame,
+  battleshipMiniGame,
+]
 
 export function getMiniGame(id: string): MiniGameDefinition | undefined {
   return miniGames.find(g => g.id === id)


### PR DESCRIPTION
## Summary
- split minigame definitions into `Minigame/Battleship.ts` and `Minigame/TicTacToe.ts`
- export new modules from `minigames.ts`
- use typed `itemId` references for rewards

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot mismatched and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ad2a4afe0832a92d97c2056b7b472