### PR TITLE
Fix battle effect binding

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -202,7 +202,7 @@ function onClick(_e: MouseEvent) {
           :fainted="playerFainted"
           :flash="flashPlayer"
           flipped
-          :effects="props.showEffects ? dex.effects : []"
+          :effects="props.showEffects ? dex.effects.value : []"
           :disease="disease.active"
           :disease-remaining="disease.remaining"
           @faint-end="onPlayerFaintEnd"


### PR DESCRIPTION
## Summary
- pass `dex.effects.value` instead of the ref so BattleShlagemon receives an `ActiveEffect[]`

## Testing
- `pnpm test` *(fails: getActivePinia() was called but no active Pinia, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687eb4226dac832a8d5375b201a03f93