### PR TITLE
Adjust video script output and visuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cypress/downloads
 public/assets/fonts
 node-compile-cache
 scripts/venv/*
+scripts/musique/


### PR DESCRIPTION
## Summary
- ignore generated `scripts/musique` folder
- shrink Shlagéball pulse effect
- add animated logo to video output
- enlarge and style music title text
- write generated videos to `scripts/musique`

## Testing
- `pnpm test` *(fails: component Header.vue snapshot mismatch and 29 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_687f7cac253c832a85773c20779eb7bd