### PR TITLE
Add item translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2789,6 +2789,188 @@ data:
       loseText: Lost! Try again whenever you like.
       restart: Restart
       back: Back
+  items:
+    items:
+      defensePotion:
+        name: Defense Potion
+        description: Temporarily increases defense.
+        details: Briefly boosts your active Shlagémon's defense.
+      superDefensePotion:
+        name: Super Defense Potion
+        description: Greatly increases defense.
+        details: Significantly boosts your active Shlagémon's defense.
+      hyperDefensePotion:
+        name: Hyper Defense Potion
+        description: Maximizes defense temporarily.
+        details: Massively boosts your active Shlagémon's defense.
+      attackPotion:
+        name: Attack Potion
+        description: Temporarily increases attack.
+        details: Briefly boosts your active Shlagémon's attack.
+      superAttackPotion:
+        name: Super Attack Potion
+        description: Greatly increases attack.
+        details: Significantly boosts your active Shlagémon's attack.
+      hyperAttackPotion:
+        name: Hyper Attack Potion
+        description: Maximizes attack temporarily.
+        details: Massively boosts your active Shlagémon's attack.
+      vitalityPotion:
+        name: Vitality Potion
+        description: Temporarily increases HP.
+        details: Increases your active Shlagémon's HP by 10% for a few minutes.
+      superVitalityPotion:
+        name: Super Vitality Potion
+        description: Greatly increases HP.
+        details: Increases your active Shlagémon's HP by 25% for a few minutes.
+      hyperVitalityPotion:
+        name: Hyper Vitality Potion
+        description: Maximizes HP temporarily.
+        details: Increases your active Shlagémon's HP by 50% for a few minutes.
+      xpPotion:
+        name: Experience Potion
+        description: Temporarily increases XP gains.
+        details: Improves XP gained by 10% for a few minutes.
+      superXpPotion:
+        name: Super Experience Potion
+        description: Greatly increases XP gains.
+        details: Improves XP gained by 25% for a few minutes.
+      hyperXpPotion:
+        name: Hyper Experience Potion
+        description: Maximizes XP gains temporarily.
+        details: Improves XP gained by 50% for a few minutes.
+      capturePotion:
+        name: Capture Potion
+        description: Slightly increases capture chance.
+        details: Improves capture chance by 10% for a few minutes.
+      superCapturePotion:
+        name: Super Capture Potion
+        description: Greatly increases capture chance.
+        details: Improves capture chance by 25% for a few minutes.
+      hyperCapturePotion:
+        name: Hyper Capture Potion
+        description: Maximizes capture chance.
+        details: Improves capture chance by 50% for a few minutes.
+      potion:
+        name: Gross Potion
+        description: Heals 50 HP of your Shlagémon.
+        details: Restores 50 HP to your active Shlagémon during battle.
+      superPotion:
+        name: Super Potion
+        description: Heals 100 HP of your Shlagémon.
+        details: Restores 100 HP to your active Shlagémon during battle.
+      hyperPotion:
+        name: Hyper Potion
+        description: Heals 200 HP of your Shlagémon.
+        details: Restores 200 HP to your active Shlagémon during battle.
+      multiExp:
+        name: Multi-EXP
+        description: Shares XP with a Shlagémon.
+        details: Shares 50% of the XP earned in battle with the holder.
+      thunderStone:
+        name: Thunder Stone
+        description: Allows certain electric evolutions.
+        details: Evolves Pikachiant into Raïchiotte.
+      steroids:
+        name: Steroids
+        description: Enables certain "toxic bodybuilder" evolutions.
+        details: Evolves Macho into Masschopeur if he spent at least 3h at the gym.
+      ultraSteroid:
+        name: Ultra-Steroid
+        description: A substance banned in 97 countries.
+        details: Evolves Masschopeur into Macintosh, an irreversible hypertrophy.
+      eggBox:
+        name: Egg Box
+        description: Stores all your eggs without cluttering the inventory.
+      fireEgg:
+        name: Fire Egg
+        description: A burning hot egg.
+      waterEgg:
+        name: Water Egg
+        description: A dripping wet egg.
+      grassEgg:
+        name: Grass Egg
+        description: An egg that smells like grass.
+      psyEgg:
+        name: Psy Egg
+        description: An egg that stares intensely at you.
+      thunderEgg:
+        name: Thunder Egg
+        description: An egg crackling with sparks.
+    shlageball:
+      shlageball:
+        name: Shlagéball
+        description: Used to catch wild Shlagémon.
+        details: >-
+          Allows you to catch the current opponent. Lower HP means higher catch
+          chance.
+      superShlageball:
+        name: Super Shlagéball
+        description: Improves catch chances.
+        details: Gives a small bonus when catching stubborn Shlagémon.
+      hyperShlageball:
+        name: Hyper Shlagéball
+        description: Offers very high catch chances.
+        details: Designed for tough Shlagémon, it grants a huge bonus.
+    wearables:
+      attackRing:
+        attackRing:
+          name: Attack Ring
+          description: Increases the wearer's attack.
+          details: When worn, boosts attack by 15%. Can stack with attack potions.
+        advancedAttackRing:
+          name: Advanced Attack Ring
+          description: Strongly increases the wearer's attack.
+          details: When worn, boosts attack by 25%. Can stack with attack potions.
+        attackAmulet:
+          name: Attack Amulet
+          description: Greatly increases the wearer's attack.
+          details: When worn, boosts attack by 33%. Can stack with attack potions.
+      defenseRing:
+        defenseRing:
+          name: Defense Ring
+          description: Increases the wearer's defense.
+          details: When worn, boosts defense by 15%. Can stack with defense potions.
+        advancedDefenseRing:
+          name: Advanced Defense Ring
+          description: Strongly increases the wearer's defense.
+          details: When worn, boosts defense by 25%. Can stack with defense potions.
+        defenseAmulet:
+          name: Defense Amulet
+          description: Greatly increases the wearer's defense.
+          details: When worn, boosts defense by 33%. Can stack with defense potions.
+      vitalityRing:
+        vitalityRing:
+          name: Vitality Ring
+          description: Increases the wearer's max HP.
+          details: When worn, increases max HP by 15%. Can stack with vitality potions.
+        advancedVitalityRing:
+          name: Advanced Vitality Ring
+          description: Strongly increases the wearer's max HP.
+          details: When worn, increases max HP by 25%. Can stack with vitality potions.
+        vitalityAmulet:
+          name: Vitality Amulet
+          description: Greatly increases the wearer's max HP.
+          details: When worn, increases max HP by 33%. Can stack with vitality potions.
+      xpRing:
+        xpRing:
+          name: Experience Ring
+          description: Increases the wearer's XP.
+          details: >-
+            When worn, increases experience gained in battle by 15%. Can stack
+            with XP potions.
+        advancedXpRing:
+          name: Advanced Experience Ring
+          description: Strongly increases the wearer's XP.
+          details: >-
+            When worn, increases experience gained in battle by 25%. Can stack
+            with XP potions.
+        xpAmulet:
+          name: Experience Amulet
+          description: Greatly increases the wearer's XP.
+          details: >-
+            When worn, increases experience gained in battle by 33%. Can stack
+            with XP potions.
 pages:
   index:
     title: Shlagemon

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2873,6 +2873,225 @@ data:
       loseText: Perdu ! Recommence quand tu veux.
       restart: Recommencer
       back: Retour
