### PR TITLE
Fix shlagemon description i18n keys

### DIFF
--- a/src/components/deck/DeckDetail.vue
+++ b/src/components/deck/DeckDetail.vue
@@ -25,7 +25,7 @@ const { t } = useI18n()
       />
     </div>
     <p class="tiny-scrollbar max-h-40 overflow-auto text-sm italic">
-      {{ t(`shlagemons.${props.mon.id}.description`) }}
+      {{ t(props.mon.descriptionKey || props.mon.description) }}
     </p>
     <div v-if="props.mon.evolution" class="flex flex-col items-center text-sm font-medium">
       <span>{{ t('deckDetail.evolution') }}</span>

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -163,7 +163,7 @@ const captureInfo = computed(() => {
         </UiCheckBox>
       </div>
       <p class="tiny-scrollbar max-h-25 overflow-auto text-sm italic">
-        {{ mon.base.description }}
+        {{ t(mon.base.descriptionKey || mon.base.description) }}
       </p>
       <ShlagemonStats :stats="stats" />
       <ShlagemonXpBar :mon="mon" />

--- a/src/data/shlagemons.ts
+++ b/src/data/shlagemons.ts
@@ -4,4 +4,11 @@ export const modules = import.meta.glob<{ default: BaseShlagemon }>('./shlagemon
 
 export const allShlagemons: BaseShlagemon[] = Object.entries(modules)
   .filter(([path]) => !path.endsWith('index.ts'))
-  .map(([, m]) => m.default)
+  .map(([path, m]) => {
+    const base = m.default
+    const rel = path
+      .replace('./shlagemons/', '')
+      .replace(/\.ts$/, '')
+    base.descriptionKey = `data.shlagemons.${rel}.description`
+    return base
+  })

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -8,6 +8,8 @@ export interface BaseShlagemon {
   id: string
   name: string
   description: string
+  /** i18n key for the description */
+  descriptionKey?: string
   /**
    * Primary and optional secondary type of the Shlagémon.
    * The first element represents the main type.


### PR DESCRIPTION
## Summary
- add optional `descriptionKey` to `BaseShlagemon`
- compute `descriptionKey` for each shlagemon when building data
- read translated descriptions in DeckDetail and Shlagemon Detail

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: cannot find names, type errors)*
- `pnpm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d10c75d84832a85620333dfdf3b33