### PR TITLE
Fix pinia persisted state tests

### DIFF
--- a/test/egg-persist.test.ts
+++ b/test/egg-persist.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
 import { allShlagemons } from '../src/data/shlagemons'
 import { useEggStore } from '../src/stores/egg'
 import { eggSerializer } from '../src/utils/egg-serialize'
@@ -9,6 +10,8 @@ describe('egg persistence', () => {
   it('restores incubator from storage', () => {
     const pinia = createPinia()
     pinia.use(piniaPluginPersistedstate)
+    const app = createApp({})
+    app.use(pinia)
     setActivePinia(pinia)
 
     const stored = eggSerializer.serialize({

--- a/test/mainpanel-hydration.test.ts
+++ b/test/mainpanel-hydration.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
 import { useMainPanelStore } from '../src/stores/mainPanel'
 import { useZoneStore } from '../src/stores/zone'
 
@@ -10,6 +11,8 @@ describe('main panel hydration', () => {
   it('falls back from arena panel when not in battle', () => {
     const pinia = createPinia()
     pinia.use(piniaPluginPersistedstate)
+    const app = createApp({})
+    app.use(pinia)
     setActivePinia(pinia)
 
     // simulate persisted state

--- a/test/mobile-tab-persist.test.ts
+++ b/test/mobile-tab-persist.test.ts
@@ -1,12 +1,15 @@
 import { createPinia, setActivePinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
 import { useMobileTabStore } from '../src/stores/mobileTab'
 
 describe('mobile tab persistence', () => {
   it('restores current tab from storage', () => {
     const pinia = createPinia()
     pinia.use(piniaPluginPersistedstate)
+    const app = createApp({})
+    app.use(pinia)
     setActivePinia(pinia)
 
     // simulate previously saved tab

--- a/test/zone-persist.test.ts
+++ b/test/zone-persist.test.ts
@@ -1,12 +1,15 @@
 import { createPinia, setActivePinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
 import { useZoneStore } from '../src/stores/zone'
 
 describe('zone persistence', () => {
   it('restores current zone from storage', () => {
     const pinia = createPinia()
     pinia.use(piniaPluginPersistedstate)
+    const app = createApp({})
+    app.use(pinia)
     setActivePinia(pinia)
 
     // simulate previously saved zone


### PR DESCRIPTION
## Summary
- ensure persistedstate plugin activates in unit tests by installing pinia on a dummy Vue app

## Testing
- `pnpm test:unit test/egg-persist.test.ts`
- `pnpm test:unit test/zone-persist.test.ts`
- `pnpm test:unit test/mobile-tab-persist.test.ts`
- `pnpm test:unit test/mainpanel-hydration.test.ts`
- `pnpm test:unit` *(fails: 23 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68849cb3f500832ab8621cf37706232f