### PR TITLE
Fix taquin end sequence

### DIFF
--- a/src/components/minigame/MiniGameShlagTaquin.vue
+++ b/src/components/minigame/MiniGameShlagTaquin.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { useElementSize, useEventListener, useSwipe } from '@vueuse/core'
+import { useElementSize, useEventListener, useSwipe, useTimeoutFn } from '@vueuse/core'
 import { useSlidingPuzzle } from '~/composables/useSlidingPuzzle'
 
 const props = withDefaults(defineProps<{ difficulty?: 'easy' | 'hard' }>(), {
   difficulty: 'easy',
 })
-const emit = defineEmits<{ (e: 'gameEnd', result: 'success'): void }>()
+const emit = defineEmits<{ (e: 'win'): void }>()
 
 const size = computed(() => props.difficulty === 'hard' ? 4 : 3)
 
@@ -60,7 +60,7 @@ watch(size, async () => {
 
 watch(() => puzzle.solved, (v) => {
   if (v)
-    setTimeout(() => emit('gameEnd', 'success'), 1000)
+    useTimeoutFn(() => emit('win'), 2000)
 })
 </script>
 
@@ -128,13 +128,6 @@ watch(() => puzzle.solved, (v) => {
           }"
           @click="puzzle.moveTile(tile.idx)"
         />
-      </div>
-
-      <div
-        v-if="puzzle.solved"
-        class="absolute bottom-4 left-1/2 z-20 animate-bounce text-xl font-bold -translate-x-1/2"
-      >
-        Gagné !
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- emit `win` event from the taquin minigame after a 2 second delay when solved
- remove the `Gagné !` text so only the image is shown on completion

## Testing
- `pnpm test` *(fails: cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6880dbf1f7b8832a901db439523361a8