### PR TITLE
Prevent legendary shlagemons from hatching

### DIFF
--- a/src/stores/egg.ts
+++ b/src/stores/egg.ts
@@ -3,7 +3,6 @@ import type { TypeName } from '~/data/shlagemons-type'
 import type { BaseShlagemon } from '~/type'
 import { defineStore } from 'pinia'
 import { allShlagemons } from '~/data/shlagemons'
-import { mewteub } from '~/data/shlagemons/mewteub'
 import { eggSerializer } from '~/utils/egg-serialize'
 import { pickRandomByCoefficient } from '~/utils/spawn'
 
@@ -24,11 +23,9 @@ export const useEggStore = defineStore('egg', () => {
   function startIncubation(type: EggType) {
     if (incubator.value.length >= 4)
       return false
-    let candidates = allShlagemons.filter(b =>
-      b.types.some(t => t.id === type),
-    )
-    if (type === 'psy')
-      candidates = candidates.filter(b => b.id !== mewteub.id)
+    const candidates = allShlagemons
+      .filter(b => b.types.some(t => t.id === type))
+      .filter(b => !b.legendary)
     const base = pickRandomByCoefficient(candidates)
     const duration = (base.coefficient / 10) * 60_000
     const startedAt = Date.now()

--- a/src/stores/eggMonsModal.ts
+++ b/src/stores/eggMonsModal.ts
@@ -4,7 +4,6 @@ import type { Item } from '~/type/item'
 import { defineStore } from 'pinia'
 import { eggTypeMap } from '~/constants/egg'
 import { allShlagemons } from '~/data/shlagemons'
-import { mewteub } from '~/data/shlagemons/mewteub'
 
 export const useEggMonsModalStore = defineStore('eggMonsModal', () => {
   const { isVisible, open: openModal, close } = createModalStore()
@@ -17,7 +16,7 @@ export const useEggMonsModalStore = defineStore('eggMonsModal', () => {
       return []
     return allShlagemons
       .filter(b => b.types.some(t => t.id === type.value))
-      .filter(b => !(type.value === 'psy' && b.id === mewteub.id))
+      .filter(b => !b.legendary)
   })
 
   function open(id: EggItemId, eggItem: Item) {


### PR DESCRIPTION
## Summary
- remove old Mewteub specific filter for eggs
- exclude legendary shlagemons when incubating eggs
- hide legendary shlagemons in egg modal

## Testing
- `pnpm typecheck` *(fails: PersistedStateOptions not found)*
- `pnpm test` *(fails to resolve component imports)*

------
https://chatgpt.com/codex/tasks/task_e_6881f326f63c832a9791683679b736ec