+  items:
+    items:
+      defensePotion:
+        name: Potion de Défense
+        description: Augmente temporairement la défense.
+        details: Renforce brièvement la défense de votre Shlagémon actif.
+      superDefensePotion:
+        name: Super Potion de Défense
+        description: Augmente beaucoup la défense.
+        details: Renforce considérablement la défense de votre Shlagémon actif.
+      hyperDefensePotion:
+        name: Hyper Potion de Défense
+        description: Maximise temporairement la défense.
+        details: Booste énormément la défense de votre Shlagémon actif.
+      attackPotion:
+        name: Potion d'Attaque
+        description: Augmente temporairement l'attaque.
+        details: Renforce brièvement l'attaque de votre Shlagémon actif.
+      superAttackPotion:
+        name: Super Potion d'Attaque
+        description: Augmente beaucoup l'attaque.
+        details: Renforce considérablement l'attaque de votre Shlagémon actif.
+      hyperAttackPotion:
+        name: Hyper Potion d'Attaque
+        description: Maximise temporairement l'attaque.
+        details: Booste énormément l'attaque de votre Shlagémon actif.
+      vitalityPotion:
+        name: Potion de Vitalité
+        description: Augmente temporairement les PV.
+        details: >-
+          Augmente les PV de votre Shlagémon actif de 10% pendant quelques
+          minutes.
+      superVitalityPotion:
+        name: Super Potion de Vitalité
+        description: Augmente beaucoup les PV.
+        details: >-
+          Augmente les PV de votre Shlagémon actif de 25% pendant quelques
+          minutes.
+      hyperVitalityPotion:
+        name: Hyper Potion de Vitalité
+        description: Maximise temporairement les PV.
+        details: >-
+          Augmente les PV de votre Shlagémon actif de 50% pendant quelques
+          minutes.
+      xpPotion:
+        name: Potion d'Expérience
+        description: Augmente temporairement les gains d'XP.
+        details: Améliore l'XP gagnée de 10% pendant quelques minutes.
+      superXpPotion:
+        name: Super Potion d'Expérience
+        description: Augmente beaucoup les gains d'XP.
+        details: Améliore l'XP gagnée de 25% pendant quelques minutes.
+      hyperXpPotion:
+        name: Hyper Potion d'Expérience
+        description: Maximise temporairement les gains d'XP.
+        details: Améliore l'XP gagnée de 50% pendant quelques minutes.
+      capturePotion:
+        name: Potion de Capture
+        description: Augmente légèrement les chances de capture.
+        details: Améliore la probabilité de capture de 10% pendant quelques minutes.
+      superCapturePotion:
+        name: Super Potion de Capture
+        description: Augmente beaucoup les chances de capture.
+        details: Améliore la probabilité de capture de 25% pendant quelques minutes.
+      hyperCapturePotion:
+        name: Hyper Potion de Capture
+        description: Maximise les chances de capture.
+        details: Améliore la probabilité de capture de 50% pendant quelques minutes.
+      potion:
+        name: Potion Dégueulasse
+        description: Soigne 50 HP de votre Shlagémon.
+        details: Redonne 50 points de vie à votre Shlagémon actif pendant le combat.
+      superPotion:
+        name: Super Potion
+        description: Soigne 100 HP de votre Shlagémon.
+        details: Redonne 100 points de vie à votre Shlagémon actif pendant le combat.
+      hyperPotion:
+        name: Hyper Potion
+        description: Soigne 200 HP de votre Shlagémon.
+        details: Redonne 200 points de vie à votre Shlagémon actif pendant le combat.
+      multiExp:
+        name: Multi-EXP
+        description: Partage l'XP avec un Shlagémon.
+        details: >-
+          Permet de partager 50% de l'XP gagnée en combat avec le Shlagémon
+          porteur.
+      thunderStone:
+        name: Pierre Foutre
+        description: Permet certaines évolutions de type électrique.
+        details: Fait évoluer Pikachiant en Raïchiotte.
+      steroids:
+        name: Stéroïdes
+        description: Permet certaines évolutions de type "gros beauf bodybuildé toxique".
+        details: >-
+          Fait évoluer Macho en Masschopeur, à condition qu’il ait passé au
+          moins 3h à la salle, sans jambes, évidemment.
+      ultraSteroid:
+        name: Ultra-Stéroïde
+        description: >-
+          Une substance interdite dans 97 pays, 2 dimensions et au moins une
+          timeline.
+        details: >-
+          Fait évoluer Masschopeur en Macintosh, une forme d’hypertrophie
+          critique atteignant le point de non-retour. À manipuler avec des
+          gants, une perche, et un avocat.
+      eggBox:
+        name: Boîte à œufs
+        description: Permet de stocker tous tes œufs sans encombrer l'inventaire.
+      fireEgg:
+        name: Œuf Feu
+        description: Un œuf chaud bouillant.
+      waterEgg:
+        name: Œuf Eau
+        description: Un œuf qui ruisselle.
+      grassEgg:
+        name: Œuf Herbe
+        description: Un œuf qui sent la pelouse.
+      psyEgg:
+        name: Œuf Psy
+        description: Un œuf qui te fixe intensément.
+      thunderEgg:
+        name: Œuf Foudre
+        description: Un œuf parcouru d'étincelles.
+    shlageball:
+      shlageball:
+        name: Shlagéball
+        description: Permet de capturer des Shlagémons sauvages.
+        details: >-
+          Permet de capturer le Shlagémon actuellement en combat. Moins il a de
+          points de vie, plus la chance de capture augmente.
+      superShlageball:
+        name: Super Shlagéball
+        description: Améliore les chances de capture.
+        details: >-
+          Capture des Shlagémons plus récalcitrants avec un léger bonus de
+          chance.
+      hyperShlageball:
+        name: Hyper Shlagéball
+        description: Offre de très hautes chances de capture.
+        details: >-
+          Conçue pour capturer les Shlagémons coriaces, elle bénéficie d’un gros
+          bonus.
+    wearables:
+      attackRing:
+        attackRing:
+          name: Bague d'attaque
+          description: Augmente l'attaque du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente son attaque de 15%. Effet
+            cumulable avec les potions d'attaque.
+        advancedAttackRing:
+          name: Bague d'attaque avancée
+          description: Augmente fortement l'attaque du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente son attaque de 25%. Effet
+            cumulable avec les potions d'attaque.
+        attackAmulet:
+          name: Amulette d'attaque
+          description: Augmente grandement l'attaque du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente son attaque de 33%. Effet
+            cumulable avec les potions d'attaque.
+      defenseRing:
+        defenseRing:
+          name: Bague de défense
+          description: Augmente la défense du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente sa défense de 15%. Effet
+            cumulable avec les potions de défense.
+        advancedDefenseRing:
+          name: Bague de défense avancée
+          description: Augmente fortement la défense du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente sa défense de 25%. Effet
+            cumulable avec les potions de défense.
+        defenseAmulet:
+          name: Amulette de défense
+          description: Augmente grandement la défense du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente sa défense de 33%. Effet
+            cumulable avec les potions de défense.
+      vitalityRing:
+        vitalityRing:
+          name: Bague Vitalesque
+          description: Augmente les PV max du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente ses PV maximum de 15%. Effet
+            cumulable avec les potions de vitalité.
+        advancedVitalityRing:
+          name: Bague Vitalesque avancée
+          description: Augmente fortement les PV max du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente ses PV maximum de 25%. Effet
+            cumulable avec les potions de vitalité.
+        vitalityAmulet:
+          name: Amulette Vitalesque
+          description: Augmente grandement les PV max du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente ses PV maximum de 33%. Effet
+            cumulable avec les potions de vitalité.
+      xpRing:
+        xpRing:
+          name: Anneau d'expérience
+          description: Augmente l'XP du porteur.
+          details: >-
+            Porté par un Shlagémon, il augmente l'expérience gagnée en combat de
+            15%. Effet cumulable avec les potions d'expérience.
+        advancedXpRing:
+          name: Anneau d'expérience avancé
+          description: Augmente fortement l'XP du porteur.
+          details: >-
+            Porté par un Shlagémon, il augmente l'expérience gagnée en combat de
+            25%. Effet cumulable avec les potions d'expérience.
+        xpAmulet:
+          name: Amulette d'expérience
+          description: Augmente grandement l'XP du porteur.
+          details: >-
+            Portée par un Shlagémon, elle augmente l'expérience gagnée en combat
+            de 33%. Effet cumulable avec les potions d'expérience.
 pages:
   index:
     title: Shlagémon

