### PR TITLE
Add i18n for ShlagPairs attempts

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -436,6 +436,9 @@ components:
           text: Equip it on the Shlagemon of your choice.
         step6:
           text: Good luck from here on!
+  minigame:
+    MiniGameShlagPairs:
+      attempts: '{n} attempt | {n} attempts'
 data:
   shlagemons:
     01-05:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -457,6 +457,9 @@ components:
           text: Équipe-le sur le Shlagémon de ton choix.
         step6:
           text: Bonne chance pour la suite !
+  minigame:
+    MiniGameShlagPairs:
+      attempts: '{n} tentative | {n} tentatives'
 data:
   shlagemons:
     01-05:

--- a/src/components/minigame/MiniGameShlagPairs.i18n.yml
+++ b/src/components/minigame/MiniGameShlagPairs.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  attempts: '{n} tentative | {n} tentatives'
+en:
+  attempts: '{n} attempt | {n} attempts'

--- a/src/components/minigame/MiniGameShlagPairs.vue
+++ b/src/components/minigame/MiniGameShlagPairs.vue
@@ -4,6 +4,9 @@ import { allShlagemons } from '~/data/shlagemons'
 import { useAudioStore } from '~/stores/audio'
 
 const emit = defineEmits(['win'])
+
+const { t } = useI18n()
+
 const audio = useAudioStore()
 
 interface Cell {
@@ -105,7 +108,7 @@ onMounted(reset)
       </div>
     </div>
     <div class="mt-2 text-center text-sm font-bold">
-      {{ attempts }} tentative{{ attempts > 1 ? 's' : '' }}
+      {{ t('components.minigame.MiniGameShlagPairs.attempts', attempts) }}
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- localize attempts counter in MiniGameShlagPairs
- add translations for attempts

## Testing
- `pnpm run i18n`
- `pnpm test` *(fails: Failed Tests 49)*

------
https://chatgpt.com/codex/tasks/task_e_688169da6460832a8c6490795c03d104