### PR TITLE
Add typing sfx

### DIFF
--- a/src/components/ui/TypingText.vue
+++ b/src/components/ui/TypingText.vue
@@ -7,6 +7,8 @@ const emit = defineEmits<{
   (e: 'finished'): void
 }>()
 
+const audio = useAudioStore()
+
 const display = ref('')
 let timer: ReturnType<typeof setTimeout> | undefined
 
@@ -19,6 +21,7 @@ function start() {
   let i = 0
   function type() {
     display.value += props.text[i++]
+    audio.playTypingSfx()
     if (i < props.text.length)
       timer = setTimeout(type, props.speed)
     else

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -41,6 +41,14 @@ export const useAudioStore = defineStore('audio', () => {
   ] as const
   let lastBuyIndex = -1
 
+  const typingSfx = [
+    '/audio/sfx/typing/type-1.ogg',
+    '/audio/sfx/typing/type-2.ogg',
+    '/audio/sfx/typing/type-3.ogg',
+    '/audio/sfx/typing/type-4.ogg',
+  ] as const
+  let lastTypingIndex = -1
+
   function randomTrack(category: keyof typeof tracks) {
     const list = tracks[category]
     return list[Math.floor(Math.random() * list.length)]
@@ -133,6 +141,14 @@ export const useAudioStore = defineStore('audio', () => {
     playSfx(buySfx[index])
   }
 
+  function playTypingSfx() {
+    let index = Math.floor(Math.random() * typingSfx.length)
+    if (index === lastTypingIndex)
+      index = (index + 1) % typingSfx.length
+    lastTypingIndex = index
+    playSfx(typingSfx[index])
+  }
+
   watch(musicVolume, (v) => {
     if (currentMusic.value)
       currentMusic.value.volume(v)
@@ -160,6 +176,7 @@ export const useAudioStore = defineStore('audio', () => {
     stopMusic,
     playSfx,
     playBuySfx,
+    playTypingSfx,
   }
 }, {
   persist: {


### PR DESCRIPTION
## Summary
- add `playTypingSfx` helper to audio store
- play typing sound for every character shown in `TypingText`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: FetchError while downloading Google Fonts and numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687e1f758ed8832aa965e36b2c6f9bb8