### PR TITLE
Add i18n entries for theme toggle and update snackbar

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -68,6 +68,11 @@ components:
         utility: Utility
     Zone:
       capturedAlt: captured
+  ThemeToggle:
+    toggle: Switch theme
+  UpdateSnackbar:
+    updateAvailable: Update available
+    reload: Reload
 data:
   shlagemons:
     01-05:
@@ -836,8 +841,14 @@ data:
     55-60:
       amonichiasse:
         description: >-
-          Ce mollusque fossilisé traîne une coquille couverte de taches
-          douteuses. Il dégage une odeur de cave humide et de gastro chronique.
+          Amonichiasse est un mollusque fossilisé qui pue la diarrhée aquatique.
+          Sa coquille gluante est couverte de taches brunâtres, comme si elle
+          avait été utilisée comme seau de secours dans une gastro collective.
+          Deux petits yeux globuleux dépassent mollement de son mucus,
+          constamment embués par la vapeur tiède qu’il dégage. Il avance
+          lentement, en laissant derrière lui une traînée suspecte et visqueuse.
+          Certains dresseurs affirment qu’il émet des bruits de gargouillis
+          intestinaux quand on le secoue trop fort.
       kraputo:
         description: >-
           Ce crabe éraflé se cache sous un casque cassé et offre ses pinces au

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -69,6 +69,11 @@ components:
         utility: Utilitaire
     Zone:
       capturedAlt: capturé
+  ThemeToggle:
+    toggle: Changer de thème
+  UpdateSnackbar:
+    updateAvailable: Mise à jour de l'application disponible
+    reload: Recharger
 data:
   shlagemons:
     01-05:
@@ -846,8 +851,14 @@ data:
     55-60:
       amonichiasse:
         description: >-
-          Ce mollusque fossilisé traîne une coquille couverte de taches
-          douteuses. Il dégage une odeur de cave humide et de gastro chronique.
+          Amonichiasse est un mollusque fossilisé qui pue la diarrhée aquatique.
+          Sa coquille gluante est couverte de taches brunâtres, comme si elle
+          avait été utilisée comme seau de secours dans une gastro collective.
+          Deux petits yeux globuleux dépassent mollement de son mucus,
+          constamment embués par la vapeur tiède qu’il dégage. Il avance
+          lentement, en laissant derrière lui une traînée suspecte et visqueuse.
+          Certains dresseurs affirment qu’il émet des bruits de gargouillis
+          intestinaux quand on le secoue trop fort.
       kraputo:
         description: >-
           Ce crabe éraflé se cache sous un casque cassé et offre ses pinces au

--- a/src/components/ThemeToggle.i18n.yml
+++ b/src/components/ThemeToggle.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  toggle: Changer de thème
+en:
+  toggle: Switch theme

--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 const isDark = useDark()
 const toggle = useToggle(isDark)
+const { t } = useI18n()
 </script>
 
 <template>
   <button
-    aria-label="Changer de thème"
+    :aria-label="t('components.ThemeToggle.toggle')"
     class="relative h-6 w-12 rounded-full bg-gray-200 transition-colors dark:bg-gray-700"
     type="button"
     @click="toggle()"

--- a/src/components/UpdateSnackbar.i18n.yml
+++ b/src/components/UpdateSnackbar.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  updateAvailable: Mise à jour de l'application disponible
+  reload: Recharger
+en:
+  updateAvailable: Update available
+  reload: Reload

--- a/src/components/UpdateSnackbar.vue
+++ b/src/components/UpdateSnackbar.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { usePwaUpdateStore } from '~/stores/pwaUpdate'
 
 const store = usePwaUpdateStore()
+const { t } = useI18n()
 </script>
 
 <template>
   <Transition name="slide-fade">
     <div v-if="store.needRefresh" class="pointer-events-none fixed inset-x-0 bottom-4 z-100 flex justify-center">
       <div class="pointer-events-auto flex items-center gap-2 rounded bg-gray-200 px-4 py-2 text-gray-800 shadow" dark="bg-gray-800 text-white">
-        <span>Mise à jour de l'application disponible</span>
+        <span>{{ t('components.UpdateSnackbar.updateAvailable') }}</span>
         <UiButton type="primary" variant="solid" @click="store.reload">
-          Recharger
+          {{ t('components.UpdateSnackbar.reload') }}
         </UiButton>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add ThemeToggle translation file and wire up translation usage
- add UpdateSnackbar translation file and wire up translation usage
- regenerate locale YAML files

## Testing
- `pnpm lint`
- `pnpm test` *(fails: failed to resolve fonts and missing components)*

------
https://chatgpt.com/codex/tasks/task_e_687cb73ca7c0832aae2d88ba6c15257a