### PR TITLE
Fix Connect Four translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1242,6 +1242,15 @@ data:
 
         We can't find him: he's the one who stays, by mistake, at the bottom of
         a bag. His dream? Be ignored perfectly, like a wet cash ticket.
+  Minigame:
+    ConnectFour:
+      startText: Fancy a game of Connect Four?
+      yes: Yes
+      no: No
+      winText: Well played! You win a Fire Egg.
+      super: Awesome!
+      loseText: Draw or lost! Try again whenever you like.
+      back: Back
 pages:
   indexPage:
     title: Shlagemon

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1263,6 +1263,15 @@ data:
 
         On ne le trouve pas : c’est lui qui reste, par erreur, au fond d’un sac.
         Son rêve ? Être ignoré parfaitement, comme un ticket de caisse mouillé.
+  Minigame:
+    ConnectFour:
+      startText: Une partie de Puissance 4 ?
+      yes: Oui
+      no: Non
+      winText: Bien joué ! Tu gagnes un œuf Feu.
+      super: Super !
+      loseText: Match nul ou perdu ! Recommence quand tu veux.
+      back: Retour
 pages:
   indexPage:
     title: Shlagémon

--- a/src/data/Minigame/ConnectFour.i18n.yml
+++ b/src/data/Minigame/ConnectFour.i18n.yml
@@ -1,17 +1,16 @@
-data.minigame.connectFour:
-  fr:
-    startText: Une partie de Puissance 4 ?
-    yes: Oui
-    no: Non
-    winText: Bien joué ! Tu gagnes un œuf Feu.
-    super: Super !
-    loseText: Match nul ou perdu ! Recommence quand tu veux.
-    back: Retour
-  en:
-    startText: Fancy a game of Connect Four?
-    yes: Yes
-    no: No
-    winText: Well played! You win a Fire Egg.
-    super: Awesome!
-    loseText: Draw or lost! Try again whenever you like.
-    back: Back
+fr:
+  startText: Une partie de Puissance 4 ?
+  yes: Oui
+  no: Non
+  winText: Bien joué ! Tu gagnes un œuf Feu.
+  super: Super !
+  loseText: Match nul ou perdu ! Recommence quand tu veux.
+  back: Retour
+en:
+  startText: Fancy a game of Connect Four?
+  yes: Yes
+  no: No
+  winText: Well played! You win a Fire Egg.
+  super: Awesome!
+  loseText: Draw or lost! Try again whenever you like.
+  back: Back

--- a/src/data/Minigame/ConnectFour.ts
+++ b/src/data/Minigame/ConnectFour.ts
@@ -1,4 +1,5 @@
 import type { MiniGameDefinition } from '~/type/minigame'
+import { i18n } from '~/modules/i18n'
 import { useMainPanelStore } from '~/stores/mainPanel'
 import { useMiniGameStore } from '~/stores/miniGame'
 import { sachatte } from '../characters/sachatte'
@@ -16,11 +17,11 @@ export const connectFourMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: $t('data.minigame.connectFour.startText'),
+        text: i18n.global.t('data.Minigame.ConnectFour.startText'),
         responses: [
-          { label: $t('data.minigame.connectFour.yes'), type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.ConnectFour.yes'), type: 'primary', action: start },
           {
-            label: $t('data.minigame.connectFour.no'),
+            label: i18n.global.t('data.Minigame.ConnectFour.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -35,9 +36,9 @@ export const connectFourMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'win',
-        text: $t('data.minigame.connectFour.winText'),
+        text: i18n.global.t('data.Minigame.ConnectFour.winText'),
         responses: [
-          { label: $t('data.minigame.connectFour.super'), type: 'valid', action: done },
+          { label: i18n.global.t('data.Minigame.ConnectFour.super'), type: 'valid', action: done },
         ],
       },
     ]
@@ -46,9 +47,9 @@ export const connectFourMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: $t('data.minigame.connectFour.loseText'),
+        text: i18n.global.t('data.Minigame.ConnectFour.loseText'),
         responses: [
-          { label: $t('data.minigame.connectFour.back'), type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.ConnectFour.back'), type: 'danger', action: done },
         ],
       },
     ]

--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -7,7 +7,7 @@ import { useLocaleStore } from '~/stores/locale'
 // https://vitejs.dev/guide/features.html#glob-import
 //
 // Don't need this? Try vitesse-lite: https://github.com/antfu/vitesse-lite
-const i18n = createI18n({
+export const i18n = createI18n({
   legacy: false,
   locale: '',
   messages: {},


### PR DESCRIPTION
## Summary
- export i18n instance
- use i18n in ConnectFour mini-game
- fix ConnectFour translation file format
- regenerate locales

## Testing
- `pnpm test:unit` *(fails: Failed to resolve imports; ENETUNREACH while fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687d0f9cf720832aab3b78a47e7ddea1