### PR TITLE
Show info when evolution already owned

### DIFF
--- a/src/components/shlagemon/EvolutionModal.vue
+++ b/src/components/shlagemon/EvolutionModal.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 const store = useEvolutionStore()
+const dex = useShlagedexStore()
+
+const hasEvolution = computed(() => {
+  if (!store.pending)
+    return false
+  return dex.shlagemons.some(m => m.base.id === store.pending!.to.id)
+})
 </script>
 
 <template>
@@ -17,6 +24,12 @@ const store = useEvolutionStore()
       </h3>
       <p class="text-center">
         « {{ store.pending?.mon.base.name }} » veut évoluer en « {{ store.pending?.to.name }} », voulez-vous le laisser faire ou l'empêcher de répandre sa shlaguitude ?
+      </p>
+      <p
+        v-if="hasEvolution"
+        class="text-center text-xs text-red-500 dark:text-red-400"
+      >
+        Vous possédez déjà l'évolution de ce Shlagémon
       </p>
       <div class="flex gap-2">
         <UiButton type="valid" class="flex items-center gap-1" @click="store.accept">


### PR DESCRIPTION
## Summary
- show a red note in EvolutionModal when the evolved form is already in the Shlagedex

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688164b2ad7c832a842e3ea51c88c534