### PR TITLE
Fix Vue component shim typings

### DIFF
--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ts/no-empty-object-type */
 declare interface Window {
   // extend the window
 }
@@ -6,13 +7,13 @@ declare interface Window {
 declare module '*.md' {
   import type { DefineComponent } from 'vue'
 
-  const component: DefineComponent<object, object, any>
+  const component: DefineComponent<{}, {}, unknown>
   export default component
 }
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
 
-  const component: DefineComponent<object, object, any>
+  const component: DefineComponent<{}, {}, unknown>
   export default component
 }


### PR DESCRIPTION
## Summary
- update `src/shims.d.ts` to use `DefineComponent<{}, {}, unknown>`
- silence eslint rule complaining about empty object types

## Testing
- `pnpm run typecheck` *(fails: Type errors in src/utils/shlagedex-serialize.ts)*
- `pnpm run test:unit` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b5c9c1fd4832aae326364fd0c7b9d