### PR TITLE
Fix i18n locale loader

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -16,9 +16,9 @@ export const i18n = createI18n({
 })
 
 const localesMap = Object.fromEntries(
-  Object.entries(import.meta.glob('../../locales/*.yml'))
-    .map(([path, loadLocale]) => [path.match(/([\w-]*)\.yml$/)?.[1], loadLocale]),
-) as Record<Locale, () => Promise<{ default: Record<string, string> }>>
+  Object.entries(import.meta.glob('../../locales/*.yml', { eager: true, import: 'default' }))
+    .map(([path, messages]) => [path.match(/([\w-]*)\.yml$/)?.[1], messages]),
+) as Record<Locale, Record<string, string>>
 
 export const availableLocales = Object.keys(localesMap) as Locale[]
 
@@ -48,8 +48,9 @@ export async function loadLanguageAsync(lang: Locale): Promise<Locale> {
     return setI18nLanguage(lang)
 
   // If the language hasn't been loaded yet
-  const messages = await localesMap[lang]()
-  i18n.global.setLocaleMessage(lang, messages.default)
+  const messages = localesMap[lang]
+  if (messages)
+    i18n.global.setLocaleMessage(lang, messages)
   loadedLanguages.push(lang)
   return setI18nLanguage(lang)
 }


### PR DESCRIPTION
## Summary
- eagerly load locales during app startup
- handle locale messages directly instead of via async functions

## Testing
- `pnpm test` *(fails: Error: Failed to resolve import "../src/data/items/items" from tests)*

------
https://chatgpt.com/codex/tasks/task_e_6886653d9bd4832a8ec91465f07850a8