### PR TITLE
Fix disease store hydration

### DIFF
--- a/src/stores/disease.ts
+++ b/src/stores/disease.ts
@@ -43,9 +43,9 @@ export const useDiseaseStore = defineStore('disease', () => {
     afterHydrate(ctx) {
       const store = ctx.store as ReturnType<typeof useDiseaseStore>
       if (typeof store.active !== 'object')
-        store.active = ref(Boolean(store.active))
+        store.active.value = Boolean(store.active)
       if (typeof store.remaining !== 'object')
-        store.remaining = ref(Number(store.remaining) || 0)
+        store.remaining.value = Number(store.remaining) || 0
     },
   },
 })


### PR DESCRIPTION
## Summary
- preserve `active` and `remaining` refs when hydrating the disease store

## Testing
- `pnpm test` *(fails: Snapshot mismatch and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6886382e1300832abbea2c6e2bf15565