### PR TITLE
Allow XP above zone level with penalty

### DIFF
--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -107,10 +107,10 @@ async function handleEnd(result: 'win' | 'lose' | 'draw') {
     notifyAchievement({ type: 'battle-win', stronger })
     if (dex.activeShlagemon) {
       const xp = dex.xpGainForLevel(defeated.lvl)
-      await dex.gainXp(dex.activeShlagemon, xp, zone.current.maxLevel)
+      await dex.gainXp(dex.activeShlagemon, xp, undefined, undefined, zone.current.maxLevel)
       const holder = wearableItemStore.getHolder('multi-exp')
       if (holder)
-        await dex.gainXp(holder, Math.round(xp * 0.5), zone.current.maxLevel)
+        await dex.gainXp(holder, Math.round(xp * 0.5), undefined, undefined, zone.current.maxLevel)
     }
   }
   else if (result === 'lose') {

--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -88,10 +88,10 @@ async function onCaptureEnd(success: boolean) {
     notifyAchievement({ type: 'capture', shiny: props.enemy.isShiny })
     if (dex.activeShlagemon) {
       const xp = dex.xpGainForLevel(props.enemy.lvl)
-      await dex.gainXp(dex.activeShlagemon, xp, zone.current.maxLevel)
+      await dex.gainXp(dex.activeShlagemon, xp, undefined, undefined, zone.current.maxLevel)
       const holder = wearableItemStore.getHolder('multi-exp')
       if (holder)
-        await dex.gainXp(holder, Math.round(xp * 0.5), zone.current.maxLevel)
+        await dex.gainXp(holder, Math.round(xp * 0.5), undefined, undefined, zone.current.maxLevel)
     }
     emit('capture')
     showConfetti.value = true

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -472,12 +472,15 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     amount: number,
     maxLevel = 100,
     healPercent = 100,
+    zoneMaxLevel?: number,
   ) {
     if (mon.lvl >= maxLevel)
       return
     const bonus = wearableBonus(mon.heldItemId, 'xp')
     if (bonus)
       amount = Math.round(amount * (1 + bonus / 100))
+    if (zoneMaxLevel && mon.lvl >= zoneMaxLevel)
+      amount = Math.round(amount / 2)
     mon.xp += amount
     while (mon.lvl < maxLevel && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)


### PR DESCRIPTION
## Summary
- tweak `gainXp` in `shlagedex` store to support an optional zone level cap and apply a penalty when above it
- adjust battle logic to pass zone level cap to `gainXp`

## Testing
- `pnpm test` *(fails: snapshots and many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6881618ce630832abf428d3140375372