### PR TITLE
Implement minigame sound effects

### DIFF
--- a/src/components/minigame/MiniGameShlagPairs.vue
+++ b/src/components/minigame/MiniGameShlagPairs.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { useElementSize, useTimeoutFn } from '@vueuse/core'
 import { allShlagemons } from '~/data/shlagemons'
+import { useAudioStore } from '~/stores/audio'
 
 const emit = defineEmits(['win'])
+const audio = useAudioStore()
 
 interface Cell {
   id: number
@@ -63,6 +65,7 @@ function choose(cell: Cell) {
   if (cell.state !== 'hidden' || selected.value.length >= 2)
     return
   cell.state = 'revealed'
+  audio.playSfx('/audio/sfx/mini-game/shlagpairs/turn.ogg')
   selected.value.push(cell)
   if (selected.value.length === 2) {
     if (selected.value[0].monId === selected.value[1].monId) {

--- a/src/composables/useConnectFour.ts
+++ b/src/composables/useConnectFour.ts
@@ -1,3 +1,5 @@
+import { useAudioStore } from '~/stores/audio'
+
 export const ROWS = 6
 export const COLS = 7
 
@@ -105,6 +107,7 @@ export function useConnectFour() {
   const finished = ref(false)
   const winningCells = ref<number[]>([])
   const lastMove = ref<number | null>(null)
+  const audio = useAudioStore()
 
   function reset() {
     board.value = createConnectFourBoard()
@@ -127,6 +130,7 @@ export function useConnectFour() {
     const col = bestColumn(board.value)
     const idx = drop(board.value, col, 'ai')
     lastMove.value = idx
+    audio.playSfx('/audio/sfx/mini-game/connectfour/ai.ogg')
     const combo = checkWin(board.value, 'ai')
     if (combo)
       return end(false, combo)
@@ -142,6 +146,7 @@ export function useConnectFour() {
     if (idx === null)
       return
     lastMove.value = idx
+    audio.playSfx('/audio/sfx/mini-game/connectfour/player.ogg')
     const combo = checkWin(board.value, 'player')
     if (combo)
       return end(true, combo)

--- a/src/composables/useSlidingPuzzle.ts
+++ b/src/composables/useSlidingPuzzle.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import { allShlagemons } from '~/data/shlagemons'
+import { useAudioStore } from '~/stores/audio'
 
 export interface SlidingPuzzle {
   tiles: number[]
@@ -40,6 +41,7 @@ export function useSlidingPuzzle(size: number) {
   const emptyIndex = ref(0)
   const image = ref('')
   const solved = ref(false)
+  const audio = useAudioStore()
 
   function reset() {
     const mon = allShlagemons[Math.floor(Math.random() * allShlagemons.length)]
@@ -58,6 +60,7 @@ export function useSlidingPuzzle(size: number) {
       = [tiles.value[emptyIndex.value], tiles.value[idx]]
     emptyIndex.value = idx
     solved.value = tiles.value.every((v, i) => v === i)
+    audio.playSfx('/audio/sfx/mini-game/taquin/move.ogg')
   }
 
   function move(dir: 'up' | 'down' | 'left' | 'right') {


### PR DESCRIPTION
## Summary
- trigger Connect Four SFX for AI and player turns
- play move sound in taquin sliding puzzle
- add card flip SFX to ShlagPairs mini-game

## Testing
- `pnpm lint`
- `pnpm test` *(fails: ENETUNREACH fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687e274f0e54832ab03d747f46aa847b