### PR TITLE
Fix locale initialization

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -59,13 +59,12 @@ export async function loadLanguageAsync(lang: Locale): Promise<Locale> {
 export const install: UserModule = ({ app, isClient }) => {
   app.use(i18n)
   const localeStore = useLocaleStore()
-  let lang: Locale = localeStore.locale.value
 
   if (isClient && !localStorage.getItem('locale')) {
     const navigatorLang = navigator.language || 'en'
-    lang = navigatorLang.toLowerCase().startsWith('fr') ? 'fr' : 'en'
+    const lang = navigatorLang.toLowerCase().startsWith('fr') ? 'fr' : 'en'
     localeStore.setLocale(lang)
   }
 
-  loadLanguageAsync(lang)
+  loadLanguageAsync(localeStore.locale.value)
 }


### PR DESCRIPTION
## Summary
- ensure a plain string is passed when loading i18n locale

## Testing
- `pnpm test` *(fails: Failed to resolve import "../src/data/items/items" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68867a33bc24832a809f933d58e761ef