### PR TITLE
Centralize zone selection logic

### DIFF
--- a/src/components/leaflet/map.vue
+++ b/src/components/leaflet/map.vue
@@ -26,6 +26,10 @@ function selectZone(id: ZoneId) {
     leafletMap.value?.panTo([pos.lat, pos.lng])
 }
 
+defineExpose({
+  selectZone,
+})
+
 onMounted(() => {
   const map = leafletMap.value!
   const markers = useMapMarkers(map)

--- a/src/components/panel/Map.vue
+++ b/src/components/panel/Map.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
+import type LeafletMap from '~/components/leaflet/map.vue'
+import type { ZoneId } from '~/type/zone'
+
 const zone = useZoneStore()
+const mapRef = ref<InstanceType<typeof LeafletMap> | null>(null)
+
+provide('selectZone', (id: ZoneId) => {
+  mapRef.value?.selectZone(id)
+})
 </script>
 
 <template>
@@ -14,6 +22,6 @@ const zone = useZoneStore()
         class="mb-1 h-1"
       />
     </div>
-    <LeafletMap @select="zone.setZone" />
+    <LeafletMap ref="mapRef" @select="zone.setZone" />
   </div>
 </template>

--- a/src/components/zone/NextButton.vue
+++ b/src/components/zone/NextButton.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
+import type { ZoneId } from '~/type/zone'
+
 const zone = useZoneStore()
 const dex = useShlagedexStore()
 const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
+
+const selectZone = inject<(id: ZoneId) => void>('selectZone')
 
 const disabled = computed(() => accessibleZones.value[accessibleZones.value.length - 1]?.id === zone.currentId)
 
@@ -10,7 +14,7 @@ function goNext() {
     return
   const idx = accessibleZones.value.findIndex(z => z.id === zone.currentId)
   if (idx < accessibleZones.value.length - 1)
-    zone.setZone(accessibleZones.value[idx + 1].id)
+    (selectZone ?? zone.setZone)(accessibleZones.value[idx + 1].id)
 }
 </script>
 

--- a/src/components/zone/PrevButton.vue
+++ b/src/components/zone/PrevButton.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
+import type { ZoneId } from '~/type/zone'
+
 const zone = useZoneStore()
 const dex = useShlagedexStore()
 const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
+
+const selectZone = inject<(id: ZoneId) => void>('selectZone')
 
 const disabled = computed(() => accessibleZones.value[0]?.id === zone.currentId)
 
@@ -10,7 +14,7 @@ function goPrev() {
     return
   const idx = accessibleZones.value.findIndex(z => z.id === zone.currentId)
   if (idx > 0)
-    zone.setZone(accessibleZones.value[idx - 1].id)
+    (selectZone ?? zone.setZone)(accessibleZones.value[idx - 1].id)
 }
 </script>
 


### PR DESCRIPTION
## Summary
- expose `selectZone` from `LeafletMap`
- provide `selectZone` in `panel/Map`
- use injected `selectZone` in `PrevButton` and `NextButton`

## Testing
- `pnpm test` *(fails: Test Files 25 failed | 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68834c91ca90832ab79b8fa80825cd95