### PR TITLE
Fix shlagedex serializer types

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -1,3 +1,4 @@
+import type { PersistedStateOptions } from 'pinia-plugin-persistedstate'
 import type { ActiveEffect } from '~/type/effect'
 import type { Item, WearableItem } from '~/type/item'
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
@@ -669,5 +670,5 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
           effect.timeout = useTimeoutFn(() => store.removeEffect(effect.id), effect.expiresAt - now)
       })
     },
-  },
+  } as PersistedStateOptions,
 })

--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -1,3 +1,4 @@
+import type { Serializer } from 'pinia-plugin-persistedstate'
 import type { ActiveEffect } from '~/type/effect'
 import type { DexShlagemon } from '~/type/shlagemon'
 import { allShlagemons } from '~/data/shlagemons'
@@ -33,7 +34,7 @@ interface StoredDex extends Omit<SerializedDex, 'shlagemons' | 'activeShlagemon'
   activeShlagemon: StoredDexMon | null
 }
 
-export const shlagedexSerializer = {
+export const shlagedexSerializer: Serializer<SerializedDex> = {
   serialize(data: SerializedDex): string {
     return JSON.stringify({
       ...data,


### PR DESCRIPTION
## Summary
- type the custom serializer with `pinia-plugin-persistedstate`
- ensure the Shlagedex store uses typed persist options

## Testing
- `pnpm test` *(fails: "Test Files  32 failed | 18 passed")*

------
https://chatgpt.com/codex/tasks/task_e_687f54555ef0832a98bfff7e29b526dc