### PR TITLE
Fix missing MonsModal translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -100,6 +100,8 @@ components:
     BoxModal:
       title: Egg box
       empty: No egg
+    MonsModal:
+      title: Shlagemons from {name}
   inventory:
     EvolutionItemModal:
       title: Use {name}

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -102,6 +102,8 @@ components:
     BoxModal:
       title: Boîte à œufs
       empty: Aucun œuf
+    MonsModal:
+      title: Shlagémons de {name}
   inventory:
     EvolutionItemModal:
       title: Utiliser {name}


### PR DESCRIPTION
## Summary
- add missing French and English translations for MonsModal

## Testing
- `pnpm test` *(fails: 25 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68839524b0f8832a91e014c90da5901f