### PR TITLE
Implement egg incubation panel

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -190,6 +190,7 @@ declare global {
   const useDocumentVisibility: typeof import('@vueuse/core')['useDocumentVisibility']
   const useDraggable: typeof import('@vueuse/core')['useDraggable']
   const useDropZone: typeof import('@vueuse/core')['useDropZone']
+  const useEggHatchModalStore: typeof import('./stores/eggHatchModal')['useEggHatchModalStore']
   const useEggStore: typeof import('./stores/egg')['useEggStore']
   const useElementBounding: typeof import('@vueuse/core')['useElementBounding']
   const useElementByPoint: typeof import('@vueuse/core')['useElementByPoint']
@@ -606,6 +607,7 @@ declare module 'vue' {
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>
     readonly useDropZone: UnwrapRef<typeof import('@vueuse/core')['useDropZone']>
+    readonly useEggHatchModalStore: UnwrapRef<typeof import('./stores/eggHatchModal')['useEggHatchModalStore']>
     readonly useEggStore: UnwrapRef<typeof import('./stores/egg')['useEggStore']>
     readonly useElementBounding: UnwrapRef<typeof import('@vueuse/core')['useElementBounding']>
     readonly useElementByPoint: UnwrapRef<typeof import('@vueuse/core')['useElementByPoint']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -47,6 +47,7 @@ declare module 'vue' {
     DialogStarter: typeof import('./components/dialog/Starter.vue')['default']
     DialogVitalityRingDialog: typeof import('./components/dialog/VitalityRingDialog.vue')['default']
     DialogXpRingDialog: typeof import('./components/dialog/XpRingDialog.vue')['default']
+    EggHatchModal: typeof import('./components/egg/HatchModal.vue')['default']
     IconBadgeFatAss: typeof import('./components/icon/badge/FatAss.vue')['default']
     IconBadgeShit: typeof import('./components/icon/badge/Shit.vue')['default']
     IconBadgeStench: typeof import('./components/icon/badge/Stench.vue')['default']

--- a/src/components/egg/HatchModal.vue
+++ b/src/components/egg/HatchModal.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import ShlagemonImage from '~/components/shlagemon/Image.vue'
+import { useEggHatchModalStore } from '~/stores/eggHatchModal'
+
+const modal = useEggHatchModalStore()
+</script>
+
+<template>
+  <Modal v-model="modal.isVisible" footer-close>
+    <div class="flex flex-col items-center gap-2">
+      <h3 class="text-center text-lg font-bold">
+        Vous avez obtenu {{ modal.mon?.base.name }} !
+      </h3>
+      <ShlagemonImage
+        v-if="modal.mon"
+        :id="modal.mon.base.id"
+        :alt="modal.mon.base.name"
+        class="h-24 w-24"
+      />
+    </div>
+  </Modal>
+</template>

--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -26,6 +26,8 @@ const ballFilter = computed(() =>
   'catchBonus' in props.item ? { filter: `hue-rotate(${ballHues[props.item.id]})` } : {},
 )
 
+const isEgg = computed(() => props.item.id.startsWith('oeuf-'))
+
 const actionLabel = computed(() => {
   if ('catchBonus' in props.item || props.item.wearable)
     return props.disabled ? 'Équipé' : 'Équiper'
@@ -96,6 +98,7 @@ watch(showInfo, (val) => {
     <div class="flex items-center justify-end gap-1">
       <span class="font-bold">x{{ props.qty }}</span>
       <UiButton
+        v-if="!isEgg"
         class="flex items-center gap-1 text-xs"
         :disabled="props.disabled"
         @click.stop="emit('use')"
@@ -125,6 +128,7 @@ watch(showInfo, (val) => {
           {{ details }}
         </p>
         <UiButton
+          v-if="!isEgg"
           class="flex items-center gap-1 text-xs"
           :disabled="props.disabled"
           @click.stop="useFromModal"

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -1,10 +1,43 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import EggHatchModal from '~/components/egg/HatchModal.vue'
+import { allItems } from '~/data/items/items'
 import { useEggStore } from '~/stores/egg'
+import { useEggHatchModalStore } from '~/stores/eggHatchModal'
+import { useInventoryStore } from '~/stores/inventory'
 
 const eggs = useEggStore()
+const inventory = useInventoryStore()
+const modal = useEggHatchModalStore()
 const now = ref(Date.now())
-setInterval(() => now.value = Date.now(), 1000)
+function tick() {
+  now.value = Date.now()
+}
+setInterval(tick, 1000)
+
+const inventoryEggs = computed(() => {
+  return ['oeuf-feu', 'oeuf-eau', 'oeuf-herbe']
+    .map(id => ({
+      id,
+      item: allItems.find(i => i.id === id)!,
+      qty: inventory.items[id] || 0,
+    }))
+    .filter(e => e.qty > 0)
+})
+
+function startIncubation(id: string) {
+  if (eggs.incubator)
+    return
+  const map = { 'oeuf-feu': 'feu', 'oeuf-eau': 'eau', 'oeuf-herbe': 'plante' } as const
+  if (eggs.startIncubation(map[id]))
+    inventory.remove(id as any)
+}
+
+function hatch() {
+  const mon = eggs.hatchEgg()
+  if (mon)
+    modal.open(mon)
+}
 
 function remaining(egg: { hatchesAt: number }) {
   return Math.max(0, Math.ceil((egg.hatchesAt - now.value) / 1000))
@@ -19,27 +52,65 @@ function remaining(egg: { hatchesAt: number }) {
       </h3>
     </template>
     <template #content>
-      <div v-if="!eggs.eggs.length" class="text-center text-sm">
-        Aucun œuf en incubation
-      </div>
-      <div
-        v-for="egg in eggs.eggs"
-        :key="egg.id"
-        class="flex items-center justify-between border-b p-1"
-      >
-        <div class="flex items-center gap-1">
-          <div
-            class="i-game-icons:egg-eye h-6 w-6"
-            :class="{
-              'text-orange-500 dark:text-orange-400': egg.type === 'feu',
-              'text-blue-500 dark:text-blue-400': egg.type === 'eau',
-              'text-green-500 dark:text-green-400': egg.type === 'herbe',
-            }"
-          />
-          <span class="text-sm capitalize">{{ egg.type }}</span>
+      <div class="flex flex-col gap-2">
+        <div>
+          <h4 class="font-semibold">
+            Incubateur
+          </h4>
+          <div class="flex-center flex-col gap-1 border rounded p-2">
+            <template v-if="eggs.incubator">
+              <div
+                class="i-game-icons:egg-eye h-8 w-8"
+                :class="{
+                  'text-orange-500 dark:text-orange-400': eggs.incubator.type === 'feu',
+                  'text-blue-500 dark:text-blue-400': eggs.incubator.type === 'eau',
+                  'text-green-500 dark:text-green-400': eggs.incubator.type === 'plante',
+                }"
+              />
+              <span v-if="!eggs.isReady" class="text-xs">{{ remaining(eggs.incubator) }}s</span>
+              <UiButton v-else class="text-xs" @click="hatch">
+                Éclore
+              </UiButton>
+            </template>
+            <span v-else class="text-sm">Aucun œuf</span>
+          </div>
         </div>
-        <span class="text-xs">{{ remaining(egg) }}s</span>
+        <div>
+          <h4 class="font-semibold">
+            Vos œufs
+          </h4>
+          <div v-if="inventoryEggs.length" class="flex flex-col gap-1">
+            <div
+              v-for="entry in inventoryEggs"
+              :key="entry.id"
+              class="flex items-center justify-between border-b p-1"
+            >
+              <div class="flex items-center gap-1">
+                <div
+                  v-if="entry.item.icon"
+                  class="h-6 w-6"
+                  :class="[entry.item.icon, entry.item.iconClass]"
+                />
+                <span class="text-sm">{{ entry.item.name }}</span>
+              </div>
+              <div class="flex items-center gap-1">
+                <span class="text-xs font-bold">x{{ entry.qty }}</span>
+                <UiButton
+                  v-if="!eggs.incubator"
+                  class="text-xs"
+                  @click="startIncubation(entry.id)"
+                >
+                  Incuber
+                </UiButton>
+              </div>
+            </div>
+          </div>
+          <div v-else class="text-center text-sm">
+            Aucun œuf dans l'inventaire
+          </div>
+        </div>
       </div>
+      <EggHatchModal />
     </template>
   </LayoutScrollablePanel>
 </template>

--- a/src/stores/eggHatchModal.ts
+++ b/src/stores/eggHatchModal.ts
@@ -1,0 +1,16 @@
+import type { DexShlagemon } from '~/type/shlagemon'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { createModalStore } from './helpers'
+
+export const useEggHatchModalStore = defineStore('eggHatchModal', () => {
+  const { isVisible, open: openModal, close } = createModalStore()
+  const mon = ref<DexShlagemon | null>(null)
+
+  function open(newMon: DexShlagemon) {
+    mon.value = newMon
+    openModal()
+  }
+
+  return { isVisible, mon, open, close }
+})

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -5,7 +5,6 @@ import { allItems } from '~/data/items/items'
 import { allShlagemons } from '~/data/shlagemons'
 import { notifyAchievement } from './achievements'
 import { useCaptureLimitModalStore } from './captureLimitModal'
-import { useEggStore } from './egg'
 import { useFeatureLockStore } from './featureLock'
 import { useGameStore } from './game'
 import { useItemUsageStore } from './itemUsage'
@@ -194,24 +193,6 @@ export const useInventoryStore = defineStore('inventory', () => {
       'shlageball': capture,
       'super-shlageball': capture,
       'hyper-shlageball': capture,
-      'oeuf-feu': () => {
-        const eggs = useEggStore()
-        eggs.addEgg('feu')
-        remove(id)
-        return true
-      },
-      'oeuf-eau': () => {
-        const eggs = useEggStore()
-        eggs.addEgg('eau')
-        remove(id)
-        return true
-      },
-      'oeuf-herbe': () => {
-        const eggs = useEggStore()
-        eggs.addEgg('herbe')
-        remove(id)
-        return true
-      },
     }
 
     const handler = handlers[id]

--- a/test/egg.test.ts
+++ b/test/egg.test.ts
@@ -13,12 +13,14 @@ describe('egg workflow', () => {
     const dex = useShlagedexStore()
 
     inventory.add('oeuf-feu')
-    expect(inventory.useItem('oeuf-feu')).toBe(true)
-    expect(eggs.eggs.length).toBe(1)
+    eggs.startIncubation('feu')
+    inventory.remove('oeuf-feu')
+    expect(eggs.incubator).not.toBeNull()
 
     vi.advanceTimersByTime(61_000)
-    vi.runOnlyPendingTimers()
-    expect(eggs.eggs.length).toBe(0)
+    expect(eggs.isReady).toBe(true)
+    const mon = eggs.hatchEgg()
+    expect(mon).not.toBeNull()
     expect(dex.shlagemons.length).toBe(1)
     vi.useRealTimers()
   })


### PR DESCRIPTION
## Summary
- switch egg store to single incubator and manual hatching
- remove use button for eggs in inventory
- add egg hatch modal and panel UI
- update inventory store and tests

## Testing
- `pnpm lint --fix`
- `pnpm test` *(fails: Failed to resolve some imports, network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ad3600320832ab05468ee650444b6