### PR TITLE
Use toRef for highestLevel in zone visit store

### DIFF
--- a/src/stores/zoneVisit.ts
+++ b/src/stores/zoneVisit.ts
@@ -4,7 +4,7 @@ export const useZoneVisitStore = defineStore('zoneVisit', () => {
   const visited = ref<Record<string, boolean>>({})
   const dex = useShlagedexStore()
 
-  const { accessibleZones } = useZoneAccess(dex.highestLevel)
+  const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
 
   const hasNewZone = computed(
     () => accessibleZones.value.length > 1


### PR DESCRIPTION
## Summary
- maintain reactivity by passing a ref to `useZoneAccess`

## Testing
- `pnpm test` *(fails: failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ebe1b9b40832ab2a90074109405aa