### PR TITLE
Fix trainer heal percentage test

### DIFF
--- a/test/trainer-store.test.ts
+++ b/test/trainer-store.test.ts
@@ -7,7 +7,7 @@ describe('trainer battle store', () => {
     setActivePinia(createPinia())
     const store = useTrainerBattleStore()
     expect(store.levelUpHealPercent).toBe(15)
-    expect(store.winHealPercent).toBe(15)
+    expect(store.winHealPercent).toBe(33.33)
   })
 
   it('isActive reflects queue state', () => {


### PR DESCRIPTION
## Summary
- update trainer battle store test to match new heal value

## Testing
- `pnpm exec vitest run test/trainer-store.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6884a3fcb9c4832aa9279e81c77ab626