### PR TITLE
Adjust capture probabilities

### DIFF
--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -23,9 +23,9 @@ export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
 
 export function captureChanceFromHp(ratio: number): number {
   const r = Math.min(1, Math.max(0, ratio))
-  if (r <= 0.1)
-    return 100
-  return 100 - ((r - 0.1) / 0.9) * 20
+  const baseChance = 80
+  const multiplier = 3 ** (1 - r)
+  return baseChance * multiplier
 }
 
 export function simpleCapture(enemy: DexShlagemon): boolean {

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -25,7 +25,7 @@ describe('capture mechanics', () => {
     expect(tryCapture(mon, balls[0])).toBe(false)
   })
 
-  it('hyper ball versus strong foe gives around 10% chance', () => {
+  it('hyper ball versus strong foe gives around 25% chance', () => {
     const mon = createDexShlagemon(carapouffe, false, 1, 100)
     mon.coefficient = 1000
     mon.hp = 100
@@ -35,7 +35,7 @@ describe('capture mechanics', () => {
     const levelMod = 1 / (1 + mon.lvl / 40)
     const difficultyMod = 1.3
     const chance = Math.min(100, hpChance * coefMod * levelMod * balls[2].catchBonus * difficultyMod)
-    expect(chance).toBeCloseTo(10, 1)
+    expect(chance).toBeCloseTo(26.6, 1)
   })
 
   it('regular ball against lvl1 coefficient1 foe at full HP is almost guaranteed', () => {


### PR DESCRIPTION
## Summary
- adjust capture chance calculation to scale exponentially as HP decreases
- update capture tests for the new scaling

## Testing
- `pnpm test` *(fails: Failed to resolve imports and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cb7e70ce0832aa8bb205a811d64cf