### PR TITLE
Fix overlapping music tracks

### DIFF
--- a/src/modules/audio.ts
+++ b/src/modules/audio.ts
@@ -9,6 +9,6 @@ export const install: UserModule = ({ isClient }) => {
   if (audio.isMusicEnabled && !audio.currentMusic) {
     const track = getZoneTrack(zone.current.id, zone.current.type)
     if (track)
-      audio.playMusic(track)
+      audio.fadeToMusic(track)
   }
 }

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -89,14 +89,26 @@ export const useAudioStore = defineStore('audio', () => {
   }
 
   let fadeTimer: ReturnType<typeof setTimeout> | null = null
+  let fadingOut: Howl | null = null
 
   function fadeToMusic(track: string) {
     if (!currentMusic.value) {
       playMusic(track)
       return
     }
+
     if ((currentMusic.value as any)._src === track)
       return
+
+    if (fadeTimer) {
+      clearTimeout(fadeTimer)
+      if (fadingOut) {
+        fadingOut.stop()
+        fadingOut.unload()
+        fadingOut = null
+      }
+      fadeTimer = null
+    }
 
     const old = currentMusic.value
     const next = createMusic(track)
@@ -113,11 +125,11 @@ export const useAudioStore = defineStore('audio', () => {
       next.play()
       next.fade(0, musicVolume.value, 1000)
       old.fade(old.volume(), 0, 1000)
-      if (fadeTimer)
-        clearTimeout(fadeTimer)
+      fadingOut = old
       fadeTimer = setTimeout(() => {
-        old.stop()
-        old.unload()
+        fadingOut?.stop()
+        fadingOut?.unload()
+        fadingOut = null
         fadeTimer = null
       }, 1000)
     }


### PR DESCRIPTION
## Summary
- avoid multiple music tracks by cleaning previous fade when starting a new one
- use `fadeToMusic` everywhere when initializing audio

## Testing
- `pnpm test` *(fails: vitest resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f4e050a98832a9ea28a998fa7a7a0