### PR TITLE
Add i18n for panel components

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,6 +14,60 @@ components:
       settings: Settings
       developer: Developer
       logoAlt: Shlagemon logo
+  panel:
+    Achievements:
+      all: All
+      unlocked: Unlocked
+      locked: To unlock
+    BonusDetails:
+      intro1: >-
+        The Shlagedex bonus matches your **potential ShlagéDex**. It represents
+        the maximum bonus you could obtain by capturing all available Shlagémon.
+      intro2: >-
+        It is based on the completion rate of this potential Shlagedex as well
+        as your team's average level.
+      formula: Bonus = average level × 2 × (completion rate / 100)
+      completion: 'Completion:'
+      averageLevel: 'Average level:'
+      currentBonus: 'Current bonus:'
+    Inventory:
+      sort:
+        type: Type
+        name: Name
+        price: Price
+      category:
+        active: Active
+        passive: Passive
+        utility: Utility
+      equip: You equipped the {item}
+    PlayerInfos:
+      sick: 'Sick: {n} battles left'
+      dex: ShlageDex
+      averageLevel: Average level
+      bonus: Bonus
+      balls: ShlageBalls
+      ballAlt: ball
+    Poulailler:
+      title: Henhouse
+      exit: Exit
+      incubator: Incubator
+      noEgg: No egg
+      yourEggs: Your eggs
+      incubate: Incubate
+      noEggBox: No egg in the box
+    Shop:
+      title: Shop
+      details: Details
+      buy: Buy x{qty} for
+      back: Put back
+      exit: Leave the shop
+      bought: You bought {qty} × {item} for {cost} {currency}
+      category:
+        active: Active
+        passive: Passive
+        utility: Utility
+    Zone:
+      capturedAlt: captured
 data:
   shlagemons:
     01-05:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -14,6 +14,61 @@ components:
       settings: Paramètres
       developer: Développeur
       logoAlt: Logo Shlagémon
+  panel:
+    Achievements:
+      all: Tous
+      unlocked: Débloqués
+      locked: À débloquer
+    BonusDetails:
+      intro1: >-
+        Le bonus du Shlagedex correspond à votre **ShlagéDex potentiel**. Il
+        représente le bonus maximal que vous pourriez obtenir en capturant tous
+        les Shlagémon accessibles.
+      intro2: >-
+        Il se base sur le pourcentage de complétion de ce ShlagéDex potentiel
+        ainsi que sur le niveau moyen de votre équipe.
+      formula: Bonus = niveau moyen × 2 × (taux de complétion / 100)
+      completion: 'Complétion :'
+      averageLevel: 'Niveau moyen :'
+      currentBonus: 'Bonus actuel :'
+    Inventory:
+      sort:
+        type: Type
+        name: Nom
+        price: Prix
+      category:
+        active: Actif
+        passive: Passif
+        utility: Utilitaire
+      equip: Vous avez équipé la {item}
+    PlayerInfos:
+      sick: 'Malade : {n} combats restants'
+      dex: ShlagéDex
+      averageLevel: Niveau moyen
+      bonus: Bonus
+      balls: ShlagéBalls
+      ballAlt: ball
+    Poulailler:
+      title: Poulailler
+      exit: Quitter
+      incubator: Incubateur
+      noEgg: Aucun œuf
+      yourEggs: Vos œufs
+      incubate: Incuber
+      noEggBox: Aucun œuf dans la boîte
+    Shop:
+      title: Boutique
+      details: Détails
+      buy: Acheter x{qty} pour
+      back: Retour dans le rayon
+      exit: Quitter la boutique
+      bought: Vous avez acheté {qty} × {item} pour {cost} {currency}
+      category:
+        active: Actif
+        passive: Passif
+        utility: Utilitaire
+    Zone:
+      capturedAlt: capturé
 data:
   shlagemons:
     01-05:

