### PR TITLE
Fix zone visit circular dependency

### DIFF
--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -16,8 +16,6 @@ export const useZoneStore = defineStore('zone', () => {
     const zone = zones.value.find(z => z.id === currentId.value)
     return zone ?? zones.value[0]
   })
-  const visit = useZoneVisitStore()
-  visit.markVisited(currentId.value)
   const xpZones = computed(() =>
     zones.value.filter(z => (z.maxLevel ?? 0) > 0),
   )

--- a/src/stores/zoneVisit.ts
+++ b/src/stores/zoneVisit.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
+import { zonesData } from '~/data/zones'
 
 export const useZoneVisitStore = defineStore('zoneVisit', () => {
-  const visited = ref<Record<string, boolean>>({})
+  const visited = ref<Record<string, boolean>>({ [zonesData[0].id]: true })
   const dex = useShlagedexStore()
 
   const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))


### PR DESCRIPTION
## Summary
- remove eager call to `useZoneVisitStore` in `zone` store
- mark the first zone as visited in `zoneVisit` store

## Testing
- `pnpm test` *(fails: 13 failed, 38 passed)*
- `pnpm test test/zone-visit.test.ts` *(passes)*

------
https://chatgpt.com/codex/tasks/task_e_6884a402ac04832a843ca1d8c64f8dc5