### PR TITLE
Improve dialog typing interaction

### DIFF
--- a/src/components/ui/TypingText.vue
+++ b/src/components/ui/TypingText.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 const props = withDefaults(defineProps<{ text: string, speed?: number }>(), {
-  speed: 50,
+  speed: 20,
 })
+
+const emit = defineEmits<{
+  (e: 'finished'): void
+}>()
 
 const display = ref('')
 let timer: ReturnType<typeof setTimeout> | undefined
@@ -11,12 +15,14 @@ function start() {
   if (timer)
     clearTimeout(timer)
   if (!props.text)
-    return
+    return emit('finished')
   let i = 0
   function type() {
     display.value += props.text[i++]
     if (i < props.text.length)
       timer = setTimeout(type, props.speed)
+    else
+      emit('finished')
   }
   type()
 }


### PR DESCRIPTION
## Summary
- increase `TypingText` typing speed
- emit a `finished` event when typing completes
- bounce dialog buttons only when text is fully written

## Testing
- `pnpm lint`
- `pnpm test` *(fails: fetch error when downloading Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687dd92d0b0c832a951420342304df66