### PR TITLE
Fix i18n fallback locale

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -12,6 +12,7 @@ import { useLocaleStore } from '~/stores/locale'
 export const i18n = createI18n({
   legacy: false,
   locale: '',
+  fallbackLocale: 'en',
   messages: {},
 })
 


### PR DESCRIPTION
## Summary
- add `fallbackLocale: 'en'` to i18n configuration

## Testing
- `pnpm test` *(fails: snapshot mismatches and other errors)*
- `pnpm typecheck` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68866f962174832a8082d58610e2c07e