--- a/src/components/panel/Achievements.i18n.yml
+++ b/src/components/panel/Achievements.i18n.yml
@@ -1,0 +1,8 @@
+fr:
+  all: Tous
+  unlocked: Débloqués
+  locked: À débloquer
+en:
+  all: All
+  unlocked: Unlocked
+  locked: To unlock

--- a/src/components/panel/Achievements.vue
+++ b/src/components/panel/Achievements.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { useAchievementsStore } from '~/stores/achievements'
 import { useAchievementsFilterStore } from '~/stores/achievementsFilter'
 
@@ -7,10 +8,11 @@ const openedId = ref<string | null>(null)
 const store = useAchievementsStore()
 const filter = useAchievementsFilterStore()
 
+const { t } = useI18n()
 const statusOptions = [
-  { label: 'Tous', value: 'all' },
-  { label: 'Débloqués', value: 'unlocked' },
-  { label: 'À débloquer', value: 'locked' },
+  { label: t('components.panel.Achievements.all'), value: 'all' },
+  { label: t('components.panel.Achievements.unlocked'), value: 'unlocked' },
+  { label: t('components.panel.Achievements.locked'), value: 'locked' },
 ]
 
 const list = computed(() => {

--- a/src/components/panel/BonusDetails.i18n.yml
+++ b/src/components/panel/BonusDetails.i18n.yml
@@ -1,0 +1,18 @@
+fr:
+  intro1: >-
+    Le bonus du Shlagedex correspond à votre **ShlagéDex potentiel**. Il représente le bonus maximal que vous pourriez obtenir en capturant tous les Shlagémon accessibles.
+  intro2: >-
+    Il se base sur le pourcentage de complétion de ce ShlagéDex potentiel ainsi que sur le niveau moyen de votre équipe.
+  formula: Bonus = niveau moyen × 2 × (taux de complétion / 100)
+  completion: 'Complétion :'
+  averageLevel: 'Niveau moyen :'
+  currentBonus: 'Bonus actuel :'
+en:
+  intro1: >-
+    The Shlagedex bonus matches your **potential ShlagéDex**. It represents the maximum bonus you could obtain by capturing all available Shlagémon.
+  intro2: >-
+    It is based on the completion rate of this potential Shlagedex as well as your team's average level.
+  formula: Bonus = average level × 2 × (completion rate / 100)
+  completion: 'Completion:'
+  averageLevel: 'Average level:'
+  currentBonus: 'Current bonus:'

--- a/src/components/panel/BonusDetails.vue
+++ b/src/components/panel/BonusDetails.vue
@@ -1,34 +1,29 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 const dex = useShlagedexStore()
+const { t } = useI18n()
 </script>
 
 <template>
   <div class="flex flex-col gap-2 text-sm">
-    <p>
-      Le bonus du Shlagedex correspond à votre
-      <strong>Shlag&eacute;Dex potentiel</strong>.
-      Il repr&eacute;sente le bonus maximal que vous pourriez obtenir en
-      capturant tous les Shlag&eacute;mon accessibles.
-    </p>
-    <p>
-      Il se base sur le pourcentage de compl&eacute;tion de ce Shlagedex
-      potentiel ainsi que sur le niveau moyen de votre &eacute;quipe.
-    </p>
+    <p v-html="t('components.panel.BonusDetails.intro1')" />
+    <p v-html="t('components.panel.BonusDetails.intro2')" />
     <p class="text-center text-xs font-mono">
-      Bonus = niveau moyen × 2 × (taux de complétion / 100)
+      {{ t('components.panel.BonusDetails.formula') }}
     </p>
     <div class="mt-2 flex flex-col gap-1">
       <div class="flex items-center gap-2">
         <IconShlagedex class="h-5 w-5" />
-        <span>Complétion : {{ Math.round(dex.potentialCompletionPercent) }}%</span>
+        <span>{{ t('components.panel.BonusDetails.completion') }} {{ Math.round(dex.potentialCompletionPercent) }}%</span>
       </div>
       <div class="flex items-center gap-2">
         <IconXp class="h-5 w-5" />
-        <span>Niveau moyen : {{ dex.averageLevel.toFixed(1) }}</span>
+        <span>{{ t('components.panel.BonusDetails.averageLevel') }} {{ dex.averageLevel.toFixed(1) }}</span>
       </div>
       <div class="flex items-center gap-2">
         <IconBonus class="h-5 w-5" />
-        <span>Bonus actuel : +{{ Math.round(dex.bonusPercent) }}%</span>
+        <span>{{ t('components.panel.BonusDetails.currentBonus') }} +{{ Math.round(dex.bonusPercent) }}%</span>
       </div>
     </div>
   </div>

--- a/src/components/panel/Inventory.i18n.yml
+++ b/src/components/panel/Inventory.i18n.yml
@@ -1,0 +1,20 @@
+fr:
+  sort:
+    type: Type
+    name: Nom
+    price: Prix
+  category:
+    active: Actif
+    passive: Passif
+    utility: Utilitaire
+  equip: 'Vous avez équipé la {item}'
+en:
+  sort:
+    type: Type
+    name: Name
+    price: Price
+  category:
+    active: Active
+    passive: Passive
+    utility: Utility
+  equip: 'You equipped the {item}'

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -2,6 +2,7 @@
 import type { BallId } from '~/data/items/shlageball'
 import type { Item } from '~/type/item'
 import { toast } from 'vue3-toastify'
+import { useI18n } from 'vue-i18n'
 import EggBoxModal from '~/components/egg/BoxModal.vue'
 import {
   itemCategoryTabBaseColors,
@@ -25,15 +26,16 @@ const wearableStore = useWearableItemStore()
 const filter = useInventoryFilterStore()
 const featureLock = useFeatureLockStore()
 const usage = useItemUsageStore()
+const { t } = useI18n()
 const sortOptions = [
-  { label: 'Type', value: 'type' },
-  { label: 'Nom', value: 'name' },
-  { label: 'Prix', value: 'price' },
+  { label: t('components.panel.Inventory.sort.type'), value: 'type' },
+  { label: t('components.panel.Inventory.sort.name'), value: 'name' },
+  { label: t('components.panel.Inventory.sort.price'), value: 'price' },
 ]
 const categoryOptions = [
-  { label: 'Actif', value: 'actif', icon: 'i-carbon-flash' },
-  { label: 'Passif', value: 'passif', icon: 'i-carbon-timer' },
-  { label: 'Utilitaire', value: 'utilitaire', icon: 'i-carbon-tool-box' },
+  { label: t('components.panel.Inventory.category.active'), value: 'actif', icon: 'i-carbon-flash' },
+  { label: t('components.panel.Inventory.category.passive'), value: 'passif', icon: 'i-carbon-timer' },
+  { label: t('components.panel.Inventory.category.utility'), value: 'utilitaire', icon: 'i-carbon-tool-box' },
 ] as const
 const availableCategories = computed(() =>
   categoryOptions.filter(opt =>
@@ -108,7 +110,7 @@ function onUse(item: Item) {
   if ('catchBonus' in item) {
     ballStore.setBall(item.id as BallId)
     usage.markUsed(item.id)
-    toast(`Vous avez équipé la ${item.name}`)
+    toast(t('components.panel.Inventory.equip', { item: item.name }))
   }
   else if (item.type === 'evolution') {
     evoItemStore.open(item)

--- a/src/components/panel/PlayerInfos.i18n.yml
+++ b/src/components/panel/PlayerInfos.i18n.yml
@@ -1,0 +1,14 @@
+fr:
+  sick: 'Malade : {n} combats restants'
+  dex: ShlagéDex
+  averageLevel: Niveau moyen
+  bonus: Bonus
+  balls: ShlagéBalls
+  ballAlt: ball
+en:
+  sick: 'Sick: {n} battles left'
+  dex: ShlageDex
+  averageLevel: Average level
+  bonus: Bonus
+  balls: ShlageBalls
+  ballAlt: ball

--- a/src/components/panel/PlayerInfos.vue
+++ b/src/components/panel/PlayerInfos.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { allShlagemons } from '~/data/shlagemons'
 import { useBallStore } from '~/stores/ball'
 import { useDiseaseStore } from '~/stores/disease'
@@ -14,6 +15,7 @@ const player = usePlayerStore()
 const disease = useDiseaseStore()
 
 const showBonus = ref(false)
+const { t } = useI18n()
 
 const totalInDex = allShlagemons.length
 </script>
@@ -27,26 +29,26 @@ const totalInDex = allShlagemons.length
       {{ player.pseudo }}
       <UiTooltip
         v-if="disease.active"
-        :text="`Malade : ${disease.remaining} combats restants`"
+        :text="t('components.panel.PlayerInfos.sick', { n: disease.remaining })"
       >
         <div class="i-mdi:emoticon-sick text-red-500" />
       </UiTooltip>
     </span>
     <UiCurrencyAmount :amount="game.shlagidolar" currency="shlagidolar" />
     <UiCurrencyAmount :amount="game.shlagidiamond" currency="shlagidiamond" />
-    <UiTooltip text="ShlagéDex">
+    <UiTooltip :text="t('components.panel.PlayerInfos.dex')">
       <div class="min-w-0 flex items-center gap-1">
         <IconShlagedex class="h-4 w-4" />
         <span class="shrink-0 font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
       </div>
     </UiTooltip>
-    <UiTooltip text="Niveau moyen">
+    <UiTooltip :text="t('components.panel.PlayerInfos.averageLevel')">
       <div class="min-w-0 flex items-center gap-1">
         <IconXp class="h-4 w-4" />
         <span class="shrink-0 font-bold">{{ dex.averageLevel.toFixed(1) }}</span>
       </div>
     </UiTooltip>
-    <UiTooltip text="Bonus">
+    <UiTooltip :text="t('components.panel.PlayerInfos.bonus')">
       <div
         class="min-w-0 flex cursor-pointer items-center gap-1"
         @click="showBonus = true"
@@ -58,14 +60,14 @@ const totalInDex = allShlagemons.length
     <Modal v-model="showBonus" footer-close>
       <PanelBonusDetails />
     </Modal>
-    <UiTooltip text="ShlagéBalls">
+    <UiTooltip :text="t('components.panel.PlayerInfos.balls')">
       <div
         class="min-w-0 flex cursor-pointer items-center gap-1"
         @click="ballStore.open()"
       >
         <img
           src="/items/shlageball/shlageball.png"
-          alt="ball"
+          :alt="t('components.panel.PlayerInfos.ballAlt')"
           class="h-4 w-4"
           :style="{ filter: `hue-rotate(${ballHues[ballStore.current]})` }"
         >

--- a/src/components/panel/Poulailler.i18n.yml
+++ b/src/components/panel/Poulailler.i18n.yml
@@ -1,0 +1,16 @@
+fr:
+  title: Poulailler
+  exit: Quitter
+  incubator: Incubateur
+  noEgg: Aucun œuf
+  yourEggs: Vos œufs
+  incubate: Incuber
+  noEggBox: Aucun œuf dans la boîte
+en:
+  title: Henhouse
+  exit: Exit
+  incubator: Incubator
+  noEgg: No egg
+  yourEggs: Your eggs
+  incubate: Incubate
+  noEggBox: No egg in the box

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { EggItemId } from '~/stores/eggBox'
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import EggHatchModal from '~/components/egg/HatchModal.vue'
 import { allItems } from '~/data/items/items'
 import { useEggStore } from '~/stores/egg'
@@ -12,6 +13,7 @@ const eggs = useEggStore()
 const box = useEggBoxStore()
 const modal = useEggHatchModalStore()
 const panel = useMainPanelStore()
+const { t } = useI18n()
 const now = ref(Date.now())
 function tick() {
   now.value = Date.now()
@@ -52,7 +54,7 @@ function remaining(egg: { hatchesAt: number }) {
     <template #header>
       <div class="w-full flex items-center justify-between">
         <h3 class="font-bold">
-          Poulailler
+          {{ t('components.panel.Poulailler.title') }}
         </h3>
         <UiButton
           type="danger"
@@ -61,7 +63,7 @@ function remaining(egg: { hatchesAt: number }) {
           @click="panel.showVillage()"
         >
           <div class="i-carbon:exit" />
-          Quitter
+          {{ t('components.panel.Poulailler.exit') }}
         </UiButton>
       </div>
     </template>
@@ -69,7 +71,7 @@ function remaining(egg: { hatchesAt: number }) {
       <div class="flex flex-col gap-2">
         <div>
           <h4 class="font-semibold">
-            Incubateur
+            {{ t('components.panel.Poulailler.incubator') }}
           </h4>
           <div class="flex-center flex-col gap-1 border rounded p-2">
             <template v-if="eggs.incubator">
@@ -87,12 +89,12 @@ function remaining(egg: { hatchesAt: number }) {
               />
               <span v-if="!eggs.isReady" class="text-xs">{{ remaining(eggs.incubator) }}s</span>
             </template>
-            <span v-else class="text-sm">Aucun œuf</span>
+            <span v-else class="text-sm">{{ t('components.panel.Poulailler.noEgg') }}</span>
           </div>
         </div>
         <div>
           <h4 class="font-semibold">
-            Vos œufs
+            {{ t('components.panel.Poulailler.yourEggs') }}
           </h4>
           <div v-if="inventoryEggs.length" class="flex flex-col gap-1">
             <div
@@ -115,13 +117,13 @@ function remaining(egg: { hatchesAt: number }) {
                   class="text-xs"
                   @click="startIncubation(entry.id)"
                 >
-                  Incuber
+                  {{ t('components.panel.Poulailler.incubate') }}
                 </UiButton>
               </div>
             </div>
           </div>
           <div v-else class="text-center text-sm">
-            Aucun œuf dans la boîte
+            {{ t('components.panel.Poulailler.noEggBox') }}
           </div>
         </div>
       </div>

--- a/src/components/panel/Shop.i18n.yml
+++ b/src/components/panel/Shop.i18n.yml
@@ -1,0 +1,22 @@
+fr:
+  title: Boutique
+  details: Détails
+  buy: 'Acheter x{qty} pour'
+  back: Retour dans le rayon
+  exit: Quitter la boutique
+  bought: 'Vous avez acheté {qty} × {item} pour {cost} {currency}'
+  category:
+    active: Actif
+    passive: Passif
+    utility: Utilitaire
+en:
+  title: Shop
+  details: Details
+  buy: 'Buy x{qty} for'
+  back: Put back
+  exit: Leave the shop
+  bought: 'You bought {qty} × {item} for {cost} {currency}'
+  category:
+    active: Active
+    passive: Passive
+    utility: Utility

--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { toast } from 'vue3-toastify'
+import { useI18n } from 'vue-i18n'
 import {
   itemCategoryTabBaseColors,
   itemCategoryTabColors,
@@ -18,12 +19,13 @@ const zone = useZoneStore()
 const game = useGameStore()
 const inventory = useInventoryStore()
 const audio = useAudioStore()
+const { t } = useI18n()
 const shopItems = computed(() => zone.current.village?.shop?.items || [])
 const filter = useShopFilterStore()
 const categoryOptions = [
-  { label: 'Actif', value: 'actif', icon: 'i-carbon-flash' },
-  { label: 'Passif', value: 'passif', icon: 'i-carbon-timer' },
-  { label: 'Utilitaire', value: 'utilitaire', icon: 'i-carbon-tool-box' },
+  { label: t('components.panel.Shop.category.active'), value: 'actif', icon: 'i-carbon-flash' },
+  { label: t('components.panel.Shop.category.passive'), value: 'passif', icon: 'i-carbon-timer' },
+  { label: t('components.panel.Shop.category.utility'), value: 'utilitaire', icon: 'i-carbon-tool-box' },
 ] as const
 const availableCategories = computed(() =>
   categoryOptions.filter(opt => shopItems.value.some(i => i.category === opt.value)),
@@ -91,7 +93,12 @@ function buy() {
       ? 'Shlagédiamant'
       : 'Shlagédollar'
     const currencyName = cost > 1 ? `${currency}s` : currency
-    toast.success(`Vous avez acheté ${selectedQty.value} \u00D7 ${selectedItem.value.name} pour ${cost.toLocaleString()} ${currencyName}`)
+    toast.success(t('components.panel.Shop.bought', {
+      qty: selectedQty.value,
+      item: selectedItem.value.name,
+      cost: cost.toLocaleString(),
+      currency: currencyName,
+    }))
     selectedItem.value = null
   }
 }
@@ -104,7 +111,7 @@ function closeShop() {
 <template>
   <div class="flex flex-1 flex-col gap-1 overflow-hidden p-1" v-bind="$attrs">
     <h2 class="text-center font-bold">
-      Boutique
+      {{ t('components.panel.Shop.title') }}
     </h2>
     <UiTabBar
       v-if="availableCategories.length > 0"
@@ -125,7 +132,7 @@ function closeShop() {
         @click="selectItem(item)"
       >
         <UiButton class="ml-auto text-xs" @click.stop="selectItem(item)">
-          Détails
+          {{ t('components.panel.Shop.details') }}
         </UiButton>
       </ShopItemCard>
     </div>
@@ -140,7 +147,7 @@ function closeShop() {
         class="flex flex-1 items-center gap-1"
         @click="buy"
       >
-        Acheter x{{ selectedQty }} pour
+        {{ t('components.panel.Shop.buy', { qty: selectedQty }) }}
         <UiCurrencyAmount :amount="(selectedItem?.price || 0) * selectedQty" :currency="selectedItem?.currency ?? 'shlagidolar'" />
       </UiButton>
       <div class="w-full flex gap-1" md="flex-col w-auto">
@@ -152,12 +159,12 @@ function closeShop() {
           @click="selectedItem = null"
         >
           <div class="i-carbon:return" />
-          Retour dans le rayon
+          {{ t('components.panel.Shop.back') }}
         </UiButton>
 
         <UiButton type="danger" variant="outline" class="w-full flex gap-2 text-xs" @click="closeShop">
           <div class="i-carbon:exit" />
-          Quitter la boutique
+          {{ t('components.panel.Shop.exit') }}
         </UiButton>
       </div>
     </div>

--- a/src/components/panel/Zone.i18n.yml
+++ b/src/components/panel/Zone.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  capturedAlt: capturé
+en:
+  capturedAlt: captured

--- a/src/components/panel/Zone.vue
+++ b/src/components/panel/Zone.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Zone } from '~/type'
+import { useI18n } from 'vue-i18n'
 import { useArenaStore } from '~/stores/arena'
 import { useDialogStore } from '~/stores/dialog'
 import { useFeatureLockStore } from '~/stores/featureLock'
@@ -17,6 +18,7 @@ const progress = useZoneProgressStore()
 const dialog = useDialogStore()
 const featureLock = useFeatureLockStore()
 const visit = useZoneVisitStore()
+const { t } = useI18n()
 
 const zoneButtonsDisabled = computed(
   () =>
@@ -165,7 +167,7 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
           <img
             v-if="allCaptured(z)"
             src="/items/shlageball/shlageball.png"
-            alt="capturé"
+            :alt="t('components.panel.Zone.capturedAlt')"
             class="h-4 w-4"
             :style="perfectZone(z) ? { filter: 'hue-rotate(60deg) brightness(1.1)' } : {}"
           >


### PR DESCRIPTION
## Summary
- add translation yaml files for panel components
- replace hardcoded strings with `t()` calls
- merge i18n resources

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ENETUNREACH fetching google fonts; multiple unit tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687cb11036e4832aa851f9b2e57abadb