### PR TITLE
Fix map center button visibility

### DIFF
--- a/src/components/leaflet/map.vue
+++ b/src/components/leaflet/map.vue
@@ -97,8 +97,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="h-full w-full">
-    <LeafletCenterCurrentZoneButton :map="leafletMap" />
+  <div class="relative h-full w-full">
+    <LeafletCenterCurrentZoneButton v-bind="{ map: leafletMap }" />
     <div ref="mapRef" class="h-full w-full" v-bind="$attrs" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- keep the ref when passing the map instance to the center button

## Testing
- `pnpm test` *(fails: injection "selectZone" not found and many other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688394e28304832aa5bd7613eff35787