### PR TITLE
Fix shop item detail with null

### DIFF
--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -135,7 +135,7 @@ function closeShop() {
         </UiButton>
       </ShopItemCard>
     </div>
-    <div v-show="selectedItem" class="tiny-scrollbar flex-1 overflow-auto">
+    <div v-if="selectedItem" class="tiny-scrollbar flex-1 overflow-auto">
       <ShopItemDetail v-model:qty="selectedQty" :item="selectedItem" />
     </div>
     <div class="flex flex-wrap gap-2 bg-white dark:bg-gray-900" md="flex-nowrap justify-end">


### PR DESCRIPTION
## Summary
- avoid rendering `ItemDetail` when there is no selected item

## Testing
- `pnpm test:unit` *(fails: getActivePinia() was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_687e873b26cc832a834952304c05459e