### PR TITLE
Fix village path color for locked villages

### DIFF
--- a/src/components/leaflet/map.vue
+++ b/src/components/leaflet/map.vue
@@ -82,7 +82,8 @@ onMounted(() => {
       const arrival = idx % 2 === 0 ? 'vertical' : 'horizontal'
       const start = arrival === 'vertical' ? 'horizontal' : 'vertical'
       const path = buildSimplePath(target.position!, village.position!, start)
-      lines.value.push(...drawPolylineWithBorder(path, '#22c55e', 10))
+      const color = canAccess(village) ? '#22c55e' : '#9ca3af'
+      lines.value.push(...drawPolylineWithBorder(path, color, 10))
     })
   }
 


### PR DESCRIPTION
## Summary
- draw village paths as gray when the village is locked

## Testing
- `pnpm test` *(fails: Test Files 25 failed | 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68836c0c1d0c832aa369e54740f5d93d