### PR TITLE
Add WearableItemIcon component

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -381,6 +381,9 @@ declare global {
   export type { BattleCoreOptions } from './composables/useBattleCore'
   import('./composables/useBattleCore')
   // @ts-ignore
+  export type { Cell } from './composables/useBattleship'
+  import('./composables/useBattleship')
+  // @ts-ignore
   export type { Achievement, AchievementEvent } from './stores/achievements'
   import('./stores/achievements')
   // @ts-ignore
@@ -398,6 +401,9 @@ declare global {
   // @ts-ignore
   export type { DialogDone } from './stores/dialog'
   import('./stores/dialog')
+  // @ts-ignore
+  export type { EggType, Egg } from './stores/egg'
+  import('./stores/egg')
   // @ts-ignore
   export type { EventMap, EventCallback } from './stores/event'
   import('./stores/event')
@@ -420,9 +426,14 @@ import { UnwrapRef } from 'vue'
 declare module 'vue' {
   interface GlobalComponents {}
   interface ComponentCustomProperties {
+    readonly BOARD_SIZE: UnwrapRef<typeof import('./composables/useBattleship')['BOARD_SIZE']>
+    readonly CENTER_CELLS: UnwrapRef<typeof import('./composables/useTicTacToe')['CENTER_CELLS']>
     readonly EffectScope: UnwrapRef<typeof import('vue')['EffectScope']>
+    readonly SIZE: UnwrapRef<typeof import('./composables/useTicTacToe')['SIZE']>
     readonly asyncComputed: UnwrapRef<typeof import('@vueuse/core')['asyncComputed']>
     readonly autoResetRef: UnwrapRef<typeof import('@vueuse/core')['autoResetRef']>
+    readonly check: UnwrapRef<typeof import('./composables/useTicTacToe')['check']>
+    readonly combos: UnwrapRef<typeof import('./composables/useTicTacToe')['combos']>
     readonly computed: UnwrapRef<typeof import('vue')['computed']>
     readonly computedAsync: UnwrapRef<typeof import('@vueuse/core')['computedAsync']>
     readonly computedEager: UnwrapRef<typeof import('@vueuse/core')['computedEager']>
@@ -431,6 +442,7 @@ declare module 'vue' {
     readonly controlledComputed: UnwrapRef<typeof import('@vueuse/core')['controlledComputed']>
     readonly controlledRef: UnwrapRef<typeof import('@vueuse/core')['controlledRef']>
     readonly createApp: UnwrapRef<typeof import('vue')['createApp']>
+    readonly createBattleshipAI: UnwrapRef<typeof import('./composables/useBattleship')['createBattleshipAI']>
     readonly createEventHook: UnwrapRef<typeof import('@vueuse/core')['createEventHook']>
     readonly createGlobalState: UnwrapRef<typeof import('@vueuse/core')['createGlobalState']>
     readonly createInjectionState: UnwrapRef<typeof import('@vueuse/core')['createInjectionState']>
@@ -449,6 +461,7 @@ declare module 'vue' {
     readonly eagerComputed: UnwrapRef<typeof import('@vueuse/core')['eagerComputed']>
     readonly effectScope: UnwrapRef<typeof import('vue')['effectScope']>
     readonly extendRef: UnwrapRef<typeof import('@vueuse/core')['extendRef']>
+    readonly findBestMove: UnwrapRef<typeof import('./composables/useTicTacToe')['findBestMove']>
     readonly getCurrentInstance: UnwrapRef<typeof import('vue')['getCurrentInstance']>
     readonly getCurrentScope: UnwrapRef<typeof import('vue')['getCurrentScope']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
@@ -558,6 +571,7 @@ declare module 'vue' {
     readonly useBattleEffects: UnwrapRef<typeof import('./composables/battleEngine')['useBattleEffects']>
     readonly useBattleStatsStore: UnwrapRef<typeof import('./stores/battleStats')['useBattleStatsStore']>
     readonly useBattleStore: UnwrapRef<typeof import('./stores/battle')['useBattleStore']>
+    readonly useBattleship: UnwrapRef<typeof import('./composables/useBattleship')['useBattleship']>
     readonly useBluetooth: UnwrapRef<typeof import('@vueuse/core')['useBluetooth']>
     readonly useBreakpoints: UnwrapRef<typeof import('@vueuse/core')['useBreakpoints']>
     readonly useBroadcastChannel: UnwrapRef<typeof import('@vueuse/core')['useBroadcastChannel']>
@@ -593,6 +607,8 @@ declare module 'vue' {
     readonly useDocumentVisibility: UnwrapRef<typeof import('@vueuse/core')['useDocumentVisibility']>
     readonly useDraggable: UnwrapRef<typeof import('@vueuse/core')['useDraggable']>
     readonly useDropZone: UnwrapRef<typeof import('@vueuse/core')['useDropZone']>
+    readonly useEggHatchModalStore: UnwrapRef<typeof import('./stores/eggHatchModal')['useEggHatchModalStore']>
+    readonly useEggStore: UnwrapRef<typeof import('./stores/egg')['useEggStore']>
     readonly useElementBounding: UnwrapRef<typeof import('@vueuse/core')['useElementBounding']>
     readonly useElementByPoint: UnwrapRef<typeof import('@vueuse/core')['useElementByPoint']>
     readonly useElementHover: UnwrapRef<typeof import('@vueuse/core')['useElementHover']>
@@ -716,6 +732,7 @@ declare module 'vue' {
     readonly useThrottle: UnwrapRef<typeof import('@vueuse/core')['useThrottle']>
     readonly useThrottleFn: UnwrapRef<typeof import('@vueuse/core')['useThrottleFn']>
     readonly useThrottledRefHistory: UnwrapRef<typeof import('@vueuse/core')['useThrottledRefHistory']>
+    readonly useTicTacToe: UnwrapRef<typeof import('./composables/useTicTacToe')['useTicTacToe']>
     readonly useTimeAgo: UnwrapRef<typeof import('@vueuse/core')['useTimeAgo']>
     readonly useTimeout: UnwrapRef<typeof import('@vueuse/core')['useTimeout']>
     readonly useTimeoutFn: UnwrapRef<typeof import('@vueuse/core')['useTimeoutFn']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -62,6 +62,7 @@ declare module 'vue' {
     InventoryEvolutionItemModal: typeof import('./components/inventory/EvolutionItemModal.vue')['default']
     InventoryItemCard: typeof import('./components/inventory/ItemCard.vue')['default']
     InventoryItemShortcutModal: typeof import('./components/inventory/ItemShortcutModal.vue')['default']
+    InventoryWearableItemIcon: typeof import('./components/inventory/WearableItemIcon.vue')['default']
     InventoryWearableItemModal: typeof import('./components/inventory/WearableItemModal.vue')['default']
     LayoutGameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     LayoutHeader: typeof import('./components/layout/Header.vue')['default']

--- a/src/components/inventory/WearableItemIcon.vue
+++ b/src/components/inventory/WearableItemIcon.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { Item } from '~/type/item'
+
+const props = defineProps<{ item: Item }>()
+</script>
+
+<template>
+  <div
+    v-if="props.item.icon"
+    v-bind="$attrs"
+    :title="props.item.name"
+    :class="[props.item.icon, props.item.iconClass]"
+  />
+  <img
+    v-else-if="props.item.image"
+    v-bind="$attrs"
+    :title="props.item.name"
+    :src="props.item.image"
+    :alt="props.item.name"
+    class="object-contain"
+  >
+</template>

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import WearableItemIcon from '~/components/inventory/WearableItemIcon.vue'
 import ShlagemonStats from '~/components/shlagemon/Stats.vue'
 import { allItems } from '~/data/items/items'
 import { useDiseaseStore } from '~/stores/disease'
@@ -128,17 +129,10 @@ const captureInfo = computed(() => {
         />
         <div class="absolute right-0 top-0 flex items-center gap-1">
           <template v-if="heldItem">
-            <div
-              v-if="heldItem.icon"
+            <WearableItemIcon
+              :item="heldItem"
               class="h-5 w-5"
-              :class="[heldItem.icon, heldItem.iconClass]"
             />
-            <img
-              v-else-if="heldItem.image"
-              :src="heldItem.image"
-              :alt="heldItem.name"
-              class="h-5 w-5 object-contain"
-            >
             <UiButton
               type="icon"
               class="h-7 w-7"

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import WearableItemIcon from '~/components/inventory/WearableItemIcon.vue'
 import { allItems } from '~/data/items/items'
 import { useDexFilterStore } from '~/stores/dexFilter'
 import { useFeatureLockStore } from '~/stores/featureLock'
@@ -162,17 +163,10 @@ function changeActive(mon: DexShlagemon) {
         @click.stop="handleClick(mon)"
       >
         <div v-if="mon.heldItemId" class="absolute right-1 top-1 h-4 w-4">
-          <div
-            v-if="items[mon.heldItemId]?.icon"
+          <WearableItemIcon
+            :item="items[mon.heldItemId]"
             class="h-4 w-4"
-            :class="[items[mon.heldItemId].icon, items[mon.heldItemId].iconClass]"
           />
-          <img
-            v-else-if="items[mon.heldItemId]?.image"
-            :src="items[mon.heldItemId].image"
-            :alt="items[mon.heldItemId].name"
-            class="h-4 w-4 object-contain"
-          >
         </div>
         <div class="absolute bottom-0 right-2 text-xs">
           lvl {{ mon.lvl }}


### PR DESCRIPTION
## Summary
- show wearable items with new `WearableItemIcon` component
- reuse component in Shlagemon list and detail views
- update auto-import declarations

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot and store tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b44844c4c832a9e6770065f8831f8