### PR TITLE
Apply Pokémon font and adjust logo position

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -27,7 +27,7 @@ function onDoubleClick() {
 <template>
   <header class="h-12 flex items-center justify-between bg-gray-100 p-4 dark:bg-gray-800">
     <div class="flex items-center gap-2">
-      <img src="/logo.png" :alt="t('components.layout.Header.logoAlt')" class="h-20 -my-4">
+      <img src="/logo.png" :alt="t('components.layout.Header.logoAlt')" class="h-20 -mb-2 -mt-6">
     </div>
     <div class="flex items-center gap-2">
       <ThemeToggle />

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -10,8 +10,25 @@ useHead({
 
 <template>
   <div class="mx-auto max-w-160 w-full py-10 text-center">
-    <h1 class="mb-4 text-2xl font-bold">
+    <h1 class="pokemon-title mb-4 text-2xl font-bold">
       {{ t('pages.indexPage.welcome') }}
     </h1>
   </div>
 </template>
+
+<style scoped>
+@font-face {
+  font-family: 'Pokemon Hollow';
+  src: url('/scripts/clip/Pokemon Hollow.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+.pokemon-title {
+  font-family: 'Pokemon Hollow', sans-serif;
+  color: #c7a008;
+  -webkit-text-stroke: 2px #2a75bb;
+  /* For browsers supporting the standard property */
+  text-stroke: 2px #2a75bb;
+}
+</style>


### PR DESCRIPTION
## Summary
- use Pokémon Hollow font for the home title and color/stroke to match series style
- move the Pokémon logo higher in the header

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_687f807cf4c0832a9a3f73eebb2be873