### PR TITLE
Add typing effect and bounce on dialog buttons

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -134,6 +134,7 @@ declare module 'vue' {
     UiSortControls: typeof import('./components/ui/SortControls.vue')['default']
     UiTabBar: typeof import('./components/ui/TabBar.vue')['default']
     UiTooltip: typeof import('./components/ui/Tooltip.vue')['default']
+    UiTypingText: typeof import('./components/ui/TypingText.vue')['default']
     UpdateSnackbar: typeof import('./components/UpdateSnackbar.vue')['default']
     VillageZoneActions: typeof import('./components/village/ZoneActions.vue')['default']
     ZoneButtonVillage: typeof import('./components/zone/ButtonVillage.vue')['default']

--- a/src/components/dialog/Box.vue
+++ b/src/components/dialog/Box.vue
@@ -62,9 +62,7 @@ function choose(r: DialogResponse) {
 
       <div class="col-span-2 h-full flex flex-col gap-2 bg-gray-100 p-2 dark:bg-gray-800">
         <div class="flex flex-1 flex-col justify-center">
-          <div>
-            {{ currentNode?.text }}
-          </div>
+          <UiTypingText v-if="currentNode" :text="currentNode.text" />
 
           <UiImageByBackground
             v-if="currentNode?.imageUrl"
@@ -80,7 +78,7 @@ function choose(r: DialogResponse) {
         v-for="r in currentNode?.responses"
         :key="r.label"
         :type="r.type"
-        :class="buttonClass"
+        :class="[buttonClass, (r.type === 'valid' || r.type === 'primary') && 'animate-bounce']"
         class="max-w-50vw"
         md="text-sm"
         @click="choose(r)"

--- a/src/components/ui/TypingText.vue
+++ b/src/components/ui/TypingText.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ text: string, speed?: number }>(), {
+  speed: 50,
+})
+
+const display = ref('')
+let timer: ReturnType<typeof setTimeout> | undefined
+
+function start() {
+  display.value = ''
+  if (timer)
+    clearTimeout(timer)
+  if (!props.text)
+    return
+  let i = 0
+  function type() {
+    display.value += props.text[i++]
+    if (i < props.text.length)
+      timer = setTimeout(type, props.speed)
+  }
+  type()
+}
+
+watch(() => props.text, start, { immediate: true })
+
+onUnmounted(() => {
+  if (timer)
+    clearTimeout(timer)
+})
+</script>
+
+<template>
+  <span>{{ display }}</span>
+</template>


### PR DESCRIPTION
## Summary
- animate important dialog buttons with `animate-bounce`
- show dialog text progressively with new `UiTypingText` component

## Testing
- `pnpm test` *(fails: ENETUNREACH while fetching fonts and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dd53a8090832abda54344bb6bbfe6