### PR TITLE
Fix store hydration bug

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -651,20 +651,22 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     clearEffects,
     effects,
     evolveWithItem,
+    removeEffect,
   }
 }, {
   persist: {
     debug: true,
     serializer: shlagedexSerializer,
     afterHydrate(ctx) {
+      const store = ctx.store as ReturnType<typeof useShlagedexStore>
       const now = Date.now()
-      ctx.store.effects.slice().forEach((effect) => {
+      store.effects.slice().forEach((effect) => {
         if (effect.expiresAt <= now) {
-          removeEffect(effect.id)
+          store.removeEffect(effect.id)
           return
         }
         if (typeof effect.timeout?.stop !== 'function')
-          effect.timeout = useTimeoutFn(() => removeEffect(effect.id), effect.expiresAt - now)
+          effect.timeout = useTimeoutFn(() => store.removeEffect(effect.id), effect.expiresAt - now)
       })
     },
   },


### PR DESCRIPTION
## Summary
- expose `removeEffect` so it can be used after hydration
- use the store instance in `afterHydrate` to correctly reschedule effect timeouts

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: numerous existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e85c3cc7c832a8d9b88dae2f6aa67