### PR TITLE
Fix map resize

### DIFF
--- a/src/composables/leaflet/useLeafletMap.ts
+++ b/src/composables/leaflet/useLeafletMap.ts
@@ -11,6 +11,13 @@ export function useLeafletMap(options: UseLeafletMapOptions = {}) {
   const map = ref<LeafletMap | null>(null)
   const tileLayer = ref<TileLayer | null>(null)
 
+  useResizeObserver(mapRef, () => {
+    map.value?.invalidateSize()
+  })
+  useEventListener('resize', () => {
+    map.value?.invalidateSize()
+  })
+
   const minLat = 45
   const minLng = -90
 


### PR DESCRIPTION
## Summary
- call `invalidateSize` when map container resizes

## Testing
- `pnpm test` *(fails: battlecapture.test.ts, trainer-store.test.ts, zone-heal.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6884efef29d0832aa55a9203cb4541fb