### PR TITLE
Refactor zone panel with dedicated button components

### DIFF
--- a/src/components/zone/ZoneButtonVillage.vue
+++ b/src/components/zone/ZoneButtonVillage.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import type { Zone } from '~/type/zone'
+import { useArenaStore } from '~/stores/arena'
+import { useDialogStore } from '~/stores/dialog'
+import { useFeatureLockStore } from '~/stores/featureLock'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
+import { useZoneVisitStore } from '~/stores/zoneVisit'
+
+const props = defineProps<{ zone: Zone }>()
+const zoneStore = useZoneStore()
+const panel = useMainPanelStore()
+const arena = useArenaStore()
+const progress = useZoneProgressStore()
+const dialog = useDialogStore()
+const featureLock = useFeatureLockStore()
+const visit = useZoneVisitStore()
+
+const zoneButtonsDisabled = computed(
+  () =>
+    panel.current === 'trainerBattle'
+    || panel.current === 'arena'
+    || dialog.isDialogVisible
+    || arena.inBattle
+    || featureLock.areZonesLocked,
+)
+
+function buttonDisabled() {
+  return zoneButtonsDisabled.value
+}
+
+function selectZone() {
+  if (buttonDisabled())
+    return
+  zoneStore.setZone(props.zone.id)
+}
+
+function classes() {
+  const z = props.zone
+  const classes: string[] = []
+  if (z.id === zoneStore.current.id) {
+    classes.push('bg-primary text-dark dark:bg-light')
+    return classes.join(' ')
+  }
+  classes.push('bg-green-300 dark:bg-green-800')
+  return classes.join(' ')
+}
+</script>
+
+<template>
+  <button
+    class="relative grid grid-rows-2 aspect-square gap-1 rounded px-2 py-1 text-xs"
+    :class="[
+      classes(),
+      buttonDisabled() ? 'opacity-50 cursor-not-allowed' : '',
+      props.zone.id !== zoneStore.current.id && !visit.visited[props.zone.id] ? 'animate-pulse-alt  animate-count-infinite' : '',
+    ]"
+    :disabled="buttonDisabled()"
+    @click="selectZone"
+  >
+    <UiBadge
+      v-if="props.zone.id === zoneStore.current.id"
+      inner
+      size="square"
+      icon="i-carbon:user-filled"
+    />
+    <div class="flex-center">
+      <div class="i-game-icons:village h-6 w-6" />
+    </div>
+    <div class="flex-center">
+      <span>{{ props.zone.name }}</span>
+    </div>
+    <div class="flex items-center justify-center gap-2">
+      <div v-if="progress.isArenaCompleted(props.zone.id)" class="i-mdi:sword-cross h-4 w-4" />
+      <div v-else-if="props.zone.arena" class="i-mdi:sword-cross h-4 w-4 opacity-50 grayscale" />
+    </div>
+  </button>
+</template>

