### PR TITLE
Refactor item id usage

### DIFF
--- a/cypress/e2e/multi-exp.spec.ts
+++ b/cypress/e2e/multi-exp.spec.ts
@@ -1,9 +1,11 @@
+import { multiExp } from '../../src/data/items/items'
+
 describe('multi-exp item', () => {
   beforeEach(() => {
     cy.visit('/', {
       onBeforeLoad(win) {
         win.localStorage.clear()
-        win.localStorage.setItem('inventory', JSON.stringify({ items: { 'multi-exp': 1 } }))
+        win.localStorage.setItem('inventory', JSON.stringify({ items: { [multiExp.id]: 1 } }))
       },
     })
   })

--- a/src/components/dialog/AttackPotionDialog.vue
+++ b/src/components/dialog/AttackPotionDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { attackPotion } from '~/data/items/items'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
@@ -39,7 +40,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.AttackPotionDialog.steps.step4.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add('attack-potion', 1)
+          inventory.add(attackPotion.id, 1)
           emit('done', 'attackPotion')
         },
       },

--- a/src/components/dialog/CapturePotionDialog.vue
+++ b/src/components/dialog/CapturePotionDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { capturePotion } from '~/data/items/items'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
@@ -47,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.CapturePotionDialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add('capture-potion', 1)
+          inventory.add(capturePotion.id, 1)
           emit('done', 'capturePotion')
         },
       },

--- a/src/components/dialog/EggBoxDialog.vue
+++ b/src/components/dialog/EggBoxDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { eggBox } from '~/data/items/items'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
@@ -42,7 +43,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         action: () => {
           box.unlock()
           box.importFromInventory(inventory.items as any)
-          inventory.add('egg-box')
+          inventory.add(eggBox.id)
           emit('done', 'eggBox')
         },
       },

--- a/src/components/dialog/FirstLossDialog.vue
+++ b/src/components/dialog/FirstLossDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { potion } from '~/data/items/items'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
@@ -43,7 +44,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.FirstLossDialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add('potion', 10)
+          inventory.add(potion.id, 10)
           emit('done', 'firstLoss')
         },
       },

--- a/src/components/dialog/KingUnlockDialog.vue
+++ b/src/components/dialog/KingUnlockDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { defensePotion } from '~/data/items/items'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
@@ -55,7 +56,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.KingUnlockDialog.steps.step6.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add('defense-potion', 1)
+          inventory.add(defensePotion.id, 1)
           emit('done', 'kingUnlock')
         },
       },

--- a/src/components/dialog/Level5Dialog.vue
+++ b/src/components/dialog/Level5Dialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { shlageball } from '~/data/items/shlageball'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
@@ -47,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.Level5Dialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add('shlageball', 10)
+          inventory.add(shlageball.id, 10)
           emit('done', 'level5')
         },
       },

--- a/src/components/dialog/NewZoneDialog.vue
+++ b/src/components/dialog/NewZoneDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
+import { xpPotion } from '~/data/items/items'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
@@ -41,7 +42,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.NewZoneDialog.steps.step4.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add('xp-potion', 1)
+          inventory.add(xpPotion.id, 1)
           visit.markAllAccessibleVisited()
           mobile.set('zones')
           emit('done', 'newZone')

--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { storeToRefs } from 'pinia'
+import { eggBox } from '~/data/items/items'
 import { ballHues } from '~/utils/ball'
 
 const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
@@ -26,7 +27,7 @@ const ballFilter = computed(() =>
 )
 
 const isEgg = computed(() => props.item.id.startsWith('oeuf-'))
