### PR TITLE
Fix shlag cards display

### DIFF
--- a/src/components/minigame/MiniGameShlagCards.vue
+++ b/src/components/minigame/MiniGameShlagCards.vue
@@ -166,32 +166,36 @@ onMounted(reset)
 </script>
 
 <template>
-  <div ref="wrapper" class="flex flex-1 flex-col items-center gap-2 bg-[url('/textures/table.jpg')] bg-cover p-2" md="p-4">
+  <div ref="wrapper" class="relative flex flex-1 flex-col items-center gap-2 bg-[url('/textures/table.jpg')] bg-cover p-2" md="p-4">
     <div class="text-sm font-bold">
       {{ player.score }} - {{ opponent.score }}
     </div>
     <div class="w-full flex flex-wrap justify-center gap-1">
+      <MinigameShlagCard v-for="c in opponent.hand" :key="c.id" :card="c" :size="cardSize" />
+    </div>
+    <div class="mt-auto w-full flex flex-wrap justify-center gap-1">
       <MinigameShlagCard
         v-for="c in player.hand"
         :key="c.id"
         :card="c"
         :size="cardSize"
         selectable
+        highlight
         @select="play(c)"
       />
-    </div>
-    <div v-if="selectedPlayer && selectedOpponent" class="my-2 flex items-center gap-2">
-      <MinigameShlagCard :card="selectedPlayer" :revealed="revealed" :size="cardSize" />
-      <span class="font-bold">VS</span>
-      <MinigameShlagCard :card="selectedOpponent" :revealed="revealed" :size="cardSize" />
-    </div>
-    <div class="w-full flex flex-wrap justify-center gap-1">
-      <MinigameShlagCard v-for="c in opponent.hand" :key="c.id" :card="c" :size="cardSize" />
     </div>
     <div v-if="history.length" class="w-full text-xs" md="w-1/2">
       <div v-for="(h, i) in history" :key="i" class="border-b py-1">
         {{ h.player.name }} vs {{ h.opponent.name }} - {{ h.winner }}
       </div>
+    </div>
+    <div
+      v-if="selectedPlayer && selectedOpponent"
+      class="absolute inset-0 flex items-center justify-center gap-2 bg-black/50"
+    >
+      <MinigameShlagCard :card="selectedPlayer" :revealed="revealed" :size="cardSize" />
+      <span class="font-bold">VS</span>
+      <MinigameShlagCard :card="selectedOpponent" :revealed="revealed" :size="cardSize" />
     </div>
   </div>
 </template>

--- a/src/components/minigame/ShlagCard.vue
+++ b/src/components/minigame/ShlagCard.vue
@@ -3,7 +3,7 @@ import type { ShlagCard } from '~/type'
 import { computed } from 'vue'
 import { shlagemonTypes } from '~/data/shlagemons-type'
 
-const props = defineProps<{ card: ShlagCard, revealed?: boolean, selectable?: boolean, size?: number }>()
+const props = defineProps<{ card: ShlagCard, revealed?: boolean, selectable?: boolean, size?: number, highlight?: boolean }>()
 const emit = defineEmits<{ (e: 'select'): void }>()
 const size = computed(() => props.size ?? 80)
 </script>
@@ -11,6 +11,7 @@ const size = computed(() => props.size ?? 80)
 <template>
   <div
     class="relative"
+    :class="props.highlight ? 'ring-2 ring-blue-500 dark:ring-blue-400' : ''"
     :style="{ width: `${size}px`, height: `${size * 1.4}px` }"
     @click="props.selectable && emit('select')"
   >


### PR DESCRIPTION
## Summary
- highlight player cards with a blue ring
- switch player and opponent deck positions
- overlay the VS cards to avoid layout shift

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Tests failed. Watching for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_687e826febe4832a91cf0dc0c4079f27