### PR TITLE
Fix Salamiches i18n entry

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -181,7 +181,7 @@ components:
             attacks. All your potion bonuses are cancelled on entry. Choose
             well-trained Shlagemons strong against opposite types.
           responses:
-            start: Let''s go!
+            start: Let's go!
             quit: Leave
     AttackPotionDialog:
       steps:
@@ -284,8 +284,8 @@ components:
             next: Continue
         step2:
           text: >-
-            I'm {name}. To help you, I'll give you a very special item: the
-            Multi-UXP.
+            As {name}, I am proud of you. To help you on your adventure, I will
+            give you a very special item: the Multi-EXP.
           responses:
             back: Back
             next: Continue
@@ -400,28 +400,28 @@ components:
         start:
           text: Hi, I'm {name}, my friends say I smell nice.
           responses:
-            next: You don''t look very smart.
+            next: You don't look very smart.
         step2:
           text: Screw you kid, I'm going to force you to adopt one of my Shlagemons.
           responses:
             next: Oh nooo, not a Shlagemon, they smell too bad!
         choice:
           text: >-
-            I''ll let you choose the least awful one, which Shlagemon do you
+            I'll let you choose the least awful one, which Shlagemon do you
             want?
         common:
           responses:
-            back: Don''t you have something better than this crap?
+            back: Don't you have something better than this crap?
         bulgrosboule:
-          text: I wouldn''t pick that one, it''s horribly bad.
+          text: I wouldn't pick that one, it's horribly bad.
           responses:
-            valid: I don''t like it much but ok
+            valid: I don't like it much but ok
         salamiches:
           text: Careful, it belches fire when it eats bread.
           responses:
             valid: Thanks {name}
         carapouffe:
-          text: Careful, it can''t swim.
+          text: Careful, it can't swim.
           responses:
             valid: Thanks {name}
     WearableItemDialog:
@@ -449,6 +449,8 @@ components:
         - Rarely seen someone so pathetic.
       validate: Validate
       attemptsLeft: '{n} attempts left'
+      win: You've cracked a Shlag's mind!
+      lose: Even a Grimer would have done it
     MiniGameShlagPairs:
       attempts: '{n} attempt | {n} attempts'
     ShlagMindSelectionModal:
@@ -1509,13 +1511,12 @@ data:
 
         Mewteub is rare. Too rare. And frankly, it might be better that way.
     salamiches:
-      salamiches:
-        name: Salamiches
-        description: >
-          Salamiches burns with the weak flame of an empty lighter. Always
-          shirtless, he records himself spitting sparks on trash cans. His
-          special ability, *Ego Fire*, boosts his power whenever people boo him.
-          Loyal unless offered a free kebab or a sale at the auto shop.
+      name: Salamiches
+      description: >
+        Salamiches burns with the weak flame of an empty lighter. Always
+        shirtless, he records himself spitting sparks on trash cans. His special
+        ability, *Ego Fire*, boosts his power whenever people boo him. Loyal
+        unless offered a free kebab or a sale at the auto shop.
     sulfusouris:
       description: >-
         Sulfumouse is a legendary Shalagemon born of a short circuit in an

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -298,8 +298,8 @@ components:
             next: Continuer
         step2:
           text: >-
-            Je suis {name}. Pour t'aider, je vais te remettre un objet très
-            spécial : le Multi-UXP.
+            En tant que {name} je suis fier de toi. Pour t'aider dans ton
+            aventure, je vais te remettre un objet très spécial : le Multi-EXP.
           responses:
             back: Retour
             next: Continuer
@@ -432,11 +432,11 @@ components:
           text: Je te laisse choisir le moins pire, tu veux quel Shlagémon ?
         common:
           responses:
-            back: T''as pas mieux que cette merde ?
+            back: T'as pas mieux que cette merde ?
         bulgrosboule:
           text: Je te déconseille de choisir celui là, il est horriblement mauvais.
           responses:
-            valid: Je l''aime pas trop mais ok
+            valid: Je l'aime pas trop mais ok
         salamiches:
           text: Attention, il rote du feu quand il mange du pain.
           responses:
@@ -470,6 +470,8 @@ components:
         - Rarement vu quelqu'un aussi merdique.
       validate: Valider
       attemptsLeft: '{n} tentatives restantes'
+      win: T'as percé le cerveau d'un Shlag !
+      lose: Même un Petmorv y serait arrivé
     MiniGameShlagPairs:
       attempts: '{n} tentative | {n} tentatives'
     ShlagMindSelectionModal:
@@ -1538,21 +1540,20 @@ data:
         Mewteub est rare. Trop rare. Et franchement, c’est peut-être mieux
         ainsi.
     salamiches:
