### PR TITLE
fix ActiveEffect timeout type

### DIFF
--- a/src/type/effect.ts
+++ b/src/type/effect.ts
@@ -9,5 +9,5 @@ export interface ActiveEffect {
   expiresAt: number
   /** @deprecated No longer used, kept for save compatibility */
   amount?: number
-  timeout?: Stoppable
+  timeout?: Stoppable<[]>
 }


### PR DESCRIPTION
## Summary
- specify `Stoppable<[]>` for `ActiveEffect.timeout`

## Testing
- `pnpm test` *(fails: "getActivePinia" was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_687ec85d17ec832a98201969a9948b33