### PR TITLE
Disable locked zone map markers

### DIFF
--- a/src/components/leaflet/map.vue
+++ b/src/components/leaflet/map.vue
@@ -31,15 +31,18 @@ onMounted(() => {
   const markers = useMapMarkers(map)
   const { drawPolylineWithBorder } = useMapPaths(map)
 
+  const dex = useShlagedexStore()
+  const { canAccess, accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
+
   zones.forEach((zone) => {
-    if (zone.position)
-      markers.addMarker(zone, selectZone)
+    if (!zone.position)
+      return
+    const locked = !canAccess(zone)
+    markers.addMarker(zone, selectZone, locked)
   })
 
   const savageZones = zones.filter(z => z.type === 'sauvage' && z.position)
   const villages = zones.filter(z => z.type === 'village' && z.position)
-  const dex = useShlagedexStore()
-  const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
 
   const lines = ref<Polyline[]>([])
 

--- a/src/composables/leaflet/useLeafletMarker.ts
+++ b/src/composables/leaflet/useLeafletMarker.ts
@@ -6,15 +6,19 @@ export function useLeafletMarker(options: {
   position: LatLngExpression
   iconUrl?: string
   size?: number
+  className?: string
+  interactive?: boolean
 }): Marker {
-  const { map, position, iconUrl } = options
+  const { map, position, iconUrl, className } = options
   const size = options.size || 48
   const marker = new Marker(position, {
+    interactive: options.interactive ?? true,
     icon: iconUrl
       ? new Icon({
         iconUrl,
         iconSize: [size, size],
         iconAnchor: [Math.round(size / 2), size],
+        className,
       })
       : undefined,
   })

--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -7,14 +7,16 @@ export function useMapMarkers(map: LeafletMap) {
     return `/map/icons/${id}.webp`
   }
 
-  function addMarker(zone: Zone, onSelect?: (id: ZoneId) => void) {
+  function addMarker(zone: Zone, onSelect?: (id: ZoneId) => void, inactive = false) {
     const marker = useLeafletMarker({
       map,
       position: [zone.position.lat, zone.position.lng] as LatLngExpression,
       iconUrl: iconPath(zone.id),
       size: 48,
+      className: inactive ? 'grayscale opacity-50' : undefined,
+      interactive: !inactive,
     })
-    if (onSelect)
+    if (onSelect && !inactive)
       marker.on('click', () => onSelect(zone.id))
     return marker
   }


### PR DESCRIPTION
## Summary
- respect zone access rules when creating map markers
- mark locked zones as inactive and prevent clicks

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68825d614fa8832a8adfef2af5bb9e7f