### PR TITLE
Update connect four board size

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -10,6 +10,7 @@ declare global {
   const CENTER_CELLS: typeof import('./composables/useTicTacToe')['CENTER_CELLS']
   const COLS: typeof import('./composables/useConnectFour')['COLS']
   const EffectScope: typeof import('vue')['EffectScope']
+  const HIDDEN_COLS: typeof import('./composables/useConnectFour')['HIDDEN_COLS']
   const ROWS: typeof import('./composables/useConnectFour')['ROWS']
   const SIZE: typeof import('./composables/useTicTacToe')['SIZE']
   const asyncComputed: typeof import('@vueuse/core')['asyncComputed']
@@ -452,6 +453,7 @@ declare module 'vue' {
     readonly CENTER_CELLS: UnwrapRef<typeof import('./composables/useTicTacToe')['CENTER_CELLS']>
     readonly COLS: UnwrapRef<typeof import('./composables/useConnectFour')['COLS']>
     readonly EffectScope: UnwrapRef<typeof import('vue')['EffectScope']>
+    readonly HIDDEN_COLS: UnwrapRef<typeof import('./composables/useConnectFour')['HIDDEN_COLS']>
     readonly ROWS: UnwrapRef<typeof import('./composables/useConnectFour')['ROWS']>
     readonly SIZE: UnwrapRef<typeof import('./composables/useTicTacToe')['SIZE']>
     readonly asyncComputed: UnwrapRef<typeof import('@vueuse/core')['asyncComputed']>

--- a/src/components/minigame/MiniGamePuissance4.vue
+++ b/src/components/minigame/MiniGamePuissance4.vue
@@ -4,6 +4,10 @@ const emit = defineEmits(['win', 'lose', 'draw'])
 const { board, finished, winningCells, lastMove, reset, play } = useConnectFour()
 const hoverCol = ref<number | null>(null)
 
+function isHiddenColumn(col: number) {
+  return HIDDEN_COLS.includes(col)
+}
+
 const wrapper = ref<HTMLElement | null>(null)
 const { width, height } = useElementSize(wrapper)
 const boardWidth = computed(() => Math.min(width.value, height.value * COLS / ROWS))
@@ -28,7 +32,7 @@ function onClick(i: number) {
 }
 
 function setHover(i: number) {
-  if (!finished.value)
+  if (!finished.value && !isHiddenColumn(i % COLS))
     hoverCol.value = i % COLS
 }
 
@@ -49,8 +53,11 @@ onMounted(reset)
         v-for="(cell, i) in board"
         :key="i"
         class="relative aspect-square flex items-center justify-center overflow-hidden rounded-full bg-[#1e2f70]"
-        :class="hoverCol === i % COLS && !finished ? 'bg-[#273878]' : ''"
-        :hover="!finished ? 'scale-105' : undefined"
+        :class="[
+          hoverCol === i % COLS && !finished ? 'bg-[#273878]' : '',
+          isHiddenColumn(i % COLS) ? 'cursor-default' : '',
+        ]"
+        :hover="!finished && !isHiddenColumn(i % COLS) ? 'scale-105' : undefined"
         @mouseenter="setHover(i)"
         @mouseleave="clearHover"
         @click="onClick(i)"

--- a/src/composables/useConnectFour.ts
+++ b/src/composables/useConnectFour.ts
@@ -1,7 +1,8 @@
 import { useAudioStore } from '~/stores/audio'
 
 export const ROWS = 6
-export const COLS = 7
+export const COLS = 9
+export const HIDDEN_COLS = [0, COLS - 1]
 
 type Cell = null | 'player' | 'ai'
 
@@ -32,17 +33,19 @@ export function createConnectFourBoard(): Cell[] {
   return Array.from({ length: ROWS * COLS }).fill(null) as Cell[]
 }
 
-export function getValidColumns(board: Cell[]): number[] {
+export function getValidColumns(board: Cell[], excludeHidden = false): number[] {
   const cols: number[] = []
   for (let c = 0; c < COLS; c++) {
+    if (excludeHidden && HIDDEN_COLS.includes(c))
+      continue
     if (!board[c])
       cols.push(c)
   }
   return cols
 }
 
-export function randomColumn(board: Cell[]): number {
-  const valid = getValidColumns(board)
+export function randomColumn(board: Cell[], excludeHidden = false): number {
+  const valid = getValidColumns(board, excludeHidden)
   return valid[Math.floor(Math.random() * valid.length)]
 }
 
@@ -88,7 +91,7 @@ function minimax(board: Cell[], depth: number, maximizing: boolean, alpha: numbe
     return Infinity
   if (checkWin(board, 'player'))
     return -Infinity
-  const valid = getValidColumns(board)
+  const valid = getValidColumns(board, maximizing)
   if (depth === 0 || valid.length === 0)
     return evaluateBoard(board)
 
@@ -118,8 +121,8 @@ function minimax(board: Cell[], depth: number, maximizing: boolean, alpha: numbe
   }
 }
 
-export function bestColumn(board: Cell[], depth = 3): number {
-  const valid = getValidColumns(board)
+export function bestColumn(board: Cell[], depth = 4): number {
+  const valid = getValidColumns(board, true)
   let bestScore = -Infinity
   let best: number[] = []
   for (const col of valid) {

--- a/test/connectfour-ai.test.ts
+++ b/test/connectfour-ai.test.ts
@@ -1,30 +1,40 @@
 import { describe, expect, it } from 'vitest'
-import { bestColumn, COLS, createConnectFourBoard, drop, randomColumn, ROWS } from '../src/composables/useConnectFour'
+import { bestColumn, COLS, createConnectFourBoard, drop, HIDDEN_COLS, randomColumn, ROWS } from '../src/composables/useConnectFour'
 
 describe('connect four ai', () => {
   it('never selects a full column', () => {
     const board = createConnectFourBoard()
     for (let r = 0; r < ROWS; r++)
-      board[r * COLS] = 'player'
+      board[r * COLS + 1] = 'player'
     const choices = new Set<number>()
     for (let i = 0; i < 20; i++)
-      choices.add(randomColumn(board))
-    expect(choices.has(0)).toBe(false)
+      choices.add(randomColumn(board, true))
+    expect(choices.has(1)).toBe(false)
   })
 
   it('wins when possible', () => {
     const board = createConnectFourBoard()
-    drop(board, 0, 'ai')
     drop(board, 1, 'ai')
     drop(board, 2, 'ai')
-    expect(bestColumn(board)).toBe(3)
+    drop(board, 3, 'ai')
+    expect(bestColumn(board)).toBe(4)
   })
 
   it('blocks player winning move', () => {
     const board = createConnectFourBoard()
-    drop(board, 0, 'player')
     drop(board, 1, 'player')
     drop(board, 2, 'player')
-    expect(bestColumn(board)).toBe(3)
+    drop(board, 3, 'player')
+    expect(bestColumn(board)).toBe(4)
+  })
+
+  it('never plays in hidden columns', () => {
+    const board = createConnectFourBoard()
+    for (let i = 0; i < 10; i++) {
+      expect(randomColumn(board, true)).not.toBe(HIDDEN_COLS[0])
+      expect(randomColumn(board, true)).not.toBe(HIDDEN_COLS[1])
+    }
+    const best = bestColumn(board)
+    expect(HIDDEN_COLS).not.toContain(best)
   })
 })

--- a/test/connectfour-component.test.ts
+++ b/test/connectfour-component.test.ts
@@ -1,10 +1,17 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import MiniGamePuissance4 from '../src/components/minigame/MiniGamePuissance4.vue'
+import { COLS, ROWS } from '../src/composables/useConnectFour'
 
 describe('connect four component', () => {
   it('renders without crashing', () => {
     const wrapper = mount(MiniGamePuissance4)
     expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders correct number of cells', () => {
+    const wrapper = mount(MiniGamePuissance4)
+    const cells = wrapper.findAll('button')
+    expect(cells.length).toBe(ROWS * COLS)
   })
 })


### PR DESCRIPTION
## Summary
- widen the connect four board to 9 columns
- keep track of hidden columns and ignore them in AI logic
- tweak connect four AI depth and prevent hover on hidden cells
- verify hidden columns aren't used in tests
- show correct number of cells in the component test

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688558bd7ff8832aac9b406752104cea