### PR TITLE
Add border highlight for active zone

### DIFF
--- a/src/components/zone/ButtonVillage.vue
+++ b/src/components/zone/ButtonVillage.vue
@@ -34,6 +34,7 @@ function classes() {
   const classes: string[] = []
   if (z.id === zoneStore.current.id) {
     classes.push('bg-primary text-dark dark:bg-light')
+    classes.push('border-2 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400')
     return classes.join(' ')
   }
   classes.push('bg-green-300 dark:bg-green-800')
@@ -52,12 +53,6 @@ function classes() {
     :disabled="buttonDisabled()"
     @click="selectZone"
   >
-    <UiBadge
-      v-if="props.zone.id === zoneStore.current.id"
-      inner
-      size="square"
-      icon="i-carbon:user-filled"
-    />
     <div class="flex-center">
       <div class="i-game-icons:village h-6 w-6" />
     </div>

--- a/src/components/zone/ButtonWild.vue
+++ b/src/components/zone/ButtonWild.vue
@@ -38,6 +38,7 @@ function classes() {
   const classes: string[] = []
   if (z.id === zoneStore.current.id) {
     classes.push('bg-primary text-dark dark:bg-light')
+    classes.push('border-2 border-blue-500 dark:border-blue-400 ring-2 ring-blue-500 dark:ring-blue-400')
     return classes.join(' ')
   }
 
@@ -90,12 +91,6 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
     :disabled="buttonDisabled()"
     @click="selectZone"
   >
-    <UiBadge
-      v-if="props.zone.id === zoneStore.current.id"
-      inner
-      size="square"
-      icon="i-carbon:user-filled"
-    />
     <span class="text-2xs absolute left-1 top-0.5">{{ props.zone.minLevel }}</span>
     <span class="text-2xs absolute right-1 top-0.5">{{ props.zone.maxLevel }}</span>
     <div class="flex-center">


### PR DESCRIPTION
## Summary
- highlight active Zone button with a blue border instead of a badge icon

## Testing
- `pnpm test:unit` *(fails: Tests failed, watching for file changes)*
- `pnpm test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_687dd3bfb7c0832ab0533e70e8e53536