### PR TITLE
Fix heal percent after trainer battles

### DIFF
--- a/src/stores/trainerBattle.ts
+++ b/src/stores/trainerBattle.ts
@@ -6,7 +6,7 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   const queue = ref<Trainer[]>([])
   const currentIndex = ref(0)
   const levelUpHealPercent = ref(15)
-  const winHealPercent = ref(33.33)
+  const winHealPercent = ref(15)
 
   function setQueue(list: Trainer[]) {
     queue.value = list


### PR DESCRIPTION
## Summary
- align trainer heal percent with tests

## Testing
- `pnpm exec vitest run test/trainer-store.test.ts test/trainer-battle-heal.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6884a3f8bc70832aba3086edab84d48a