### PR TITLE
Fix inventory tab highlight

### DIFF
--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -70,11 +70,9 @@ const tabs = computed(() =>
   categories.value.map(cat => ({
     label: cat.label,
     component: getTabComponent(cat.value),
-    highlight: inventory.list.some((entry) => {
-      if (cat.value !== 'all' && entry.item.category !== cat.value)
-        return false
-      return !usage.used[entry.item.id]
-    }),
+    highlight: inventory.list.some(entry =>
+      entry.item.category === cat.value && !usage.used[entry.item.id],
+    ),
   })),
 )
 


### PR DESCRIPTION
## Summary
- highlight only entries matching the current tab category

## Testing
- `pnpm test` *(fails: 5 failed, 46 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68863c6e8090832aac3647b4f4a2e0a7