### PR TITLE
Fix owned ball visibility in trainer battles

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -33,7 +33,10 @@ const nextPlayer = ref<DexShlagemon | null>(null)
 const displayedEnemy = ref(props.enemy)
 const nextEnemy = ref<DexShlagemon | null>(null)
 
-const showOwnedBall = computed(() => zone.current.type === 'sauvage')
+const panel = useMainPanelStore()
+const showOwnedBall = computed(() =>
+  zone.current.type === 'sauvage' && panel.current === 'battle',
+)
 const enemyOwned = computed(() => {
   const id = displayedEnemy.value?.base.id
   return id ? dex.capturedBaseIds.has(id) : false


### PR DESCRIPTION
## Summary
- hide the owned ball indicator during trainer battles

## Testing
- `pnpm test` *(fails: trainer-store, component, connectfour-ai, zone-heal, battlecapture)*

------
https://chatgpt.com/codex/tasks/task_e_68862a9d3844832aa004348817e06da4