### PR TITLE
Fix sortOptions type in List.vue

### DIFF
--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -23,7 +23,7 @@ const featureLock = useFeatureLockStore()
 const isLocked = featureLock.isShlagedexLocked
 const items = Object.fromEntries(allItems.map(i => [i.id, i])) as Record<string, typeof allItems[number]>
 
-const sortOptions = [
+const sortOptions: { label: string, value: string | number }[] = [
   { label: 'Niveau', value: 'level' },
   { label: 'Rareté', value: 'rarity' },
   { label: 'Shiny', value: 'shiny' },
@@ -35,7 +35,7 @@ const sortOptions = [
   { label: 'Nb obtentions', value: 'count' },
   { label: 'Première capture', value: 'date' },
   { label: 'Proche d\'évoluer', value: 'evolution' },
-] as const
+]
 
 const displayedMons = computed(() => {
   let mons = props.mons.slice()


### PR DESCRIPTION
## Summary
- remove the `as const` assertion from `sortOptions`
- annotate `sortOptions` with `{ label: string, value: string | number }[]`

## Testing
- `pnpm test` *(fails: getActivePinia error)*

------
https://chatgpt.com/codex/tasks/task_e_687ebe171e30832a99cf3927dcab92f8