-      salamiches:
-        name: Salamiches
-        description: >
-          Salamiches brûle, mais pas de feu noble, non, plutôt de feu de briquet
-          BIC vide qu’on rallume à la 27ᵉ tentative. Toujours torse nu, même en
-          hiver, il arbore une crête en feu mal fixée et des lunettes de soleil
-          qui fondent partiellement à chaque attaque. Il se nourrit
-          exclusivement de chips au paprika, de whisky bon marché, et
-          d’approbation sociale. On le trouve souvent en train de se filmer en
-          selfie pendant qu’il crache des étincelles sur des poubelles. Sa
-          capacité spéciale, *Feu d’ego*, augmente sa puissance chaque fois
-          qu’il se fait huer. Il envoie des punchlines nulles entre deux jets de
-          flamme molle, et rêve de devenir influenceur muscu alors qu’il n’a que
-          deux abdos (et encore, en ombrage). C’est un être loyal, sauf si on
-          lui propose un kebab gratuit ou une promotion chez Feu Vert.
+      name: Salamiches
+      description: >
+        Salamiches brûle, mais pas de feu noble, non, plutôt de feu de briquet
+        BIC vide qu’on rallume à la 27ᵉ tentative. Toujours torse nu, même en
+        hiver, il arbore une crête en feu mal fixée et des lunettes de soleil
+        qui fondent partiellement à chaque attaque. Il se nourrit exclusivement
+        de chips au paprika, de whisky bon marché, et d’approbation sociale. On
+        le trouve souvent en train de se filmer en selfie pendant qu’il crache
+        des étincelles sur des poubelles. Sa capacité spéciale, *Feu d’ego*,
+        augmente sa puissance chaque fois qu’il se fait huer. Il envoie des
+        punchlines nulles entre deux jets de flamme molle, et rêve de devenir
+        influenceur muscu alors qu’il n’a que deux abdos (et encore, en
+        ombrage). C’est un être loyal, sauf si on lui propose un kebab gratuit
+        ou une promotion chez Feu Vert.
     sulfusouris:
       description: >-
         Sulfusouris est un Shlagémon légendaire né d’un court-circuit dans un

--- a/src/data/shlagemons/salamiches.i18n.yml
+++ b/src/data/shlagemons/salamiches.i18n.yml
@@ -1,24 +1,22 @@
 fr:
-  salamiches:
-    name: Salamiches
-    description: >
-      Salamiches brûle, mais pas de feu noble, non, plutôt de feu de briquet BIC
-      vide qu’on rallume à la 27ᵉ tentative. Toujours torse nu, même en hiver,
-      il arbore une crête en feu mal fixée et des lunettes de soleil qui fondent
-      partiellement à chaque attaque. Il se nourrit exclusivement de chips au
-      paprika, de whisky bon marché, et d’approbation sociale. On le trouve
-      souvent en train de se filmer en selfie pendant qu’il crache des
-      étincelles sur des poubelles. Sa capacité spéciale, *Feu d’ego*, augmente
-      sa puissance chaque fois qu’il se fait huer. Il envoie des punchlines
-      nulles entre deux jets de flamme molle, et rêve de devenir influenceur
-      muscu alors qu’il n’a que deux abdos (et encore, en ombrage). C’est un
-      être loyal, sauf si on lui propose un kebab gratuit ou une promotion chez
-      Feu Vert.
+  name: Salamiches
+  description: >
+    Salamiches brûle, mais pas de feu noble, non, plutôt de feu de briquet BIC
+    vide qu’on rallume à la 27ᵉ tentative. Toujours torse nu, même en hiver,
+    il arbore une crête en feu mal fixée et des lunettes de soleil qui fondent
+    partiellement à chaque attaque. Il se nourrit exclusivement de chips au
+    paprika, de whisky bon marché, et d’approbation sociale. On le trouve
+    souvent en train de se filmer en selfie pendant qu’il crache des
+    étincelles sur des poubelles. Sa capacité spéciale, *Feu d’ego*, augmente
+    sa puissance chaque fois qu’il se fait huer. Il envoie des punchlines
+    nulles entre deux jets de flamme molle, et rêve de devenir influenceur
+    muscu alors qu’il n’a que deux abdos (et encore, en ombrage). C’est un
+    être loyal, sauf si on lui propose un kebab gratuit ou une promotion chez
+    Feu Vert.
 en:
-  salamiches:
-    name: Salamiches
-    description: >
-      Salamiches burns with the weak flame of an empty lighter. Always
-      shirtless, he records himself spitting sparks on trash cans. His special
-      ability, *Ego Fire*, boosts his power whenever people boo him. Loyal
-      unless offered a free kebab or a sale at the auto shop.
+  name: Salamiches
+  description: >
+    Salamiches burns with the weak flame of an empty lighter. Always
+    shirtless, he records himself spitting sparks on trash cans. His special
+    ability, *Ego Fire*, boosts his power whenever people boo him. Loyal
+    unless offered a free kebab or a sale at the auto shop.


### PR DESCRIPTION
## Summary
- clean `salamiches.i18n.yml` so fields live directly under language keys
- regenerate locale files and remove nested `salamiches` blocks

## Testing
- `pnpm i18n`
- `pnpm test` *(fails: Tests failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_68839fa9f414832a8376cdb397ab326b