### PR TITLE
Fix xp bar animation overshoot

### DIFF
--- a/src/components/ui/ProgressBar.vue
+++ b/src/components/ui/ProgressBar.vue
@@ -57,15 +57,15 @@ watch(
 
 @keyframes xp-gain {
   0% {
-    transform: scale(1);
+    transform: scaleY(1);
     box-shadow: 0 0 0 0 rgba(250, 204, 21, 0.7);
   }
   50% {
-    transform: scale(1.1);
+    transform: scaleY(1.2);
     box-shadow: 0 0 6px 2px rgba(250, 204, 21, 0.7);
   }
   100% {
-    transform: scale(1);
+    transform: scaleY(1);
     box-shadow: 0 0 0 0 rgba(250, 204, 21, 0);
   }
 }


### PR DESCRIPTION
## Summary
- tweak xp bar gain animation to avoid stretching

## Testing
- `pnpm test` *(fails: expected 13 to be 12, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688166421890832abaeb3b8d007faa44