### PR TITLE
Use i18n keys in minigame intro dialogs

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -57,7 +57,7 @@ declare module 'vue' {
     IconDisease: typeof import('./components/icon/Disease.vue')['default']
     IconMultiExp: typeof import('./components/icon/MultiExp.vue')['default']
     IconShlagedex: typeof import('./components/icon/Shlagedex.vue')['default']
-    IconShlagidiamond: typeof import('./components/icon/Shlagidiamond.vue')['default']
+    IconShlagidiamond: typeof import('./components/icon/shlagidiamond.vue')['default']
     IconShlagidolar: typeof import('./components/icon/Shlagidolar.vue')['default']
     IconXp: typeof import('./components/icon/Xp.vue')['default']
     InventoryEvolutionItemModal: typeof import('./components/inventory/EvolutionItemModal.vue')['default']

--- a/src/data/Minigame/Battleship.ts
+++ b/src/data/Minigame/Battleship.ts
@@ -17,11 +17,11 @@ export const battleshipMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: 'Une partie de bataille navale ?',
+        text: i18n.global.t('data.Minigame.Battleship.startText'),
         responses: [
-          { label: 'Oui', type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.Battleship.yes'), type: 'primary', action: start },
           {
-            label: 'Non',
+            label: i18n.global.t('data.Minigame.Battleship.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -48,10 +48,10 @@ export const battleshipMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: 'Perdu ! Recommence quand tu veux.',
+        text: i18n.global.t('data.Minigame.Battleship.loseText'),
         responses: [
-          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
-          { label: 'Retour', type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.Battleship.restart'), type: 'primary', action: () => miniGame.play() },
+          { label: i18n.global.t('data.Minigame.Battleship.back'), type: 'danger', action: done },
         ],
       },
     ]

--- a/src/data/Minigame/ShlagPairs.ts
+++ b/src/data/Minigame/ShlagPairs.ts
@@ -17,11 +17,11 @@ export const shlagPairsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: 'Une partie du jeu des paires ?',
+        text: i18n.global.t('data.Minigame.ShlagPairs.startText'),
         responses: [
-          { label: 'Oui', type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.ShlagPairs.yes'), type: 'primary', action: start },
           {
-            label: 'Non',
+            label: i18n.global.t('data.Minigame.ShlagPairs.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -48,10 +48,10 @@ export const shlagPairsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: 'Dommage !',
+        text: i18n.global.t('data.Minigame.ShlagPairs.loseText'),
         responses: [
-          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
-          { label: 'Retour', type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.ShlagPairs.restart'), type: 'primary', action: () => miniGame.play() },
+          { label: i18n.global.t('data.Minigame.ShlagPairs.back'), type: 'danger', action: done },
         ],
       },
     ]

--- a/src/data/Minigame/ShlagTaquin.ts
+++ b/src/data/Minigame/ShlagTaquin.ts
@@ -17,11 +17,11 @@ export const shlagTaquinMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: 'Une partie de taquin ?',
+        text: i18n.global.t('data.Minigame.ShlagTaquin.startText'),
         responses: [
-          { label: 'Oui', type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.ShlagTaquin.yes'), type: 'primary', action: start },
           {
-            label: 'Non',
+            label: i18n.global.t('data.Minigame.ShlagTaquin.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -48,10 +48,10 @@ export const shlagTaquinMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: 'Perdu ! Recommence quand tu veux.',
+        text: i18n.global.t('data.Minigame.ShlagTaquin.loseText'),
         responses: [
-          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
-          { label: 'Retour', type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.ShlagTaquin.restart'), type: 'primary', action: () => miniGame.play() },
+          { label: i18n.global.t('data.Minigame.ShlagTaquin.back'), type: 'danger', action: done },
         ],
       },
     ]

--- a/src/data/Minigame/TicTacToe.ts
+++ b/src/data/Minigame/TicTacToe.ts
@@ -17,11 +17,11 @@ export const ticTacToeMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: 'Envie d\'une partie de morpion ?',
+        text: i18n.global.t('data.Minigame.TicTacToe.startText'),
         responses: [
-          { label: 'Oui', type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.TicTacToe.yes'), type: 'primary', action: start },
           {
-            label: 'Non',
+            label: i18n.global.t('data.Minigame.TicTacToe.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -48,10 +48,10 @@ export const ticTacToeMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: 'Perdu ! Recommence quand tu veux.',
+        text: i18n.global.t('data.Minigame.TicTacToe.loseText'),
         responses: [
-          { label: 'Recommencer', type: 'primary', action: () => miniGame.play() },
-          { label: 'Retour', type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.TicTacToe.restart'), type: 'primary', action: () => miniGame.play() },
+          { label: i18n.global.t('data.Minigame.TicTacToe.back'), type: 'danger', action: done },
         ],
       },
     ]


### PR DESCRIPTION
## Summary
- pull i18n strings for minigame intros and failure dialogs
- regenerate locale files

## Testing
- `pnpm run i18n`
- `pnpm test` *(fails: Snapshot mismatch and many failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_688166dbef2c832a86f73e85559cae3d