-const isEggBox = computed(() => props.item.id === 'egg-box')
+const isEggBox = computed(() => props.item.id === eggBox.id)
 
 const actionLabel = computed(() => {
   if (isEggBox.value)

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -4,6 +4,7 @@ import type { BallId } from '~/data/items/shlageball'
 import type { Item, ItemCategory } from '~/type/item'
 import { defineComponent, h } from 'vue'
 import { toast } from 'vue3-toastify'
+import { eggBox as eggBoxItem } from '~/data/items/items'
 import InventoryItemCard from '../inventory/ItemCard.vue'
 
 const inventory = useInventoryStore()
@@ -149,7 +150,7 @@ function onUse(item: Item) {
   else if (item.wearable) {
     wearableStore.open(item)
   }
-  else if (item.id === 'egg-box') {
+  else if (item.id === eggBoxItem.id) {
     eggBox.open()
     usage.markUsed(item.id)
   }

--- a/src/stores/ball.ts
+++ b/src/stores/ball.ts
@@ -1,9 +1,9 @@
 import type { BallId } from '~/data/items/shlageball'
 import { defineStore } from 'pinia'
-import { balls } from '~/data/items/shlageball'
+import { balls, shlageball } from '~/data/items/shlageball'
 
 export const useBallStore = defineStore('ball', () => {
-  const current = ref<BallId>('shlageball')
+  const current = ref<BallId>(shlageball.id)
   const isVisible = ref(false)
 
   const currentBall = computed(() =>
@@ -24,7 +24,7 @@ export const useBallStore = defineStore('ball', () => {
   }
 
   function reset() {
-    current.value = 'shlageball'
+    current.value = shlageball.id
   }
 
   return { current, currentBall, isVisible, open, close, setBall, reset }

--- a/src/stores/equipment.ts
+++ b/src/stores/equipment.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { multiExp } from '~/data/items/items'
 
 export const useEquipmentStore = defineStore('equipment', () => {
   const holders = ref<Record<string, string | null>>({})
@@ -40,7 +41,7 @@ export const useEquipmentStore = defineStore('equipment', () => {
     inventory.remove(itemId)
     if (isVitalityItem(itemId))
       mon.hpCurrent = dex.maxHp(mon)
-    if (itemId !== 'multi-exp')
+    if (itemId !== multiExp.id)
       dex.setActiveShlagemon(mon)
   }
 

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -1,7 +1,12 @@
 import type { ItemId } from '~/data/items/items'
 import type { Item } from '~/type/item'
 import { defineStore } from 'pinia'
-import { allItems } from '~/data/items/items'
+import {
+  allItems,
+  hyperShlageball,
+  shlageball,
+  superShlageball,
+} from '~/data/items/items'
 import { allShlagemons } from '~/data/shlagemons'
 
 export const useInventoryStore = defineStore('inventory', () => {
@@ -102,13 +107,13 @@ export const useInventoryStore = defineStore('inventory', () => {
     }
 
     const handlers: Record<ItemId, () => boolean> = {
-      'egg-box': () => {
+      [eggBox.id]: () => {
         eggBox.open()
         return true
       },
-      'shlageball': capture,
-      'super-shlageball': capture,
-      'hyper-shlageball': capture,
+      [shlageball.id]: capture,
+      [superShlageball.id]: capture,
+      [hyperShlageball.id]: capture,
     }
 
     const typeHandlers: Record<string, (power: number) => boolean> = {

--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -1,7 +1,12 @@
 import type { ItemId } from '~/data/items/items'
 import type { BallId } from '~/data/items/shlageball'
 import { defineStore } from 'pinia'
-import { allItems } from '~/data/items/items'
+import {
+  allItems,
+  hyperPotion,
+  potion,
+  superPotion,
+} from '~/data/items/items'
 
 export interface UseItemAction {
   type: 'use-item'
@@ -16,9 +21,9 @@ export interface ShortcutEntry {
 }
 
 const defaultShortcuts: ShortcutEntry[] = [
-  { key: 'a', action: { type: 'use-item', itemId: 'potion' } },
-  { key: 'z', action: { type: 'use-item', itemId: 'super-potion' } },
-  { key: 'e', action: { type: 'use-item', itemId: 'hyper-potion' } },
+  { key: 'a', action: { type: 'use-item', itemId: potion.id } },
+  { key: 'z', action: { type: 'use-item', itemId: superPotion.id } },
+  { key: 'e', action: { type: 'use-item', itemId: hyperPotion.id } },
 ]
 
 export const useShortcutsStore = defineStore('shortcuts', () => {

--- a/test/battlecapture.test.ts
+++ b/test/battlecapture.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import BattleCapture from '../src/components/battle/BattleCapture.vue'
+import { shlageball } from '../src/data/items/shlageball'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useBallStore } from '../src/stores/ball'
 import { useInventoryStore } from '../src/stores/inventory'
@@ -20,8 +21,8 @@ describe('battleCapture', () => {
     const inventory = useInventoryStore()
     const player = usePlayerStore()
 
-    ball.current = 'shlageball'
-    inventory.add('shlageball')
+    ball.current = shlageball.id
+    inventory.add(shlageball.id)
     player.captureLevelCap = 100
 
     const enemy = createDexShlagemon(carapouffe)

--- a/test/feature-lock.test.ts
+++ b/test/feature-lock.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import InventoryPanel from '../src/components/panel/Inventory.vue'
 import ZonePanel from '../src/components/panel/Zone.vue'
 import ShlagemonList from '../src/components/shlagemon/ShlagemonList.vue'
+import { potion } from '../src/data/items/items'
 import { carapouffe } from '../src/data/shlagemons'
 import { useFeatureLockStore } from '../src/stores/featureLock'
 import { useInventoryStore } from '../src/stores/inventory'
@@ -42,7 +43,7 @@ describe('feature lock flags', () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     const inventory = useInventoryStore()
-    inventory.add('potion')
+    inventory.add(potion.id)
     const featureLock = useFeatureLockStore()
     featureLock.lockInventory()
     const wrapper = mount(InventoryPanel, { global: { plugins: [pinia] } })

--- a/test/inventory.test.ts
+++ b/test/inventory.test.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
+import { potion, shlageball } from '../src/data/items/items'
 import { carapouffe } from '../src/data/shlagemons'
 import { useCaptureLimitModalStore } from '../src/stores/captureLimitModal'
 import { useInventoryStore } from '../src/stores/inventory'
@@ -14,8 +15,8 @@ describe('inventory actions', () => {
     const mon = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(mon)
     mon.hpCurrent = 10
-    inventory.add('potion')
-    const result = inventory.useItem('potion')
+    inventory.add(potion.id)
+    const result = inventory.useItem(potion.id)
     expect(result).toBe(true)
     expect(mon.hpCurrent).toBeGreaterThan(10)
   })
@@ -25,8 +26,8 @@ describe('inventory actions', () => {
     const inventory = useInventoryStore()
     const dex = useShlagedexStore()
     const count = dex.shlagemons.length
-    inventory.add('shlageball')
-    const result = inventory.useItem('shlageball')
+    inventory.add(shlageball.id)
+    const result = inventory.useItem(shlageball.id)
     expect(result).toBe(true)
     expect(dex.shlagemons.length).toBe(count + 1)
   })
@@ -39,8 +40,8 @@ describe('inventory actions', () => {
     const modal = useCaptureLimitModalStore()
 
     player.captureLevelCap = 0
-    inventory.add('shlageball')
-    const result = inventory.useItem('shlageball')
+    inventory.add(shlageball.id)
+    const result = inventory.useItem(shlageball.id)
 
     expect(result).toBe(false)
     expect(dex.shlagemons.length).toBe(0)

--- a/test/shortcuts.test.ts
+++ b/test/shortcuts.test.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
+import { potion, superPotion } from '../src/data/items/items'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useInventoryStore } from '../src/stores/inventory'
 import { useShlagedexStore } from '../src/stores/shlagedex'
@@ -16,14 +17,14 @@ describe('shortcuts', () => {
     // need an active shlagemon for potions to work
     const mon = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(mon)
-    inventory.add('potion')
-    inventory.add('super-potion')
+    inventory.add(potion.id)
+    inventory.add(superPotion.id)
     shortcuts.shortcuts = [
-      { key: 'a', action: { type: 'use-item', itemId: 'potion' } },
-      { key: 'a', action: { type: 'use-item', itemId: 'super-potion' } },
+      { key: 'a', action: { type: 'use-item', itemId: potion.id } },
+      { key: 'a', action: { type: 'use-item', itemId: superPotion.id } },
     ]
     shortcuts.handleKeydown(new KeyboardEvent('keydown', { key: 'a' }))
-    expect(inventory.items.potion).toBeUndefined()
-    expect(inventory.items['super-potion']).toBeUndefined()
+    expect(inventory.items[potion.id]).toBeUndefined()
+    expect(inventory.items[superPotion.id]).toBeUndefined()
   })
 })

--- a/test/sort-item.test.ts
+++ b/test/sort-item.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import Shlagedex from '../src/components/panel/Shlagedex.vue'
+import { potion } from '../src/data/items/items'
 import { carapouffe, sacdepates } from '../src/data/shlagemons'
 import { useDexFilterStore } from '../src/stores/dexFilter'
 import { useShlagedexStore } from '../src/stores/shlagedex'
@@ -14,7 +15,7 @@ describe('shlagedex sort item', () => {
     const filter = useDexFilterStore()
     const withoutItem = dex.createShlagemon(carapouffe, false)
     const withItem = dex.createShlagemon(sacdepates, false)
-    withItem.heldItemId = 'potion'
+    withItem.heldItemId = potion.id
     filter.sortBy = 'item'
     const wrapper = mount(Shlagedex, {
       global: {


### PR DESCRIPTION
## Summary
- reference item IDs via constants instead of raw strings
- update dialogs and stores to use item constants
- adjust tests to use item constants

## Testing
- `pnpm test` *(fails: Snapshots 1 failed; Test Files 31 failed | 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881f3d5a8a4832a93a6cd674186a1ed