--- a/src/components/dialog/WearableItemDialog.vue
+++ b/src/components/dialog/WearableItemDialog.vue
@@ -25,7 +25,7 @@ const potionText: Record<WearableItem['effectType'], string> = {
 const dialogTree = computed(() =>
   buildDialog([
     t('components.dialog.WearableItemDialog.steps.step1.text', { count: props.requiredCount }),
-    t('components.dialog.WearableItemDialog.steps.step2.text', { name: props.item.name }),
+    t('components.dialog.WearableItemDialog.steps.step2.text', { name: t(props.item.nameKey || props.item.name) }),
     t('components.dialog.WearableItemDialog.steps.step3.text', { stat: effectText[props.item.effectType], percent: props.item.percent }),
     t('components.dialog.WearableItemDialog.steps.step4.text', { potion: potionText[props.item.effectType] }),
     t('components.dialog.WearableItemDialog.steps.step5.text'),

--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -18,7 +18,9 @@ function onCardClick() {
   showInfo.value = true
   usage.markUsed(props.item.id)
 }
-const details = computed(() => props.item.details || props.item.description)
+const details = computed(() =>
+  t(props.item.detailsKey || props.item.descriptionKey || props.item.description),
+)
 const ballFilter = computed(() =>
   'catchBonus' in props.item ? { filter: `hue-rotate(${ballHues[props.item.id]})` } : {},
 )
@@ -79,11 +81,11 @@ watch(showInfo, (val) => {
         <img
           v-else-if="props.item.image"
           :src="props.item.image"
-          :alt="props.item.name"
+          :alt="t(props.item.nameKey || props.item.name)"
           class="h-8 w-8 object-contain"
           :style="ballFilter"
         >
-        <span class="font-bold">{{ props.item.name }}</span>
+        <span class="font-bold">{{ t(props.item.nameKey || props.item.name) }}</span>
       </div>
       <UiKbd
         v-if="!isMobile"
@@ -117,12 +119,12 @@ watch(showInfo, (val) => {
         <img
           v-else-if="props.item.image"
           :src="props.item.image"
-          :alt="props.item.name"
+          :alt="t(props.item.nameKey || props.item.name)"
           class="h-16 w-16 object-contain"
           :style="ballFilter"
         >
         <h3 class="text-lg font-bold">
-          {{ props.item.name }}
+          {{ t(props.item.nameKey || props.item.name) }}
         </h3>
         <p class="text-center text-sm">
           {{ details }}

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -97,8 +97,11 @@ function getList(category: ItemCategory | 'all') {
     if (category !== 'all')
       list = list.filter(e => e.item.category === category)
     const q = filter.search.toLowerCase().trim()
-    if (q)
-      list = list.filter(entry => entry.item.name.toLowerCase().includes(q))
+    if (q) {
+      list = list.filter(entry =>
+        t(entry.item.nameKey || entry.item.name).toLowerCase().includes(q),
+      )
+    }
     switch (filter.sortBy) {
       case 'type':
         list.sort((a, b) => {
@@ -109,7 +112,9 @@ function getList(category: ItemCategory | 'all') {
         })
         break
       case 'name':
-        list.sort((a, b) => a.item.name.localeCompare(b.item.name))
+        list.sort((a, b) =>
+          t(a.item.nameKey || a.item.name).localeCompare(t(b.item.nameKey || b.item.name)),
+        )
         break
       case 'price':
         list.sort((a, b) => (a.item.price ?? 0) - (b.item.price ?? 0))
@@ -136,7 +141,7 @@ function onUse(item: Item) {
   if ('catchBonus' in item) {
     ballStore.setBall(item.id as BallId)
     usage.markUsed(item.id)
-    toast(t('components.panel.Inventory.equip', { item: item.name }))
+    toast(t('components.panel.Inventory.equip', { item: t(item.nameKey || item.name) }))
   }
   else if (item.type === 'evolution') {
     evoItemStore.open(item)

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -88,7 +88,7 @@ function remaining(egg: { hatchesAt: number }) {
                 class="h-6 w-6"
                 :class="[entry.item.icon, entry.item.iconClass]"
               />
-              <span class="text-sm">{{ entry.item.name }}</span>
+              <span class="text-sm">{{ t(entry.item.nameKey || entry.item.name) }}</span>
             </div>
             <div class="flex items-center gap-1">
               <span class="text-xs font-bold">x{{ entry.qty }}</span>

--- a/src/components/shlagemon/WearableEquipModal.vue
+++ b/src/components/shlagemon/WearableEquipModal.vue
@@ -19,8 +19,8 @@ const { t } = useI18n()
         >
           <div class="flex items-center gap-2">
             <div v-if="o.item.icon" class="h-6 w-6" :class="[o.item.icon, o.item.iconClass]" />
-            <img v-else-if="o.item.image" :src="o.item.image" :alt="o.item.name" class="h-6 w-6 object-contain">
-            <span>{{ o.item.name }}</span>
+            <img v-else-if="o.item.image" :src="o.item.image" :alt="t(o.item.nameKey || o.item.name)" class="h-6 w-6 object-contain">
+            <span>{{ t(o.item.nameKey || o.item.name) }}</span>
           </div>
           <span class="text-xs font-bold">x{{ o.qty }}</span>
         </UiButton>

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -2,6 +2,8 @@
 import type { Item } from '~/type/item'
 
 const props = defineProps<{ item: Item }>()
+
+const { t } = useI18n()
 </script>
 
 <template>
@@ -11,10 +13,10 @@ const props = defineProps<{ item: Item }>()
       class="h-8 w-8"
       :class="[props.item.iconClass, props.item.icon]"
     />
-    <img v-else-if="props.item.image" :src="props.item.image" :alt="props.item.name" class="h-8 w-8 object-contain">
+    <img v-else-if="props.item.image" :src="props.item.image" :alt="t(props.item.nameKey || props.item.name)" class="h-8 w-8 object-contain">
     <div class="flex flex-1 flex-col text-left">
-      <span class="font-bold">{{ props.item.name }}</span>
-      <span class="text-xs">{{ props.item.description }}</span>
+      <span class="font-bold">{{ t(props.item.nameKey || props.item.name) }}</span>
+      <span class="text-xs">{{ t(props.item.descriptionKey || props.item.description) }}</span>
     </div>
     <UiCurrencyAmount :amount="props.item.price ?? 0" :currency="props.item.currency ?? 'shlagidolar'" />
     <slot />

--- a/src/components/shop/ItemDetail.vue
+++ b/src/components/shop/ItemDetail.vue
@@ -2,7 +2,10 @@
 import type { Item } from '~/type/item'
 
 const props = withDefaults(defineProps<{ item: Item, qty?: number }>(), { qty: 1 })
+
 const emit = defineEmits<{ (e: 'update:qty', value: number): void }>()
+
+const { t } = useI18n()
 
 const game = useGameStore()
 const qty = ref(props.qty)
@@ -34,7 +37,9 @@ function setMax() {
   qty.value = maxQty.value
 }
 
-const details = computed(() => props.item.details || props.item.description)
+const details = computed(() =>
+  t(props.item.detailsKey || props.item.descriptionKey || props.item.description),
+)
 </script>
 
 <template>
@@ -45,9 +50,9 @@ const details = computed(() => props.item.details || props.item.description)
         class="h-10 w-10"
         :class="[props.item.iconClass, props.item.icon]"
       />
-      <img v-else-if="props.item.image" :src="props.item.image" :alt="props.item.name" class="h-10 w-10 object-contain">
+      <img v-else-if="props.item.image" :src="props.item.image" :alt="t(props.item.nameKey || props.item.name)" class="h-10 w-10 object-contain">
       <h3 class="text-lg font-bold">
-        {{ props.item.name }}
+        {{ t(props.item.nameKey || props.item.name) }}
       </h3>
     </div>
     <div class="flex items-center gap-1">

--- a/src/data/items/items.i18n.yml
+++ b/src/data/items/items.i18n.yml
@@ -1,0 +1,214 @@
+en:
+  defensePotion:
+    name: Defense Potion
+    description: Temporarily increases defense.
+    details: Briefly boosts your active Shlagémon's defense.
+  superDefensePotion:
+    name: Super Defense Potion
+    description: Greatly increases defense.
+    details: Significantly boosts your active Shlagémon's defense.
+  hyperDefensePotion:
+    name: Hyper Defense Potion
+    description: Maximizes defense temporarily.
+    details: Massively boosts your active Shlagémon's defense.
+  attackPotion:
+    name: Attack Potion
+    description: Temporarily increases attack.
+    details: Briefly boosts your active Shlagémon's attack.
+  superAttackPotion:
+    name: Super Attack Potion
+    description: Greatly increases attack.
+    details: Significantly boosts your active Shlagémon's attack.
+  hyperAttackPotion:
+    name: Hyper Attack Potion
+    description: Maximizes attack temporarily.
+    details: Massively boosts your active Shlagémon's attack.
+  vitalityPotion:
+    name: Vitality Potion
+    description: Temporarily increases HP.
+    details: Increases your active Shlagémon's HP by 10% for a few minutes.
+  superVitalityPotion:
+    name: Super Vitality Potion
+    description: Greatly increases HP.
+    details: Increases your active Shlagémon's HP by 25% for a few minutes.
+  hyperVitalityPotion:
+    name: Hyper Vitality Potion
+    description: Maximizes HP temporarily.
+    details: Increases your active Shlagémon's HP by 50% for a few minutes.
+  xpPotion:
+    name: Experience Potion
+    description: Temporarily increases XP gains.
+    details: Improves XP gained by 10% for a few minutes.
+  superXpPotion:
+    name: Super Experience Potion
+    description: Greatly increases XP gains.
+    details: Improves XP gained by 25% for a few minutes.
+  hyperXpPotion:
+    name: Hyper Experience Potion
+    description: Maximizes XP gains temporarily.
+    details: Improves XP gained by 50% for a few minutes.
+  capturePotion:
+    name: Capture Potion
+    description: Slightly increases capture chance.
+    details: Improves capture chance by 10% for a few minutes.
+  superCapturePotion:
+    name: Super Capture Potion
+    description: Greatly increases capture chance.
+    details: Improves capture chance by 25% for a few minutes.
+  hyperCapturePotion:
+    name: Hyper Capture Potion
+    description: Maximizes capture chance.
+    details: Improves capture chance by 50% for a few minutes.
+  potion:
+    name: Gross Potion
+    description: Heals 50 HP of your Shlagémon.
+    details: Restores 50 HP to your active Shlagémon during battle.
+  superPotion:
+    name: Super Potion
+    description: Heals 100 HP of your Shlagémon.
+    details: Restores 100 HP to your active Shlagémon during battle.
+  hyperPotion:
+    name: Hyper Potion
+    description: Heals 200 HP of your Shlagémon.
+    details: Restores 200 HP to your active Shlagémon during battle.
+  multiExp:
+    name: Multi-EXP
+    description: Shares XP with a Shlagémon.
+    details: Shares 50% of the XP earned in battle with the holder.
+  thunderStone:
+    name: Thunder Stone
+    description: Allows certain electric evolutions.
+    details: Evolves Pikachiant into Raïchiotte.
+  steroids:
+    name: Steroids
+    description: Enables certain "toxic bodybuilder" evolutions.
+    details: Evolves Macho into Masschopeur if he spent at least 3h at the gym.
+  ultraSteroid:
+    name: Ultra-Steroid
+    description: A substance banned in 97 countries.
+    details: Evolves Masschopeur into Macintosh, an irreversible hypertrophy.
+  eggBox:
+    name: Egg Box
+    description: Stores all your eggs without cluttering the inventory.
+  fireEgg:
+    name: Fire Egg
+    description: A burning hot egg.
+  waterEgg:
+    name: Water Egg
+    description: A dripping wet egg.
+  grassEgg:
+    name: Grass Egg
+    description: An egg that smells like grass.
+  psyEgg:
+    name: Psy Egg
+    description: An egg that stares intensely at you.
+  thunderEgg:
+    name: Thunder Egg
+    description: An egg crackling with sparks.
+fr:
+  defensePotion:
+    name: Potion de Défense
+    description: Augmente temporairement la défense.
+    details: Renforce brièvement la défense de votre Shlagémon actif.
+  superDefensePotion:
+    name: Super Potion de Défense
+    description: Augmente beaucoup la défense.
+    details: Renforce considérablement la défense de votre Shlagémon actif.
+  hyperDefensePotion:
+    name: Hyper Potion de Défense
+    description: Maximise temporairement la défense.
+    details: Booste énormément la défense de votre Shlagémon actif.
+  attackPotion:
+    name: Potion d'Attaque
+    description: Augmente temporairement l'attaque.
+    details: Renforce brièvement l'attaque de votre Shlagémon actif.
+  superAttackPotion:
+    name: Super Potion d'Attaque
+    description: Augmente beaucoup l'attaque.
+    details: Renforce considérablement l'attaque de votre Shlagémon actif.
+  hyperAttackPotion:
+    name: Hyper Potion d'Attaque
+    description: Maximise temporairement l'attaque.
+    details: Booste énormément l'attaque de votre Shlagémon actif.
+  vitalityPotion:
+    name: Potion de Vitalité
+    description: Augmente temporairement les PV.
+    details: Augmente les PV de votre Shlagémon actif de 10% pendant quelques minutes.
+  superVitalityPotion:
+    name: Super Potion de Vitalité
+    description: Augmente beaucoup les PV.
+    details: Augmente les PV de votre Shlagémon actif de 25% pendant quelques minutes.
+  hyperVitalityPotion:
+    name: Hyper Potion de Vitalité
+    description: Maximise temporairement les PV.
+    details: Augmente les PV de votre Shlagémon actif de 50% pendant quelques minutes.
+  xpPotion:
+    name: Potion d'Expérience
+    description: Augmente temporairement les gains d'XP.
+    details: Améliore l'XP gagnée de 10% pendant quelques minutes.
+  superXpPotion:
+    name: Super Potion d'Expérience
+    description: Augmente beaucoup les gains d'XP.
+    details: Améliore l'XP gagnée de 25% pendant quelques minutes.
+  hyperXpPotion:
+    name: Hyper Potion d'Expérience
+    description: Maximise temporairement les gains d'XP.
+    details: Améliore l'XP gagnée de 50% pendant quelques minutes.
+  capturePotion:
+    name: Potion de Capture
+    description: Augmente légèrement les chances de capture.
+    details: Améliore la probabilité de capture de 10% pendant quelques minutes.
+  superCapturePotion:
+    name: Super Potion de Capture
+    description: Augmente beaucoup les chances de capture.
+    details: Améliore la probabilité de capture de 25% pendant quelques minutes.
+  hyperCapturePotion:
+    name: Hyper Potion de Capture
+    description: Maximise les chances de capture.
+    details: Améliore la probabilité de capture de 50% pendant quelques minutes.
+  potion:
+    name: Potion Dégueulasse
+    description: Soigne 50 HP de votre Shlagémon.
+    details: Redonne 50 points de vie à votre Shlagémon actif pendant le combat.
+  superPotion:
+    name: Super Potion
+    description: Soigne 100 HP de votre Shlagémon.
+    details: Redonne 100 points de vie à votre Shlagémon actif pendant le combat.
+  hyperPotion:
+    name: Hyper Potion
+    description: Soigne 200 HP de votre Shlagémon.
+    details: Redonne 200 points de vie à votre Shlagémon actif pendant le combat.
+  multiExp:
+    name: Multi-EXP
+    description: Partage l'XP avec un Shlagémon.
+    details: Permet de partager 50% de l'XP gagnée en combat avec le Shlagémon porteur.
+  thunderStone:
+    name: Pierre Foutre
+    description: Permet certaines évolutions de type électrique.
+    details: Fait évoluer Pikachiant en Raïchiotte.
+  steroids:
+    name: Stéroïdes
+    description: Permet certaines évolutions de type "gros beauf bodybuildé toxique".
+    details: Fait évoluer Macho en Masschopeur, à condition qu’il ait passé au moins 3h à la salle, sans jambes, évidemment.
+  ultraSteroid:
+    name: Ultra-Stéroïde
+    description: Une substance interdite dans 97 pays, 2 dimensions et au moins une timeline.
+    details: Fait évoluer Masschopeur en Macintosh, une forme d’hypertrophie critique atteignant le point de non-retour. À manipuler avec des gants, une perche, et un avocat.
+  eggBox:
+    name: Boîte à œufs
+    description: Permet de stocker tous tes œufs sans encombrer l'inventaire.
+  fireEgg:
+    name: Œuf Feu
+    description: Un œuf chaud bouillant.
+  waterEgg:
+    name: Œuf Eau
+    description: Un œuf qui ruisselle.
+  grassEgg:
+    name: Œuf Herbe
+    description: Un œuf qui sent la pelouse.
+  psyEgg:
+    name: Œuf Psy
+    description: Un œuf qui te fixe intensément.
+  thunderEgg:
+    name: Œuf Foudre
+    description: Un œuf parcouru d'étincelles.

--- a/src/data/items/items.ts
+++ b/src/data/items/items.ts
@@ -24,8 +24,11 @@ import {
 // @unocss-include
 export const defensePotion: Item = {
   id: 'defense-potion',
+  nameKey: 'data.items.items.defensePotion.name',
   name: 'Potion de Défense',
+  descriptionKey: 'data.items.items.defensePotion.description',
   description: 'Augmente temporairement la défense.',
+  detailsKey: 'data.items.items.defensePotion.details',
   details: 'Renforce brièvement la défense de votre Shlagémon actif.',
   type: 'defense',
   power: 10,
@@ -38,8 +41,11 @@ export const defensePotion: Item = {
 
 export const superDefensePotion: Item = {
   id: 'super-defense-potion',
+  nameKey: 'data.items.items.superDefensePotion.name',
   name: 'Super Potion de Défense',
+  descriptionKey: 'data.items.items.superDefensePotion.description',
   description: 'Augmente beaucoup la défense.',
+  detailsKey: 'data.items.items.superDefensePotion.details',
   details: 'Renforce considérablement la défense de votre Shlagémon actif.',
   type: 'defense',
   power: 25,
@@ -52,8 +58,11 @@ export const superDefensePotion: Item = {
 
 export const hyperDefensePotion: Item = {
   id: 'hyper-defense-potion',
+  nameKey: 'data.items.items.hyperDefensePotion.name',
   name: 'Hyper Potion de Défense',
+  descriptionKey: 'data.items.items.hyperDefensePotion.description',
   description: 'Maximise temporairement la défense.',
+  detailsKey: 'data.items.items.hyperDefensePotion.details',
   details: 'Booste énormément la défense de votre Shlagémon actif.',
   type: 'defense',
   power: 50,
@@ -66,8 +75,11 @@ export const hyperDefensePotion: Item = {
 
 export const attackPotion: Item = {
   id: 'attack-potion',
+  nameKey: 'data.items.items.attackPotion.name',
   name: 'Potion d\'Attaque',
+  descriptionKey: 'data.items.items.attackPotion.description',
   description: 'Augmente temporairement l\'attaque.',
+  detailsKey: 'data.items.items.attackPotion.details',
   details: 'Renforce brièvement l\'attaque de votre Shlagémon actif.',
   type: 'attack',
   power: 10,
@@ -80,8 +92,11 @@ export const attackPotion: Item = {
 
 export const superAttackPotion: Item = {
   id: 'super-attack-potion',
+  nameKey: 'data.items.items.superAttackPotion.name',
   name: 'Super Potion d\'Attaque',
+  descriptionKey: 'data.items.items.superAttackPotion.description',
   description: 'Augmente beaucoup l\'attaque.',
+  detailsKey: 'data.items.items.superAttackPotion.details',
   details: 'Renforce considérablement l\'attaque de votre Shlagémon actif.',
   type: 'attack',
   power: 25,
@@ -94,8 +109,11 @@ export const superAttackPotion: Item = {
 
 export const hyperAttackPotion: Item = {
   id: 'hyper-attack-potion',
+  nameKey: 'data.items.items.hyperAttackPotion.name',
   name: 'Hyper Potion d\'Attaque',
+  descriptionKey: 'data.items.items.hyperAttackPotion.description',
   description: 'Maximise temporairement l\'attaque.',
+  detailsKey: 'data.items.items.hyperAttackPotion.details',
   details: 'Booste énormément l\'attaque de votre Shlagémon actif.',
   type: 'attack',
   power: 50,
@@ -108,8 +126,11 @@ export const hyperAttackPotion: Item = {
 
 export const vitalityPotion: Item = {
   id: 'vitality-potion',
+  nameKey: 'data.items.items.vitalityPotion.name',
   name: 'Potion de Vitalité',
+  descriptionKey: 'data.items.items.vitalityPotion.description',
   description: 'Augmente temporairement les PV.',
+  detailsKey: 'data.items.items.vitalityPotion.details',
   details: 'Augmente les PV de votre Shlagémon actif de 10% pendant quelques minutes.',
   type: 'vitality',
   power: 10,
@@ -122,8 +143,11 @@ export const vitalityPotion: Item = {
 
 export const superVitalityPotion: Item = {
   id: 'super-vitality-potion',
+  nameKey: 'data.items.items.superVitalityPotion.name',
   name: 'Super Potion de Vitalité',
+  descriptionKey: 'data.items.items.superVitalityPotion.description',
   description: 'Augmente beaucoup les PV.',
+  detailsKey: 'data.items.items.superVitalityPotion.details',
   details: 'Augmente les PV de votre Shlagémon actif de 25% pendant quelques minutes.',
   type: 'vitality',
   power: 25,
@@ -136,8 +160,11 @@ export const superVitalityPotion: Item = {
 
 export const hyperVitalityPotion: Item = {
   id: 'hyper-vitality-potion',
+  nameKey: 'data.items.items.hyperVitalityPotion.name',
   name: 'Hyper Potion de Vitalité',
+  descriptionKey: 'data.items.items.hyperVitalityPotion.description',
   description: 'Maximise temporairement les PV.',
+  detailsKey: 'data.items.items.hyperVitalityPotion.details',
   details: 'Augmente les PV de votre Shlagémon actif de 50% pendant quelques minutes.',
   type: 'vitality',
   power: 50,
@@ -150,8 +177,11 @@ export const hyperVitalityPotion: Item = {
 
 export const xpPotion: Item = {
   id: 'xp-potion',
+  nameKey: 'data.items.items.xpPotion.name',
   name: 'Potion d\'Expérience',
+  descriptionKey: 'data.items.items.xpPotion.description',
   description: 'Augmente temporairement les gains d\'XP.',
+  detailsKey: 'data.items.items.xpPotion.details',
   details: 'Améliore l\'XP gagnée de 10% pendant quelques minutes.',
   type: 'xp',
   power: 10,
@@ -164,8 +194,11 @@ export const xpPotion: Item = {
 
 export const superXpPotion: Item = {
   id: 'super-xp-potion',
+  nameKey: 'data.items.items.superXpPotion.name',
   name: 'Super Potion d\'Expérience',
+  descriptionKey: 'data.items.items.superXpPotion.description',
   description: 'Augmente beaucoup les gains d\'XP.',
+  detailsKey: 'data.items.items.superXpPotion.details',
   details: 'Améliore l\'XP gagnée de 25% pendant quelques minutes.',
   type: 'xp',
   power: 25,
@@ -178,8 +211,11 @@ export const superXpPotion: Item = {
 
 export const hyperXpPotion: Item = {
   id: 'hyper-xp-potion',
+  nameKey: 'data.items.items.hyperXpPotion.name',
   name: 'Hyper Potion d\'Expérience',
+  descriptionKey: 'data.items.items.hyperXpPotion.description',
   description: 'Maximise temporairement les gains d\'XP.',
+  detailsKey: 'data.items.items.hyperXpPotion.details',
   details: 'Améliore l\'XP gagnée de 50% pendant quelques minutes.',
   type: 'xp',
   power: 50,
@@ -192,8 +228,11 @@ export const hyperXpPotion: Item = {
 
 export const capturePotion: Item = {
   id: 'capture-potion',
+  nameKey: 'data.items.items.capturePotion.name',
   name: 'Potion de Capture',
+  descriptionKey: 'data.items.items.capturePotion.description',
   description: 'Augmente légèrement les chances de capture.',
+  detailsKey: 'data.items.items.capturePotion.details',
   details: 'Améliore la probabilité de capture de 10% pendant quelques minutes.',
   type: 'capture',
   power: 10,
@@ -206,8 +245,11 @@ export const capturePotion: Item = {
 
 export const superCapturePotion: Item = {
   id: 'super-capture-potion',
+  nameKey: 'data.items.items.superCapturePotion.name',
   name: 'Super Potion de Capture',
+  descriptionKey: 'data.items.items.superCapturePotion.description',
   description: 'Augmente beaucoup les chances de capture.',
+  detailsKey: 'data.items.items.superCapturePotion.details',
   details: 'Améliore la probabilité de capture de 25% pendant quelques minutes.',
   type: 'capture',
   power: 25,
@@ -220,8 +262,11 @@ export const superCapturePotion: Item = {
 
 export const hyperCapturePotion: Item = {
   id: 'hyper-capture-potion',
+  nameKey: 'data.items.items.hyperCapturePotion.name',
   name: 'Hyper Potion de Capture',
+  descriptionKey: 'data.items.items.hyperCapturePotion.description',
   description: 'Maximise les chances de capture.',
+  detailsKey: 'data.items.items.hyperCapturePotion.details',
   details: 'Améliore la probabilité de capture de 50% pendant quelques minutes.',
   type: 'capture',
   power: 50,
@@ -234,8 +279,11 @@ export const hyperCapturePotion: Item = {
 
 export const potion: Item = {
   id: 'potion',
+  nameKey: 'data.items.items.potion.name',
   name: 'Potion Dégueulasse',
+  descriptionKey: 'data.items.items.potion.description',
   description: 'Soigne 50 HP de votre Shlagémon.',
+  detailsKey: 'data.items.items.potion.details',
   details: 'Redonne 50 points de vie à votre Shlagémon actif pendant le combat.',
   type: 'heal',
   power: 50,
@@ -248,8 +296,11 @@ export const potion: Item = {
 
 export const superPotion: Item = {
   id: 'super-potion',
+  nameKey: 'data.items.items.superPotion.name',
   name: 'Super Potion',
+  descriptionKey: 'data.items.items.superPotion.description',
   description: 'Soigne 100 HP de votre Shlagémon.',
+  detailsKey: 'data.items.items.superPotion.details',
   details: 'Redonne 100 points de vie à votre Shlagémon actif pendant le combat.',
   type: 'heal',
   power: 100,
@@ -262,8 +313,11 @@ export const superPotion: Item = {
 
 export const hyperPotion: Item = {
   id: 'hyper-potion',
+  nameKey: 'data.items.items.hyperPotion.name',
   name: 'Hyper Potion',
+  descriptionKey: 'data.items.items.hyperPotion.description',
   description: 'Soigne 200 HP de votre Shlagémon.',
+  detailsKey: 'data.items.items.hyperPotion.details',
   details: 'Redonne 200 points de vie à votre Shlagémon actif pendant le combat.',
   type: 'heal',
   power: 200,
@@ -276,8 +330,11 @@ export const hyperPotion: Item = {
 
 export const multiExp: Item = {
   id: 'multi-exp',
+  nameKey: 'data.items.items.multiExp.name',
   name: 'Multi-EXP',
+  descriptionKey: 'data.items.items.multiExp.description',
   description: 'Partage l\'XP avec un Shlagémon.',
+  detailsKey: 'data.items.items.multiExp.details',
   details:
     'Permet de partager 50% de l\'XP gagnée en combat avec le Shlagémon porteur.',
   price: 20,
@@ -291,8 +348,11 @@ export const multiExp: Item = {
 
 export const thunderStone: Item = {
   id: 'pierre-foutre',
+  nameKey: 'data.items.items.thunderStone.name',
   name: 'Pierre Foutre',
+  descriptionKey: 'data.items.items.thunderStone.description',
   description: 'Permet certaines évolutions de type électrique.',
+  detailsKey: 'data.items.items.thunderStone.details',
   details: 'Fait évoluer Pikachiant en Raïchiotte.',
   price: 10,
   currency: 'shlagidiamond',
@@ -303,8 +363,11 @@ export const thunderStone: Item = {
 
 export const steroids: Item = {
   id: 'steroides',
+  nameKey: 'data.items.items.steroids.name',
   name: 'Stéroïdes',
+  descriptionKey: 'data.items.items.steroids.description',
   description: 'Permet certaines évolutions de type "gros beauf bodybuildé toxique".',
+  detailsKey: 'data.items.items.steroids.details',
   details: `Fait évoluer Macho en Masschopeur, à condition qu’il ait passé au moins 3h à la salle, sans jambes, évidemment.`,
   price: 50,
   currency: 'shlagidiamond',
@@ -316,8 +379,11 @@ export const steroids: Item = {
 
 export const ultraSteroid: Item = {
   id: 'ultra-steroide',
+  nameKey: 'data.items.items.ultraSteroid.name',
   name: 'Ultra-Stéroïde',
+  descriptionKey: 'data.items.items.ultraSteroid.description',
   description: `Une substance interdite dans 97 pays, 2 dimensions et au moins une timeline.`,
+  detailsKey: 'data.items.items.ultraSteroid.details',
   details: `Fait évoluer Masschopeur en Macintosh, une forme d’hypertrophie critique atteignant le point de non-retour. À manipuler avec des gants, une perche, et un avocat.`,
   price: 100,
   currency: 'shlagidiamond',
@@ -329,7 +395,9 @@ export const ultraSteroid: Item = {
 
 export const eggBox: Item = {
   id: 'egg-box',
+  nameKey: 'data.items.items.eggBox.name',
   name: 'Boîte à œufs',
+  descriptionKey: 'data.items.items.eggBox.description',
   description: 'Permet de stocker tous tes œufs sans encombrer l\'inventaire.',
   category: 'utilitaire',
   unique: true,
@@ -339,7 +407,9 @@ export const eggBox: Item = {
 
 export const fireEgg: Item = {
   id: 'oeuf-feu',
+  nameKey: 'data.items.items.fireEgg.name',
   name: 'Œuf Feu',
+  descriptionKey: 'data.items.items.fireEgg.description',
   description: 'Un œuf chaud bouillant.',
   price: 30,
   currency: 'shlagidolar',
@@ -350,7 +420,9 @@ export const fireEgg: Item = {
 
 export const waterEgg: Item = {
   id: 'oeuf-eau',
+  nameKey: 'data.items.items.waterEgg.name',
   name: 'Œuf Eau',
+  descriptionKey: 'data.items.items.waterEgg.description',
   description: 'Un œuf qui ruisselle.',
   price: 30,
   currency: 'shlagidolar',
@@ -361,7 +433,9 @@ export const waterEgg: Item = {
 
 export const grassEgg: Item = {
   id: 'oeuf-herbe',
+  nameKey: 'data.items.items.grassEgg.name',
   name: 'Œuf Herbe',
+  descriptionKey: 'data.items.items.grassEgg.description',
   description: 'Un œuf qui sent la pelouse.',
   price: 30,
   currency: 'shlagidolar',
@@ -372,7 +446,9 @@ export const grassEgg: Item = {
 
 export const psyEgg: Item = {
   id: 'oeuf-psy',
+  nameKey: 'data.items.items.psyEgg.name',
   name: 'Œuf Psy',
+  descriptionKey: 'data.items.items.psyEgg.description',
   description: 'Un œuf qui te fixe intensément.',
   price: 30,
   currency: 'shlagidolar',
@@ -383,7 +459,9 @@ export const psyEgg: Item = {
 
 export const thunderEgg: Item = {
   id: 'oeuf-foudre',
+  nameKey: 'data.items.items.thunderEgg.name',
   name: 'Œuf Foudre',
+  descriptionKey: 'data.items.items.thunderEgg.description',
   description: 'Un œuf parcouru d\'étincelles.',
   price: 30,
   currency: 'shlagidolar',

--- a/src/data/items/shlageball.i18n.yml
+++ b/src/data/items/shlageball.i18n.yml
@@ -1,0 +1,26 @@
+en:
+  shlageball:
+    name: Shlagéball
+    description: Used to catch wild Shlagémon.
+    details: Allows you to catch the current opponent. Lower HP means higher catch chance.
+  superShlageball:
+    name: Super Shlagéball
+    description: Improves catch chances.
+    details: Gives a small bonus when catching stubborn Shlagémon.
+  hyperShlageball:
+    name: Hyper Shlagéball
+    description: Offers very high catch chances.
+    details: Designed for tough Shlagémon, it grants a huge bonus.
+fr:
+  shlageball:
+    name: Shlagéball
+    description: Permet de capturer des Shlagémons sauvages.
+    details: Permet de capturer le Shlagémon actuellement en combat. Moins il a de points de vie, plus la chance de capture augmente.
+  superShlageball:
+    name: Super Shlagéball
+    description: Améliore les chances de capture.
+    details: Capture des Shlagémons plus récalcitrants avec un léger bonus de chance.
+  hyperShlageball:
+    name: Hyper Shlagéball
+    description: Offre de très hautes chances de capture.
+    details: Conçue pour capturer les Shlagémons coriaces, elle bénéficie d’un gros bonus.

--- a/src/data/items/shlageball.ts
+++ b/src/data/items/shlageball.ts
@@ -2,8 +2,11 @@ import type { Ball } from '~/type'
 
 export const shlageball: Ball = {
   id: 'shlageball',
+  nameKey: 'data.items.shlageball.shlageball.name',
   name: 'Shlagéball',
+  descriptionKey: 'data.items.shlageball.shlageball.description',
   description: 'Permet de capturer des Shlagémons sauvages.',
+  detailsKey: 'data.items.shlageball.shlageball.details',
   details:
     'Permet de capturer le Shlagémon actuellement en combat. Moins il a de points de vie, plus la chance de capture augmente.',
   price: 10,
@@ -16,8 +19,11 @@ export const shlageball: Ball = {
 
 export const superShlageball: Ball = {
   id: 'super-shlageball',
+  nameKey: 'data.items.shlageball.superShlageball.name',
   name: 'Super Shlagéball',
+  descriptionKey: 'data.items.shlageball.superShlageball.description',
   description: 'Améliore les chances de capture.',
+  detailsKey: 'data.items.shlageball.superShlageball.details',
   details:
     'Capture des Shlagémons plus récalcitrants avec un léger bonus de chance.',
   price: 1000,
@@ -30,8 +36,11 @@ export const superShlageball: Ball = {
 
 export const hyperShlageball: Ball = {
   id: 'hyper-shlageball',
+  nameKey: 'data.items.shlageball.hyperShlageball.name',
   name: 'Hyper Shlagéball',
+  descriptionKey: 'data.items.shlageball.hyperShlageball.description',
   description: 'Offre de très hautes chances de capture.',
+  detailsKey: 'data.items.shlageball.hyperShlageball.details',
   details:
     'Conçue pour capturer les Shlagémons coriaces, elle bénéficie d’un gros bonus.',
   price: 10000,

--- a/src/data/items/wearables/attackRing.i18n.yml
+++ b/src/data/items/wearables/attackRing.i18n.yml
@@ -1,0 +1,26 @@
+en:
+  attackRing:
+    name: Attack Ring
+    description: Increases the wearer's attack.
+    details: When worn, boosts attack by 15%. Can stack with attack potions.
+  advancedAttackRing:
+    name: Advanced Attack Ring
+    description: Strongly increases the wearer's attack.
+    details: When worn, boosts attack by 25%. Can stack with attack potions.
+  attackAmulet:
+    name: Attack Amulet
+    description: Greatly increases the wearer's attack.
+    details: When worn, boosts attack by 33%. Can stack with attack potions.
+fr:
+  attackRing:
+    name: Bague d'attaque
+    description: Augmente l'attaque du porteur.
+    details: Portée par un Shlagémon, elle augmente son attaque de 15%. Effet cumulable avec les potions d'attaque.
+  advancedAttackRing:
+    name: Bague d'attaque avancée
+    description: Augmente fortement l'attaque du porteur.
+    details: Portée par un Shlagémon, elle augmente son attaque de 25%. Effet cumulable avec les potions d'attaque.
+  attackAmulet:
+    name: Amulette d'attaque
+    description: Augmente grandement l'attaque du porteur.
+    details: Portée par un Shlagémon, elle augmente son attaque de 33%. Effet cumulable avec les potions d'attaque.

--- a/src/data/items/wearables/attackRing.ts
+++ b/src/data/items/wearables/attackRing.ts
@@ -2,8 +2,11 @@ import type { WearableItem } from '~/type/item'
 
 export const attackRing: WearableItem = {
   id: 'attack-ring',
+  nameKey: 'data.items.wearables.attackRing.attackRing.name',
   name: 'Bague d\'attaque',
+  descriptionKey: 'data.items.wearables.attackRing.attackRing.description',
   description: 'Augmente l\'attaque du porteur.',
+  detailsKey: 'data.items.wearables.attackRing.attackRing.details',
   details:
     'Portée par un Shlagémon, elle augmente son attaque de 15%. Effet cumulable avec les potions d\'attaque.',
   price: 20,
@@ -19,8 +22,11 @@ export const attackRing: WearableItem = {
 
 export const advancedAttackRing: WearableItem = {
   id: 'advanced-attack-ring',
+  nameKey: 'data.items.wearables.attackRing.advancedAttackRing.name',
   name: 'Bague d\'attaque avancée',
+  descriptionKey: 'data.items.wearables.attackRing.advancedAttackRing.description',
   description: 'Augmente fortement l\'attaque du porteur.',
+  detailsKey: 'data.items.wearables.attackRing.advancedAttackRing.details',
   details:
     'Portée par un Shlagémon, elle augmente son attaque de 25%. Effet cumulable avec les potions d\'attaque.',
   price: 50,
@@ -36,8 +42,11 @@ export const advancedAttackRing: WearableItem = {
 
 export const attackAmulet: WearableItem = {
   id: 'attack-amulet',
+  nameKey: 'data.items.wearables.attackRing.attackAmulet.name',
   name: 'Amulette d\'attaque',
+  descriptionKey: 'data.items.wearables.attackRing.attackAmulet.description',
   description: 'Augmente grandement l\'attaque du porteur.',
+  detailsKey: 'data.items.wearables.attackRing.attackAmulet.details',
   details:
     'Portée par un Shlagémon, elle augmente son attaque de 33%. Effet cumulable avec les potions d\'attaque.',
   price: 100,

--- a/src/data/items/wearables/defenseRing.i18n.yml
+++ b/src/data/items/wearables/defenseRing.i18n.yml
@@ -1,0 +1,26 @@
+en:
+  defenseRing:
+    name: Defense Ring
+    description: Increases the wearer's defense.
+    details: When worn, boosts defense by 15%. Can stack with defense potions.
+  advancedDefenseRing:
+    name: Advanced Defense Ring
+    description: Strongly increases the wearer's defense.
+    details: When worn, boosts defense by 25%. Can stack with defense potions.
+  defenseAmulet:
+    name: Defense Amulet
+    description: Greatly increases the wearer's defense.
+    details: When worn, boosts defense by 33%. Can stack with defense potions.
+fr:
+  defenseRing:
+    name: Bague de défense
+    description: Augmente la défense du porteur.
+    details: Portée par un Shlagémon, elle augmente sa défense de 15%. Effet cumulable avec les potions de défense.
+  advancedDefenseRing:
+    name: Bague de défense avancée
+    description: Augmente fortement la défense du porteur.
+    details: Portée par un Shlagémon, elle augmente sa défense de 25%. Effet cumulable avec les potions de défense.
+  defenseAmulet:
+    name: Amulette de défense
+    description: Augmente grandement la défense du porteur.
+    details: Portée par un Shlagémon, elle augmente sa défense de 33%. Effet cumulable avec les potions de défense.

--- a/src/data/items/wearables/defenseRing.ts
+++ b/src/data/items/wearables/defenseRing.ts
@@ -2,8 +2,11 @@ import type { WearableItem } from '~/type/item'
 
 export const defenseRing: WearableItem = {
   id: 'defense-ring',
+  nameKey: 'data.items.wearables.defenseRing.defenseRing.name',
   name: 'Bague de défense',
+  descriptionKey: 'data.items.wearables.defenseRing.defenseRing.description',
   description: 'Augmente la défense du porteur.',
+  detailsKey: 'data.items.wearables.defenseRing.defenseRing.details',
   details:
     'Portée par un Shlagémon, elle augmente sa défense de 15%. Effet cumulable avec les potions de défense.',
   price: 20,
@@ -19,8 +22,11 @@ export const defenseRing: WearableItem = {
 
 export const advancedDefenseRing: WearableItem = {
   id: 'advanced-defense-ring',
+  nameKey: 'data.items.wearables.defenseRing.advancedDefenseRing.name',
   name: 'Bague de défense avancée',
+  descriptionKey: 'data.items.wearables.defenseRing.advancedDefenseRing.description',
   description: 'Augmente fortement la défense du porteur.',
+  detailsKey: 'data.items.wearables.defenseRing.advancedDefenseRing.details',
   details:
     'Portée par un Shlagémon, elle augmente sa défense de 25%. Effet cumulable avec les potions de défense.',
   price: 50,
@@ -36,8 +42,11 @@ export const advancedDefenseRing: WearableItem = {
 
 export const defenseAmulet: WearableItem = {
   id: 'defense-amulet',
+  nameKey: 'data.items.wearables.defenseRing.defenseAmulet.name',
   name: 'Amulette de défense',
+  descriptionKey: 'data.items.wearables.defenseRing.defenseAmulet.description',
   description: 'Augmente grandement la défense du porteur.',
+  detailsKey: 'data.items.wearables.defenseRing.defenseAmulet.details',
   details:
     'Portée par un Shlagémon, elle augmente sa défense de 33%. Effet cumulable avec les potions de défense.',
   price: 100,

--- a/src/data/items/wearables/vitalityRing.i18n.yml
+++ b/src/data/items/wearables/vitalityRing.i18n.yml
@@ -1,0 +1,26 @@
+en:
+  vitalityRing:
+    name: Vitality Ring
+    description: Increases the wearer's max HP.
+    details: When worn, increases max HP by 15%. Can stack with vitality potions.
+  advancedVitalityRing:
+    name: Advanced Vitality Ring
+    description: Strongly increases the wearer's max HP.
+    details: When worn, increases max HP by 25%. Can stack with vitality potions.
+  vitalityAmulet:
+    name: Vitality Amulet
+    description: Greatly increases the wearer's max HP.
+    details: When worn, increases max HP by 33%. Can stack with vitality potions.
+fr:
+  vitalityRing:
+    name: Bague Vitalesque
+    description: Augmente les PV max du porteur.
+    details: Portée par un Shlagémon, elle augmente ses PV maximum de 15%. Effet cumulable avec les potions de vitalité.
+  advancedVitalityRing:
+    name: Bague Vitalesque avancée
+    description: Augmente fortement les PV max du porteur.
+    details: Portée par un Shlagémon, elle augmente ses PV maximum de 25%. Effet cumulable avec les potions de vitalité.
+  vitalityAmulet:
+    name: Amulette Vitalesque
+    description: Augmente grandement les PV max du porteur.
+    details: Portée par un Shlagémon, elle augmente ses PV maximum de 33%. Effet cumulable avec les potions de vitalité.

--- a/src/data/items/wearables/vitalityRing.ts
+++ b/src/data/items/wearables/vitalityRing.ts
@@ -2,8 +2,11 @@ import type { WearableItem } from '~/type/item'
 
 export const vitalityRing: WearableItem = {
   id: 'vitality-ring',
+  nameKey: 'data.items.wearables.vitalityRing.vitalityRing.name',
   name: 'Bague Vitalesque',
+  descriptionKey: 'data.items.wearables.vitalityRing.vitalityRing.description',
   description: 'Augmente les PV max du porteur.',
+  detailsKey: 'data.items.wearables.vitalityRing.vitalityRing.details',
   details:
     'Portée par un Shlagémon, elle augmente ses PV maximum de 15%. Effet cumulable avec les potions de vitalité.',
   price: 20,
@@ -19,8 +22,11 @@ export const vitalityRing: WearableItem = {
 
 export const advancedVitalityRing: WearableItem = {
   id: 'advanced-vitality-ring',
+  nameKey: 'data.items.wearables.vitalityRing.advancedVitalityRing.name',
   name: 'Bague Vitalesque avancée',
+  descriptionKey: 'data.items.wearables.vitalityRing.advancedVitalityRing.description',
   description: 'Augmente fortement les PV max du porteur.',
+  detailsKey: 'data.items.wearables.vitalityRing.advancedVitalityRing.details',
   details:
     'Portée par un Shlagémon, elle augmente ses PV maximum de 25%. Effet cumulable avec les potions de vitalité.',
   price: 50,
@@ -36,8 +42,11 @@ export const advancedVitalityRing: WearableItem = {
 
 export const vitalityAmulet: WearableItem = {
   id: 'vitality-amulet',
+  nameKey: 'data.items.wearables.vitalityRing.vitalityAmulet.name',
   name: 'Amulette Vitalesque',
+  descriptionKey: 'data.items.wearables.vitalityRing.vitalityAmulet.description',
   description: 'Augmente grandement les PV max du porteur.',
+  detailsKey: 'data.items.wearables.vitalityRing.vitalityAmulet.details',
   details:
     'Portée par un Shlagémon, elle augmente ses PV maximum de 33%. Effet cumulable avec les potions de vitalité.',
   price: 100,

--- a/src/data/items/wearables/xpRing.i18n.yml
+++ b/src/data/items/wearables/xpRing.i18n.yml
@@ -1,0 +1,26 @@
+en:
+  xpRing:
+    name: Experience Ring
+    description: Increases the wearer's XP.
+    details: When worn, increases experience gained in battle by 15%. Can stack with XP potions.
+  advancedXpRing:
+    name: Advanced Experience Ring
+    description: Strongly increases the wearer's XP.
+    details: When worn, increases experience gained in battle by 25%. Can stack with XP potions.
+  xpAmulet:
+    name: Experience Amulet
+    description: Greatly increases the wearer's XP.
+    details: When worn, increases experience gained in battle by 33%. Can stack with XP potions.
+fr:
+  xpRing:
+    name: Anneau d'expérience
+    description: Augmente l'XP du porteur.
+    details: Porté par un Shlagémon, il augmente l'expérience gagnée en combat de 15%. Effet cumulable avec les potions d'expérience.
+  advancedXpRing:
+    name: Anneau d'expérience avancé
+    description: Augmente fortement l'XP du porteur.
+    details: Porté par un Shlagémon, il augmente l'expérience gagnée en combat de 25%. Effet cumulable avec les potions d'expérience.
+  xpAmulet:
+    name: Amulette d'expérience
+    description: Augmente grandement l'XP du porteur.
+    details: Portée par un Shlagémon, elle augmente l'expérience gagnée en combat de 33%. Effet cumulable avec les potions d'expérience.

--- a/src/data/items/wearables/xpRing.ts
+++ b/src/data/items/wearables/xpRing.ts
@@ -2,8 +2,11 @@ import type { WearableItem } from '~/type/item'
 
 export const xpRing: WearableItem = {
   id: 'xp-ring',
+  nameKey: 'data.items.wearables.xpRing.xpRing.name',
   name: 'Anneau d\'expérience',
+  descriptionKey: 'data.items.wearables.xpRing.xpRing.description',
   description: 'Augmente l\'XP du porteur.',
+  detailsKey: 'data.items.wearables.xpRing.xpRing.details',
   details:
     'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 15%. Effet cumulable avec les potions d\'expérience.',
   price: 20,
@@ -19,8 +22,11 @@ export const xpRing: WearableItem = {
 
 export const advancedXpRing: WearableItem = {
   id: 'advanced-xp-ring',
+  nameKey: 'data.items.wearables.xpRing.advancedXpRing.name',
   name: 'Anneau d\'expérience avancé',
+  descriptionKey: 'data.items.wearables.xpRing.advancedXpRing.description',
   description: 'Augmente fortement l\'XP du porteur.',
+  detailsKey: 'data.items.wearables.xpRing.advancedXpRing.details',
   details:
     'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 25%. Effet cumulable avec les potions d\'expérience.',
   price: 50,
@@ -36,8 +42,11 @@ export const advancedXpRing: WearableItem = {
 
 export const xpAmulet: WearableItem = {
   id: 'xp-amulet',
+  nameKey: 'data.items.wearables.xpRing.xpAmulet.name',
   name: 'Amulette d\'expérience',
+  descriptionKey: 'data.items.wearables.xpRing.xpAmulet.description',
   description: 'Augmente grandement l\'XP du porteur.',
+  detailsKey: 'data.items.wearables.xpRing.xpAmulet.details',
   details:
     'Portée par un Shlagémon, elle augmente l\'expérience gagnée en combat de 33%. Effet cumulable avec les potions d\'expérience.',
   price: 100,

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -5,12 +5,18 @@ export type ItemCategory = 'actif' | 'passif' | 'utilitaire'
 export interface Item {
   id: string
   name: string
+  /** i18n key for the name */
+  nameKey?: string
   description: string
+  /** i18n key for the description */
+  descriptionKey?: string
   /**
    * Detailed explanation of how the item works.
    * When not provided, `description` will be used instead.
    */
   details?: string
+  /** i18n key for the details */
+  detailsKey?: string
   price?: number
   /** Currency used to buy this item. Defaults to shlagidolar. */
   currency?: ItemCurrency


### PR DESCRIPTION
## Summary
- allow item model to reference name/description/details i18n keys
- move hard-coded texts of items into `.i18n.yml` files
- display translated item names and descriptions in components
- update locale data with new item keys

## Testing
- `pnpm i18n`
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_68816b46788c832a8cb45d9d562dfaa9