### PR TITLE
Detect locale on initial load

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -241,6 +241,7 @@ declare global {
   const useLastChanged: typeof import('@vueuse/core')['useLastChanged']
   const useLink: typeof import('vue-router/auto')['useLink']
   const useLocalStorage: typeof import('@vueuse/core')['useLocalStorage']
+  const useLocaleStore: typeof import('./stores/locale')['useLocaleStore']
   const useMagicKeys: typeof import('@vueuse/core')['useMagicKeys']
   const useMainPanelStore: typeof import('./stores/mainPanel')['useMainPanelStore']
   const useManualRefHistory: typeof import('@vueuse/core')['useManualRefHistory']
@@ -661,6 +662,7 @@ declare module 'vue' {
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>
     readonly useLink: UnwrapRef<typeof import('vue-router/auto')['useLink']>
     readonly useLocalStorage: UnwrapRef<typeof import('@vueuse/core')['useLocalStorage']>
+    readonly useLocaleStore: UnwrapRef<typeof import('./stores/locale')['useLocaleStore']>
     readonly useMagicKeys: UnwrapRef<typeof import('@vueuse/core')['useMagicKeys']>
     readonly useMainPanelStore: UnwrapRef<typeof import('./stores/mainPanel')['useMainPanelStore']>
     readonly useManualRefHistory: UnwrapRef<typeof import('@vueuse/core')['useManualRefHistory']>

--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -1,6 +1,7 @@
 import type { Locale } from 'vue-i18n'
 import type { UserModule } from '~/types'
 import { createI18n } from 'vue-i18n'
+import { useLocaleStore } from '~/stores/locale'
 
 // Import i18n resources
 // https://vitejs.dev/guide/features.html#glob-import
@@ -44,7 +45,16 @@ export async function loadLanguageAsync(lang: string): Promise<Locale> {
   return setI18nLanguage(lang)
 }
 
-export const install: UserModule = ({ app }) => {
+export const install: UserModule = ({ app, isClient }) => {
   app.use(i18n)
-  loadLanguageAsync('en')
+  const localeStore = useLocaleStore()
+  let lang = localeStore.locale
+
+  if (isClient && !localStorage.getItem('locale')) {
+    const navigatorLang = navigator.language || 'en'
+    lang = navigatorLang.toLowerCase().startsWith('fr') ? 'fr' : 'en'
+    localeStore.setLocale(lang)
+  }
+
+  loadLanguageAsync(lang)
 }

--- a/src/stores/locale.ts
+++ b/src/stores/locale.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+
+export const useLocaleStore = defineStore('locale', () => {
+  const locale = ref<'en' | 'fr'>('en')
+
+  function setLocale(value: 'en' | 'fr') {
+    locale.value = value
+  }
+
+  return {
+    locale,
+    setLocale,
+  }
+}, {
+  persist: true,
+})


### PR DESCRIPTION
## Summary
- persist current locale in new Pinia store
- use locale store to detect browser language on first run
- auto import locale store

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fonts.googleapis.com fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687cbd286890832ab3937cc3e205dfc0