### PR TITLE
Fix i18n namespaced keys

### DIFF
--- a/src/components/deck/DeckDetail.vue
+++ b/src/components/deck/DeckDetail.vue
@@ -28,13 +28,13 @@ const { t } = useI18n()
       {{ t(props.mon.descriptionKey || props.mon.description) }}
     </p>
     <div v-if="props.mon.evolution" class="flex flex-col items-center text-sm font-medium">
-      <span>{{ t('deckDetail.evolution') }}</span>
+      <span>{{ t('components.deck.DeckDetail.evolution') }}</span>
       <div class="mt-1 flex items-center gap-1">
         <UiButton variant="outline" @click="emit('openMon', props.mon.evolution.base)">
           {{ props.mon.evolution.base.name }}
         </UiButton>
         <span v-if="props.mon.evolution.condition.type === 'lvl'">
-          - {{ t('deckDetail.level', { n: props.mon.evolution.condition.value }) }}
+          - {{ t('components.deck.DeckDetail.level', { n: props.mon.evolution.condition.value }) }}
         </span>
         <span v-else>
           - {{ props.mon.evolution.condition.value.name }}

--- a/src/components/deck/DeckList.vue
+++ b/src/components/deck/DeckList.vue
@@ -20,7 +20,7 @@ const displayed = computed(() => {
 <template>
   <LayoutScrollablePanel>
     <template #header>
-      <UiSearchInput v-model="search" :placeholder="t('deckList.search')" />
+      <UiSearchInput v-model="search" :placeholder="t('components.deck.DeckList.search')" />
     </template>
     <template #content>
       <div

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 const { t } = useI18n()
 useHead({
-  title: () => t('indexPage.title'),
+  title: () => t('pages.indexPage.title'),
   meta: [
-    { name: 'description', content: t('indexPage.description') },
+    { name: 'description', content: t('pages.indexPage.description') },
   ],
 })
 </script>
@@ -11,7 +11,7 @@ useHead({
 <template>
   <div class="mx-auto max-w-160 w-full py-10 text-center">
     <h1 class="mb-4 text-2xl font-bold">
-      {{ t('indexPage.welcome') }}
+      {{ t('pages.indexPage.welcome') }}
     </h1>
   </div>
 </template>

--- a/src/pages/shlagedex.vue
+++ b/src/pages/shlagedex.vue
@@ -8,7 +8,7 @@ const showDetail = ref(false)
 const selected = ref<BaseShlagemon | null>(null)
 const { t } = useI18n()
 useHead({
-  title: () => t('shlagedexPage.title'),
+  title: () => t('pages.shlagedexPage.title'),
 })
 
 function open(mon: BaseShlagemon) {


### PR DESCRIPTION
## Summary
- use fully-qualified i18n keys in DeckDetail and DeckList
- update index and shlagedex pages to match namespaced keys

## Testing
- `pnpm i18n`
- `pnpm test` *(fails: getActivePinia)*

------
https://chatgpt.com/codex/tasks/task_e_687f55ad8e8c832a99f5d65331f33368