### PR TITLE
Fix highlight animation on active tabs

### DIFF
--- a/src/components/ui/TabBar.vue
+++ b/src/components/ui/TabBar.vue
@@ -28,7 +28,7 @@ function select(val: string | number) {
           : [
             props.colors?.[opt.value] ?? 'bg-white dark:bg-gray-900',
             props.disabled ? '' : props.hoverColors?.[opt.value] ?? 'hover:bg-gray-100 dark:hover:bg-gray-800',
-            opt.highlight && !props.disabled ? props.highlightClasses ?? 'animate-pulse-alt animate-count-infinite' : '',
+            opt.highlight && opt.value !== props.modelValue && !props.disabled ? props.highlightClasses ?? 'animate-pulse-alt animate-count-infinite' : '',
           ],
         props.disabled ? 'pointer-events-none opacity-50' : '',
       ]"

--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -126,7 +126,7 @@ watch(() => props.tabs, () => nextTick(checkTabsOverflow))
         class="min-w-0 flex flex-1 items-center gap-1 px-1 text-center"
         :class="[
           `${tabButtonActiveClasses(i)} ${tabButtonClasses}`,
-          tab.highlight ? 'animate-pulse-alt animate-count-infinite' : '',
+          tab.highlight && active !== i ? 'animate-pulse-alt animate-count-infinite' : '',
         ]"
         @click="select(i)"
       >


### PR DESCRIPTION
## Summary
- disable highlight animation for active tabs

## Testing
- `pnpm test` *(fails: Snapshot mismatched and other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885fdd06744832aae897fb5a6c66d3d