### PR TITLE
Add highlight option to Tabs

### DIFF
--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -70,6 +70,11 @@ const tabs = computed(() =>
   categories.value.map(cat => ({
     label: cat.label,
     component: getTabComponent(cat.value),
+    highlight: inventory.list.some((entry) => {
+      if (cat.value !== 'all' && entry.item.category !== cat.value)
+        return false
+      return !usage.used[entry.item.id]
+    }),
   })),
 )
 

--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -8,9 +8,15 @@ interface Label {
   icon?: string
 }
 
+interface Tab {
+  label: Label
+  component: Component
+  highlight?: boolean
+}
+
 const props = withDefaults(defineProps<{
   modelValue?: number
-  tabs: { label: Label, component: Component }[]
+  tabs: Tab[]
   isSmall?: boolean
 }>(), {
   modelValue: 0,
@@ -118,7 +124,10 @@ watch(() => props.tabs, () => nextTick(checkTabsOverflow))
         v-for="(tab, i) in props.tabs"
         :key="i"
         class="min-w-0 flex flex-1 items-center gap-1 px-1 text-center"
-        :class="`${tabButtonActiveClasses(i)} ${tabButtonClasses}`"
+        :class="[
+          `${tabButtonActiveClasses(i)} ${tabButtonClasses}`,
+          tab.highlight ? 'animate-pulse-alt animate-count-infinite' : '',
+        ]"
         @click="select(i)"
       >
         <!-- Si pas assez de place et icône dispo, on montre QUE l'icône -->


### PR DESCRIPTION
## Summary
- allow Tabs to highlight individual tabs
- track items not yet used and highlight the inventory tab accordingly

## Testing
- `pnpm test` *(fails: battlecapture, zone-heal, trainer-store, component Header.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68855cf2c774832aa85dd0cf0fc31d69