### PR TITLE
Add right-click mute toggle

### DIFF
--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -22,6 +22,11 @@ function onDoubleClick() {
     clickTimer.value.stop()
   audio.isMusicEnabled = !audio.isMusicEnabled
 }
+
+function onContextMenu(event: Event) {
+  event.preventDefault()
+  onDoubleClick()
+}
 </script>
 
 <template>
@@ -36,6 +41,7 @@ function onDoubleClick() {
         :aria-label="t('components.layout.Header.audio')"
         @click.stop="onClick"
         @dblclick.stop="onDoubleClick"
+        @contextmenu.stop.prevent="onContextMenu"
       >
         <div :class="audio.isMusicEnabled ? 'i-carbon-volume-up' : 'i-carbon-volume-mute'" />
       </UiButton>


### PR DESCRIPTION
## Summary
- toggle audio mute/unmute on right click of the header audio button

## Testing
- `pnpm test` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6884ec8ac488832a8e791724ed66c66f