### PR TITLE
Fix rarity 100 coefficient

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -156,7 +156,15 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   ) {
     if (!force && mon.rarity !== 100)
       return
-    const target = zoneId ? { id: zoneId } : zoneStore.getZoneForLevel(mon.lvl)
+    const levelZone = zoneStore.getZoneForLevel(mon.lvl)
+    const highestAccessible = accessibleXpZones.value[accessibleXpZones.value.length - 1]
+    const levelRank = levelZone ? zoneStore.getZoneRank(levelZone.id) : 1
+    const accessibleRank = highestAccessible ? zoneStore.getZoneRank(highestAccessible.id) : levelRank
+    const target = zoneId
+      ? { id: zoneId }
+      : mon.rarity === 100 && highestAccessible && accessibleRank > levelRank && highestAccessible.minLevel <= mon.lvl + 1
+        ? highestAccessible
+        : levelZone
     if (!target)
       return
     const rank = zoneStore.getZoneRank(target.id)


### PR DESCRIPTION
## Summary
- update coefficient calculation when a Shlagémon reaches rarity 100

## Testing
- `pnpm vitest run test/shlagedex.test.ts`
- `pnpm test` *(fails: Test timed out, many failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884a3f0814c832a896d18db29146258