--- a/src/components/zone/ZoneButtonWild.vue
+++ b/src/components/zone/ZoneButtonWild.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import type { SavageZone } from '~/type/zone'
+import { useI18n } from 'vue-i18n'
+import { useArenaStore } from '~/stores/arena'
+import { useDialogStore } from '~/stores/dialog'
+import { useFeatureLockStore } from '~/stores/featureLock'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useShlagedexStore } from '~/stores/shlagedex'
+import { useZoneStore } from '~/stores/zone'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
+import { useZoneVisitStore } from '~/stores/zoneVisit'
+
+const props = defineProps<{ zone: SavageZone }>()
+const zoneStore = useZoneStore()
+const dex = useShlagedexStore()
+const panel = useMainPanelStore()
+const arena = useArenaStore()
+const progress = useZoneProgressStore()
+const dialog = useDialogStore()
+const featureLock = useFeatureLockStore()
+const visit = useZoneVisitStore()
+const { t } = useI18n()
+
+const zoneButtonsDisabled = computed(
+  () =>
+    panel.current === 'trainerBattle'
+    || panel.current === 'arena'
+    || dialog.isDialogVisible
+    || arena.inBattle
+    || featureLock.areZonesLocked,
+)
+
+function buttonDisabled() {
+  if (zoneButtonsDisabled.value)
+    return true
+  return zoneStore.wildCooldownRemaining > 0
+}
+
+function selectZone() {
+  if (buttonDisabled())
+    return
+  zoneStore.setZone(props.zone.id)
+}
+
+function classes() {
+  const z = props.zone
+  const classes: string[] = []
+  if (z.id === zoneStore.current.id) {
+    classes.push('bg-primary text-dark dark:bg-light')
+    return classes.join(' ')
+  }
+
+  const level = dex.activeShlagemon?.lvl || 0
+  if (z.maxLevel < level)
+    classes.push('bg-blue-200 dark:bg-gray-700')
+  else if (level >= z.minLevel && level <= z.maxLevel)
+    classes.push('bg-blue-500 dark:bg-blue-600')
+  else if (z.minLevel > level && z.minLevel - level <= 5)
+    classes.push('bg-orange-400 dark:bg-orange-800')
+  else
+    classes.push('bg-red-400 dark:bg-red-700')
+
+  return classes.join(' ')
+}
+
+function allCaptured() {
+  const list = props.zone.shlagemons
+  if (!list?.length)
+    return false
+  return list.every(base => dex.shlagemons.some(mon => mon.base.id === base.id))
+}
+
+function perfectZone() {
+  const list = props.zone.shlagemons
+  if (!list?.length)
+    return false
+  return list.every((base) => {
+    const mon = dex.shlagemons.find(m => m.base.id === base.id)
+    return mon?.rarity === 100
+  })
+}
+
+function kingDefeated() {
+  const hasKing = props.zone.hasKing ?? props.zone.type === 'sauvage'
+  return hasKing && progress.isKingDefeated(props.zone.id)
+}
+
+const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
+</script>
+
+<template>
+  <button
+    class="relative grid grid-rows-2 aspect-square gap-1 rounded px-2 py-1 text-xs"
+    :class="[
+      classes(),
+      buttonDisabled() ? 'opacity-50 cursor-not-allowed' : '',
+      props.zone.id !== zoneStore.current.id && !visit.visited[props.zone.id] ? highlightClasses : '',
+    ]"
+    :disabled="buttonDisabled()"
+    @click="selectZone"
+  >
+    <UiBadge
+      v-if="props.zone.id === zoneStore.current.id"
+      inner
+      size="square"
+      icon="i-carbon:user-filled"
+    />
+    <span class="text-2xs absolute left-1 top-0.5">{{ props.zone.minLevel }}</span>
+    <span class="text-2xs absolute right-1 top-0.5">{{ props.zone.maxLevel }}</span>
+    <div class="flex-center">
+      <div class="i-game-icons:forest h-6 w-6" />
+    </div>
+    <div class="flex-center">
+      <span>{{ props.zone.name }}</span>
+    </div>
+    <div class="flex items-center justify-center gap-2">
+      <img
+        v-if="allCaptured()"
+        src="/items/shlageball/shlageball.png"
+        :alt="t('components.panel.Zone.capturedAlt')"
+        class="h-4 w-4"
+        :style="perfectZone() ? { filter: 'hue-rotate(60deg) brightness(1.1)' } : {}"
+      >
+      <div
+        v-if="kingDefeated()"
+        class="i-game-icons:crown h-4 w-4"
+      />
+    </div>
+  </button>
+</template>


### PR DESCRIPTION
## Summary
- create `ZoneButtonWild` and `ZoneButtonVillage` for simpler zone management
- update `PanelZone` to use the new components and split lists for wild areas and villages
- show min and max level on wild zone buttons
- allow horizontal scrolling for village list via mouse wheel

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to fetch web fonts, unable to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d12fcd878832a97142adfc3c93add