### PR TITLE
Add Connect Four mini game

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -8,11 +8,14 @@ export {}
 declare global {
   const BOARD_SIZE: typeof import('./composables/useBattleship')['BOARD_SIZE']
   const CENTER_CELLS: typeof import('./composables/useTicTacToe')['CENTER_CELLS']
+  const COLS: typeof import('./composables/useConnectFour')['COLS']
   const EffectScope: typeof import('vue')['EffectScope']
+  const ROWS: typeof import('./composables/useConnectFour')['ROWS']
   const SIZE: typeof import('./composables/useTicTacToe')['SIZE']
   const asyncComputed: typeof import('@vueuse/core')['asyncComputed']
   const autoResetRef: typeof import('@vueuse/core')['autoResetRef']
   const check: typeof import('./composables/useTicTacToe')['check']
+  const checkWin: typeof import('./composables/useConnectFour')['checkWin']
   const combos: typeof import('./composables/useTicTacToe')['combos']
   const computed: typeof import('vue')['computed']
   const computedAsync: typeof import('@vueuse/core')['computedAsync']
@@ -23,6 +26,7 @@ declare global {
   const controlledRef: typeof import('@vueuse/core')['controlledRef']
   const createApp: typeof import('vue')['createApp']
   const createBattleshipAI: typeof import('./composables/useBattleship')['createBattleshipAI']
+  const createConnectFourBoard: typeof import('./composables/useConnectFour')['createConnectFourBoard']
   const createEventHook: typeof import('@vueuse/core')['createEventHook']
   const createGlobalState: typeof import('@vueuse/core')['createGlobalState']
   const createInjectionState: typeof import('@vueuse/core')['createInjectionState']
@@ -40,6 +44,7 @@ declare global {
   const defineComponent: typeof import('vue')['defineComponent']
   const defineLoader: typeof import('vue-router/auto')['defineLoader']
   const definePage: typeof import('unplugin-vue-router/runtime')['definePage']
+  const drop: typeof import('./composables/useConnectFour')['drop']
   const eagerComputed: typeof import('@vueuse/core')['eagerComputed']
   const effectScope: typeof import('vue')['effectScope']
   const eggIds: typeof import('./stores/eggBox')['eggIds']
@@ -48,6 +53,7 @@ declare global {
   const getActiveHead: typeof import('@unhead/vue')['getActiveHead']
   const getCurrentInstance: typeof import('vue')['getCurrentInstance']
   const getCurrentScope: typeof import('vue')['getCurrentScope']
+  const getValidColumns: typeof import('./composables/useConnectFour')['getValidColumns']
   const h: typeof import('vue')['h']
   const ignorableWatch: typeof import('@vueuse/core')['ignorableWatch']
   const inject: typeof import('vue')['inject']
@@ -88,6 +94,7 @@ declare global {
   const preferredDark: typeof import('./composables/dark')['preferredDark']
   const provide: typeof import('vue')['provide']
   const provideLocal: typeof import('@vueuse/core')['provideLocal']
+  const randomColumn: typeof import('./composables/useConnectFour')['randomColumn']
   const reactify: typeof import('@vueuse/core')['reactify']
   const reactifyObject: typeof import('@vueuse/core')['reactifyObject']
   const reactive: typeof import('vue')['reactive']
@@ -167,6 +174,7 @@ declare global {
   const useCloned: typeof import('@vueuse/core')['useCloned']
   const useColorMode: typeof import('@vueuse/core')['useColorMode']
   const useConfirmDialog: typeof import('@vueuse/core')['useConfirmDialog']
+  const useConnectFour: typeof import('./composables/useConnectFour')['useConnectFour']
   const useCountdown: typeof import('@vueuse/core')['useCountdown']
   const useCounter: typeof import('@vueuse/core')['useCounter']
   const useCssModule: typeof import('vue')['useCssModule']
@@ -434,11 +442,14 @@ declare module 'vue' {
   interface ComponentCustomProperties {
     readonly BOARD_SIZE: UnwrapRef<typeof import('./composables/useBattleship')['BOARD_SIZE']>
     readonly CENTER_CELLS: UnwrapRef<typeof import('./composables/useTicTacToe')['CENTER_CELLS']>
+    readonly COLS: UnwrapRef<typeof import('./composables/useConnectFour')['COLS']>
     readonly EffectScope: UnwrapRef<typeof import('vue')['EffectScope']>
+    readonly ROWS: UnwrapRef<typeof import('./composables/useConnectFour')['ROWS']>
     readonly SIZE: UnwrapRef<typeof import('./composables/useTicTacToe')['SIZE']>
     readonly asyncComputed: UnwrapRef<typeof import('@vueuse/core')['asyncComputed']>
     readonly autoResetRef: UnwrapRef<typeof import('@vueuse/core')['autoResetRef']>
     readonly check: UnwrapRef<typeof import('./composables/useTicTacToe')['check']>
+    readonly checkWin: UnwrapRef<typeof import('./composables/useConnectFour')['checkWin']>
     readonly combos: UnwrapRef<typeof import('./composables/useTicTacToe')['combos']>
     readonly computed: UnwrapRef<typeof import('vue')['computed']>
     readonly computedAsync: UnwrapRef<typeof import('@vueuse/core')['computedAsync']>
@@ -449,6 +460,7 @@ declare module 'vue' {
     readonly controlledRef: UnwrapRef<typeof import('@vueuse/core')['controlledRef']>
     readonly createApp: UnwrapRef<typeof import('vue')['createApp']>
     readonly createBattleshipAI: UnwrapRef<typeof import('./composables/useBattleship')['createBattleshipAI']>
+    readonly createConnectFourBoard: UnwrapRef<typeof import('./composables/useConnectFour')['createConnectFourBoard']>
     readonly createEventHook: UnwrapRef<typeof import('@vueuse/core')['createEventHook']>
     readonly createGlobalState: UnwrapRef<typeof import('@vueuse/core')['createGlobalState']>
     readonly createInjectionState: UnwrapRef<typeof import('@vueuse/core')['createInjectionState']>
@@ -464,6 +476,7 @@ declare module 'vue' {
     readonly debouncedWatch: UnwrapRef<typeof import('@vueuse/core')['debouncedWatch']>
     readonly defineAsyncComponent: UnwrapRef<typeof import('vue')['defineAsyncComponent']>
     readonly defineComponent: UnwrapRef<typeof import('vue')['defineComponent']>
+    readonly drop: UnwrapRef<typeof import('./composables/useConnectFour')['drop']>
     readonly eagerComputed: UnwrapRef<typeof import('@vueuse/core')['eagerComputed']>
     readonly effectScope: UnwrapRef<typeof import('vue')['effectScope']>
     readonly eggIds: UnwrapRef<typeof import('./stores/eggBox')['eggIds']>
@@ -471,6 +484,7 @@ declare module 'vue' {
     readonly findBestMove: UnwrapRef<typeof import('./composables/useTicTacToe')['findBestMove']>
     readonly getCurrentInstance: UnwrapRef<typeof import('vue')['getCurrentInstance']>
     readonly getCurrentScope: UnwrapRef<typeof import('vue')['getCurrentScope']>
+    readonly getValidColumns: UnwrapRef<typeof import('./composables/useConnectFour')['getValidColumns']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
     readonly ignorableWatch: UnwrapRef<typeof import('@vueuse/core')['ignorableWatch']>
     readonly inject: UnwrapRef<typeof import('vue')['inject']>
@@ -511,6 +525,7 @@ declare module 'vue' {
     readonly preferredDark: UnwrapRef<typeof import('./composables/dark')['preferredDark']>
     readonly provide: UnwrapRef<typeof import('vue')['provide']>
     readonly provideLocal: UnwrapRef<typeof import('@vueuse/core')['provideLocal']>
+    readonly randomColumn: UnwrapRef<typeof import('./composables/useConnectFour')['randomColumn']>
     readonly reactify: UnwrapRef<typeof import('@vueuse/core')['reactify']>
     readonly reactifyObject: UnwrapRef<typeof import('@vueuse/core')['reactifyObject']>
     readonly reactive: UnwrapRef<typeof import('vue')['reactive']>
@@ -590,6 +605,7 @@ declare module 'vue' {
     readonly useCloned: UnwrapRef<typeof import('@vueuse/core')['useCloned']>
     readonly useColorMode: UnwrapRef<typeof import('@vueuse/core')['useColorMode']>
     readonly useConfirmDialog: UnwrapRef<typeof import('@vueuse/core')['useConfirmDialog']>
+    readonly useConnectFour: UnwrapRef<typeof import('./composables/useConnectFour')['useConnectFour']>
     readonly useCountdown: UnwrapRef<typeof import('@vueuse/core')['useCountdown']>
     readonly useCounter: UnwrapRef<typeof import('@vueuse/core')['useCounter']>
     readonly useCssModule: UnwrapRef<typeof import('vue')['useCssModule']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -73,6 +73,7 @@ declare module 'vue' {
     LayoutMobileMenu: typeof import('./components/layout/MobileMenu.vue')['default']
     LayoutScrollablePanel: typeof import('./components/layout/ScrollablePanel.vue')['default']
     MinigameBattleship: typeof import('./components/minigame/Battleship.vue')['default']
+    MinigameMiniGamePuissance4: typeof import('./components/minigame/MiniGamePuissance4.vue')['default']
     MinigameTicTacToe: typeof import('./components/minigame/TicTacToe.vue')['default']
     Modal: typeof import('./components/modal/index.vue')['default']
     PanelAchievements: typeof import('./components/panel/Achievements.vue')['default']

--- a/src/components/minigame/MiniGamePuissance4.vue
+++ b/src/components/minigame/MiniGamePuissance4.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { useElementSize, useTimeoutFn } from '@vueuse/core'
+import { COLS, ROWS, useConnectFour } from '~/composables/useConnectFour'
+
+const emit = defineEmits(['win', 'lose'])
+
+const { board, finished, winningCells, lastMove, reset, play } = useConnectFour()
+
+const wrapper = ref<HTMLElement | null>(null)
+const { width, height } = useElementSize(wrapper)
+const boardWidth = computed(() => Math.min(width.value, height.value * COLS / ROWS))
+const boardHeight = computed(() => boardWidth.value * ROWS / COLS)
+
+watch(winningCells, (cells) => {
+  if (!cells.length)
+    return
+  const win = board.value[cells[0]] === 'player'
+  useTimeoutFn(() => emit(win ? 'win' : 'lose'), 800)
+})
+
+function onClick(i: number) {
+  if (finished.value)
+    return
+  const col = i % COLS
+  play(col)
+}
+
+onMounted(reset)
+</script>
+
+<template>
+  <div ref="wrapper" class="flex flex-1 items-center justify-center">
+    <div
+      class="relative grid gap-1 rounded p-2" md="gap-2 p-3"
+      :style="{ gridTemplateColumns: `repeat(${COLS},1fr)`, width: `${boardWidth}px`, height: `${boardHeight}px`, background: '#3755a4' }"
+    >
+      <button
+        v-for="(cell, i) in board"
+        :key="i"
+        class="relative aspect-square flex items-center justify-center overflow-hidden rounded-full bg-[#1e2f70]"
+        :hover="!finished.value ? 'scale-105' : undefined"
+        @click="onClick(i)"
+      >
+        <div
+          v-if="cell"
+          class="absolute inset-0 m-auto h-4/5 w-4/5 rounded-full"
+          :class="[
+            cell === 'player' ? 'bg-[#ff4444] dark:bg-[#ff5555]' : 'bg-[#fce83a] border-2 border-yellow-700',
+            lastMove === i ? 'animate-drop' : '',
+            winningCells.includes(i) ? 'animate-glow' : '',
+          ]"
+        />
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@keyframes drop {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes glow {
+  0%,
+  100% {
+    box-shadow: 0 0 0px rgba(255, 255, 255, 0.8);
+  }
+  50% {
+    box-shadow: 0 0 8px rgba(255, 255, 255, 1);
+  }
+}
+
+.animate-drop {
+  animation: drop 0.3s ease-out;
+}
+
+.animate-glow {
+  animation: glow 1s ease-in-out infinite;
+}
+</style>

--- a/src/composables/useConnectFour.ts
+++ b/src/composables/useConnectFour.ts
@@ -1,0 +1,141 @@
+import { ref } from 'vue'
+
+export const ROWS = 6
+export const COLS = 7
+
+type Cell = null | 'player' | 'ai'
+
+export function createConnectFourBoard(): Cell[] {
+  return Array.from({ length: ROWS * COLS }).fill(null)
+}
+
+export function getValidColumns(board: Cell[]): number[] {
+  const cols: number[] = []
+  for (let c = 0; c < COLS; c++) {
+    if (!board[c])
+      cols.push(c)
+  }
+  return cols
+}
+
+export function randomColumn(board: Cell[]): number {
+  const valid = getValidColumns(board)
+  return valid[Math.floor(Math.random() * valid.length)]
+}
+
+function drop(board: Cell[], col: number, player: 'player' | 'ai'): number | null {
+  for (let r = ROWS - 1; r >= 0; r--) {
+    const idx = r * COLS + col
+    if (!board[idx]) {
+      board[idx] = player
+      return idx
+    }
+  }
+  return null
+}
+
+function checkWin(board: Cell[], player: 'player' | 'ai'): number[] | null {
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      const idx = r * COLS + c
+      if (board[idx] !== player)
+        continue
+      // horizontal
+      if (c <= COLS - 4
+        && board[idx + 1] === player
+        && board[idx + 2] === player
+        && board[idx + 3] === player) {
+        return [idx, idx + 1, idx + 2, idx + 3]
+      }
+      // vertical
+      if (r <= ROWS - 4
+        && board[idx + COLS] === player
+        && board[idx + COLS * 2] === player
+        && board[idx + COLS * 3] === player) {
+        return [idx, idx + COLS, idx + COLS * 2, idx + COLS * 3]
+      }
+      // diag down-right
+      if (r <= ROWS - 4 && c <= COLS - 4
+        && board[idx + COLS + 1] === player
+        && board[idx + COLS * 2 + 2] === player
+        && board[idx + COLS * 3 + 3] === player) {
+        return [idx, idx + COLS + 1, idx + COLS * 2 + 2, idx + COLS * 3 + 3]
+      }
+      // diag up-right
+      if (r >= 3 && c <= COLS - 4
+        && board[idx - COLS + 1] === player
+        && board[idx - COLS * 2 + 2] === player
+        && board[idx - COLS * 3 + 3] === player) {
+        return [idx, idx - COLS + 1, idx - COLS * 2 + 2, idx - COLS * 3 + 3]
+      }
+    }
+  }
+  return null
+}
+
+export function useConnectFour() {
+  const board = ref<Cell[]>(createConnectFourBoard())
+  const turn = ref<'player' | 'ai'>('player')
+  const finished = ref(false)
+  const winningCells = ref<number[]>([])
+  const lastMove = ref<number | null>(null)
+
+  function reset() {
+    board.value = createConnectFourBoard()
+    turn.value = 'player'
+    finished.value = false
+    winningCells.value = []
+    lastMove.value = null
+  }
+
+  function end(win: boolean, combo: number[] | null) {
+    finished.value = true
+    if (combo)
+      winningCells.value = combo
+    return win
+  }
+
+  function aiMove() {
+    if (finished.value)
+      return
+    const col = randomColumn(board.value)
+    const idx = drop(board.value, col, 'ai')
+    lastMove.value = idx
+    const combo = checkWin(board.value, 'ai')
+    if (combo)
+      return end(false, combo)
+    if (board.value.every(Boolean))
+      return end(false, null)
+    turn.value = 'player'
+  }
+
+  function play(col: number) {
+    if (finished.value || turn.value !== 'player')
+      return
+    const idx = drop(board.value, col, 'player')
+    if (idx === null)
+      return
+    lastMove.value = idx
+    const combo = checkWin(board.value, 'player')
+    if (combo)
+      return end(true, combo)
+    if (board.value.every(Boolean))
+      return end(false, null)
+    turn.value = 'ai'
+    const delay = 800 + Math.random() * 400
+    setTimeout(aiMove, delay)
+  }
+
+  function checkAndSetWinner(player: 'player' | 'ai') {
+    const combo = checkWin(board.value, player)
+    if (combo) {
+      winningCells.value = combo
+      return true
+    }
+    return false
+  }
+
+  return { board, turn, finished, winningCells, lastMove, reset, play, aiMove, checkAndSetWinner }
+}
+
+export { checkWin, drop }

--- a/src/data/Minigame/ConnectFour.i18n.yml
+++ b/src/data/Minigame/ConnectFour.i18n.yml
@@ -1,0 +1,17 @@
+data.minigame.connectFour:
+  fr:
+    startText: Une partie de Puissance 4 ?
+    yes: Oui
+    no: Non
+    winText: Bien joué ! Tu gagnes un œuf Feu.
+    super: Super !
+    loseText: Match nul ou perdu ! Recommence quand tu veux.
+    back: Retour
+  en:
+    startText: Fancy a game of Connect Four?
+    yes: Yes
+    no: No
+    winText: Well played! You win a Fire Egg.
+    super: Awesome!
+    loseText: Draw or lost! Try again whenever you like.
+    back: Back

--- a/src/data/Minigame/ConnectFour.ts
+++ b/src/data/Minigame/ConnectFour.ts
@@ -1,0 +1,56 @@
+import type { MiniGameDefinition } from '~/type/minigame'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMiniGameStore } from '~/stores/miniGame'
+import { sachatte } from '../characters/sachatte'
+import { fireEgg } from '../items/items'
+
+export const connectFourMiniGame: MiniGameDefinition = {
+  id: 'connectfour',
+  label: 'Puissance 4',
+  character: sachatte,
+  component: () => import('~/components/minigame/MiniGamePuissance4.vue'),
+  reward: { type: 'item', itemId: fireEgg.id },
+  createIntro(start) {
+    const miniGame = useMiniGameStore()
+    const panel = useMainPanelStore()
+    return [
+      {
+        id: 'start',
+        text: $t('data.minigame.connectFour.startText'),
+        responses: [
+          { label: $t('data.minigame.connectFour.yes'), type: 'primary', action: start },
+          {
+            label: $t('data.minigame.connectFour.no'),
+            type: 'danger',
+            action: () => {
+              miniGame.quit()
+              panel.showVillage()
+            },
+          },
+        ],
+      },
+    ]
+  },
+  createSuccess(done) {
+    return [
+      {
+        id: 'win',
+        text: $t('data.minigame.connectFour.winText'),
+        responses: [
+          { label: $t('data.minigame.connectFour.super'), type: 'valid', action: done },
+        ],
+      },
+    ]
+  },
+  createFailure(done) {
+    return [
+      {
+        id: 'fail',
+        text: $t('data.minigame.connectFour.loseText'),
+        responses: [
+          { label: $t('data.minigame.connectFour.back'), type: 'danger', action: done },
+        ],
+      },
+    ]
+  },
+}

--- a/src/data/minigames.ts
+++ b/src/data/minigames.ts
@@ -1,10 +1,12 @@
 import type { MiniGameDefinition } from '~/type/minigame'
 import { battleshipMiniGame } from './Minigame/Battleship'
+import { connectFourMiniGame } from './Minigame/ConnectFour'
 import { ticTacToeMiniGame } from './Minigame/TicTacToe'
 
 export const miniGames: MiniGameDefinition[] = [
   ticTacToeMiniGame,
   battleshipMiniGame,
+  connectFourMiniGame,
 ]
 
 export function getMiniGame(id: string): MiniGameDefinition | undefined {

--- a/src/data/zones/villages/village60.ts
+++ b/src/data/zones/villages/village60.ts
@@ -23,7 +23,9 @@ export const village60: Zone = {
   id: 'village-cassos-land',
   name: 'Village des Cassos',
   type: 'village',
-  actions: [],
+  actions: [
+    { id: 'minigame', label: 'Mini-jeu' },
+  ],
   minLevel: 60,
   arena: {
     get arena() { return arena60 },
@@ -52,4 +54,5 @@ export const village60: Zone = {
       ],
     },
   },
+  miniGame: 'connectfour',
 }

--- a/src/type/minigame.ts
+++ b/src/type/minigame.ts
@@ -26,4 +26,4 @@ export interface MiniGameDefinition {
   createFailure: (done: () => void) => DialogNode[]
 }
 
-export type MiniGameId = 'tictactoe' | 'battleship'
+export type MiniGameId = 'tictactoe' | 'battleship' | 'connectfour'

--- a/test/connectfour-ai.test.ts
+++ b/test/connectfour-ai.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { COLS, createConnectFourBoard, randomColumn, ROWS } from '../src/composables/useConnectFour'
+
+describe('connect four ai', () => {
+  it('never selects a full column', () => {
+    const board = createConnectFourBoard()
+    for (let r = 0; r < ROWS; r++)
+      board[r * COLS] = 'player'
+    const choices = new Set<number>()
+    for (let i = 0; i < 20; i++)
+      choices.add(randomColumn(board))
+    expect(choices.has(0)).toBe(false)
+  })
+})

--- a/test/connectfour-component.test.ts
+++ b/test/connectfour-component.test.ts
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import MiniGamePuissance4 from '../src/components/minigame/MiniGamePuissance4.vue'
+
+describe('connect four component', () => {
+  it('renders without crashing', () => {
+    const wrapper = mount(MiniGamePuissance4)
+    expect(wrapper.exists()).toBe(true)
+  })
+})

--- a/test/minigame.test.ts
+++ b/test/minigame.test.ts
@@ -35,4 +35,13 @@ describe('mini game store', () => {
     mini.finish(true)
     expect(inventory.items['oeuf-eau']).toBe(1)
   })
+
+  it('grants fire egg on connect four victory', () => {
+    setActivePinia(createPinia())
+    const mini = useMiniGameStore()
+    const inventory = useInventoryStore()
+    mini.select('connectfour')
+    mini.finish(true)
+    expect(inventory.items['oeuf-feu']).toBe(1)
+  })
 })


### PR DESCRIPTION
## Summary
- add Connect Four composable and component
- register new mini game with translations and reward
- enable game in village 60
- extend mini game tests

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fetch error for Google Fonts and missing components)*

------
https://chatgpt.com/codex/tasks/task_e_687d0cac3d50832aa6a8529ffbdaf293