### PR TITLE
Fix map order and centering

### DIFF
--- a/src/components/leaflet/map.vue
+++ b/src/components/leaflet/map.vue
@@ -63,15 +63,15 @@ onMounted(() => {
     )
     const accessibleCount = accessibleSavage.length
 
-    if (accessibleCount > 1) {
-      const path = buildZigzagPath(savageZones.slice(0, accessibleCount))
-      lines.value.push(...drawPolylineWithBorder(path, '#facc15'))
-    }
-
     if (accessibleCount < savageZones.length) {
       const start = Math.max(accessibleCount - 1, 0)
       const path = buildZigzagPath(savageZones.slice(start))
       lines.value.push(...drawPolylineWithBorder(path, '#9ca3af'))
+    }
+
+    if (accessibleCount > 1) {
+      const path = buildZigzagPath(savageZones.slice(0, accessibleCount))
+      lines.value.push(...drawPolylineWithBorder(path, '#facc15'))
     }
 
     villages.forEach((village) => {

--- a/src/components/panel/Map.vue
+++ b/src/components/panel/Map.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
 import type LeafletMap from '~/components/leaflet/map.vue'
 import type { ZoneId } from '~/type/zone'
+import { onMounted, watch } from 'vue'
 
 const zone = useZoneStore()
 const mapRef = ref<InstanceType<typeof LeafletMap> | null>(null)
 
 provide('selectZone', (id: ZoneId) => {
+  mapRef.value?.selectZone(id)
+})
+
+onMounted(() => {
+  mapRef.value?.selectZone(zone.currentZoneId)
+})
+
+watch(() => zone.currentZoneId, (id) => {
   mapRef.value?.selectZone(id)
 })
 </script>

--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -34,7 +34,7 @@ export function useMapMarkers(map: LeafletMap) {
       const icons = [ball, crown, arena].filter(Boolean).join('')
       return `<div class="flex flex-col items-center ${inactive ? 'grayscale opacity-50' : ''}">
         ${icon}
-        <div class="flex gap-0.5 mt-1 bg-dark/50 px-2 py-1 rounded-full">${icons}</div>
+        <div class="flex gap-0.5 -mt-1 bg-dark/50 px-2 py-1 rounded-full">${icons}</div>
       </div>`
     }
 


### PR DESCRIPTION
## Summary
- draw wild zone paths with grey path beneath yellow path
- raise zone completion bubble on map markers
- pan to current zone when map loads or zone changes

## Testing
- `pnpm test` *(fails: 25 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68836a5c0460832ab07066864f46fce7