### PR TITLE
Fix evolution coefficient calculation

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -428,7 +428,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       if (activeShlagemon.value?.id === mon.id)
         activeShlagemon.value = existing
       recomputeHighestLevel()
-      updateCoefficient(existing, zoneStore.current.id, true, true)
+      updateCoefficient(existing, undefined, true, true)
     }
     else {
       mon.base = to
@@ -438,7 +438,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       mon.captureDate = new Date().toISOString()
       mon.captureCount = 1
       toast(`${mon.base.name} a évolué !`)
-      updateCoefficient(mon, zoneStore.current.id, true, true)
+      updateCoefficient(mon, undefined, true, true)
     }
   }
 

--- a/test/battle-zone-rank.test.ts
+++ b/test/battle-zone-rank.test.ts
@@ -56,6 +56,7 @@ describe('zone rank scaling', () => {
     dex.captureShlagemon(carapouffe)
     await Promise.resolve()
     expect(mon.rarity).toBe(100)
-    expect(mon.coefficient).toBe(carapouffe.coefficient * rank)
+    const expected = (mon.lvl + 1) * rank
+    expect(mon.coefficient).toBe(expected)
   })
 })

--- a/test/evolution-coefficient.test.ts
+++ b/test/evolution-coefficient.test.ts
@@ -1,26 +1,27 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
-import abraquemar from '../src/data/shlagemons/10-15/abraquemar'
-import alakalbar from '../src/data/shlagemons/evolutions/alakalbar'
+import jeunebelette from '../src/data/shlagemons/01-05/jeunebelette'
+import vieuxBlaireau from '../src/data/shlagemons/evolutions/vieuxblaireau'
 import { useEvolutionStore } from '../src/stores/evolution'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useZoneStore } from '../src/stores/zone'
+import { useZoneProgressStore } from '../src/stores/zoneProgress'
 import { xpForLevel } from '../src/utils/dexFactory'
 
 describe('evolution coefficient bonus', () => {
-  it('applies current zone rank when evolving', async () => {
+  it('uses level zone rank when evolving', async () => {
     setActivePinia(createPinia())
     const zone = useZoneStore()
+    const progress = useZoneProgressStore()
     const dex = useShlagedexStore()
     const evo = useEvolutionStore()
     vi.spyOn(evo, 'requestEvolution').mockResolvedValue(true)
-    const rank = 4
-    vi.spyOn(zone, 'getZoneRank').mockReturnValue(rank)
+    progress.defeatKing('plaine-kekette')
     zone.setZone('plaine-kekette')
-    const mon = dex.createShlagemon(abraquemar)
-    mon.rarity = 50
-    await dex.gainXp(mon, xpForLevel(1) + xpForLevel(2))
-    expect(mon.base.id).toBe(alakalbar.id)
+    const mon = dex.createShlagemon(jeunebelette)
+    await dex.gainXp(mon, xpForLevel(1) + xpForLevel(2) + xpForLevel(3) + xpForLevel(4))
+    const rank = zone.getZoneRank('bois-de-bouffon')
+    expect(mon.base.id).toBe(vieuxBlaireau.id)
     expect(mon.coefficient).toBe((mon.lvl + 1) * rank)
   })
 })


### PR DESCRIPTION
## Summary
- avoid stat drop when evolving by using level-based zone rank
- update evolution coefficient tests
- adjust battle zone coefficient expectation

## Testing
- `npx vitest run test/evolution-coefficient.test.ts`
- `npx vitest run test/battle-zone-rank.test.ts`
- `npx vitest run` *(fails: achievements.test.ts, arena-enemy-coefficient.test.ts, battle-core.test.ts, battle-switch.test.ts, battlecapture.test.ts, capture.test.ts, disease-damage.test.ts, egg-persist.test.ts, trainer-store.test.ts, zone-heal.test.ts, zone-persist.test.ts, zone-visit.test.ts, zone.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6883a169f0ac832aa452755fea345f3f