### PR TITLE
Fix egg box import type

### DIFF
--- a/src/components/dialog/EggBoxDialog.vue
+++ b/src/components/dialog/EggBoxDialog.vue
@@ -42,7 +42,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         type: 'valid',
         action: () => {
           box.unlock()
-          box.importFromInventory(inventory.items as any)
+          box.importFromInventory(inventory.items)
           inventory.add(eggBox.id)
           emit('done', 'eggBox')
         },

--- a/src/stores/eggBox.ts
+++ b/src/stores/eggBox.ts
@@ -29,12 +29,13 @@ export const useEggBoxStore = defineStore('eggBox', () => {
       delete eggs.value[id]
   }
 
-  function importFromInventory(items: Partial<Record<ItemId, number>>) {
+  function importFromInventory(items: MaybeRef<Partial<Record<ItemId, number>>>) {
+    const source = unref(items)
     for (const id of eggIds) {
-      const count = items[id]
+      const count = source[id]
       if (count && count > 0) {
         addEgg(id, count)
-        delete items[id]
+        delete source[id]
       }
     }
   }


### PR DESCRIPTION
## Summary
- allow EggBoxStore importFromInventory to accept a ref
- use inventory.items directly in EggBoxDialog

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot mismatch and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688654cb6200832aa0755ae87e36958d