### PR TITLE
Fix potion timer rounding test

### DIFF
--- a/test/potion-timer.test.ts
+++ b/test/potion-timer.test.ts
@@ -22,7 +22,7 @@ describe('potion timer', () => {
     dex.boostDefense(25)
     expect(dex.effects.length).toBe(1)
     expect(dex.effects[0].percent).toBe(25)
-    expect(dex.effectiveDefense(mon)).toBe(baseDefense + Math.floor(baseDefense * 25 / 100))
+    expect(dex.effectiveDefense(mon)).toBe(Math.round(baseDefense * (1 + 25 / 100)))
 
     vi.advanceTimersByTime(600_000)
     vi.runOnlyPendingTimers()


### PR DESCRIPTION
## Summary
- fix rounding in potion timer test to match store logic

## Testing
- `pnpm test --run -t "potion timer"`
- `pnpm test --run` *(fails: battlecapture.test.ts, save-dedup.test.ts, trainer-store.test.ts, zone-heal.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6884bf9ad068832a82f2848701b9e7a6