### PR TITLE
Fix battle capture test timing

### DIFF
--- a/test/battlecapture.test.ts
+++ b/test/battlecapture.test.ts
@@ -35,6 +35,7 @@ describe('battleCapture', () => {
     })
 
     await wrapper.get('button').trigger('click')
+    await Promise.resolve()
     vi.runOnlyPendingTimers()
     vi.runOnlyPendingTimers()
     expect(captureSpy).toHaveBeenCalledWith(enemy)


### PR DESCRIPTION
## Summary
- ensure pending timers resolve after trigger

## Testing
- `pnpm vitest run test/battlecapture.test.ts` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6884a3dc4dc0832abe2092d4c3bac8c1