### PR TITLE
Add persist paths typing

### DIFF
--- a/src/pinia.d.ts
+++ b/src/pinia.d.ts
@@ -1,0 +1,17 @@
+import type { Path } from 'deep-pick-omit'
+import type { StateTree } from 'pinia'
+import type { PersistenceOptions } from 'pinia-plugin-persistedstate'
+import 'pinia-plugin-persistedstate'
+
+declare module 'pinia-plugin-persistedstate' {
+  interface Persistence<State extends StateTree = StateTree> {
+    /**
+     * Dot-notation paths to pick from state before persisting.
+     * Alias for `pick` from the library.
+     */
+    paths?: Path<State>[] | string[]
+  }
+
+  // Provide backwards-compatible alias used in the codebase
+  type PersistedStateOptions<State extends StateTree = StateTree> = PersistenceOptions<State>
+}

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -400,7 +400,6 @@ export const useAchievementsStore = defineStore('achievements', () => {
   return { list, unlockedList, hasAny, handleEvent, reset }
 }, {
   persist: {
-    // @ts-expect-error wrong typings from pinia-plugin
     paths: ['counters'],
   },
 })


### PR DESCRIPTION
## Summary
- augment pinia-plugin-persistedstate typings so `persist` supports `{ paths: string[] }`
- remove leftover `@ts-expect-error` comment in achievements store

## Testing
- `pnpm typecheck` *(fails: various type errors)*
- `pnpm test` *(fails: 24 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6882a7cf9428832a80749b7af4c34db3