### PR TITLE
Wrap village and mini-games in TitledPanel

### DIFF
--- a/src/components/panel/MiniGame.i18n.yml
+++ b/src/components/panel/MiniGame.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  exit: Quitter
+en:
+  exit: Exit

--- a/src/components/panel/MiniGame.vue
+++ b/src/components/panel/MiniGame.vue
@@ -6,6 +6,7 @@ const mini = useMiniGameStore()
 const panel = useMainPanelStore()
 const zone = useZoneStore()
 const audio = useAudioStore()
+const { t } = useI18n()
 const miniGameMusic = '/audio/musics/games/mini-game.ogg'
 const zoneTrack = computed(() => getZoneTrack(zone.current.id, zone.current.type) ?? miniGameMusic)
 const gameDef = computed(() => mini.currentId ? getMiniGame(mini.currentId) : undefined)
@@ -22,7 +23,7 @@ function start() {
   mini.play()
   audio.fadeToMusic(miniGameMusic)
 }
-function exit() {
+function leaveGame() {
   mini.quit()
   panel.showVillage()
   audio.fadeToMusic(zoneTrack.value)
@@ -38,47 +39,54 @@ function draw() {
 }
 
 const intro = computed(() => gameDef.value?.createIntro(start))
-const success = computed(() => gameDef.value?.createSuccess(exit))
-const drawDialog = computed(() => gameDef.value?.createDraw?.(exit))
-const failure = computed(() => gameDef.value?.createFailure(exit))
+const success = computed(() => gameDef.value?.createSuccess(leaveGame))
+const drawDialog = computed(() => gameDef.value?.createDraw?.(leaveGame))
+const failure = computed(() => gameDef.value?.createFailure(leaveGame))
 </script>
 
 <template>
-  <div v-if="gameDef" class="tiny-scrollbar flex flex-col overflow-auto">
-    <DialogBox
-      v-if="mini.phase === 'intro'"
-      :character="gameDef.character"
-      :dialog-tree="intro!"
-      :exit-track="miniGameMusic"
-      orientation="col"
-    />
-    <component
-      :is="GameComp"
-      v-else-if="mini.phase === 'game'"
-      @win="win"
-      @lose="lose"
-      @draw="draw"
-    />
-    <DialogBox
-      v-else-if="mini.phase === 'success'"
-      :character="gameDef.character"
-      :dialog-tree="success!"
-      :exit-track="zoneTrack"
-      orientation="col"
-    />
-    <DialogBox
-      v-else-if="mini.phase === 'failure'"
-      :character="gameDef.character"
-      :dialog-tree="failure!"
-      :exit-track="zoneTrack"
-      orientation="col"
-    />
-    <DialogBox
-      v-else-if="mini.phase === 'draw'"
-      :character="gameDef.character"
-      :dialog-tree="drawDialog!"
-      :exit-track="zoneTrack"
-      orientation="col"
-    />
-  </div>
+  <LayoutTitledPanel
+    v-if="gameDef"
+    :title="gameDef.label"
+    :exit-text="t('components.panel.MiniGame.exit')"
+    @exit="leaveGame"
+  >
+    <div class="tiny-scrollbar flex flex-col overflow-auto">
+      <DialogBox
+        v-if="mini.phase === 'intro'"
+        :character="gameDef.character"
+        :dialog-tree="intro!"
+        :exit-track="miniGameMusic"
+        orientation="col"
+      />
+      <component
+        :is="GameComp"
+        v-else-if="mini.phase === 'game'"
+        @win="win"
+        @lose="lose"
+        @draw="draw"
+      />
+      <DialogBox
+        v-else-if="mini.phase === 'success'"
+        :character="gameDef.character"
+        :dialog-tree="success!"
+        :exit-track="zoneTrack"
+        orientation="col"
+      />
+      <DialogBox
+        v-else-if="mini.phase === 'failure'"
+        :character="gameDef.character"
+        :dialog-tree="failure!"
+        :exit-track="zoneTrack"
+        orientation="col"
+      />
+      <DialogBox
+        v-else-if="mini.phase === 'draw'"
+        :character="gameDef.character"
+        :dialog-tree="drawDialog!"
+        :exit-track="zoneTrack"
+        orientation="col"
+      />
+    </div>
+  </LayoutTitledPanel>
 </template>

--- a/src/components/panel/Village.i18n.yml
+++ b/src/components/panel/Village.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  exit: Quitter le Village
+en:
+  exit: Leave the village

--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -2,19 +2,30 @@
 import ZoneActions from '../village/ZoneActions.vue'
 
 const zone = useZoneStore()
+const panel = useMainPanelStore()
+const { t } = useI18n()
+
+function leaveVillage() {
+  if (zone.current.attachedTo)
+    zone.setZone(zone.current.attachedTo)
+  panel.showBattle()
+}
 </script>
 
 <template>
-  <div class="flex flex-col items-center gap-2">
-    <UiImageByBackground
-      v-if="zone.current.image"
-      :src="zone.current.image"
-      :alt="zone.current.name"
-      class="aspect-video h-full max-h-60 w-full object-contain md:max-h-80"
-    />
-    <h2 class="text-center font-bold">
-      {{ zone.current.name }}
-    </h2>
-    <ZoneActions />
-  </div>
+  <LayoutTitledPanel
+    :title="zone.current.name"
+    :exit-text="t('components.panel.Village.exit')"
+    @exit="leaveVillage"
+  >
+    <div class="flex flex-col items-center gap-2">
+      <UiImageByBackground
+        v-if="zone.current.image"
+        :src="zone.current.image"
+        :alt="zone.current.name"
+        class="aspect-video h-full max-h-60 w-full object-contain md:max-h-80"
+      />
+      <ZoneActions />
+    </div>
+  </LayoutTitledPanel>
 </template>


### PR DESCRIPTION
## Summary
- wrap Village panel in `TitledPanel` with custom exit logic
- return to wild zone when leaving a village
- wrap mini games in `TitledPanel`
- add translations for the new panels

## Testing
- `pnpm test` *(fails: Aborting after running 10000 timers, assuming an infinite loop)*

------
https://chatgpt.com/codex/tasks/task_e_6884f229993c832a8250c8330b806858