### PR TITLE
Fix unused variable warning in Panel

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -140,7 +140,7 @@ onUnmounted(() => {
       </div>
 
       <button
-        v-for="(enemy, i) in enemyTeam"
+        v-for="(_, i) in enemyTeam"
         :key="i"
         class="aspect-square border-blue-600 rounded-full bg-blue-500/30"
         @click="openDex(i)"


### PR DESCRIPTION
## Summary
- fix unused loop variable in Panel.vue

## Testing
- `pnpm typecheck` *(fails: Property 'baseId' is missing in type 'DexShlagemon')*
- `pnpm test` *(fails due to network errors and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ea6aef4d4832ab27db3b04967e254