### PR TITLE
Fix dialog response types

### DIFF
--- a/src/components/dialog/Starter.vue
+++ b/src/components/dialog/Starter.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { BaseShlagemon } from '~/type'
+import type { ButtonType } from '~/type/button'
 import type { DialogNode } from '~/type/dialog'
 import { profMerdant } from '~/data/characters/prof-merdant'
 import bulgrosboule from '~/data/shlagemons/bulgrosboule'
@@ -22,19 +23,19 @@ function imageUrl(id: string) {
   return `/shlagemons/${id}/${id}.png`
 }
 
-const dialogTree = computed<DialogNode[]>(() => [
+const dialogTree = computed((): DialogNode[] => [
   {
     id: 'start',
     text: t('components.dialog.Starter.steps.start.text', { name: profMerdant.name }),
     responses: [
-      { label: t('components.dialog.Starter.steps.start.responses.next'), nextId: '2', type: 'primary' },
+      { label: t('components.dialog.Starter.steps.start.responses.next'), nextId: '2', type: 'primary' as ButtonType },
     ],
   },
   {
     id: '2',
     text: t('components.dialog.Starter.steps.step2.text'),
     responses: [
-      { label: t('components.dialog.Starter.steps.step2.responses.next'), nextId: 'choice', type: 'primary' },
+      { label: t('components.dialog.Starter.steps.step2.responses.next'), nextId: 'choice', type: 'primary' as ButtonType },
     ],
   },
   {
@@ -44,7 +45,7 @@ const dialogTree = computed<DialogNode[]>(() => [
       label: s.name,
       nextId: nextId(s.id),
       imageUrl: '/items/shlageball/shlageball.png',
-      type: 'primary',
+      type: 'primary' as ButtonType,
     })),
   },
   ...starters.map(s => ({
@@ -52,10 +53,10 @@ const dialogTree = computed<DialogNode[]>(() => [
     text: t(`components.dialog.Starter.steps.${s.id}.text`),
     imageUrl: imageUrl(s.id),
     responses: [
-      { label: t('components.dialog.Starter.steps.common.responses.back'), nextId: 'choice', type: 'danger' },
+      { label: t('components.dialog.Starter.steps.common.responses.back'), nextId: 'choice', type: 'danger' as ButtonType },
       {
         label: t(`components.dialog.Starter.steps.${s.id}.responses.valid`, { name: profMerdant.name }),
-        type: 'valid',
+        type: 'valid' as ButtonType,
         action: () => {
           gameState.setStarterId(s.id)
           dex.createShlagemon(s)


### PR DESCRIPTION
## Summary
- use `ButtonType` for starter dialog response objects
- annotate starter dialog tree as `DialogNode[]`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Type errors in multiple files)*
- `pnpm test` *(fails: 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68863c8e12e8832ab3ca8267d7cad1d2