### PR TITLE
Fix zone change watchers

### DIFF
--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type'
+import { storeToRefs } from 'pinia'
 import { EQUILIBRE_RANK } from '~/constants/battle'
 import { multiExp } from '~/data/items/items'
 import { allShlagemons } from '~/data/shlagemons'
@@ -8,6 +9,7 @@ import { pickRandomByCoefficient } from '~/utils/spawn'
 
 const dex = useShlagedexStore()
 const zone = useZoneStore()
+const { selectedAt } = storeToRefs(zone)
 const progress = useZoneProgressStore()
 const wearableItemStore = useWearableItemStore()
 const events = useEventStore()
@@ -65,7 +67,7 @@ watch(
 )
 
 watch(
-  () => zone.selectedAt,
+  selectedAt,
   () => {
     if (dex.activeShlagemon)
       dex.activeShlagemon.hpCurrent = dex.maxHp(dex.activeShlagemon)

--- a/src/components/leaflet/CenterCurrentZoneButton.vue
+++ b/src/components/leaflet/CenterCurrentZoneButton.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import type { Map as LeafletMap } from 'leaflet'
+import { storeToRefs } from 'pinia'
 import { useZoneStore } from '~/stores/zone'
 
 const props = defineProps<{ map?: LeafletMap | null }>()
 
 const zone = useZoneStore()
+const { currentId } = storeToRefs(zone)
 const visible = ref(false)
 
 function isCentered(map: LeafletMap): boolean {
@@ -38,7 +40,7 @@ watch(
   { immediate: true },
 )
 
-watch(() => zone.currentId, () => {
+watch(currentId, () => {
   update()
 })
 

--- a/src/components/leaflet/map.vue
+++ b/src/components/leaflet/map.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Polyline } from 'leaflet'
 import type { Zone, ZoneId } from '~/type'
+import { storeToRefs } from 'pinia'
 import { onMounted, ref, toRef, watch } from 'vue'
 import { useLeafletMap } from '~/composables/leaflet/useLeafletMap'
 import { useMapMarkers } from '~/composables/leaflet/useMapMarkers'
@@ -19,6 +20,7 @@ const emit = defineEmits<{
 const { mapRef, map: leafletMap } = useLeafletMap()
 const zones = props.zones ?? zonesData
 const zoneStore = useZoneStore()
+const { currentId } = storeToRefs(zoneStore)
 
 function selectZone(id: ZoneId) {
   emit('select', id)
@@ -47,8 +49,8 @@ onMounted(() => {
     markers.addMarker(zone, selectZone, locked)
   })
 
-  markers.highlightActive(zoneStore.currentId)
-  watch(() => zoneStore.currentId, id => markers.highlightActive(id))
+  markers.highlightActive(currentId.value)
+  watch(currentId, id => markers.highlightActive(id))
 
   const savageZones = zones.filter(z => z.type === 'sauvage' && z.position)
   const villages = zones.filter(z => z.type === 'village' && z.position)
@@ -100,7 +102,7 @@ onMounted(() => {
       markers.setInactive(zone.id, locked)
     })
     draw()
-    markers.highlightActive(zoneStore.currentId)
+    markers.highlightActive(currentId.value)
   }, { immediate: true })
 })
 </script>

--- a/src/components/panel/Map.vue
+++ b/src/components/panel/Map.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import type LeafletMap from '~/components/leaflet/map.vue'
 import type { ZoneId } from '~/type/zone'
+import { storeToRefs } from 'pinia'
 import { onMounted, watch } from 'vue'
 
 const zone = useZoneStore()
+const { currentZoneId } = storeToRefs(zone)
 const mapRef = ref<InstanceType<typeof LeafletMap> | null>(null)
 
 provide('selectZone', (id: ZoneId) => {
@@ -11,10 +13,10 @@ provide('selectZone', (id: ZoneId) => {
 })
 
 onMounted(() => {
-  mapRef.value?.selectZone(zone.currentZoneId)
+  mapRef.value?.selectZone(currentZoneId.value)
 })
 
-watch(() => zone.currentZoneId, (id) => {
+watch(currentZoneId, (id) => {
   mapRef.value?.selectZone(id)
 })
 </script>


### PR DESCRIPTION
## Summary
- watch zone store refs directly using `storeToRefs`
- keep zone markers, center button and panel map in sync
- restart battle when the zone selection changes

## Testing
- `pnpm test` *(fails: 5 failed, 46 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6884b11c8594832a92aeedb3bf622aec