### PR TITLE
Remove unused avatar-url prop in dialog components

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -192,7 +192,6 @@ onUnmounted(featureLock.unlockAll)
       </template>
       <DialogBox
         :character="trainer.character"
-        :avatar-url="`/characters/${trainer.character.id}/${trainer.character.id}.png`"
         :dialog-tree="beforeDialogTree"
       />
     </div>
@@ -213,7 +212,6 @@ onUnmounted(featureLock.unlockAll)
     <div v-else class="h-full flex flex-col items-center gap-2 text-center">
       <DialogBox
         :character="trainer.character"
-        :avatar-url="`/characters/${trainer.character.id}/${trainer.character.id}.png`"
         :dialog-tree="afterDialogTree"
       />
     </div>

--- a/src/components/dialog/AnotherShlagemonDialog.vue
+++ b/src/components/dialog/AnotherShlagemonDialog.vue
@@ -34,7 +34,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/ArenaDefeatDialog.vue
+++ b/src/components/dialog/ArenaDefeatDialog.vue
@@ -43,7 +43,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="arena.arenaData!.character"
-    :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
     :exit-track="exitTrack"
   />

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -45,7 +45,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="arena.arenaData!.character"
-    :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
     :exit-track="exitTrack"
   />

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -42,7 +42,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="arena.arenaData!.character"
-    :avatar-url="`/characters/${arena.arenaData?.character.id}/${arena.arenaData?.character.id}.png`"
     :dialog-tree="dialogTree"
     :exit-track="exitTrack"
   />

--- a/src/components/dialog/AttackPotionDialog.vue
+++ b/src/components/dialog/AttackPotionDialog.vue
@@ -51,7 +51,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/components/dialog/CapturePotionDialog.vue
+++ b/src/components/dialog/CapturePotionDialog.vue
@@ -59,7 +59,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/components/dialog/EggBoxDialog.vue
+++ b/src/components/dialog/EggBoxDialog.vue
@@ -54,7 +54,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/components/dialog/FirstLossDialog.vue
+++ b/src/components/dialog/FirstLossDialog.vue
@@ -55,7 +55,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/HalfDexDialog.vue
+++ b/src/components/dialog/HalfDexDialog.vue
@@ -51,7 +51,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    avatar-url="/characters/prof-merdant/prof-merdant.png"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/KingUnlockDialog.vue
+++ b/src/components/dialog/KingUnlockDialog.vue
@@ -67,7 +67,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/components/dialog/Level5Dialog.vue
+++ b/src/components/dialog/Level5Dialog.vue
@@ -59,7 +59,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/NewZoneDialog.vue
+++ b/src/components/dialog/NewZoneDialog.vue
@@ -55,7 +55,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/components/dialog/Starter.vue
+++ b/src/components/dialog/Starter.vue
@@ -71,7 +71,6 @@ const dialogTree = computed<DialogNode[]>(() => [
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
   />
 </template>

--- a/src/components/dialog/WearableItemDialog.vue
+++ b/src/components/dialog/WearableItemDialog.vue
@@ -40,7 +40,6 @@ const dialogTree = computed(() =>
 <template>
   <DialogBox
     :character="profMerdant"
-    :avatar-url="`/characters/${profMerdant.id}/${profMerdant.id}.png`"
     :dialog-tree="dialogTree"
     orientation="col"
   />

--- a/src/components/panel/MiniGame.vue
+++ b/src/components/panel/MiniGame.vue
@@ -48,7 +48,6 @@ const failure = computed(() => gameDef.value?.createFailure(exit))
     <DialogBox
       v-if="mini.phase === 'intro'"
       :character="gameDef.character"
-      :avatar-url="`/characters/${gameDef.character.id}/${gameDef.character.id}.png`"
       :dialog-tree="intro!"
       :exit-track="miniGameMusic"
       orientation="col"
@@ -63,7 +62,6 @@ const failure = computed(() => gameDef.value?.createFailure(exit))
     <DialogBox
       v-else-if="mini.phase === 'success'"
       :character="gameDef.character"
-      :avatar-url="`/characters/${gameDef.character.id}/${gameDef.character.id}.png`"
       :dialog-tree="success!"
       :exit-track="zoneTrack"
       orientation="col"
@@ -71,7 +69,6 @@ const failure = computed(() => gameDef.value?.createFailure(exit))
     <DialogBox
       v-else-if="mini.phase === 'failure'"
       :character="gameDef.character"
-      :avatar-url="`/characters/${gameDef.character.id}/${gameDef.character.id}.png`"
       :dialog-tree="failure!"
       :exit-track="zoneTrack"
       orientation="col"
@@ -79,7 +76,6 @@ const failure = computed(() => gameDef.value?.createFailure(exit))
     <DialogBox
       v-else-if="mini.phase === 'draw'"
       :character="gameDef.character"
-      :avatar-url="`/characters/${gameDef.character.id}/${gameDef.character.id}.png`"
       :dialog-tree="drawDialog!"
       :exit-track="zoneTrack"
       orientation="col"


### PR DESCRIPTION
## Summary
- cleanup `DialogBox` usage by dropping obsolete `avatar-url` prop

## Testing
- `pnpm test` *(fails: Failed to resolve some Vue imports, snapshot mismatches and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880ef78e268832aa5c92e796bddca58