### PR TITLE
Update map paths and zone data

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -366,6 +366,7 @@ declare global {
   const useWindowScroll: typeof import('@vueuse/core')['useWindowScroll']
   const useWindowSize: typeof import('@vueuse/core')['useWindowSize']
   const useZoneAccess: typeof import('./stores/zoneAccess')['useZoneAccess']
+  const useZoneCompletion: typeof import('./composables/useZoneCompletion')['useZoneCompletion']
   const useZoneMonsModalStore: typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']
   const useZoneProgressStore: typeof import('./stores/zoneProgress')['useZoneProgressStore']
   const useZoneStore: typeof import('./stores/zone')['useZoneStore']
@@ -799,6 +800,7 @@ declare module 'vue' {
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
     readonly useZoneAccess: UnwrapRef<typeof import('./stores/zoneAccess')['useZoneAccess']>
+    readonly useZoneCompletion: UnwrapRef<typeof import('./composables/useZoneCompletion')['useZoneCompletion']>
     readonly useZoneMonsModalStore: UnwrapRef<typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']>
     readonly useZoneProgressStore: UnwrapRef<typeof import('./stores/zoneProgress')['useZoneProgressStore']>
     readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -58,7 +58,7 @@ declare module 'vue' {
     IconDisease: typeof import('./components/icon/Disease.vue')['default']
     IconMultiExp: typeof import('./components/icon/MultiExp.vue')['default']
     IconShlagedex: typeof import('./components/icon/Shlagedex.vue')['default']
-    IconShlagidiamond: typeof import('./components/icon/Shlagidiamond.vue')['default']
+    IconShlagidiamond: typeof import('./components/icon/shlagidiamond.vue')['default']
     IconShlagidolar: typeof import('./components/icon/Shlagidolar.vue')['default']
     IconXp: typeof import('./components/icon/Xp.vue')['default']
     InventoryEvolutionItemModal: typeof import('./components/inventory/EvolutionItemModal.vue')['default']

--- a/src/composables/leaflet/useMapPaths.ts
+++ b/src/composables/leaflet/useMapPaths.ts
@@ -28,26 +28,41 @@ export function buildZigzagPath(zones: Zone[]): LatLngExpression[] {
   return path
 }
 
-export function buildSimplePath(from: Position, to: Position): LatLngExpression[] {
+export function buildSimplePath(
+  from: Position,
+  to: Position,
+  first: 'vertical' | 'horizontal' = 'vertical',
+): LatLngExpression[] {
+  if (first === 'vertical') {
+    return [
+      [from.lat, from.lng],
+      [to.lat, from.lng],
+      [to.lat, to.lng],
+    ]
+  }
   return [
     [from.lat, from.lng],
-    [to.lat, from.lng],
+    [from.lat, to.lng],
     [to.lat, to.lng],
   ]
 }
 
 export function useMapPaths(map: LeafletMap) {
-  function drawPolylineWithBorder(path: LatLngExpression[], color = '#ffaa00') {
+  function drawPolylineWithBorder(
+    path: LatLngExpression[],
+    color = '#ffaa00',
+    weight = 14,
+  ) {
     const border = new Polyline(path, {
       color: '#000000',
-      weight: 18,
+      weight: weight + 4,
       opacity: 1,
       smoothFactor: 4,
     }).addTo(map)
 
     const line = new Polyline(path, {
       color,
-      weight: 14,
+      weight,
       opacity: 1,
       smoothFactor: 4,
     }).addTo(map)

--- a/src/data/zones/villages/village10.ts
+++ b/src/data/zones/villages/village10.ts
@@ -17,6 +17,7 @@ export const village10: Zone = {
   name: 'Veaux du Gland sur Marne',
   type: 'village',
   position: move.bottom(savage05.position, VILLAGE_OFFSET),
+  attachedTo: savage05.id,
   minLevel: 10,
   actions: [],
   village: {

--- a/src/data/zones/villages/village100.ts
+++ b/src/data/zones/villages/village100.ts
@@ -22,13 +22,15 @@ import {
   xpPotion,
 } from '~/data/items/items'
 import { hyperShlageball, shlageball, superShlageball } from '~/data/items/shlageball'
+import { move } from '~/utils/position'
 import { savage95 } from '../savages/95-cratere-des-legends'
 
 export const village100: Zone = {
   id: 'village-giga-schlag',
   name: 'Citadelle Giga-Schlag',
   type: 'village',
-  position: { lat: savage95.position.lat, lng: savage95.position.lng + VILLAGE_OFFSET },
+  position: move.right(savage95.position, VILLAGE_OFFSET),
+  attachedTo: savage95.id,
   actions: [
     { id: 'minigame', label: 'Mini-jeu' },
   ],

--- a/src/data/zones/villages/village20.ts
+++ b/src/data/zones/villages/village20.ts
@@ -18,6 +18,7 @@ export const village20: Zone = {
   name: 'Village Sux-Mais-Bouls',
   type: 'village',
   position: move.bottom(savage15.position, VILLAGE_OFFSET),
+  attachedTo: savage15.id,
   actions: [
     { id: 'minigame', label: 'Mini-jeu' },
   ],

--- a/src/data/zones/villages/village40.ts
+++ b/src/data/zones/villages/village40.ts
@@ -16,6 +16,7 @@ import {
   xpPotion,
 } from '~/data/items/items'
 import { shlageball, superShlageball } from '~/data/items/shlageball'
+import { move } from '~/utils/position'
 import { arena40 } from '../../arenas'
 import { savage35 } from '../savages/35-route-du-nawak'
 
@@ -23,7 +24,8 @@ export const village40: Zone = {
   id: 'village-paume',
   name: 'Village Paumé du cul',
   type: 'village',
-  position: { lat: savage35.position.lat, lng: savage35.position.lng + VILLAGE_OFFSET },
+  position: move.right(savage35.position, VILLAGE_OFFSET),
+  attachedTo: savage35.id,
   actions: [],
   minLevel: 40,
   arena: {

--- a/src/data/zones/villages/village50.ts
+++ b/src/data/zones/villages/village50.ts
@@ -17,13 +17,15 @@ import {
   xpPotion,
 } from '~/data/items/items'
 import { shlageball, superShlageball } from '~/data/items/shlageball'
+import { move } from '~/utils/position'
 import { savage45 } from '../savages/45-catacombes-merdifientes'
 
 export const village50: Zone = {
   id: 'village-caca-boudin',
   name: 'Village Fiente-sur-Mer',
   type: 'village',
-  position: { lat: savage45.position.lat, lng: savage45.position.lng + VILLAGE_OFFSET },
+  position: move.right(savage45.position, VILLAGE_OFFSET),
+  attachedTo: savage45.id,
   actions: [],
   minLevel: 50,
   village: {

--- a/src/data/zones/villages/village60.ts
+++ b/src/data/zones/villages/village60.ts
@@ -18,6 +18,7 @@ import {
   xpPotion,
 } from '~/data/items/items'
 import { shlageball, superShlageball } from '~/data/items/shlageball'
+import { move } from '~/utils/position'
 import { arena60 } from '../../arenas'
 import { savage55 } from '../savages/55-vallee-des-chieurs'
 
@@ -25,7 +26,8 @@ export const village60: Zone = {
   id: 'village-cassos-land',
   name: 'Village des Cassos',
   type: 'village',
-  position: { lat: savage55.position.lat, lng: savage55.position.lng + VILLAGE_OFFSET },
+  position: move.right(savage55.position, VILLAGE_OFFSET),
+  attachedTo: savage55.id,
   actions: [
     { id: 'minigame', label: 'Mini-jeu' },
   ],

--- a/src/data/zones/villages/village80.ts
+++ b/src/data/zones/villages/village80.ts
@@ -22,13 +22,15 @@ import {
   xpPotion,
 } from '~/data/items/items'
 import { hyperShlageball, shlageball, superShlageball } from '~/data/items/shlageball'
+import { move } from '~/utils/position'
 import { savage75 } from '../savages/75-route-so-dom'
 
 export const village80: Zone = {
   id: 'village-clitoland',
   name: 'Clito Land',
   type: 'village',
-  position: { lat: savage75.position.lat, lng: savage75.position.lng + VILLAGE_OFFSET },
+  position: move.right(savage75.position, VILLAGE_OFFSET),
+  attachedTo: savage75.id,
   actions: [],
   minLevel: 80,
   village: {

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -55,6 +55,8 @@ export interface SavageZone extends BaseZone {
 interface NonSavageZone extends BaseZone {
   type: Exclude<ZoneType, 'sauvage'>
   maxLevel?: undefined // interdit explicitement (ou facultatif si tu préfères)
+  /** Zone sauvage à laquelle cette zone est reliée */
+  attachedTo?: SavageZoneId
 }
 
 // Union finale


### PR DESCRIPTION
## Summary
- add `attachedTo` field for linking villages to zones
- centralize line drawing with weights in map paths composable
- draw zigzag routes in a single yellow polyline
- connect villages to their zone with thin green lines
- place villages with helper moves

## Testing
- `pnpm test` *(fails: numerous assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688350df4eb0832a8d5715820163f308