### PR TITLE
Improve header i18n

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,6 +5,15 @@ components:
       level: lvl {n}
     DeckList:
       search: Search
+  layout:
+    Header:
+      title: Shlagemon - It smells very strong
+      language: Language
+      locale: Locale
+      audio: Audio
+      settings: Settings
+      developer: Developer
+      logoAlt: Shlagemon logo
 data:
   shlagemons:
     01-05:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -5,6 +5,15 @@ components:
       level: lvl {n}
     DeckList:
       search: Rechercher
+  layout:
+    Header:
+      title: Shlagémon - Ça sent très fort
+      language: Langue
+      locale: Locale
+      audio: Audio
+      settings: Paramètres
+      developer: Développeur
+      logoAlt: Logo Shlagémon
 data:
   shlagemons:
     01-05:

--- a/src/components/layout/Header.i18n.yml
+++ b/src/components/layout/Header.i18n.yml
@@ -1,0 +1,16 @@
+fr:
+  title: Shlagémon - Ça sent très fort
+  language: Langue
+  locale: Locale
+  audio: Audio
+  settings: Paramètres
+  developer: Développeur
+  logoAlt: Logo Shlagémon
+en:
+  title: Shlagemon - It smells very strong
+  language: Language
+  locale: Locale
+  audio: Audio
+  settings: Settings
+  developer: Developer
+  logoAlt: Shlagemon logo

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -8,7 +8,7 @@ const showAudio = ref(false)
 const showDeveloper = ref(false)
 const clickTimer = ref<UseTimeoutFnReturn | null>(null)
 const audio = useAudioStore()
-const { locale } = useI18n()
+const { t, locale } = useI18n()
 const currentLocale = Intl.DateTimeFormat().resolvedOptions().locale
 
 function onClick() {
@@ -29,11 +29,11 @@ function onDoubleClick() {
 <template>
   <header class="h-12 flex items-center justify-between bg-gray-100 p-4 dark:bg-gray-800">
     <div class="flex items-center gap-2">
-      <img src="/logo.png" alt="Logo Shlagémon" class="h-20 -my-4">
+      <img src="/logo.png" :alt="t('header.logoAlt')" class="h-20 -my-4">
       <div class="flex flex-col text-xs leading-tight">
-        <span class="font-bold sm:text-sm">Shlagémon - Ça sent très fort</span>
-        <span>Langue: {{ locale }}</span>
-        <span>Locale: {{ currentLocale }}</span>
+        <span class="font-bold sm:text-sm">{{ t('header.title') }}</span>
+        <span>{{ t('header.language') }}: {{ locale }}</span>
+        <span>{{ t('header.locale') }}: {{ currentLocale }}</span>
       </div>
     </div>
     <div class="flex items-center gap-2">
@@ -41,18 +41,18 @@ function onDoubleClick() {
       <ThemeToggle />
       <UiButton
         type="icon"
-        aria-label="Audio"
+        :aria-label="t('header.audio')"
         @click.stop="onClick"
         @dblclick.stop="onDoubleClick"
       >
         <div :class="audio.isMusicEnabled ? 'i-carbon-volume-up' : 'i-carbon-volume-mute'" />
       </UiButton>
       <AudioSettingsModal v-model="showAudio" />
-      <UiButton type="icon" aria-label="Paramètres" @click="showSettings = true">
+      <UiButton type="icon" :aria-label="t('header.settings')" @click="showSettings = true">
         <div class="i-carbon-settings" />
       </UiButton>
       <SettingsSettingsModal v-model="showSettings" />
-      <UiButton type="icon" aria-label="Développeur" @click="showDeveloper = true">
+      <UiButton type="icon" :aria-label="t('header.developer')" @click="showDeveloper = true">
         <div class="i-carbon-debug" />
       </UiButton>
       <DeveloperSettingsModal v-model="showDeveloper" />


### PR DESCRIPTION
## Summary
- translate `Header.vue`
- add `Header.i18n.yml` and merge locales

## Testing
- `pnpm i18n`
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetch errors during font download)*

------
https://chatgpt.com/codex/tasks/task_e_687be1b713e4832a945e81ef3ff6d7f3