### PR TITLE
Add evolution details link in dex

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -4,6 +4,7 @@ import PanelAchievements from '~/components/panel/Achievements.vue'
 import PanelInventory from '~/components/panel/Inventory.vue'
 import PanelShlagedex from '~/components/panel/Shlagedex.vue'
 import PanelZone from '~/components/panel/Zone.vue'
+import ShlagemonDetailModal from '~/components/shlagemon/DetailModal.vue'
 
 const lockStore = useFeatureLockStore()
 const shlagedex = useShlagedexStore()
@@ -133,6 +134,7 @@ const bottomLocked = computed(() => {
       <ShlagemonEvolutionModal />
       <ShlagemonTypeChartModal />
       <ShlagemonWearableEquipModal />
+      <ShlagemonDetailModal />
     </div>
   </div>
 </template>

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -34,6 +34,7 @@ const store = useShlagedexStore()
 const wearableItemStore = useWearableItemStore()
 const equipModal = useWearableEquipModalStore()
 const disease = useDiseaseStore()
+const detailModal = useDexDetailModalStore()
 const { t } = useI18n()
 const showConfirm = ref(false)
 
@@ -41,6 +42,12 @@ const heldItem = computed(() => {
   if (!props.mon?.heldItemId)
     return null
   return allItems.find(i => i.id === props.mon!.heldItemId) || null
+})
+
+const ownedEvolution = computed(() => {
+  if (!props.mon?.base.evolution)
+    return null
+  return store.shlagemons.find(m => m.base.id === props.mon!.base.evolution!.base.id) || null
 })
 
 const evolutionInfo = computed(() => {
@@ -85,6 +92,11 @@ function cancelRelease() {
 function openEquip() {
   if (props.mon)
     equipModal.open(props.mon)
+}
+
+function openOwnedEvolution() {
+  if (ownedEvolution.value)
+    detailModal.open(ownedEvolution.value)
 }
 const captureInfo = computed(() => {
   if (!props.mon)
@@ -150,7 +162,19 @@ const captureInfo = computed(() => {
         </div>
       </div>
       <div v-if="evolutionInfo" class="flex-center flex-col gap-1">
-        <div class="rounded-full bg-blue-200 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-700 dark:text-blue-200">
+        <button
+          v-if="ownedEvolution"
+          type="button"
+          class="rounded-full bg-blue-200 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-700 dark:text-blue-200"
+          hover="bg-blue-300 dark:bg-blue-600"
+          @click="openOwnedEvolution"
+        >
+          {{ evolutionInfo }}
+        </button>
+        <div
+          v-else
+          class="rounded-full bg-blue-200 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-700 dark:text-blue-200"
+        >
           {{ evolutionInfo }}
         </div>
         <UiCheckBox v-model="allowEvolution" class="flex items-center gap-2 text-xs">

--- a/src/components/shlagemon/DetailModal.vue
+++ b/src/components/shlagemon/DetailModal.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+const modal = useDexDetailModalStore()
+</script>
+
+<template>
+  <Modal
+    v-model="modal.isVisible"
+    footer-close
+    :golden-border="modal.mon?.rarity === 100"
+    @close="modal.close()"
+  >
+    <ShlagemonDetail
+      :mon="modal.mon"
+      @release="modal.close()"
+      @active="modal.close()"
+    />
+  </Modal>
+</template>

--- a/src/stores/dexDetailModal.ts
+++ b/src/stores/dexDetailModal.ts
@@ -1,0 +1,14 @@
+import type { DexShlagemon } from '~/type/shlagemon'
+import { defineStore } from 'pinia'
+
+export const useDexDetailModalStore = defineStore('dexDetailModal', () => {
+  const { isVisible, open: openModal, close } = createModalStore('dex')
+  const mon = ref<DexShlagemon | null>(null)
+
+  function open(target: DexShlagemon) {
+    mon.value = target
+    openModal()
+  }
+
+  return { isVisible, mon, open, close }
+})


### PR DESCRIPTION
## Summary
- open detail of evolved shlagemon in new modal
- handle owned evolution button in shlagemon detail
- register new modal on the game grid

## Testing
- `pnpm lint`
- `pnpm test` *(fails: getActivePinia)*

------
https://chatgpt.com/codex/tasks/task_e_687f7564749c832a8374f2c49d0b1fea