### PR TITLE
Fix crash in ShlagCards AI when opponent hand empty

### DIFF
--- a/src/components/minigame/MiniGameShlagCards.vue
+++ b/src/components/minigame/MiniGameShlagCards.vue
@@ -86,6 +86,8 @@ function play(card: ShlagCard) {
 }
 
 function aiSelect() {
+  if (!opponent.hand.length)
+    return
   const idx = Math.floor(Math.random() * opponent.hand.length)
   let card = opponent.hand[idx]
   hiddenOpponentCards.add(card.id)


### PR DESCRIPTION
## Summary
- guard against empty opponent hand in `MiniGameShlagCards`

## Testing
- `pnpm test` *(fails: ENETUNREACH fetching fonts, failed imports, missing Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_687ec1efe984832a9ff7d81f1925942a