### PR TITLE
Fix i18n Locale typing

### DIFF
--- a/src/components/LanguageSelector.vue
+++ b/src/components/LanguageSelector.vue
@@ -10,7 +10,7 @@ const options = computed(() => availableLocales.map(l => ({
 })))
 
 async function change(val: string | number) {
-  const lang = val as string
+  const lang = val as Locale
   store.setLocale(lang as 'en' | 'fr')
   await loadLanguageAsync(lang)
 }

--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -20,12 +20,12 @@ const localesMap = Object.fromEntries(
     .map(([path, loadLocale]) => [path.match(/([\w-]*)\.yml$/)?.[1], loadLocale]),
 ) as Record<Locale, () => Promise<{ default: Record<string, string> }>>
 
-export const availableLocales = Object.keys(localesMap)
+export const availableLocales = Object.keys(localesMap) as Locale[]
 
-const loadedLanguages: string[] = []
+const loadedLanguages: Locale[] = []
 
 function setI18nLanguage(lang: Locale) {
-  i18n.global.locale.value = lang as any
+  i18n.global.locale.value = lang
   if (typeof document !== 'undefined')
     document.documentElement.setAttribute('lang', lang)
   if (getCurrentInstance()) {
@@ -38,7 +38,7 @@ function setI18nLanguage(lang: Locale) {
   return lang
 }
 
-export async function loadLanguageAsync(lang: string): Promise<Locale> {
+export async function loadLanguageAsync(lang: Locale): Promise<Locale> {
   // If the same language
   if (i18n.global.locale.value === lang)
     return setI18nLanguage(lang)
@@ -57,7 +57,7 @@ export async function loadLanguageAsync(lang: string): Promise<Locale> {
 export const install: UserModule = ({ app, isClient }) => {
   app.use(i18n)
   const localeStore = useLocaleStore()
-  let lang = localeStore.locale
+  let lang: Locale = localeStore.locale.value
 
   if (isClient && !localStorage.getItem('locale')) {
     const navigatorLang = navigator.language || 'en'


### PR DESCRIPTION
## Summary
- make LanguageSelector use Locale directly
- tighten i18n Locale typing for loaded languages and locale list

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688654b799bc832abdd970f395aa059b