### PR TITLE
Add restart button to mini-game failure screens

### DIFF
--- a/src/data/Minigame/Battleship.i18n.yml
+++ b/src/data/Minigame/Battleship.i18n.yml
@@ -6,6 +6,7 @@ data.minigame.battleship:
     winText: Victoire ! Tu gagnes un œuf Eau.
     super: Super !
     loseText: Perdu ! Recommence quand tu veux.
+    restart: Recommencer
     back: Retour
   en:
     startText: How about a game of Battleship?
@@ -14,4 +15,5 @@ data.minigame.battleship:
     winText: Victory! You win a Water Egg.
     super: Awesome!
     loseText: Lost! Try again whenever you like.
+    restart: Restart
     back: Back

--- a/src/data/Minigame/Battleship.ts
+++ b/src/data/Minigame/Battleship.ts
@@ -43,11 +43,13 @@ export const battleshipMiniGame: MiniGameDefinition = {
     ]
   },
   createFailure(done) {
+    const miniGame = useMiniGameStore()
     return [
       {
         id: 'fail',
         text: 'Perdu ! Recommence quand tu veux.',
         responses: [
+          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
           { label: 'Retour', type: 'danger', action: done },
         ],
       },

--- a/src/data/Minigame/ConnectFour.i18n.yml
+++ b/src/data/Minigame/ConnectFour.i18n.yml
@@ -6,6 +6,7 @@ fr:
   super: Super !
   loseText: Perdu ! Recommence quand tu veux.
   drawText: Match nul ! Recommence quand tu veux.
+  restart: Recommencer
   back: Retour
 en:
   startText: Fancy a game of Connect Four?
@@ -15,4 +16,5 @@ en:
   super: Awesome!
   loseText: Lost! Try again whenever you like.
   drawText: Draw! Try again whenever you like.
+  restart: Restart
   back: Back

--- a/src/data/Minigame/ConnectFour.ts
+++ b/src/data/Minigame/ConnectFour.ts
@@ -44,22 +44,26 @@ export const connectFourMiniGame: MiniGameDefinition = {
     ]
   },
   createDraw(done) {
+    const miniGame = useMiniGameStore()
     return [
       {
         id: 'draw',
         text: i18n.global.t('data.Minigame.ConnectFour.drawText'),
         responses: [
+          { label: i18n.global.t('data.Minigame.ConnectFour.restart'), type: 'primary', action: () => miniGame.play() },
           { label: i18n.global.t('data.Minigame.ConnectFour.back'), type: 'danger', action: done },
         ],
       },
     ]
   },
   createFailure(done) {
+    const miniGame = useMiniGameStore()
     return [
       {
         id: 'fail',
         text: i18n.global.t('data.Minigame.ConnectFour.loseText'),
         responses: [
+          { label: i18n.global.t('data.Minigame.ConnectFour.restart'), type: 'primary', action: () => miniGame.play() },
           { label: i18n.global.t('data.Minigame.ConnectFour.back'), type: 'danger', action: done },
         ],
       },

--- a/src/data/Minigame/ShlagCards.i18n.yml
+++ b/src/data/Minigame/ShlagCards.i18n.yml
@@ -5,6 +5,7 @@ fr:
   winText: Bien joué ! Tu gagnes un œuf Psy.
   super: Super !
   loseText: Perdu ! Recommence quand tu veux.
+  restart: Recommencer
   back: Retour
 en:
   startText: Fancy a game of Shlag Cards?
@@ -13,4 +14,5 @@ en:
   winText: Well played! You win a Psy Egg.
   super: Awesome!
   loseText: Lost! Try again whenever you like.
+  restart: Restart
   back: Back

--- a/src/data/Minigame/ShlagCards.ts
+++ b/src/data/Minigame/ShlagCards.ts
@@ -44,11 +44,13 @@ export const shlagCardsMiniGame: MiniGameDefinition = {
     ]
   },
   createFailure(done) {
+    const miniGame = useMiniGameStore()
     return [
       {
         id: 'fail',
         text: i18n.global.t('data.Minigame.ShlagCards.loseText'),
         responses: [
+          { label: i18n.global.t('data.Minigame.ShlagCards.restart'), type: 'primary', action: () => miniGame.play() },
           { label: i18n.global.t('data.Minigame.ShlagCards.back'), type: 'danger', action: done },
         ],
       },

--- a/src/data/Minigame/ShlagPairs.i18n.yml
+++ b/src/data/Minigame/ShlagPairs.i18n.yml
@@ -6,6 +6,7 @@ data.minigame.shlagpairs:
     winText: Bien joué !
     super: Super !
     loseText: Dommage !
+    restart: Recommencer
     back: Retour
   en:
     startText: Fancy a game of pairs?
@@ -14,4 +15,5 @@ data.minigame.shlagpairs:
     winText: Well played!
     super: Awesome!
     loseText: Too bad!
+    restart: Restart
     back: Back

--- a/src/data/Minigame/ShlagPairs.ts
+++ b/src/data/Minigame/ShlagPairs.ts
@@ -43,11 +43,13 @@ export const shlagPairsMiniGame: MiniGameDefinition = {
     ]
   },
   createFailure(done) {
+    const miniGame = useMiniGameStore()
     return [
       {
         id: 'fail',
         text: 'Dommage !',
         responses: [
+          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
           { label: 'Retour', type: 'danger', action: done },
         ],
       },

--- a/src/data/Minigame/ShlagTaquin.i18n.yml
+++ b/src/data/Minigame/ShlagTaquin.i18n.yml
@@ -6,6 +6,7 @@ data.minigame.taquin:
     winText: Bravo ! Tu gagnes un œuf Foudre.
     super: Super !
     loseText: Perdu ! Recommence quand tu veux.
+    restart: Recommencer
     back: Retour
   en:
     startText: Fancy a sliding puzzle game?
@@ -14,4 +15,5 @@ data.minigame.taquin:
     winText: Congrats! You win a Thunder Egg.
     super: Awesome!
     loseText: Lost! Try again whenever you like.
+    restart: Restart
     back: Back

--- a/src/data/Minigame/ShlagTaquin.ts
+++ b/src/data/Minigame/ShlagTaquin.ts
@@ -43,11 +43,13 @@ export const shlagTaquinMiniGame: MiniGameDefinition = {
     ]
   },
   createFailure(done) {
+    const miniGame = useMiniGameStore()
     return [
       {
         id: 'fail',
         text: 'Perdu ! Recommence quand tu veux.',
         responses: [
+          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
           { label: 'Retour', type: 'danger', action: done },
         ],
       },

--- a/src/data/Minigame/TicTacToe.i18n.yml
+++ b/src/data/Minigame/TicTacToe.i18n.yml
@@ -6,6 +6,7 @@ data.minigame.ticTacToe:
     winText: Bien joué ! Tu gagnes un Œuf Herbe.
     super: Super !
     loseText: Perdu ! Recommence quand tu veux.
+    restart: Recommencer
     back: Retour
   en:
     startText: Fancy a game of tic tac toe?
@@ -14,4 +15,5 @@ data.minigame.ticTacToe:
     winText: Well played! You win a Grass Egg.
     super: Awesome!
     loseText: Lost! Try again whenever you like.
+    restart: Restart
     back: Back

--- a/src/data/Minigame/TicTacToe.ts
+++ b/src/data/Minigame/TicTacToe.ts
@@ -43,11 +43,13 @@ export const ticTacToeMiniGame: MiniGameDefinition = {
     ]
   },
   createFailure(done) {
+    const miniGame = useMiniGameStore()
     return [
       {
         id: 'fail',
         text: 'Perdu ! Recommence quand tu veux.',
         responses: [
+          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
           { label: 'Retour', type: 'danger', action: done },
         ],
       },


### PR DESCRIPTION
## Summary
- add `restart` text to minigame locales
- allow restarting a minigame from the failure or draw dialogs

## Testing
- `pnpm i18n`
- `pnpm test` *(fails: modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_687df3679594832a92a1989f772fa087