### PR TITLE
Add developer debug tools

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_DEV_TOOLS=true

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_DEV_TOOLS=false

--- a/src/components/developer/SettingsModal.vue
+++ b/src/components/developer/SettingsModal.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
+import { getArena } from '~/data/arenas'
+import { allShlagemons } from '~/data/shlagemons'
 import { useDeveloperStore } from '~/stores/developer'
+import { useGameStore } from '~/stores/game'
+import { usePlayerStore } from '~/stores/player'
+import { useShlagedexStore } from '~/stores/shlagedex'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
+import { applyCurrentStats, applyStats, xpForLevel } from '~/utils/dexFactory'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits(['update:modelValue'])
@@ -10,6 +18,100 @@ const show = computed({
 })
 
 const dev = useDeveloperStore()
+const game = useGameStore()
+const dex = useShlagedexStore()
+const player = usePlayerStore()
+const zone = useZoneStore()
+const progress = useZoneProgressStore()
+
+function addMoney() {
+  game.addShlagidolar(100000)
+}
+
+function addDiamonds() {
+  game.addShlagidiamond(1000)
+}
+
+function resetMoney() {
+  game.reset()
+}
+
+function setRarity(value: number) {
+  if (!dex.activeShlagemon)
+    return
+  dex.activeShlagemon.rarity = value
+  applyStats(dex.activeShlagemon)
+  applyCurrentStats(dex.activeShlagemon)
+  dex.activeShlagemon.hpCurrent = dex.activeShlagemon.hp
+}
+
+function captureRandom() {
+  const captured = new Set(dex.shlagemons.map(m => m.base.id))
+  const available = allShlagemons.filter(b => !captured.has(b.id))
+  if (!available.length)
+    return
+  const base = available[Math.floor(Math.random() * available.length)]
+  dex.captureShlagemon(base)
+}
+
+function boostStats() {
+  const mon = dex.activeShlagemon
+  if (!mon)
+    return
+  mon.baseStats.hp += 100
+  mon.baseStats.attack += 10
+  mon.baseStats.defense += 10
+  mon.baseStats.smelling += 10
+  mon.hp += 100
+  mon.attack += 10
+  mon.defense += 10
+  mon.smelling += 10
+  mon.hpCurrent = mon.hp
+}
+
+function resetStats() {
+  const mon = dex.activeShlagemon
+  if (!mon)
+    return
+  applyStats(mon)
+  applyCurrentStats(mon)
+  mon.hpCurrent = mon.hp
+}
+
+function levelUp10() {
+  const mon = dex.activeShlagemon
+  if (!mon)
+    return
+  dex.gainXp(mon, xpForLevel(mon.lvl) * 10)
+}
+
+function resetLevel() {
+  const mon = dex.activeShlagemon
+  if (!mon)
+    return
+  mon.lvl = 1
+  mon.xp = 0
+  applyCurrentStats(mon)
+  mon.hpCurrent = mon.hp
+}
+
+function completeArena(id: string) {
+  const arena = getArena(id)
+  if (!arena)
+    return
+  player.earnBadge(arena.id)
+  progress.completeArena(id)
+  zone.completeArena(id)
+}
+
+function resetArenas() {
+  player.reset()
+  progress.reset()
+  zone.zones.forEach((z) => {
+    if (z.arena)
+      z.arena.completed = false
+  })
+}
 </script>
 
 <template>
@@ -20,5 +122,55 @@ const dev = useDeveloperStore()
     <UiCheckBox v-model="dev.debug" class="flex items-center justify-between">
       <span>Mode debug</span>
     </UiCheckBox>
+    <div class="mt-4 flex flex-col gap-2">
+      <UiButton @click="addMoney">
+        +100000 Shlagédolar
+      </UiButton>
+      <UiButton @click="addDiamonds">
+        +1000 Shlagédiamant
+      </UiButton>
+      <UiButton type="danger" variant="outline" @click="resetMoney">
+        Réinitialiser l'argent
+      </UiButton>
+
+      <UiButton :disabled="!dex.activeShlagemon" @click="setRarity(99)">
+        Rareté 99
+      </UiButton>
+      <UiButton :disabled="!dex.activeShlagemon" @click="setRarity(100)">
+        Rareté 100
+      </UiButton>
+      <UiButton type="danger" variant="outline" :disabled="!dex.activeShlagemon" @click="setRarity(1)">
+        Reset Rareté
+      </UiButton>
+
+      <UiButton @click="captureRandom">
+        Capturer un nouveau Shlagémon
+      </UiButton>
+      <UiButton :disabled="!dex.activeShlagemon" @click="boostStats">
+        Booster stats
+      </UiButton>
+      <UiButton type="danger" variant="outline" :disabled="!dex.activeShlagemon" @click="resetStats">
+        Reset stats
+      </UiButton>
+      <UiButton :disabled="!dex.activeShlagemon" @click="levelUp10">
+        +10 niveaux
+      </UiButton>
+      <UiButton type="danger" variant="outline" :disabled="!dex.activeShlagemon" @click="resetLevel">
+        Reset niveau
+      </UiButton>
+
+      <UiButton @click="completeArena('village-boule')">
+        Valider arène 1
+      </UiButton>
+      <UiButton @click="completeArena('village-paume')">
+        Valider arène 2
+      </UiButton>
+      <UiButton @click="completeArena('village-cassos-land')">
+        Valider arène 3
+      </UiButton>
+      <UiButton type="danger" variant="outline" @click="resetArenas">
+        Reset arènes
+      </UiButton>
+    </div>
   </Modal>
 </template>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -6,6 +6,7 @@ import { useAudioStore } from '~/stores/audio'
 const showSettings = ref(false)
 const showAudio = ref(false)
 const showDeveloper = ref(false)
+const showDevButton = import.meta.env.VITE_DEV_TOOLS === 'true'
 const clickTimer = ref<UseTimeoutFnReturn | null>(null)
 const audio = useAudioStore()
 const { t, locale } = useI18n()
@@ -52,10 +53,15 @@ function onDoubleClick() {
         <div class="i-carbon-settings" />
       </UiButton>
       <SettingsSettingsModal v-model="showSettings" />
-      <UiButton type="icon" :aria-label="t('header.developer')" @click="showDeveloper = true">
+      <UiButton
+        v-if="showDevButton"
+        type="icon"
+        :aria-label="t('header.developer')"
+        @click="showDeveloper = true"
+      >
         <div class="i-carbon-debug" />
       </UiButton>
-      <DeveloperSettingsModal v-model="showDeveloper" />
+      <DeveloperSettingsModal v-if="showDevButton" v-model="showDeveloper" />
     </div>
   </header>
 </template>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly VITE_DEV_TOOLS: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- show developer settings button only when `VITE_DEV_TOOLS` env var is `true`
- create env files for development and production
- extend developer modal with debug actions like giving money or badges
- type new `VITE_DEV_TOOLS` environment variable

## Testing
- `pnpm test:unit` *(fails: Failed to fetch web fonts and multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c016b1e78832ab5e6f13e35cc749b