### PR TITLE
Fix battle-core test by using enemy.value

### DIFF
--- a/test/battle-core.test.ts
+++ b/test/battle-core.test.ts
@@ -13,7 +13,7 @@ function setup() {
     createEnemy: () => dex.createShlagemon(carapouffe),
   })
   composable.startBattle()
-  return { ...composable, enemy: composable.enemy!, player }
+  return { ...composable, enemy: composable.enemy.value!, player }
 }
 
 describe('useBattleCore', () => {


### PR DESCRIPTION
## Summary
- return the enemy's value instead of its ref in the test setup

## Testing
- `CI=1 pnpm vitest run test/battle-core.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68849c9fdd34832a9d20f8370d398f0e