### PR TITLE
Fix injection warnings in ZonePanel tests

### DIFF
--- a/test/feature-lock.test.ts
+++ b/test/feature-lock.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import InventoryPanel from '../src/components/panel/Inventory.vue'
 import ZonePanel from '../src/components/panel/Zone.vue'
 import ShlagemonList from '../src/components/shlagemon/List.vue'
@@ -16,7 +16,9 @@ describe('feature lock flags', () => {
     setActivePinia(pinia)
     const featureLock = useFeatureLockStore()
     featureLock.lockZones()
-    const wrapper = mount(ZonePanel, { global: { plugins: [pinia] } })
+    const wrapper = mount(ZonePanel, {
+      global: { plugins: [pinia], provide: { selectZone: vi.fn() } },
+    })
     await wrapper.vm.$nextTick()
     const savageButtons = wrapper.findAll('#savages button')
     const villageButtons = wrapper.findAll('#villages button')

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import ZonePanel from '../src/components/panel/Zone.vue'
 import ZoneActions from '../src/components/village/ZoneActions.vue'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
@@ -25,7 +25,7 @@ describe('zone panel', () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     const wrapper = mount(ZonePanel, {
-      global: { plugins: [pinia] },
+      global: { plugins: [pinia], provide: { selectZone: vi.fn() } },
     })
     // first zone is now the Plaine Kékette
     expect(wrapper.text()).toContain('Plaine Kékette')
@@ -38,7 +38,7 @@ describe('zone panel', () => {
     const progress = useZoneProgressStore()
     const mon = dex.createShlagemon(carapouffe)
     const wrapper = mount(ZonePanel, {
-      global: { plugins: [pinia] },
+      global: { plugins: [pinia], provide: { selectZone: vi.fn() } },
     })
     let btn = [
       ...wrapper.findAll('#savages button'),
@@ -82,7 +82,9 @@ describe('zone panel', () => {
     const dex = useShlagedexStore()
     dex.createShlagemon(carapouffe)
     const panel = useMainPanelStore()
-    const wrapper = mount(ZonePanel, { global: { plugins: [pinia] } })
+    const wrapper = mount(ZonePanel, {
+      global: { plugins: [pinia], provide: { selectZone: vi.fn() } },
+    })
     panel.showTrainerBattle()
     await wrapper.vm.$nextTick()
     const buttons = [
@@ -96,7 +98,9 @@ describe('zone panel', () => {
   it('disables zone buttons when dialog is visible', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
-    const wrapper = mount(ZonePanel, { global: { plugins: [pinia] } })
+    const wrapper = mount(ZonePanel, {
+      global: { plugins: [pinia], provide: { selectZone: vi.fn() } },
+    })
     await wrapper.vm.$nextTick()
     const buttons = [
       ...wrapper.findAll('#savages button'),


### PR DESCRIPTION
## Summary
- update tests to provide `selectZone` when mounting `ZonePanel`

## Testing
- `pnpm vitest run test/zone.test.ts test/feature-lock.test.ts`
- `pnpm test:unit` *(fails: Test timed out in battlecapture.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_6884bf6daa40832a804fadd372233060