### PR TITLE
Fix conditional emission of minigame result

### DIFF
--- a/src/components/minigame/MiniGameShlagCards.vue
+++ b/src/components/minigame/MiniGameShlagCards.vue
@@ -173,7 +173,10 @@ function resolve() {
     const gameWinner = player.score >= 2 ? 'player' : opponent.score >= 2 ? 'opponent' : null
     if (gameWinner) {
       emit('gameEnd', gameWinner)
-      emit(gameWinner === 'player' ? 'win' : 'lose')
+      if (gameWinner === 'player')
+        emit('win')
+      else
+        emit('lose')
     }
     else {
       emit('turnStart', 'player')


### PR DESCRIPTION
## Summary
- fix conditional emission of win/lose events in `MiniGameShlagCards.vue`

## Testing
- `pnpm test` *(fails: getActivePinia not found, plus missing Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687ebdee57bc832aa95325f6176653a1