### PR TITLE
fix shop level from zone data

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -43,7 +43,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const accessibleShopLevel = computed(() =>
     accessibleZones.value
       .filter(z => z.village?.shop)
-      .reduce((m, z) => Math.max(m, z.village!.shop!.level), 0),
+      .reduce((m, z) => Math.max(m, z.minLevel), 0),
   )
 
   const accessibleBaseIds = computed(() => {


### PR DESCRIPTION
## Summary
- compute accessible shop level using `minLevel`

## Testing
- `pnpm test` *(fails: getActivePinia error, fetch failures)*

------
https://chatgpt.com/codex/tasks/task_e_687ebe1bab24832a9a34ba5bbfaf471d