### PR TITLE
Add language and fullscreen toggle in header

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -125,6 +125,7 @@ declare module 'vue' {
     UiButton: typeof import('./components/ui/Button.vue')['default']
     UiCheckBox: typeof import('./components/ui/CheckBox.vue')['default']
     UiCurrencyAmount: typeof import('./components/ui/CurrencyAmount.vue')['default']
+    UiFullscreenToggle: typeof import('./components/ui/FullscreenToggle.vue')['default']
     UiImageByBackground: typeof import('./components/ui/ImageByBackground.vue')['default']
     UiInfo: typeof import('./components/ui/Info.vue')['default']
     UiInputTipRange: typeof import('./components/ui/InputTipRange.vue')['default']

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import FullscreenToggle from '~/components/ui/FullscreenToggle.vue'
 import { useAudioStore } from '~/stores/audio'
 
 const showSettings = ref(false)
@@ -6,6 +8,8 @@ const showAudio = ref(false)
 const showDeveloper = ref(false)
 const clickTimer = ref<UseTimeoutFnReturn | null>(null)
 const audio = useAudioStore()
+const { locale } = useI18n()
+const currentLocale = Intl.DateTimeFormat().resolvedOptions().locale
 
 function onClick() {
   if (clickTimer.value)
@@ -24,8 +28,16 @@ function onDoubleClick() {
 
 <template>
   <header class="h-12 flex items-center justify-between bg-gray-100 p-4 dark:bg-gray-800">
-    <img src="/logo.png" alt="Logo Shlagémon" class="h-20 -my-4">
     <div class="flex items-center gap-2">
+      <img src="/logo.png" alt="Logo Shlagémon" class="h-20 -my-4">
+      <div class="flex flex-col text-xs leading-tight">
+        <span class="font-bold sm:text-sm">Shlagémon - Ça sent très fort</span>
+        <span>Langue: {{ locale }}</span>
+        <span>Locale: {{ currentLocale }}</span>
+      </div>
+    </div>
+    <div class="flex items-center gap-2">
+      <FullscreenToggle />
       <ThemeToggle />
       <UiButton
         type="icon"

--- a/src/components/ui/FullscreenToggle.vue
+++ b/src/components/ui/FullscreenToggle.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+const isFullscreen = ref(false)
+
+function toggle() {
+  if (!isFullscreen.value) {
+    document.documentElement.requestFullscreen?.()
+  }
+  else {
+    document.exitFullscreen?.()
+  }
+}
+
+useEventListener(document, 'fullscreenchange', () => {
+  isFullscreen.value = !!document.fullscreenElement
+})
+</script>
+
+<template>
+  <UiButton type="icon" aria-label="Plein écran" @click="toggle">
+    <div :class="isFullscreen ? 'i-carbon-minimize' : 'i-carbon-maximize'" />
+  </UiButton>
+</template>


### PR DESCRIPTION
## Summary
- display game language and current locale in header
- add fullscreen toggle button

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_687bcb872c70832ab2123bdb3d731f73