### PR TITLE
Fix map prop type for CenterCurrentZoneButton

### DIFF
--- a/src/components/leaflet/CenterCurrentZoneButton.vue
+++ b/src/components/leaflet/CenterCurrentZoneButton.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import type { Map as LeafletMap } from 'leaflet'
-import type { Ref } from 'vue'
 import { ref, watch } from 'vue'
 import { useZoneStore } from '~/stores/zone'
 
-const props = defineProps<{ map?: Ref<LeafletMap | null> }>()
+const props = defineProps<{ map?: LeafletMap | null }>()
 
 const zone = useZoneStore()
 const visible = ref(false)
@@ -17,7 +16,7 @@ function isCentered(map: LeafletMap): boolean {
 }
 
 function update() {
-  const map = props.map?.value
+  const map = props.map
   if (map)
     visible.value = !isCentered(map)
   else
@@ -25,7 +24,7 @@ function update() {
 }
 
 watch(
-  () => props.map?.value,
+  () => props.map,
   (map, _, onCleanup) => {
     if (!map) {
       visible.value = false
@@ -45,7 +44,7 @@ watch(() => zone.currentId, () => {
 })
 
 function center() {
-  const map = props.map?.value
+  const map = props.map
   if (!map)
     return
   const pos = zone.current.position


### PR DESCRIPTION
## Summary
- pass the Leaflet map instance instead of a `Ref`
- update watchers to handle the instance

## Testing
- `pnpm test` *(fails: vitest tests fail in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6884155a6f2c832a848f11c65e3ed66a