### PR TITLE
Fix card image overlay in pairs game

### DIFF
--- a/src/components/minigame/MiniGameShlagPairs.vue
+++ b/src/components/minigame/MiniGameShlagPairs.vue
@@ -92,8 +92,8 @@ onMounted(reset)
         @click="choose(cell)"
       >
         <div class="absolute inset-0 preserve-3d transition-transform duration-300" :class="cell.state !== 'hidden' ? 'rotate-y-180' : ''">
-          <div class="backface-hidden h-full w-full flex-center rounded bg-gray-200 dark:bg-gray-700" />
-          <div class="backface-hidden h-full w-full flex-center rotate-y-180 rounded bg-white dark:bg-gray-900">
+          <div class="backface-hidden absolute inset-0 h-full w-full flex-center rounded bg-gray-200 dark:bg-gray-700" />
+          <div class="backface-hidden absolute inset-0 h-full w-full flex-center rotate-y-180 rounded bg-white dark:bg-gray-900">
             <img :src="`/shlagemons/${cell.monId}/${cell.monId}.png`" class="h-5/6 w-5/6 object-contain" :alt="cell.monId">
           </div>
         </div>


### PR DESCRIPTION
## Summary
- keep card front/back stacked with `absolute` positioning

## Testing
- `pnpm lint`
- `pnpm test` *(fails: getActivePinia() was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_687df5059be4832ababde0ae608dee6b