### PR TITLE
Persist incubator start time

### DIFF
--- a/src/stores/egg.ts
+++ b/src/stores/egg.ts
@@ -13,6 +13,7 @@ export interface Egg {
   id: number
   type: EggType
   base: BaseShlagemon
+  startedAt: number
   hatchesAt: number
 }
 
@@ -30,8 +31,9 @@ export const useEggStore = defineStore('egg', () => {
       candidates = candidates.filter(b => b.id !== mewteub.id)
     const base = pickRandomByCoefficient(candidates)
     const duration = (base.coefficient / 10) * 60_000
-    const id = Date.now() + Math.random()
-    incubator.value.push({ id, type, base, hatchesAt: Date.now() + duration })
+    const startedAt = Date.now()
+    const id = startedAt + Math.random()
+    incubator.value.push({ id, type, base, startedAt, hatchesAt: startedAt + duration })
     return true
   }
 
@@ -63,6 +65,7 @@ export const useEggStore = defineStore('egg', () => {
   return { incubator, startIncubation, hatchEgg, cancelIncubation, isReady, reset }
 }, {
   persist: {
+    paths: ['incubator'],
     serializer: eggSerializer,
     afterHydrate(ctx) {
       const store = ctx.store as ReturnType<typeof useEggStore>

--- a/src/utils/egg-serialize.ts
+++ b/src/utils/egg-serialize.ts
@@ -6,29 +6,34 @@ interface StoredEgg {
   id: number
   type: Egg['type']
   baseId: string
+  startedAt: number
   hatchesAt: number
 }
 
-export const eggSerializer: Serializer<Egg[]> = {
-  serialize(eggs) {
-    const data: StoredEgg[] = eggs.map(e => ({
+export const eggSerializer: Serializer<{ incubator: Egg[] }> = {
+  serialize(data) {
+    const eggs = data.incubator || []
+    const list: StoredEgg[] = eggs.map(e => ({
       id: e.id,
       type: e.type,
       baseId: e.base.id,
+      startedAt: e.startedAt,
       hatchesAt: e.hatchesAt,
     }))
-    return JSON.stringify(data)
+    return JSON.stringify(list)
   },
   deserialize(raw) {
     if (!raw)
-      return []
+      return { incubator: [] }
     const list = JSON.parse(raw) as StoredEgg[]
     const baseMap = Object.fromEntries(allShlagemons.map(b => [b.id, b]))
-    return list.map(e => ({
+    const incubator = list.map(e => ({
       id: e.id,
       type: e.type,
       base: baseMap[e.baseId],
+      startedAt: e.startedAt,
       hatchesAt: e.hatchesAt,
     })).filter(e => e.base)
+    return { incubator }
   },
 }

--- a/test/egg-persist.test.ts
+++ b/test/egg-persist.test.ts
@@ -1,0 +1,34 @@
+import { createPinia, setActivePinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { describe, expect, it } from 'vitest'
+import { allShlagemons } from '../src/data/shlagemons'
+import { useEggStore } from '../src/stores/egg'
+import { eggSerializer } from '../src/utils/egg-serialize'
+
+describe('egg persistence', () => {
+  it('restores incubator from storage', () => {
+    const pinia = createPinia()
+    pinia.use(piniaPluginPersistedstate)
+    setActivePinia(pinia)
+
+    const stored = eggSerializer.serialize({
+      incubator: [
+        {
+          id: 1,
+          type: 'feu',
+          base: allShlagemons[0],
+          startedAt: 1000,
+          hatchesAt: 2000,
+        },
+      ],
+    })
+    window.localStorage.setItem('egg', stored)
+
+    const eggs = useEggStore()
+    expect(eggs.incubator.length).toBe(1)
+    const egg = eggs.incubator[0]
+    expect(egg.startedAt).toBe(1000)
+    expect(egg.hatchesAt).toBe(2000)
+    expect(egg.base.id).toBe(allShlagemons[0].id)
+  })
+})

--- a/test/egg.test.ts
+++ b/test/egg.test.ts
@@ -18,7 +18,8 @@ describe('egg workflow', () => {
     expect(eggs.incubator.length).toBe(1)
 
     const egg = eggs.incubator[0]
-    const duration = egg.hatchesAt - Date.now()
+    const duration = egg.hatchesAt - egg.startedAt
+    expect(egg.startedAt).toBeLessThanOrEqual(Date.now())
     vi.advanceTimersByTime(duration + 1)
     expect(eggs.isReady(egg)).toBe(true)
     const mon = eggs.hatchEgg(egg.id)


### PR DESCRIPTION
## Summary
- add `startedAt` property to Egg
- persist incubator array in `useEggStore`
- update egg serializer for new structure
- adjust unit tests and add persistence test

## Testing
- `pnpm exec vitest run test/egg.test.ts test/egg-persist.test.ts` *(fails: Unknown)*

------
https://chatgpt.com/codex/tasks/task_e_688164462360832aa2164784619af390