### PR TITLE
Add Taquin minigame and thunder egg

### DIFF
--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -25,7 +25,7 @@ const inventoryEggs = computed(() => {
 function startIncubation(id: string) {
   if (eggs.incubator)
     return
-  const map = { 'oeuf-feu': 'feu', 'oeuf-eau': 'eau', 'oeuf-herbe': 'plante', 'oeuf-psy': 'psy' } as const
+  const map = { 'oeuf-feu': 'feu', 'oeuf-eau': 'eau', 'oeuf-herbe': 'plante', 'oeuf-psy': 'psy', 'oeuf-foudre': 'electrique' } as const
   if (eggs.startIncubation(map[id]))
     box.removeEgg(id as EggItemId)
 }
@@ -75,6 +75,7 @@ function remaining(egg: { hatchesAt: number }) {
                     'text-orange-500 dark:text-orange-400': eggs.incubator.type === 'feu',
                     'text-blue-500 dark:text-blue-400': eggs.incubator.type === 'eau',
                     'text-green-500 dark:text-green-400': eggs.incubator.type === 'plante',
+                    'text-yellow-500 dark:text-yellow-400': eggs.incubator.type === 'electrique',
                   },
                 ]"
                 @click="eggs.isReady && hatch()"

--- a/src/data/Minigame/ShlagTaquin.i18n.yml
+++ b/src/data/Minigame/ShlagTaquin.i18n.yml
@@ -1,0 +1,17 @@
+data.minigame.taquin:
+  fr:
+    startText: Une partie de taquin ?
+    yes: Oui
+    no: Non
+    winText: Bravo ! Tu gagnes un œuf Foudre.
+    super: Super !
+    loseText: Perdu ! Recommence quand tu veux.
+    back: Retour
+  en:
+    startText: Fancy a sliding puzzle game?
+    yes: Yes
+    no: No
+    winText: Congrats! You win a Thunder Egg.
+    super: Awesome!
+    loseText: Lost! Try again whenever you like.
+    back: Back

--- a/src/data/Minigame/ShlagTaquin.ts
+++ b/src/data/Minigame/ShlagTaquin.ts
@@ -1,0 +1,56 @@
+import type { MiniGameDefinition } from '~/type/minigame'
+import { useMainPanelStore } from '~/stores/mainPanel'
+import { useMiniGameStore } from '~/stores/miniGame'
+import { sachatte } from '../characters/sachatte'
+import { thunderEgg } from '../items/items'
+
+export const shlagTaquinMiniGame: MiniGameDefinition = {
+  id: 'taquin',
+  label: 'Taquin',
+  character: sachatte,
+  component: () => import('~/components/minigame/MiniGameShlagTaquin.vue'),
+  reward: { type: 'item', itemId: thunderEgg.id },
+  createIntro(start) {
+    const miniGame = useMiniGameStore()
+    const panel = useMainPanelStore()
+    return [
+      {
+        id: 'start',
+        text: 'Une partie de taquin ?',
+        responses: [
+          { label: 'Oui', type: 'primary', action: start },
+          {
+            label: 'Non',
+            type: 'danger',
+            action: () => {
+              miniGame.quit()
+              panel.showVillage()
+            },
+          },
+        ],
+      },
+    ]
+  },
+  createSuccess(done) {
+    return [
+      {
+        id: 'win',
+        text: 'Bravo ! Tu gagnes un œuf Foudre.',
+        responses: [
+          { label: 'Super !', type: 'valid', action: done },
+        ],
+      },
+    ]
+  },
+  createFailure(done) {
+    return [
+      {
+        id: 'fail',
+        text: 'Perdu ! Recommence quand tu veux.',
+        responses: [
+          { label: 'Retour', type: 'danger', action: done },
+        ],
+      },
+    ]
+  },
+}

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -381,6 +381,17 @@ export const psyEgg: Item = {
   iconClass: 'text-pink-500 dark:text-pink-400',
 }
 
+export const thunderEgg: Item = {
+  id: 'oeuf-foudre',
+  name: 'Œuf Foudre',
+  description: 'Un œuf parcouru d\'étincelles.',
+  price: 30,
+  currency: 'shlagidolar',
+  category: 'utilitaire',
+  icon: 'i-game-icons:egg-eye',
+  iconClass: 'text-yellow-500 dark:text-yellow-400',
+}
+
 export const allItems = [
   shlageball,
   superShlageball,
@@ -424,6 +435,7 @@ export const allItems = [
   waterEgg,
   grassEgg,
   psyEgg,
+  thunderEgg,
 ] as const satisfies Item[]
 
 export type ItemId = typeof allItems[number]['id']

--- a/src/data/minigames.ts
+++ b/src/data/minigames.ts
@@ -2,6 +2,7 @@ import type { MiniGameDefinition } from '~/type/minigame'
 import { battleshipMiniGame } from './Minigame/Battleship'
 import { connectFourMiniGame } from './Minigame/ConnectFour'
 import { shlagCardsMiniGame } from './Minigame/ShlagCards'
+import { shlagTaquinMiniGame } from './Minigame/ShlagTaquin'
 import { ticTacToeMiniGame } from './Minigame/TicTacToe'
 
 export const miniGames: MiniGameDefinition[] = [
@@ -9,6 +10,7 @@ export const miniGames: MiniGameDefinition[] = [
   battleshipMiniGame,
   connectFourMiniGame,
   shlagCardsMiniGame,
+  shlagTaquinMiniGame,
 ]
 
 export function getMiniGame(id: string): MiniGameDefinition | undefined {

--- a/src/data/zones/villages/village50.ts
+++ b/src/data/zones/villages/village50.ts
@@ -48,4 +48,5 @@ export const village50: Zone = {
       icon: 'i-game-icons:bird-house',
     },
   },
+  miniGame: 'taquin',
 }

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -155,7 +155,7 @@ export const useDialogStore = defineStore('dialog', () => {
     {
       id: 'eggBox',
       component: markRaw(EggBoxDialog),
-      condition: () => !box.unlocked && ['oeuf-feu', 'oeuf-eau', 'oeuf-herbe'].some(id => inventory.items[id]),
+      condition: () => !box.unlocked && ['oeuf-feu', 'oeuf-eau', 'oeuf-herbe', 'oeuf-foudre'].some(id => inventory.items[id]),
     },
     {
       id: 'capturePotion',

--- a/src/stores/egg.ts
+++ b/src/stores/egg.ts
@@ -1,5 +1,6 @@
 import type { TypeName } from '~/data/shlagemons-type'
 import { defineStore } from 'pinia'
+import { pikachiant } from '~/data/shlagemons/15-20/pikachiant'
 import { bulgrosboule } from '~/data/shlagemons/bulgrosboule'
 import { carapouffe } from '~/data/shlagemons/carapouffe'
 import { mewteub } from '~/data/shlagemons/mewteub'
@@ -43,6 +44,8 @@ export const useEggStore = defineStore('egg', () => {
         return dex.captureShlagemon(bulgrosboule)
       case 'psy':
         return dex.captureShlagemon(mewteub)
+      case 'electrique':
+        return dex.captureShlagemon(pikachiant)
     }
     return null
   }

--- a/src/stores/eggBox.ts
+++ b/src/stores/eggBox.ts
@@ -1,7 +1,7 @@
 import type { ItemId } from '~/data/items/items'
 import { defineStore } from 'pinia'
 
-export const eggIds = ['oeuf-feu', 'oeuf-eau', 'oeuf-herbe', 'oeuf-psy'] as const
+export const eggIds = ['oeuf-feu', 'oeuf-eau', 'oeuf-herbe', 'oeuf-psy', 'oeuf-foudre'] as const
 export type EggItemId = typeof eggIds[number]
 
 export const useEggBoxStore = defineStore('eggBox', () => {

--- a/src/type/minigame.ts
+++ b/src/type/minigame.ts
@@ -27,4 +27,4 @@ export interface MiniGameDefinition {
   createFailure: (done: () => void) => DialogNode[]
 }
 
-export type MiniGameId = 'tictactoe' | 'battleship' | 'connectfour' | 'shlagcards'
+export type MiniGameId = 'tictactoe' | 'battleship' | 'connectfour' | 'shlagcards' | 'taquin'


### PR DESCRIPTION
## Summary
- add Thunder Egg item
- introduce Taquin sliding puzzle minigame and translations
- enable Taquin in level 50 village
- update egg related stores for new egg type
- color incubator for electric eggs

## Testing
- `npx eslint --fix .`
- `pnpm test:unit` *(fails: failed to fetch fonts and numerous zone errors)*

------
https://chatgpt.com/codex/tasks/task_e_687de33073a4832aa8e4755996721f9c