### PR TITLE
Fix i18n init locale

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -11,7 +11,7 @@ import { useLocaleStore } from '~/stores/locale'
 // Don't need this? Try vitesse-lite: https://github.com/antfu/vitesse-lite
 export const i18n = createI18n({
   legacy: false,
-  locale: '',
+  locale: 'en',
   fallbackLocale: 'en',
   messages: {},
 })


### PR DESCRIPTION
## Summary
- set a valid initial locale when creating the i18n instance

## Testing
- `pnpm test` *(fails: The server is being restarted or closed. Request is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_688676c01bf0832ab7dc88c7b3c17d97