### PR TITLE
Add language selector

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -141,6 +141,10 @@ components:
     title: Shlagemon - It smells very strong
     description: Catch all the Shlagemons before they rot the whole world.
     author: Shlagemon Team
+  LanguageSelector:
+    label: Language
+    en: English
+    fr: French
 data:
   shlagemons:
     01-05:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -145,6 +145,10 @@ components:
       Attrape tous les Shlagémons pour éviter qu'ils ne pourrissent la terre
       entière.
     author: Shlagémon Team
+  LanguageSelector:
+    label: Langue
+    en: Anglais
+    fr: Français
 data:
   shlagemons:
     01-05:

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -77,6 +77,7 @@ declare module 'vue' {
     InventoryItemShortcutModal: typeof import('./components/inventory/ItemShortcutModal.vue')['default']
     InventoryWearableItemIcon: typeof import('./components/inventory/WearableItemIcon.vue')['default']
     InventoryWearableItemModal: typeof import('./components/inventory/WearableItemModal.vue')['default']
+    LanguageSelector: typeof import('./components/LanguageSelector.vue')['default']
     LayoutGameGrid: typeof import('./components/layout/GameGrid.vue')['default']
     LayoutHeader: typeof import('./components/layout/Header.vue')['default']
     LayoutHomeFooter: typeof import('./components/layout/HomeFooter.vue')['default']

--- a/src/components/LanguageSelector.i18n.yml
+++ b/src/components/LanguageSelector.i18n.yml
@@ -1,0 +1,8 @@
+fr:
+  label: Langue
+  en: Anglais
+  fr: Français
+en:
+  label: Language
+  en: English
+  fr: French

--- a/src/components/LanguageSelector.vue
+++ b/src/components/LanguageSelector.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { availableLocales, loadLanguageAsync } from '~/modules/i18n'
+import { useLocaleStore } from '~/stores/locale'
+
+const { locale, t } = useI18n()
+const store = useLocaleStore()
+
+const options = computed(() => availableLocales.map(l => ({
+  label: t(`components.LanguageSelector.${l}`),
+  value: l,
+})))
+
+async function change(val: string | number) {
+  const lang = val as string
+  store.setLocale(lang as 'en' | 'fr')
+  await loadLanguageAsync(lang)
+}
+</script>
+
+<template>
+  <UiSelectOption
+    class="w-24"
+    :aria-label="t('components.LanguageSelector.label')"
+    :model-value="locale"
+    :options="options"
+    @update:model-value="change"
+  />
+</template>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import LanguageSelector from '~/components/LanguageSelector.vue'
 import FullscreenToggle from '~/components/ui/FullscreenToggle.vue'
 import { useAudioStore } from '~/stores/audio'
 
@@ -9,8 +10,7 @@ const showDeveloper = ref(false)
 const showDevButton = import.meta.env.VITE_DEV_TOOLS === 'true'
 const clickTimer = ref<UseTimeoutFnReturn | null>(null)
 const audio = useAudioStore()
-const { t, locale } = useI18n()
-const currentLocale = Intl.DateTimeFormat().resolvedOptions().locale
+const { t } = useI18n()
 
 function onClick() {
   if (clickTimer.value)
@@ -33,12 +33,11 @@ function onDoubleClick() {
       <img src="/logo.png" :alt="t('components.layout.Header.logoAlt')" class="h-20 -my-4">
       <div class="flex flex-col text-xs leading-tight">
         <span class="font-bold sm:text-sm">{{ t('components.layout.Header.title') }}</span>
-        <span>{{ t('components.layout.Header.language') }}: {{ locale }}</span>
-        <span>{{ t('components.layout.Header.locale') }}: {{ currentLocale }}</span>
       </div>
     </div>
     <div class="flex items-center gap-2">
       <FullscreenToggle />
+      <LanguageSelector />
       <ThemeToggle />
       <UiButton
         type="icon"

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import LanguageSelector from '~/components/LanguageSelector.vue'
 import { useSaveStore } from '~/stores/save'
 import ShortcutsTab from './ShortcutsTab.vue'
 
@@ -7,7 +8,7 @@ const emit = defineEmits(['update:modelValue'])
 
 const save = useSaveStore()
 
-const tab = ref<'save' | 'shortcuts'>('save')
+const tab = ref<'save' | 'shortcuts' | 'language'>('save')
 
 function close() {
   emit('update:modelValue', false)
@@ -43,6 +44,13 @@ function removeSave() {
       >
         Raccourcis
       </button>
+      <button
+        class="rounded px-2 py-1"
+        :class="tab === 'language' ? 'bg-gray-200 dark:bg-gray-700' : 'bg-gray-100 dark:bg-gray-800'"
+        @click="tab = 'language'"
+      >
+        Langue
+      </button>
     </nav>
     <LayoutScrollablePanel class="max-h-60vh">
       <template #content>
@@ -55,8 +63,11 @@ function removeSave() {
             Supprimer
           </UiButton>
         </div>
-        <div v-else class="flex flex-col gap-2">
+        <div v-else-if="tab === 'shortcuts'" class="flex flex-col gap-2">
           <ShortcutsTab />
+        </div>
+        <div v-else class="flex justify-center">
+          <LanguageSelector />
         </div>
       </template>
     </LayoutScrollablePanel>


### PR DESCRIPTION
## Summary
- add LanguageSelector component with i18n support
- expose the selector in the header
- include language tab in Settings modal
- merge translations

## Testing
- `pnpm test` *(fails: ENETUNREACH fetch fonts and vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cccd23d80832a977013fbe4b0e42a