### PR TITLE
Fix serializer error when effects missing

### DIFF
--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -38,7 +38,7 @@ export const shlagedexSerializer: Serializer<SerializedDex> = {
   serialize(data: SerializedDex): string {
     return JSON.stringify({
       ...data,
-      effects: data.effects.map(({ timeout, ...e }) => e),
+      effects: (data.effects || []).map(({ timeout, ...e }) => e),
       shlagemons: data.shlagemons.map((mon) => {
         const { base, heldItemId, ...rest } = mon
         const stored: StoredDexMon = {


### PR DESCRIPTION
## Summary
- prevent `shlagedexSerializer` from throwing when `effects` is undefined

## Testing
- `pnpm test` *(fails: 14 test files failed, 37 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6884a3eda914832a9dcf8816020bf479