### PR TITLE
fix: type for capture component

### DIFF
--- a/src/components/inventory/ItemShortcutModal.vue
+++ b/src/components/inventory/ItemShortcutModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type UiKeyCapture from '~/components/ui/KeyCapture.vue'
 import type { ItemId } from '~/data/items/items'
 
 const modal = useItemShortcutModalStore()


### PR DESCRIPTION
## Summary
- properly type the `capture` ref in `ItemShortcutModal` by importing `UiKeyCapture`

## Testing
- `pnpm test` *(fails: Failed to fetch fonts; vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_687eb47df694832abc87ca0d14ca821c