### PR TITLE
Add animated numbers to player info panel

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -119,6 +119,7 @@ declare module 'vue' {
     ShopItemCard: typeof import('./components/shop/ItemCard.vue')['default']
     ShopItemDetail: typeof import('./components/shop/ItemDetail.vue')['default']
     ThemeToggle: typeof import('./components/ThemeToggle.vue')['default']
+    UiAnimatedNumber: typeof import('./components/ui/AnimatedNumber.vue')['default']
     UiBadge: typeof import('./components/ui/Badge.vue')['default']
     UiButton: typeof import('./components/ui/Button.vue')['default']
     UiCheckBox: typeof import('./components/ui/CheckBox.vue')['default']

--- a/src/components/panel/PlayerInfos.vue
+++ b/src/components/panel/PlayerInfos.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import AnimatedNumber from '~/components/ui/AnimatedNumber.vue'
 import { allShlagemons } from '~/data/shlagemons'
 import { ballHues } from '~/utils/ball'
 
@@ -34,13 +35,14 @@ const totalInDex = allShlagemons.length
     <UiTooltip :text="t('components.panel.PlayerInfos.dex')">
       <div class="min-w-0 flex items-center gap-1">
         <IconShlagedex class="h-4 w-4" />
-        <span class="shrink-0 font-bold">{{ dex.shlagemons.length ?? 0 }} / {{ totalInDex }}</span>
+        <AnimatedNumber class="shrink-0 font-bold" :value="dex.shlagemons.length ?? 0" />
+        <span class="shrink-0">/ {{ totalInDex }}</span>
       </div>
     </UiTooltip>
     <UiTooltip :text="t('components.panel.PlayerInfos.averageLevel')">
       <div class="min-w-0 flex items-center gap-1">
         <IconXp class="h-4 w-4" />
-        <span class="shrink-0 font-bold">{{ dex.averageLevel.toFixed(1) }}</span>
+        <AnimatedNumber class="shrink-0 font-bold" :value="Number(dex.averageLevel.toFixed(1))" :precision="1" />
       </div>
     </UiTooltip>
     <UiTooltip :text="t('components.panel.PlayerInfos.bonus')">
@@ -49,7 +51,7 @@ const totalInDex = allShlagemons.length
         @click="showBonus = true"
       >
         <IconBonus class="h-4 w-4" />
-        <span class="shrink-0 font-bold">+{{ Math.round(dex.bonusPercent) }}%</span>
+        <span class="shrink-0 font-bold">+<AnimatedNumber :value="Math.round(dex.bonusPercent)" />%</span>
       </div>
     </UiTooltip>
     <UiModal v-model="showBonus" footer-close>
@@ -66,7 +68,7 @@ const totalInDex = allShlagemons.length
           class="h-4 w-4"
           :style="{ filter: `hue-rotate(${ballHues[ballStore.current]})` }"
         >
-        <span class="shrink-0 font-bold">{{ inventory.items[ballStore.current]?.toLocaleString() || 0 }}</span>
+        <AnimatedNumber class="shrink-0 font-bold" :value="inventory.items[ballStore.current] ?? 0" />
       </div>
     </UiTooltip>
     <BallSelectionModal />

--- a/src/components/ui/AnimatedNumber.vue
+++ b/src/components/ui/AnimatedNumber.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ value: number, duration?: number, precision?: number }>(), {
+  duration: 300,
+  precision: 0,
+})
+
+const factor = computed(() => 10 ** props.precision)
+const displayValue = ref(Math.round(props.value * factor.value))
+const formatted = computed(() => {
+  return (displayValue.value / factor.value).toLocaleString(undefined, {
+    minimumFractionDigits: props.precision,
+    maximumFractionDigits: props.precision,
+  })
+})
+const pulsing = ref(false)
+const { start: stopPulse } = useTimeoutFn(() => (pulsing.value = false), 300, {
+  immediate: false,
+})
+let interval: ReturnType<typeof useIntervalFn> | undefined
+
+watch(
+  () => props.value,
+  (val, old) => {
+    if (old === undefined) {
+      displayValue.value = Math.round(val * factor.value)
+      return
+    }
+    if (interval)
+      interval.pause()
+    const target = Math.round(val * factor.value)
+    const diff = target - displayValue.value
+    const step = Math.sign(diff)
+    const steps = Math.abs(diff)
+    if (!steps)
+      return
+    const stepTime = Math.max(props.duration / steps, 20)
+    interval = useIntervalFn(() => {
+      displayValue.value += step
+      if (displayValue.value === target) {
+        interval!.pause()
+        pulsing.value = true
+        stopPulse()
+      }
+    }, stepTime, { immediate: true })
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  interval?.pause()
+})
+</script>
+
+<template>
+  <span :class="pulsing ? 'count-pulse' : ''">{{ formatted }}</span>
+</template>
+
+<style scoped>
+.count-pulse {
+  animation: count-pulse 0.3s ease;
+}
+@keyframes count-pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+</style>

--- a/src/components/ui/CurrencyAmount.vue
+++ b/src/components/ui/CurrencyAmount.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import IconShlagidiamond from '~/components/icon/Shlagidiamond.vue'
 import IconShlagidolar from '~/components/icon/Shlagidolar.vue'
+import AnimatedNumber from '~/components/ui/AnimatedNumber.vue'
 
 const props = defineProps<{
   amount: number
@@ -19,7 +20,7 @@ const icon = computed(() => props.currency === 'shlagidiamond' ? IconShlagidiamo
   <UiTooltip :text="currencyName">
     <span class="inline-flex items-center gap-1">
       <component :is="icon" class="h-4 w-4" />
-      <span class="font-bold">{{ amount.toLocaleString() }}</span>
+      <AnimatedNumber class="font-bold" :value="amount" />
     </span>
   </UiTooltip>
 </template>


### PR DESCRIPTION
## Summary
- animate numeric values with new `UiAnimatedNumber`
- apply animations to player info panel and currency display

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'coefficient'))*

------
https://chatgpt.com/codex/tasks/task_e_6880fe0e228c832a9616275a27a753d8