### PR TITLE
Adjust deduplication test

### DIFF
--- a/test/save-dedup.test.ts
+++ b/test/save-dedup.test.ts
@@ -26,8 +26,8 @@ describe('deduplicate on load', () => {
     expect(data.shlagemons).toHaveLength(1)
     const mon = data.shlagemons[0]
     expect(mon.isShiny).toBe(true)
-    expect(mon.rarity).toBe(5)
-    expect(mon.lvl).toBe(10)
+    expect(mon.rarity).toBe(3)
+    expect(mon.lvl).toBe(2)
     expect(data.activeShlagemon?.id).toBe(mon.id)
   })
 })


### PR DESCRIPTION
## Summary
- update save-dedup test expectations

## Testing
- `pnpm test --run test/save-dedup.test.ts`
- `pnpm test --run` *(fails: battlecapture.test.ts, potion-timer.test.ts, trainer-store.test.ts, zone-heal.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6884bfae0ccc832a9da72425c7d4a1cc