### PR TITLE
Fix spectrum alpha gradient broadcast

### DIFF
--- a/scripts/music-video-generator.py
+++ b/scripts/music-video-generator.py
@@ -89,7 +89,8 @@ def make_audio_spectrum_clip(audio_path, duration, width=W, height=180, n_bars=6
             alphas = (np.linspace(0, 255, bar_h)).astype(np.uint8)
             bar = np.zeros((bar_h, x2 - x1, 4), dtype=np.uint8)
             bar[:, :, :3] = bar_color(i)
-            bar[:, :, 3] = alphas
+            # repeat the alpha gradient across the bar width
+            bar[:, :, 3] = alphas[:, None]
             y1 = y2 - bar_h + 1
             img[y1:y2 + 1, x1:x2, :] = bar
         return img


### PR DESCRIPTION
## Summary
- fix gradient alpha channel assignment in `music-video-generator.py`

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_687f76096f48832a86c07bb6ee3658dd