### PR TITLE
Add initial i18n files

### DIFF
--- a/scripts/merge-i18n.cjs
+++ b/scripts/merge-i18n.cjs
@@ -6,6 +6,7 @@ const baseDirs = [
   path.join(__dirname, '../src/components'),
   path.join(__dirname, '../src/stores'),
   path.join(__dirname, '../src/data'),
+  path.join(__dirname, '../src/pages'),
 ]
 
 function walk(dir, files = []) {

--- a/src/components/deck/DeckDetail.i18n.yml
+++ b/src/components/deck/DeckDetail.i18n.yml
@@ -1,0 +1,7 @@
+deckDetail:
+  fr:
+    evolution: 'Évolution :'
+    level: 'lvl {n}'
+  en:
+    evolution: 'Evolution:'
+    level: 'lvl {n}'

--- a/src/components/deck/DeckDetail.vue
+++ b/src/components/deck/DeckDetail.vue
@@ -5,6 +5,7 @@ const props = defineProps<{ mon: BaseShlagemon | null }>()
 const emit = defineEmits<{
   (e: 'openMon', mon: BaseShlagemon): void
 }>()
+const { t } = useI18n()
 </script>
 
 <template>
@@ -24,16 +25,16 @@ const emit = defineEmits<{
       />
     </div>
     <p class="tiny-scrollbar max-h-40 overflow-auto text-sm italic">
-      {{ props.mon.description }}
+      {{ t(`shlagemons.${props.mon.id}.description`) }}
     </p>
     <div v-if="props.mon.evolution" class="flex flex-col items-center text-sm font-medium">
-      <span>Évolution :</span>
+      <span>{{ t('deckDetail.evolution') }}</span>
       <div class="mt-1 flex items-center gap-1">
         <UiButton variant="outline" @click="emit('openMon', props.mon.evolution.base)">
           {{ props.mon.evolution.base.name }}
         </UiButton>
         <span v-if="props.mon.evolution.condition.type === 'lvl'">
-          - lvl {{ props.mon.evolution.condition.value }}
+          - {{ t('deckDetail.level', { n: props.mon.evolution.condition.value }) }}
         </span>
         <span v-else>
           - {{ props.mon.evolution.condition.value.name }}

--- a/src/components/deck/DeckList.i18n.yml
+++ b/src/components/deck/DeckList.i18n.yml
@@ -1,0 +1,5 @@
+deckList:
+  fr:
+    search: Rechercher
+  en:
+    search: Search

--- a/src/components/deck/DeckList.vue
+++ b/src/components/deck/DeckList.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
 }>()
 
 const search = ref('')
+const { t } = useI18n()
 
 const displayed = computed(() => {
   const q = search.value.trim().toLowerCase()
@@ -19,7 +20,7 @@ const displayed = computed(() => {
 <template>
   <LayoutScrollablePanel>
     <template #header>
-      <UiSearchInput v-model="search" placeholder="Rechercher" />
+      <UiSearchInput v-model="search" :placeholder="t('deckList.search')" />
     </template>
     <template #content>
       <div

--- a/src/data/shlagemons/salamiches.i18n.yml
+++ b/src/data/shlagemons/salamiches.i18n.yml
@@ -1,0 +1,11 @@
+shlagemons:
+  fr:
+    salamiches:
+      name: Salamiches
+      description: |
+        Salamiches brûle, mais pas de feu noble, non, plutôt de feu de briquet BIC vide qu’on rallume à la 27ᵉ tentative. Toujours torse nu, même en hiver, il arbore une crête en feu mal fixée et des lunettes de soleil qui fondent partiellement à chaque attaque. Il se nourrit exclusivement de chips au paprika, de whisky bon marché, et d’approbation sociale. On le trouve souvent en train de se filmer en selfie pendant qu’il crache des étincelles sur des poubelles. Sa capacité spéciale, *Feu d’ego*, augmente sa puissance chaque fois qu’il se fait huer. Il envoie des punchlines nulles entre deux jets de flamme molle, et rêve de devenir influenceur muscu alors qu’il n’a que deux abdos (et encore, en ombrage). C’est un être loyal, sauf si on lui propose un kebab gratuit ou une promotion chez Feu Vert.
+  en:
+    salamiches:
+      name: Salamiches
+      description: |
+        Salamiches burns with the weak flame of an empty lighter. Always shirtless, he records himself spitting sparks on trash cans. His special ability, *Ego Fire*, boosts his power whenever people boo him. Loyal unless offered a free kebab or a sale at the auto shop.

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -12,6 +12,11 @@ intro:
   aka: Also known as
   whats-your-name: What's your name?
 not-found: Not found
+deckDetail:
+  evolution: 'Evolution:'
+  level: lvl {n}
+deckList:
+  search: Search
 carreflex:
   description: >-
     Carreflex is a blocky giant that often sleeps in the middle of the road. Its
@@ -25,3 +30,17 @@ magmaretfred:
     Magmar&Fred imagines battling alongside a missing partner, spewing flames
     while telling questionable jokes. He heats things up but usually ends up
     alone on stage.
+shlagemons:
+  salamiches:
+    name: Salamiches
+    description: >
+      Salamiches burns with the weak flame of an empty lighter. Always
+      shirtless, he records himself spitting sparks on trash cans. His special
+      ability, *Ego Fire*, boosts his power whenever people boo him. Loyal
+      unless offered a free kebab or a sale at the auto shop.
+indexPage:
+  title: Shlagemon
+  description: A parody of Pokémon with crazy creatures
+  welcome: Welcome to Shlagemon
+shlagedexPage:
+  title: Shlage Deck

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -12,6 +12,11 @@ intro:
   aka: Aussi connu sous le nom de
   whats-your-name: Comment t'appelles-tu ?
 not-found: Page non trouvée
+deckDetail:
+  evolution: 'Évolution :'
+  level: lvl {n}
+deckList:
+  search: Rechercher
 carreflex:
   description: >-
     Carréflex est un colosse tout en angles qui dort généralement en plein
@@ -26,3 +31,25 @@ magmaretfred:
     Toujours en duo imaginaire avec son compère absent, Magmar&Fred crache des
     flammes en récitant des blagues douteuses. Il chauffe l'ambiance mais finit
     souvent seul sur scène.
+shlagemons:
+  salamiches:
+    name: Salamiches
+    description: >
+      Salamiches brûle, mais pas de feu noble, non, plutôt de feu de briquet BIC
+      vide qu’on rallume à la 27ᵉ tentative. Toujours torse nu, même en hiver,
+      il arbore une crête en feu mal fixée et des lunettes de soleil qui fondent
+      partiellement à chaque attaque. Il se nourrit exclusivement de chips au
+      paprika, de whisky bon marché, et d’approbation sociale. On le trouve
+      souvent en train de se filmer en selfie pendant qu’il crache des
+      étincelles sur des poubelles. Sa capacité spéciale, *Feu d’ego*, augmente
+      sa puissance chaque fois qu’il se fait huer. Il envoie des punchlines
+      nulles entre deux jets de flamme molle, et rêve de devenir influenceur
+      muscu alors qu’il n’a que deux abdos (et encore, en ombrage). C’est un
+      être loyal, sauf si on lui propose un kebab gratuit ou une promotion chez
+      Feu Vert.
+indexPage:
+  title: Shlagémon
+  description: Parodie de Pokémon avec des créatures loufoques
+  welcome: Bienvenue dans Shlagémon
+shlagedexPage:
+  title: Schlage Deck

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,18 +1,17 @@
 <script setup lang="ts">
+const { t } = useI18n()
+useHead({
+  title: () => t('indexPage.title'),
+  meta: [
+    { name: 'description', content: t('indexPage.description') },
+  ],
+})
 </script>
-
-<route lang="yaml">
-head:
-  title: Shlagémon
-  meta:
-    - name: description
-      content: Parodie de Pokémon avec des créatures loufoques
-</route>
 
 <template>
   <div class="mx-auto max-w-160 w-full py-10 text-center">
     <h1 class="mb-4 text-2xl font-bold">
-      Bienvenue dans Shlagémon
+      {{ t('indexPage.welcome') }}
     </h1>
   </div>
 </template>

--- a/src/pages/indexPage.i18n.yml
+++ b/src/pages/indexPage.i18n.yml
@@ -1,0 +1,9 @@
+indexPage:
+  fr:
+    title: Shlagémon
+    description: Parodie de Pokémon avec des créatures loufoques
+    welcome: Bienvenue dans Shlagémon
+  en:
+    title: Shlagemon
+    description: A parody of Pokémon with crazy creatures
+    welcome: Welcome to Shlagemon

--- a/src/pages/shlagedex.vue
+++ b/src/pages/shlagedex.vue
@@ -6,19 +6,16 @@ import { allShlagemons } from '~/data/shlagemons'
 
 const showDetail = ref(false)
 const selected = ref<BaseShlagemon | null>(null)
+const { t } = useI18n()
+useHead({
+  title: () => t('shlagedexPage.title'),
+})
 
 function open(mon: BaseShlagemon) {
   selected.value = mon
   showDetail.value = true
 }
 </script>
-
-<route lang="yaml">
-meta:
-  layout: home
-head:
-  title: Schlage Deck
-</route>
 
 <template>
   <div class="mx-auto max-w-160 w-full p-4">

--- a/src/pages/shlagedexPage.i18n.yml
+++ b/src/pages/shlagedexPage.i18n.yml
@@ -1,0 +1,5 @@
+shlagedexPage:
+  fr:
+    title: Schlage Deck
+  en:
+    title: Shlage Deck


### PR DESCRIPTION
## Summary
- setup page titles and welcome text with vue-i18n
- translate deck list & deck detail components
- add example monster translations (salamiches)
- merge i18n YAML for pages

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 29 failed, 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687b609e7470832aabcd76fb6e5744e5