### PR TITLE
Implement auto-select on equipment except Multi-EXP

### DIFF
--- a/src/stores/equipment.ts
+++ b/src/stores/equipment.ts
@@ -40,6 +40,8 @@ export const useEquipmentStore = defineStore('equipment', () => {
     inventory.remove(itemId)
     if (isVitalityItem(itemId))
       mon.hpCurrent = dex.maxHp(mon)
+    if (itemId !== 'multi-exp')
+      dex.setActiveShlagemon(mon)
   }
 
   function unequip(monId: string) {


### PR DESCRIPTION
## Summary
- auto select a Shlagemon when equipping any item
- skip auto selection for `multi-exp`

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue` mismatched and multiple tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881ef5dad88832a90ec61f043de78ba