### PR TITLE
Externalize minigame strings

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -436,6 +436,21 @@ components:
           text: Equip it on the Shlagemon of your choice.
         step6:
           text: Good luck from here on!
+  minigame:
+    MiniGameShlagMind:
+      messages:
+        - You're getting closer... or not.
+        - That's not it, but you're doing your best, little Shlag.
+        - Try again, champion of nothingness.
+        - You suck!
+        - You're one step away from a brain fart.
+        - Rarely seen someone so pathetic.
+      validate: Validate
+      attemptsLeft: '{n} attempts left'
+    MiniGameShlagPairs:
+      attempts: '{n} attempt | {n} attempts'
+    ShlagMindSelectionModal:
+      title: Choose a Shlagemon
 data:
   shlagemons:
     01-05:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -457,6 +457,21 @@ components:
           text: Équipe-le sur le Shlagémon de ton choix.
         step6:
           text: Bonne chance pour la suite !
+  minigame:
+    MiniGameShlagMind:
+      messages:
+        - Tu te rapproches... ou pas.
+        - Ce n'est pas ça, mais tu fais de ton mieux, petit Shlag.
+        - Essaie encore, champion du néant.
+        - Tu es nul à chier !
+        - T'es à deux doigts de faire un pet cérébral.
+        - Rarement vu quelqu'un aussi merdique.
+      validate: Valider
+      attemptsLeft: '{n} tentatives restantes'
+    MiniGameShlagPairs:
+      attempts: '{n} tentative | {n} tentatives'
+    ShlagMindSelectionModal:
+      title: Choisis un Shlagémon
 data:
   shlagemons:
     01-05:

--- a/src/components/minigame/MiniGameShlagMind.i18n.yml
+++ b/src/components/minigame/MiniGameShlagMind.i18n.yml
@@ -1,0 +1,20 @@
+fr:
+  messages:
+    - Tu te rapproches... ou pas.
+    - Ce n'est pas ça, mais tu fais de ton mieux, petit Shlag.
+    - Essaie encore, champion du néant.
+    - Tu es nul à chier !
+    - T'es à deux doigts de faire un pet cérébral.
+    - Rarement vu quelqu'un aussi merdique.
+  validate: Valider
+  attemptsLeft: '{n} tentatives restantes'
+en:
+  messages:
+    - You're getting closer... or not.
+    - That's not it, but you're doing your best, little Shlag.
+    - Try again, champion of nothingness.
+    - You suck!
+    - You're one step away from a brain fart.
+    - Rarely seen someone so pathetic.
+  validate: Validate
+  attemptsLeft: '{n} attempts left'

--- a/src/components/minigame/MiniGameShlagMind.vue
+++ b/src/components/minigame/MiniGameShlagMind.vue
@@ -1,18 +1,16 @@
 <script setup lang="ts">
 import { useTimeoutFn } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
 import { allShlagemons } from '~/data/shlagemons'
 import ShlagMindSelectionModal from './ShlagMindSelectionModal.vue'
 
 const emit = defineEmits<{ (e: 'win'): void, (e: 'lose'): void }>()
 
-const messages = [
-  'Tu te rapproches... ou pas.',
-  'Ce n\u2019est pas \u00E7a, mais tu fais de ton mieux, petit Shlag.',
-  'Essaie encore, champion du n\u00E9ant.',
-  'Tu es nul à chier !',
-  'T\u2019es \u00E0 deux doigts de faire un pet c\u00E9r\u00E9bral.',
-  'Rarement vu quelqu\'un aussi merdique.',
-]
+const { t, tm } = useI18n()
+
+const messages = computed(() =>
+  tm('components.minigame.MiniGameShlagMind.messages') as string[],
+)
 
 const palette = allShlagemons.slice(0, 12)
 const comboLength = 6
@@ -103,7 +101,8 @@ function validate() {
     useTimeoutFn(() => emit('lose'), 1200)
   }
   else {
-    message.value = messages[Math.floor(Math.random() * messages.length)]
+    const list = messages.value
+    message.value = list[Math.floor(Math.random() * list.length)]
     guess.value = Array.from({ length: comboLength }).fill(null)
   }
 }
@@ -114,7 +113,7 @@ initGame()
 <template>
   <div class="relative aspect-video h-full w-full flex flex-col items-center gap-2 p-2" md="p-4">
     <div class="text-sm font-bold">
-      {{ attemptsLeft }} tentatives restantes
+      {{ t('components.minigame.MiniGameShlagMind.attemptsLeft', { n: attemptsLeft }) }}
     </div>
     <div class="w-full flex flex-1 flex-col gap-2 overflow-y-auto">
       <TransitionGroup name="line">
@@ -178,7 +177,7 @@ initGame()
           :disabled="guess.some((v) => !v)"
           @click="validate"
         >
-          Valider
+          {{ t('components.minigame.MiniGameShlagMind.validate') }}
         </UiButton>
       </div>
     </div>

--- a/src/components/minigame/MiniGameShlagPairs.i18n.yml
+++ b/src/components/minigame/MiniGameShlagPairs.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  attempts: '{n} tentative | {n} tentatives'
+en:
+  attempts: '{n} attempt | {n} attempts'

--- a/src/components/minigame/MiniGameShlagPairs.vue
+++ b/src/components/minigame/MiniGameShlagPairs.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { useElementSize, useTimeoutFn } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
 import { allShlagemons } from '~/data/shlagemons'
 import { useAudioStore } from '~/stores/audio'
 
 const emit = defineEmits(['win'])
 const audio = useAudioStore()
+const { t } = useI18n()
 
 interface Cell {
   id: number
@@ -105,7 +107,7 @@ onMounted(reset)
       </div>
     </div>
     <div class="mt-2 text-center text-sm font-bold">
-      {{ attempts }} tentative{{ attempts > 1 ? 's' : '' }}
+      {{ t('components.minigame.MiniGameShlagPairs.attempts', attempts) }}
     </div>
   </div>
 </template>

--- a/src/components/minigame/ShlagMindSelectionModal.i18n.yml
+++ b/src/components/minigame/ShlagMindSelectionModal.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  title: Choisis un Shlagémon
+en:
+  title: Choose a Shlagemon

--- a/src/components/minigame/ShlagMindSelectionModal.vue
+++ b/src/components/minigame/ShlagMindSelectionModal.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{
   modelValue: boolean
   palette: BaseShlagemon[]
 }>()
 const emit = defineEmits(['update:modelValue', 'select'])
+
+const { t } = useI18n()
 
 function close() {
   emit('update:modelValue', false)
@@ -20,7 +23,7 @@ function choose(id: string) {
   <UiModal :model-value="props.modelValue" footer-close @update:model-value="emit('update:modelValue', $event)">
     <div class="flex flex-col items-center gap-2">
       <h3 class="text-lg font-bold">
-        Choisis un Shlagémon
+        {{ t('components.minigame.ShlagMindSelectionModal.title') }}
       </h3>
       <div class="grid grid-cols-3 gap-2" md="grid-cols-4 gap-3">
         <button


### PR DESCRIPTION
## Summary
- extract hard-coded text in ShlagMind minigames
- add corresponding translation YAML files
- use `useI18n` to access translated strings
- update compiled locale files

## Testing
- `pnpm run i18n`
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688169d7d880832a96ab6dc702fa53e6