### PR TITLE
Add marker completion icons

### DIFF
--- a/src/components/zone/ButtonVillage.vue
+++ b/src/components/zone/ButtonVillage.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import type { Zone } from '~/type/zone'
+import { useZoneCompletion } from '~/composables/useZoneCompletion'
 
 const props = defineProps<{ zone: Zone }>()
 const zoneStore = useZoneStore()
 const panel = useMainPanelStore()
 const arena = useArenaStore()
-const progress = useZoneProgressStore()
 const dialog = useDialogStore()
 const featureLock = useFeatureLockStore()
 const visit = useZoneVisitStore()
+const { arenaCompleted } = useZoneCompletion(props.zone)
 
 const zoneButtonsDisabled = computed(
   () =>
@@ -60,7 +61,7 @@ function classes() {
       <span>{{ props.zone.name }}</span>
     </div>
     <div class="h-4 flex items-center justify-center gap-2">
-      <div v-if="progress.isArenaCompleted(props.zone.id)" class="i-mdi:sword-cross h-4 w-4" />
+      <div v-if="arenaCompleted" class="i-mdi:sword-cross h-4 w-4" />
       <div v-else-if="props.zone.arena" class="i-mdi:sword-cross h-4 w-4 opacity-50 grayscale" />
     </div>
   </button>

--- a/src/components/zone/ButtonWild.vue
+++ b/src/components/zone/ButtonWild.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import type { SavageZone } from '~/type/zone'
+import { useZoneCompletion } from '~/composables/useZoneCompletion'
 
 const props = defineProps<{ zone: SavageZone }>()
 const zoneStore = useZoneStore()
 const dex = useShlagedexStore()
 const panel = useMainPanelStore()
 const arena = useArenaStore()
-const progress = useZoneProgressStore()
 const dialog = useDialogStore()
 const featureLock = useFeatureLockStore()
 const visit = useZoneVisitStore()
@@ -55,27 +55,7 @@ function classes() {
   return classes.join(' ')
 }
 
-function allCaptured() {
-  const list = props.zone.shlagemons
-  if (!list?.length)
-    return false
-  return list.every(base => dex.shlagemons.some(mon => mon.base.id === base.id))
-}
-
-function perfectZone() {
-  const list = props.zone.shlagemons
-  if (!list?.length)
-    return false
-  return list.every((base) => {
-    const mon = dex.shlagemons.find(m => m.base.id === base.id)
-    return mon?.rarity === 100
-  })
-}
-
-function kingDefeated() {
-  const hasKing = props.zone.hasKing ?? props.zone.type === 'sauvage'
-  return hasKing && progress.isKingDefeated(props.zone.id)
-}
+const { allCaptured, perfectZone, kingDefeated } = useZoneCompletion(props.zone)
 
 const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
 </script>
@@ -101,14 +81,14 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
     </div>
     <div class="flex items-center justify-center gap-2">
       <img
-        v-if="allCaptured()"
+        v-if="allCaptured"
         src="/items/shlageball/shlageball.webp"
         :alt="t('components.panel.Zone.capturedAlt')"
         class="h-4 w-4"
-        :style="perfectZone() ? { filter: 'hue-rotate(60deg) brightness(1.1)' } : {}"
+        :style="perfectZone ? { filter: 'hue-rotate(60deg) brightness(1.1)' } : {}"
       >
       <div
-        v-if="kingDefeated()"
+        v-if="kingDefeated"
         class="i-game-icons:crown h-4 w-4"
       />
     </div>

--- a/src/composables/leaflet/useLeafletMarker.ts
+++ b/src/composables/leaflet/useLeafletMarker.ts
@@ -1,26 +1,37 @@
 import type { LatLngExpression, Map as LeafletMap } from 'leaflet'
-import { Icon, Marker } from 'leaflet'
+import { DivIcon, Icon, Marker } from 'leaflet'
 
 export function useLeafletMarker(options: {
   map: LeafletMap
   position: LatLngExpression
   iconUrl?: string
+  html?: string
   size?: number
+  anchorY?: number
   className?: string
   interactive?: boolean
 }): Marker {
-  const { map, position, iconUrl, className } = options
+  const { map, position, iconUrl, html, className } = options
   const size = options.size || 48
+  const anchorY = options.anchorY ?? size
+  const icon = iconUrl
+    ? new Icon({
+      iconUrl,
+      iconSize: [size, size],
+      iconAnchor: [Math.round(size / 2), anchorY],
+      className,
+    })
+    : html
+      ? new DivIcon({
+        html,
+        className,
+        iconSize: [size, size],
+        iconAnchor: [Math.round(size / 2), anchorY],
+      })
+      : undefined
   const marker = new Marker(position, {
     interactive: options.interactive ?? true,
-    icon: iconUrl
-      ? new Icon({
-        iconUrl,
-        iconSize: [size, size],
-        iconAnchor: [Math.round(size / 2), size],
-        className,
-      })
-      : undefined,
+    icon,
   })
 
   marker.addTo(map)

--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -1,5 +1,8 @@
 import type { LatLngExpression, Map as LeafletMap } from 'leaflet'
 import type { Zone, ZoneId } from '~/type'
+import { DivIcon } from 'leaflet'
+import { watch } from 'vue'
+import { useZoneCompletion } from '~/composables/useZoneCompletion'
 import { useLeafletMarker } from './useLeafletMarker'
 
 export function useMapMarkers(map: LeafletMap) {
@@ -8,14 +11,40 @@ export function useMapMarkers(map: LeafletMap) {
   }
 
   function addMarker(zone: Zone, onSelect?: (id: ZoneId) => void, inactive = false) {
+    const { allCaptured, perfectZone, kingDefeated, arenaCompleted } = useZoneCompletion(zone)
+
+    function buildHtml() {
+      const size = 48
+      const icon = `<img src="${iconPath(zone.id)}" class="w-${size} h-${size} block" />`
+      const ball = allCaptured.value
+        ? `<img src="/items/shlageball/shlageball.webp" class="h-3 w-3${perfectZone.value ? ' filter-[hue-rotate(60deg)_brightness(1.1)]' : ''}" />`
+        : ''
+      const crown = kingDefeated.value ? '<div class="i-game-icons:crown h-3 w-3"></div>' : ''
+      const arena = arenaCompleted.value
+        ? '<div class="i-mdi:sword-cross h-3 w-3"></div>'
+        : zone.arena
+          ? '<div class="i-mdi:sword-cross h-3 w-3 opacity-50 grayscale"></div>'
+          : ''
+      const icons = [ball, crown, arena].filter(Boolean).join('')
+      return `<div class="flex flex-col items-center ${inactive ? 'grayscale opacity-50' : ''}">
+        ${icon}
+        <div class="flex gap-0.5 mt-1">${icons}</div>
+      </div>`
+    }
+
     const marker = useLeafletMarker({
       map,
       position: [zone.position.lat, zone.position.lng] as LatLngExpression,
-      iconUrl: iconPath(zone.id),
-      size: 48,
-      className: inactive ? 'grayscale opacity-50' : undefined,
+      html: buildHtml(),
+      size: 60,
+      anchorY: 48,
       interactive: !inactive,
     })
+
+    watch([allCaptured, perfectZone, kingDefeated, arenaCompleted], () => {
+      marker.setIcon(new DivIcon({ html: buildHtml(), iconSize: [60, 60], iconAnchor: [30, 48] }))
+    })
+
     if (onSelect && !inactive)
       marker.on('click', () => onSelect(zone.id))
     return marker

--- a/src/composables/useZoneCompletion.ts
+++ b/src/composables/useZoneCompletion.ts
@@ -1,0 +1,35 @@
+import type { Zone } from '~/type'
+import { computed } from 'vue'
+import { useShlagedexStore } from '~/stores/shlagedex'
+import { useZoneProgressStore } from '~/stores/zoneProgress'
+
+export function useZoneCompletion(zone: Zone) {
+  const dex = useShlagedexStore()
+  const progress = useZoneProgressStore()
+
+  const allCaptured = computed(() => {
+    const list = zone.shlagemons
+    if (!list?.length)
+      return false
+    return list.every(base => dex.shlagemons.some(mon => mon.base.id === base.id))
+  })
+
+  const perfectZone = computed(() => {
+    const list = zone.shlagemons
+    if (!list?.length)
+      return false
+    return list.every((base) => {
+      const mon = dex.shlagemons.find(m => m.base.id === base.id)
+      return mon?.rarity === 100
+    })
+  })
+
+  const kingDefeated = computed(() => {
+    const hasKing = zone.hasKing ?? zone.type === 'sauvage'
+    return hasKing && progress.isKingDefeated(zone.id)
+  })
+
+  const arenaCompleted = computed(() => progress.isArenaCompleted(zone.id))
+
+  return { allCaptured, perfectZone, kingDefeated, arenaCompleted }
+}


### PR DESCRIPTION
## Summary
- share zone completion logic via new composable
- reuse completion logic in zone buttons
- improve leaflet marker helper
- show capture, king and arena icons below map markers

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68825f6cb8b8832aba6ecc813b704944