### PR TITLE
Fix solved puzzle image overlay

### DIFF
--- a/src/components/minigame/MiniGameShlagTaquin.vue
+++ b/src/components/minigame/MiniGameShlagTaquin.vue
@@ -54,7 +54,12 @@ watch(() => puzzle.solved, (v) => {
         <div class="i-mdi:arrow-left" />
       </UiButton>
       <div ref="wrapper" class="relative" :style="{ width: `${tileSize * size}px`, height: `${tileSize * size}px` }">
-        <img v-if="puzzle.solved" :src="puzzle.image" alt="image" class="absolute inset-0 h-full w-full rounded">
+        <img
+          v-if="puzzle.solved"
+          :src="puzzle.image"
+          alt="image"
+          class="absolute inset-0 z-10 h-full w-full rounded"
+        >
         <div
           v-for="tile in visibleTiles"
           :key="tile.id"


### PR DESCRIPTION
## Summary
- ensure the final image in the sliding puzzle sits above the tiles

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: failed to fetch fonts, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687debbf56e4832a9dd4454dff965092