### PR TITLE
Fix center zone button null map error

### DIFF
--- a/src/components/leaflet/CenterCurrentZoneButton.vue
+++ b/src/components/leaflet/CenterCurrentZoneButton.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
 import type { Map as LeafletMap } from 'leaflet'
-import type { Ref } from 'vue'
+import type { PropType, Ref } from 'vue'
 import { ref, watch, watchEffect } from 'vue'
 import { useZoneStore } from '~/stores/zone'
 
-const props = defineProps<{ map: Ref<LeafletMap | null> }>()
+const props = defineProps({
+  map: {
+    type: Object as PropType<Ref<LeafletMap | null> | null>,
+    default: null,
+  },
+})
 
 const zone = useZoneStore()
 const visible = ref(false)
@@ -17,7 +22,7 @@ function isCentered(map: LeafletMap): boolean {
 }
 
 function update() {
-  const map = props.map.value
+  const map = props.map?.value ?? null
   if (map)
     visible.value = !isCentered(map)
   else
@@ -25,7 +30,7 @@ function update() {
 }
 
 watchEffect((onCleanup) => {
-  const map = props.map.value
+  const map = props.map?.value ?? null
   if (!map) {
     visible.value = false
     return
@@ -42,7 +47,7 @@ watch(() => zone.currentId, () => {
 })
 
 function center() {
-  const map = props.map.value
+  const map = props.map?.value ?? null
   if (!map)
     return
   const pos = zone.current.position


### PR DESCRIPTION
## Summary
- handle null `map` prop in `CenterCurrentZoneButton`

## Testing
- `pnpm test` *(fails: 30 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68826316894c832aa92bfee44a409ae3