### PR TITLE
Fix ShlagCards i18n keys

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1252,6 +1252,14 @@ data:
       loseText: Lost! Try again whenever you like.
       drawText: Draw! Try again whenever you like.
       back: Back
+    ShlagCards:
+      startText: Fancy a game of Shlag Cards?
+      yes: Yes
+      no: No
+      winText: Well played! You win a Psy Egg.
+      super: Awesome!
+      loseText: Lost! Try again whenever you like.
+      back: Back
 pages:
   indexPage:
     title: Shlagemon

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1273,6 +1273,14 @@ data:
       loseText: Perdu ! Recommence quand tu veux.
       drawText: Match nul ! Recommence quand tu veux.
       back: Retour
+    ShlagCards:
+      startText: Une partie de Duel de Cartes ?
+      yes: Oui
+      no: Non
+      winText: Bien joué ! Tu gagnes un œuf Psy.
+      super: Super !
+      loseText: Perdu ! Recommence quand tu veux.
+      back: Retour
 pages:
   indexPage:
     title: Shlagémon

--- a/src/data/Minigame/ShlagCards.i18n.yml
+++ b/src/data/Minigame/ShlagCards.i18n.yml
@@ -1,17 +1,16 @@
-data.minigame.shlagcards:
-  fr:
-    startText: Une partie de Duel de Cartes ?
-    yes: Oui
-    no: Non
-    winText: Bien joué ! Tu gagnes un œuf Psy.
-    super: Super !
-    loseText: Perdu ! Recommence quand tu veux.
-    back: Retour
-  en:
-    startText: Fancy a game of Shlag Cards?
-    yes: Yes
-    no: No
-    winText: Well played! You win a Psy Egg.
-    super: Awesome!
-    loseText: Lost! Try again whenever you like.
-    back: Back
+fr:
+  startText: Une partie de Duel de Cartes ?
+  yes: Oui
+  no: Non
+  winText: Bien joué ! Tu gagnes un œuf Psy.
+  super: Super !
+  loseText: Perdu ! Recommence quand tu veux.
+  back: Retour
+en:
+  startText: Fancy a game of Shlag Cards?
+  yes: Yes
+  no: No
+  winText: Well played! You win a Psy Egg.
+  super: Awesome!
+  loseText: Lost! Try again whenever you like.
+  back: Back

--- a/src/data/Minigame/ShlagCards.ts
+++ b/src/data/Minigame/ShlagCards.ts
@@ -17,11 +17,11 @@ export const shlagCardsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: i18n.global.t('data.minigame.shlagcards.startText'),
+        text: i18n.global.t('data.Minigame.ShlagCards.startText'),
         responses: [
-          { label: i18n.global.t('data.minigame.shlagcards.yes'), type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.ShlagCards.yes'), type: 'primary', action: start },
           {
-            label: i18n.global.t('data.minigame.shlagcards.no'),
+            label: i18n.global.t('data.Minigame.ShlagCards.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -36,9 +36,9 @@ export const shlagCardsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'win',
-        text: i18n.global.t('data.minigame.shlagcards.winText'),
+        text: i18n.global.t('data.Minigame.ShlagCards.winText'),
         responses: [
-          { label: i18n.global.t('data.minigame.shlagcards.super'), type: 'valid', action: done },
+          { label: i18n.global.t('data.Minigame.ShlagCards.super'), type: 'valid', action: done },
         ],
       },
     ]
@@ -47,9 +47,9 @@ export const shlagCardsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: i18n.global.t('data.minigame.shlagcards.loseText'),
+        text: i18n.global.t('data.Minigame.ShlagCards.loseText'),
         responses: [
-          { label: i18n.global.t('data.minigame.shlagcards.back'), type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.ShlagCards.back'), type: 'danger', action: done },
         ],
       },
     ]


### PR DESCRIPTION
## Summary
- correct structure of `ShlagCards.i18n.yml`
- update `ShlagCards.ts` to use CamelCase i18n path
- regenerate locale files

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve imports and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687de5f3153c832abf1b5a4b2ebdb985