### PR TITLE
Add music index generation script

### DIFF
--- a/public/music-data.json
+++ b/public/music-data.json
@@ -1,0 +1,197 @@
+[
+  {
+    "nom": "Veaux du Gland sur Marne",
+    "type": "village",
+    "url": "/audio/musics/villages/village-veaux-du-gland.ogg"
+  },
+  {
+    "nom": "Citadelle Giga-Schlag",
+    "type": "village",
+    "url": "/audio/musics/villages/village-giga-schlag.ogg"
+  },
+  {
+    "nom": "Village Sux-Mais-Bouls",
+    "type": "village",
+    "url": "/audio/musics/villages/village-boule.ogg"
+  },
+  {
+    "nom": "Village Paumé du cul",
+    "type": "village",
+    "url": "/audio/musics/villages/village-paume.ogg"
+  },
+  {
+    "nom": "Village Fiente-sur-Mer",
+    "type": "village",
+    "url": "/audio/musics/villages/village-caca-boudin.ogg"
+  },
+  {
+    "nom": "Village des Cassos",
+    "type": "village",
+    "url": "/audio/musics/villages/village-cassos-land.ogg"
+  },
+  {
+    "nom": "Clito Land",
+    "type": "village",
+    "url": "/audio/musics/villages/village-clitoland.ogg"
+  },
+  {
+    "nom": "Plaine Kékette",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/plaine-kekette.ogg"
+  },
+  {
+    "nom": "Bois des Bouffons",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/bois-de-bouffon.ogg"
+  },
+  {
+    "nom": "Chemin du Slip",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/chemin-du-slip.ogg"
+  },
+  {
+    "nom": "Ravin de la Fesse Molle",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/ravin-fesse-molle.ogg"
+  },
+  {
+    "nom": "Précipice du Vieux Nanard",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/precipice-nanard.ogg"
+  },
+  {
+    "nom": "Marais Moudugenou",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/marais-moudugenou.ogg"
+  },
+  {
+    "nom": "Forteresse Pètmoalfiak",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/forteresse-petmoalfiak.ogg"
+  },
+  {
+    "nom": "Route du Nawak",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/route-du-nawak.ogg"
+  },
+  {
+    "nom": "Mont Cul",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/mont-dracatombe.ogg"
+  },
+  {
+    "nom": "Catacombes Merdifientes",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/catacombes-merdifientes.ogg"
+  },
+  {
+    "nom": "Route Aguicheuse",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/route-aguicheuse.ogg"
+  },
+  {
+    "nom": "Vallée des Chieurs",
+    "type": "sauvage",
+    "url": "/audio/musics/battle/vallee-des-chieurs.ogg"
+  },
+  {
+    "nom": "Trou du Bide",
+    "type": "sauvage",
+    "url": null
+  },
+  {
+    "nom": "Lac aux Relous",
+    "type": "sauvage",
+    "url": null
+  },
+  {
+    "nom": "Aire du Giga Zob",
+    "type": "sauvage",
+    "url": null
+  },
+  {
+    "nom": "Mont Kouillasse",
+    "type": "sauvage",
+    "url": null
+  },
+  {
+    "nom": "Pâturage Crado",
+    "type": "sauvage",
+    "url": null
+  },
+  {
+    "nom": "Canyon à la Derp",
+    "type": "sauvage",
+    "url": null
+  },
+  {
+    "nom": "Cratère des Légends",
+    "type": "sauvage",
+    "url": null
+  },
+  {
+    "nom": "Caillou",
+    "type": "character",
+    "url": "/audio/musics/character/caillou.ogg"
+  },
+  {
+    "nom": "Donald Trompe",
+    "type": "character",
+    "url": "/audio/musics/character/donald-trompe.ogg"
+  },
+  {
+    "nom": "Emmanuel Marcon",
+    "type": "character",
+    "url": "/audio/musics/character/marcon.ogg"
+  },
+  {
+    "nom": "Marine Lahaine",
+    "type": "character",
+    "url": "/audio/musics/character/marine-lahaine.ogg"
+  },
+  {
+    "nom": "Norman le babysiter",
+    "type": "character",
+    "url": "/audio/musics/character/norman.ogg"
+  },
+  {
+    "nom": "Professeur Merdant",
+    "type": "character",
+    "url": "/audio/musics/character/prof-merdant.ogg"
+  },
+  {
+    "nom": "Professeur Shlag",
+    "type": "character",
+    "url": null
+  },
+  {
+    "nom": "Sachatte",
+    "type": "character",
+    "url": "/audio/musics/character/sachatte.ogg"
+  },
+  {
+    "nom": "Siphanus",
+    "type": "character",
+    "url": "/audio/musics/character/siphanus.ogg"
+  },
+  {
+    "nom": "Vladimir Putain",
+    "type": "character",
+    "url": "/audio/musics/character/poutine.ogg"
+  },
+  {
+    "nom": "arena20",
+    "type": "arena",
+    "url": "/audio/musics/arenas/arena20.ogg"
+  },
+  {
+    "nom": "arena40",
+    "type": "arena",
+    "url": "/audio/musics/arenas/arena40.ogg"
+  },
+  {
+    "nom": "arena60",
+    "type": "arena",
+    "url": "/audio/musics/arenas/arena60.ogg"
+  }
+]

