### PR TITLE
Add i18n for ShlagMind messages

### DIFF
--- a/src/components/minigame/MiniGameShlagMind.i18n.yml
+++ b/src/components/minigame/MiniGameShlagMind.i18n.yml
@@ -8,6 +8,8 @@ fr:
     - Rarement vu quelqu'un aussi merdique.
   validate: Valider
   attemptsLeft: '{n} tentatives restantes'
+  win: "T'as percé le cerveau d'un Shlag !"
+  lose: Même un Petmorv y serait arrivé
 en:
   messages:
     - You're getting closer... or not.
@@ -18,3 +20,5 @@ en:
     - Rarely seen someone so pathetic.
   validate: Validate
   attemptsLeft: '{n} attempts left'
+  win: "You've cracked a Shlag's mind!"
+  lose: Even a Grimer would have done it

--- a/src/components/minigame/MiniGameShlagMind.vue
+++ b/src/components/minigame/MiniGameShlagMind.vue
@@ -89,7 +89,7 @@ function validate() {
   feedback.value.push(res)
   const win = res.every(r => r === 'green')
   if (win) {
-    message.value = 'T\u2019as perc\u00E9 le cerveau d\u2019un Shlag !'
+    message.value = t('components.minigame.MiniGameShlagMind.win')
     showConfetti.value = true
     useTimeoutFn(() => {
       showConfetti.value = false
@@ -97,7 +97,7 @@ function validate() {
     }, 1200)
   }
   else if (attempts.value.length >= maxAttempts) {
-    message.value = 'M\u00EAme un Petmorv y serait arriv\u00E9'
+    message.value = t('components.minigame.MiniGameShlagMind.lose')
     useTimeoutFn(() => emit('lose'), 1200)
   }
   else {
@@ -152,7 +152,7 @@ initGame()
       <div
         v-if="
           attemptsLeft > 0
-            && message !== 'T\u2019as perc\u00e9 le cerveau d\u2019un Shlag !'
+            && message !== t('components.minigame.MiniGameShlagMind.win')
         "
         class="flex items-center justify-between"
       >


### PR DESCRIPTION
## Summary
- translate win and lose messages for ShlagMind
- use i18n keys in MiniGameShlagMind component

## Testing
- `pnpm run i18n`
- `pnpm test` *(fails: 49 failed, 40 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881e418ab6c832a9944c861efeaba8d