### PR TITLE
Add kill sound for enemy defeat

### DIFF
--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -95,6 +95,8 @@ export function useBattleCore(options: BattleCoreOptions) {
     if (enemyHp.value <= 0 || playerHp.value <= 0) {
       if (playerHp.value <= 0 && !playerFainted.value)
         audio.playSfx('/audio/sfx/die.ogg')
+      else if (enemyHp.value <= 0 && !enemyFainted.value)
+        audio.playSfx('/audio/sfx/kill.ogg')
       stopBattle()
       playerFainted.value = playerHp.value <= 0
       enemyFainted.value = enemyHp.value <= 0


### PR DESCRIPTION
## Summary
- play new kill.ogg SFX when an enemy shlagémon dies

## Testing
- `pnpm test` *(fails: Test Files 30 failed | 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687ddbe33d58832a8f5aff95ca62f0df