--- a/scripts/generate-music-json.cjs
+++ b/scripts/generate-music-json.cjs
@@ -1,0 +1,105 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+function readTracks(dir) {
+  const map = {}
+  if (!fs.existsSync(dir))
+    return map
+  const files = fs.readdirSync(dir)
+  for (const file of files) {
+    if (file.endsWith('.ogg'))
+      map[path.basename(file, '.ogg')] = path.join('/audio/musics', path.basename(dir), file)
+  }
+  return map
+}
+
+const trackDirs = [
+  'public/audio/musics/villages',
+  'public/audio/musics/battle',
+  'public/audio/musics/character',
+  'public/audio/musics/arenas',
+]
+
+const tracks = trackDirs.reduce((acc, dir) => Object.assign(acc, readTracks(path.join(__dirname, '..', dir))), {})
+
+function parseVillages() {
+  const dir = path.join(__dirname, '../src/data/zones/villages')
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.ts'))
+  return files.map((f) => {
+    const content = fs.readFileSync(path.join(dir, f), 'utf8')
+    const id = content.match(/id:\s*'([^']+)'/)
+    const name = content.match(/name:\s*'([^']+)'/)
+    if (!id || !name)
+      return null
+    return {
+      nom: name[1],
+      type: 'village',
+      url: tracks[id[1]] || null,
+    }
+  }).filter(Boolean)
+}
+
+function parseSavageZones() {
+  const file = path.join(__dirname, '../src/data/zones.ts')
+  const content = fs.readFileSync(file, 'utf8')
+  const regex = /\{\s*id:\s*'([^']+)'[^}]*?name:\s*'([^']+)'/g
+  const zones = []
+  let match = regex.exec(content)
+  while (match) {
+    zones.push({
+      nom: match[2],
+      type: 'sauvage',
+      url: tracks[match[1]] || null,
+    })
+    match = regex.exec(content)
+  }
+  return zones
+}
+
+function parseCharacters() {
+  const dir = path.join(__dirname, '../src/data/characters')
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.ts'))
+  const alias = { 'vladimir-putain': 'poutine' }
+  return files.map((f) => {
+    const content = fs.readFileSync(path.join(dir, f), 'utf8')
+    const id = content.match(/id:\s*'([^']+)'/)
+    const name = content.match(/name:\s*'([^']+)'/)
+    if (!id || !name)
+      return null
+    const key = alias[id[1]] || id[1]
+    return {
+      nom: name[1],
+      type: 'character',
+      url: tracks[key] || null,
+    }
+  }).filter(Boolean)
+}
+
+function parseArenas() {
+  const file = path.join(__dirname, '../src/data/arenas.ts')
+  const content = fs.readFileSync(file, 'utf8')
+  const regex = /export const (arena\d+):/g
+  const arenas = []
+  let match = regex.exec(content)
+  while (match) {
+    const id = match[1]
+    arenas.push({
+      nom: id,
+      type: 'arena',
+      url: tracks[id] || null,
+    })
+    match = regex.exec(content)
+  }
+  return arenas
+}
+
+const data = [
+  ...parseVillages(),
+  ...parseSavageZones(),
+  ...parseCharacters(),
+  ...parseArenas(),
+]
+
+const output = path.join(__dirname, '../public/music-data.json')
+fs.writeFileSync(output, JSON.stringify(data, null, 2))
+console.log(`Generated ${output} with ${data.length} entries`)


### PR DESCRIPTION
## Summary
- add `generate-music-json.cjs` to gather available music tracks
- output collected data to `public/music-data.json`

## Testing
- `pnpm test` *(fails: getActivePinia not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f53fe4f9c832a990511f741e2a1d4