### PR TITLE
Fix disease damage test

### DIFF
--- a/src/stores/disease.ts
+++ b/src/stores/disease.ts
@@ -39,5 +39,13 @@ export const useDiseaseStore = defineStore('disease', () => {
 
   return { active, remaining, start, reset }
 }, {
-  persist: true,
+  persist: {
+    afterHydrate(ctx) {
+      const store = ctx.store as ReturnType<typeof useDiseaseStore>
+      if (typeof store.active !== 'object')
+        store.active = ref(Boolean(store.active))
+      if (typeof store.remaining !== 'object')
+        store.remaining = ref(Number(store.remaining) || 0)
+    },
+  },
 })

--- a/test/disease-damage.test.ts
+++ b/test/disease-damage.test.ts
@@ -14,7 +14,7 @@ describe('disease damage', () => {
     const player = dex.createShlagemon(carapouffe)
     const enemy = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(player)
-    disease.active.value = true
+    disease.start()
     const initialHp = enemy.hpCurrent
     const result = battle.clickAttack(player, enemy)
     expect(result.damage).toBe(10)


### PR DESCRIPTION
## Summary
- ensure disease store state is hydrated as refs
- trigger disease with `start()` in disease damage test

## Testing
- `pnpm test -t "disease damage"`


------
https://chatgpt.com/codex/tasks/task_e_68849cb08cc4832a96cd9f781231c106