### PR TITLE
Fix battleship composable import and add test

### DIFF
--- a/src/composables/useBattleship.ts
+++ b/src/composables/useBattleship.ts
@@ -1,3 +1,4 @@
+import { useTimeoutFn } from '@vueuse/core'
 import { ref } from 'vue'
 
 export interface Cell {

--- a/test/battleship-component.test.ts
+++ b/test/battleship-component.test.ts
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import Battleship from '../src/components/minigame/Battleship.vue'
+
+describe('battleship component', () => {
+  it('renders without crashing', () => {
+    const wrapper = mount(Battleship)
+    expect(wrapper.exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- import useTimeoutFn in the Battleship composable
- verify Battleship.vue renders by mounting it in a new unit test

## Testing
- `pnpm lint`
- `pnpm test:unit --run test/battleship-component.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_687befbef758832a84583057db6f5dc2