### PR TITLE
Fix timeout type references

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Stoppable } from '@vueuse/shared'
 import type { DexShlagemon } from '~/type/shlagemon'
 import { cloneDexShlagemon } from '~/utils/clone'
 import { delay } from '~/utils/delay'
@@ -17,7 +18,7 @@ const activeSlot = ref<number | null>(null)
 const showDuel = ref(false)
 const showEnemy = ref(false)
 const enemyDetail = ref<DexShlagemon | null>(null)
-let nextTimer: UseTimeoutFnReturn | undefined
+let nextTimer: Stoppable | undefined
 
 async function autoSelect() {
   const team = dex.shlagemons

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import type { Stoppable } from '@vueuse/shared'
+
 const showSettings = ref(false)
 const showAudio = ref(false)
 const showDeveloper = ref(false)
 const showDevButton = import.meta.env.VITE_DEV_TOOLS === 'true'
-const clickTimer = ref<UseTimeoutFnReturn | null>(null)
+const clickTimer = ref<Stoppable | null>(null)
 const audio = useAudioStore()
 const { t } = useI18n()
 

--- a/src/components/panel/Shlagedex.vue
+++ b/src/components/panel/Shlagedex.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Stoppable } from '@vueuse/shared'
 import type { DexShlagemon } from '~/type/shlagemon'
 
 const dex = useShlagedexStore()
@@ -6,7 +7,7 @@ const featureLock = useFeatureLockStore()
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 
-const clickTimer = ref<UseTimeoutFnReturn | null>(null)
+const clickTimer = ref<Stoppable | null>(null)
 
 function open(mon: DexShlagemon | null) {
   if (mon) {

--- a/src/type/effect.ts
+++ b/src/type/effect.ts
@@ -1,4 +1,4 @@
-import type { UseTimeoutFnReturn } from '@vueuse/core'
+import type { Stoppable } from '@vueuse/shared'
 
 export interface ActiveEffect {
   id: number
@@ -9,5 +9,5 @@ export interface ActiveEffect {
   expiresAt: number
   /** @deprecated No longer used, kept for save compatibility */
   amount?: number
-  timeout?: UseTimeoutFnReturn
+  timeout?: Stoppable
 }


### PR DESCRIPTION
## Summary
- switch from deprecated `UseTimeoutFnReturn` type to `Stoppable`
- update arena panel, header, and Shlagedex components to use the new type

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: ActiveEffect type issues)*
- `pnpm test` *(fails: various component and store errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e9fbc84b0832ab470ad5007af7327