### PR TITLE
Fix shlag mind message display

### DIFF
--- a/src/components/minigame/MiniGameShlagMind.vue
+++ b/src/components/minigame/MiniGameShlagMind.vue
@@ -8,9 +8,10 @@ const emit = defineEmits<{ (e: 'win'): void, (e: 'lose'): void }>()
 
 const { t, tm } = useI18n()
 
-const messages = computed(() =>
-  tm('components.minigame.MiniGameShlagMind.messages') as string[],
-)
+const messages = computed(() => {
+  const list = tm('components.minigame.MiniGameShlagMind.messages')
+  return Array.isArray(list) ? list as string[] : []
+})
 
 const palette = allShlagemons.slice(0, 12)
 const comboLength = 6


### PR DESCRIPTION
## Summary
- ensure MiniGameShlagMind messages are always returned as an array

## Testing
- `pnpm test` *(fails: achievements.test.ts, arena-enemy-coefficient.test.ts, battle-core.test.ts, battle-switch.test.ts, capture.test.ts, disease-damage.test.ts, egg-persist.test.ts, evolution.test.ts, save-dedup.test.ts, tictactoe-ai.test.ts, trainer-battle-heal.test.ts, trainer-store.test.ts, zone-persist.test.ts, zone-visit.test.ts, zone.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688497dd6324832a915351dfec9c96a2