### PR TITLE
Add missing restart translation

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1252,6 +1252,7 @@ data:
       loseText: Lost! Try again whenever you like.
       drawText: Draw! Try again whenever you like.
       back: Back
+      restart: Restart
     ShlagCards:
       startText: Fancy a game of Shlag Cards?
       yes: Yes
@@ -1260,6 +1261,7 @@ data:
       super: Awesome!
       loseText: Lost! Try again whenever you like.
       back: Back
+      restart: Restart
 pages:
   indexPage:
     title: Shlagemon

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1273,6 +1273,7 @@ data:
       loseText: Perdu ! Recommence quand tu veux.
       drawText: Match nul ! Recommence quand tu veux.
       back: Retour
+      restart: Recommencer
     ShlagCards:
       startText: Une partie de Duel de Cartes ?
       yes: Oui
@@ -1281,6 +1282,7 @@ data:
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
       back: Retour
+      restart: Recommencer
 pages:
   indexPage:
     title: Shlagémon


### PR DESCRIPTION
## Summary
- add `restart` label for Connect Four game to English and French locales

## Testing
- `pnpm test` *(fails: cannot read properties of undefined and modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e19aad964832a87afe6ee2d234925