### PR TITLE
Implement quick selection from previous mastermind attempts

### DIFF
--- a/src/components/minigame/MiniGameShlagMind.vue
+++ b/src/components/minigame/MiniGameShlagMind.vue
@@ -60,6 +60,16 @@ function choose(id: string) {
   showPicker.value = false
 }
 
+function copyFromHistory(index: number, id: string) {
+  if (
+    attemptsLeft.value <= 0
+    || message.value === t('components.minigame.MiniGameShlagMind.win')
+  ) {
+    return
+  }
+  guess.value[index] = id
+}
+
 function validate() {
   if (guess.value.some(v => !v))
     return
@@ -132,8 +142,9 @@ initGame()
             >
               <img
                 :src="`/shlagemons/${id}/${id}.png`"
-                class="h-8 w-8"
+                class="h-8 w-8 cursor-pointer"
                 :alt="id"
+                @click="copyFromHistory(j, id)"
               >
             </UiTooltip>
           </div>


### PR DESCRIPTION
## Summary
- allow selecting a past guess icon to fill the current guess
- show pointer cursor over past guess icons

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched and 4 other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68863411f374832a88ad78b709528577