### PR TITLE
Limit AnimatedNumber duration

### DIFF
--- a/src/components/ui/AnimatedNumber.vue
+++ b/src/components/ui/AnimatedNumber.vue
@@ -4,6 +4,9 @@ const props = withDefaults(defineProps<{ value: number, duration?: number, preci
   precision: 0,
 })
 
+const MAX_DURATION = 660
+const MIN_STEP_TIME = 20
+
 const factor = computed(() => 10 ** props.precision)
 const displayValue = ref(Math.round(props.value * factor.value))
 const formatted = computed(() => {
@@ -29,14 +32,26 @@ watch(
       interval.pause()
     const target = Math.round(val * factor.value)
     const diff = target - displayValue.value
-    const step = Math.sign(diff)
-    const steps = Math.abs(diff)
+    const sign = Math.sign(diff)
+    let steps = Math.abs(diff)
     if (!steps)
       return
-    const stepTime = Math.max(props.duration / steps, 20)
+
+    const desiredDuration = Math.min(props.duration, MAX_DURATION)
+
+    let stepValue = sign
+    if (steps * MIN_STEP_TIME > desiredDuration) {
+      steps = Math.floor(desiredDuration / MIN_STEP_TIME)
+      steps = Math.max(1, steps)
+      stepValue = Math.ceil(Math.abs(diff) / steps) * sign
+    }
+
+    const stepTime = Math.max(desiredDuration / steps, MIN_STEP_TIME)
+
     interval = useIntervalFn(() => {
-      displayValue.value += step
-      if (displayValue.value === target) {
+      displayValue.value += stepValue
+      if ((sign > 0 && displayValue.value >= target) || (sign < 0 && displayValue.value <= target)) {
+        displayValue.value = target
         interval!.pause()
         pulsing.value = true
         stopPulse()


### PR DESCRIPTION
## Summary
- ensure AnimatedNumber animation never exceeds 0.66s

## Testing
- `pnpm test` *(fails: missing imports and failing assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68811b984c28832a9ad2dc5721f6fe53