### PR TITLE
Fix message display in ShlagMind minigame

### DIFF
--- a/src/components/minigame/MiniGameShlagMind.vue
+++ b/src/components/minigame/MiniGameShlagMind.vue
@@ -103,7 +103,8 @@ function validate() {
   }
   else {
     const list = messages.value
-    message.value = list[Math.floor(Math.random() * list.length)]
+    const idx = Math.floor(Math.random() * list.length)
+    message.value = t(`components.minigame.MiniGameShlagMind.messages[${idx}]`)
     guess.value = Array.from({ length: comboLength }).fill(null)
   }
 }


### PR DESCRIPTION
## Summary
- ensure ShlagMind random message uses translated text

## Testing
- `pnpm test` *(fails: Snapshot mismatched and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68860860c6c4832abecb75c58823ca3b