### PR TITLE
Define puzzle direction type

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -402,7 +402,7 @@ declare global {
   export type { Cell } from './composables/useBattleship'
   import('./composables/useBattleship')
   // @ts-ignore
-  export type { SlidingPuzzle } from './composables/useSlidingPuzzle'
+  export type { SlidingPuzzle, PuzzleDirection } from './composables/useSlidingPuzzle'
   import('./composables/useSlidingPuzzle')
   // @ts-ignore
   export type { Achievement, AchievementEvent } from './stores/achievements'

--- a/src/components/minigame/MiniGameShlagTaquin.vue
+++ b/src/components/minigame/MiniGameShlagTaquin.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { PuzzleDirection } from '~/composables/useSlidingPuzzle'
 import { useElementSize, useEventListener, useSwipe, useTimeoutFn } from '@vueuse/core'
 import { useSlidingPuzzle } from '~/composables/useSlidingPuzzle'
 
@@ -22,11 +23,11 @@ const { width, height } = useElementSize(wrapper)
 const squareSize = computed(() => Math.min(width.value, height.value))
 
 useSwipe(wrapper, {
-  onSwipeEnd(_, dir) {
+  onSwipeEnd(_: Event, dir: PuzzleDirection | 'none') {
     if (puzzle.solved.value || puzzle.shuffling.value)
       return
     if (dir !== 'none')
-      puzzle.move(dir as any)
+      puzzle.move(dir)
   },
 })
 

--- a/src/composables/useSlidingPuzzle.ts
+++ b/src/composables/useSlidingPuzzle.ts
@@ -10,6 +10,8 @@ export interface SlidingPuzzle {
   size: number
 }
 
+export type PuzzleDirection = 'up' | 'down' | 'left' | 'right'
+
 export function useSlidingPuzzle(size: number | Ref<number>) {
   const sizeRef = isRef(size) ? size : ref(size)
   const tiles = ref<number[]>([])
@@ -25,10 +27,10 @@ export function useSlidingPuzzle(size: number | Ref<number>) {
     solved.value = true
   }
 
-  function validDirections() {
+  function validDirections(): PuzzleDirection[] {
     const r = Math.floor(emptyIndex.value / sizeRef.value)
     const c = emptyIndex.value % sizeRef.value
-    const dirs: ('up' | 'down' | 'left' | 'right')[] = []
+    const dirs: PuzzleDirection[] = []
     if (r < sizeRef.value - 1)
       dirs.push('up')
     if (r > 0)
@@ -43,8 +45,8 @@ export function useSlidingPuzzle(size: number | Ref<number>) {
   async function shuffleBoard(moves = 50, delay = 50) {
     shuffling.value = true
     solved.value = false
-    const opposites = { up: 'down', down: 'up', left: 'right', right: 'left' } as const
-    let lastDir: 'up' | 'down' | 'left' | 'right' | null = null
+    const opposites: Record<PuzzleDirection, PuzzleDirection> = { up: 'down', down: 'up', left: 'right', right: 'left' }
+    let lastDir: PuzzleDirection | null = null
     for (let i = 0; i < moves; i++) {
       const dirs = validDirections().filter(d => opposites[d] !== lastDir)
       const dir = dirs[Math.floor(Math.random() * dirs.length)]
@@ -69,7 +71,7 @@ export function useSlidingPuzzle(size: number | Ref<number>) {
     audio.playSfx('/audio/sfx/mini-game/taquin/move.ogg')
   }
 
-  function move(dir: 'up' | 'down' | 'left' | 'right') {
+  function move(dir: PuzzleDirection) {
     const r = Math.floor(emptyIndex.value / sizeRef.value)
     const c = emptyIndex.value % sizeRef.value
     let r2 = r


### PR DESCRIPTION
## Summary
- introduce `PuzzleDirection` union in `useSlidingPuzzle`
- use this direction type in `MiniGameShlagTaquin`
- update auto-imports

## Testing
- `pnpm test` *(fails: Snapshot mismatch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688654c60dc0832aa2e48e50162c8844