### PR TITLE
Display village name in action panel

### DIFF
--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -13,6 +13,9 @@ const zone = useZoneStore()
       :alt="zone.current.name"
       class="aspect-video h-full max-h-60 w-full object-contain md:max-h-80"
     />
+    <h2 class="text-center font-bold">
+      {{ zone.current.name }}
+    </h2>
     <ZoneActions />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show the current village name above its action buttons

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Snapshots and imports fail)*

------
https://chatgpt.com/codex/tasks/task_e_687b50d1ca3c832aab944262073bce6c