### PR TITLE
Fix UI store type

### DIFF
--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -56,7 +56,7 @@ export const useDialogStore = defineStore('dialog', () => {
   const visit = useZoneVisitStore()
   const inventory = useInventoryStore()
   const box = useEggBoxStore()
-  const ui = useUIStore()
+  const ui: ReturnType<typeof useUIStore> = useUIStore()
   const mobile = useMobileTabStore()
   const potionInfo = usePotionInfoStore()
 


### PR DESCRIPTION
## Summary
- hint UI store return type in `dialog` store to keep `isMobile` as a Ref

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68863c7c8410832aa1c3e0967cf05a36