### PR TITLE
Fix shiny-text style scoping

### DIFF
--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -212,7 +212,7 @@ const captureInfo = computed(() => {
   </div>
 </template>
 
-<style>
+<style scoped>
 .shiny-text {
   background: linear-gradient(90deg, #ff00cc, #3333ff, #00ffff, #00ff00, #ffff00, #ff9900, #ff0000);
   background-size: 400% 400%;


### PR DESCRIPTION
## Summary
- scope the CSS for the shiny-text animation inside `Detail.vue`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshots mismatched and network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b5c83e33c832a918041bd29e712fc