### PR TITLE
Add zone unlock requirement for villages

### DIFF
--- a/src/components/panel/Zone.vue
+++ b/src/components/panel/Zone.vue
@@ -13,9 +13,11 @@ const accessibleZones = computed(() => zone.zones.filter(z => canAccess(z)))
 const accessibleSavages = computed(() => accessibleZones.value.filter(z => z.type === 'sauvage'))
 const accessibleVillages = computed(() => accessibleZones.value.filter(z => z.type === 'village'))
 
-function canAccess(z: Zone) {
-  if (z.type === 'village')
-    return z.minLevel <= dex.highestLevel
+function canAccess(z: Zone): boolean {
+  if (z.type === 'village') {
+    const attached = zone.zones.find(zz => zz.id === z.attachedTo)
+    return z.minLevel <= dex.highestLevel && (!!attached && canAccess(attached))
+  }
   const idx = xpZones.value.findIndex(x => x.id === z.id)
   if (idx === 0)
     return true

--- a/src/stores/zoneAccess.ts
+++ b/src/stores/zoneAccess.ts
@@ -8,9 +8,12 @@ export function useZoneAccess(highestLevel: Ref<number>) {
     zones.filter(z => (z.maxLevel ?? 0) > 0),
   )
 
-  function canAccess(z: Zone) {
-    if (z.type === 'village')
+  function canAccess(z: Zone): boolean {
+    if (z.type === 'village') {
+      const attached = zones.find(zone => zone.id === z.attachedTo)
       return z.minLevel <= unref(highestLevel)
+        && (!!attached && canAccess(attached))
+    }
     const idx = xpZones.value.findIndex(x => x.id === z.id)
     if (idx === 0)
       return true


### PR DESCRIPTION
## Summary
- adjust `useZoneAccess` to check if a village's attached wild zone is unlocked
- apply same rule in `Zone.vue`

## Testing
- `pnpm test:unit --run` *(fails: battlecapture.test.ts, component.test.ts, trainer-store.test.ts, zone-heal.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68855abfc2f4832aa458b7d96b066245