### PR TITLE
Fix translation key path for shlagemon descriptions

### DIFF
--- a/src/data/shlagemons.ts
+++ b/src/data/shlagemons.ts
@@ -9,6 +9,7 @@ export const allShlagemons: BaseShlagemon[] = Object.entries(modules)
     const rel = path
       .replace('./shlagemons/', '')
       .replace(/\.ts$/, '')
-    base.descriptionKey = `data.shlagemons.${rel}.description`
+    const key = rel.replace(/\//g, '.')
+    base.descriptionKey = `data.shlagemons.${key}.description`
     return base
   })


### PR DESCRIPTION
## Summary
- ensure slashes in shlagemon paths are converted to dots

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined / fonts fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d170af5f4832ab309bc43bb0bf0b7