### PR TITLE
Fix missing translation keys

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -78,6 +78,10 @@ components:
         utility: Utility
     Zone:
       capturedAlt: captured
+    MiniGame:
+      exit: Exit
+    Village:
+      exit: Leave the village
   ThemeToggle:
     toggle: Switch theme
   UpdateSnackbar:
@@ -2992,7 +2996,7 @@ data:
 pages:
   index:
     title: Shlagemon
-    description: A parody of Pokémon with crazy creatures
+    description: Shlagemons don't smell very good.
     welcome: Welcome to Shlagemon
   shlagedex:
     title: Shlagedex

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -80,10 +80,14 @@ components:
         utility: Utilitaire
     Zone:
       capturedAlt: capturé
+    MiniGame:
+      exit: Quitter
+    Village:
+      exit: Quitter le Village
   ThemeToggle:
     toggle: Changer de thème
   UpdateSnackbar:
-    updateAvailable: Mise à jour de l'application disponible
+    updateAvailable: Une mise à jour de l'application est disponible
     reload: Recharger
   battle:
     Capture:
@@ -3113,7 +3117,7 @@ data:
 pages:
   index:
     title: Shlagémon
-    description: Parodie de Pokémon avec des créatures loufoques
+    description: Les Shlagémons ne sentent pas très bon.
     welcome: Bienvenue dans Shlagémon
   shlagedex:
     title: Shlagédex

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -58,7 +58,7 @@ declare module 'vue' {
     IconDisease: typeof import('./components/icon/Disease.vue')['default']
     IconMultiExp: typeof import('./components/icon/MultiExp.vue')['default']
     IconShlagedex: typeof import('./components/icon/Shlagedex.vue')['default']
-    IconShlagidiamond: typeof import('./components/icon/Shlagidiamond.vue')['default']
+    IconShlagidiamond: typeof import('./components/icon/shlagidiamond.vue')['default']
     IconShlagidolar: typeof import('./components/icon/Shlagidolar.vue')['default']
     IconXp: typeof import('./components/icon/Xp.vue')['default']
     InventoryEvolutionItemModal: typeof import('./components/inventory/EvolutionItemModal.vue')['default']


### PR DESCRIPTION
## Summary
- merge i18n files to regenerate locales

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688506024968832a9cdfb68c9376d2de