### PR TITLE
Randomize TicTacToe AI delay

### DIFF
--- a/src/components/minigame/TicTacToe.vue
+++ b/src/components/minigame/TicTacToe.vue
@@ -64,7 +64,8 @@ function play(i: number) {
   if (centerFull())
     return end(false, true)
   turn.value = 'ai'
-  useTimeoutFn(aiMove, 300)
+  const delay = 250 + Math.random() * 1250
+  useTimeoutFn(aiMove, delay)
 }
 
 function end(win: boolean, draw = false) {


### PR DESCRIPTION
## Summary
- add a random delay for the TicTacToe AI move

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_68816305ce54832ab10ece0b6aa016f6