### PR TITLE
Remove difficulty modifier from capture formula

### DIFF
--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -3,11 +3,9 @@ import type { Ball, DexShlagemon } from '~/type'
 export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
   const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
   const levelMod = 1 / (1 + enemy.lvl / 40)
-  // Slightly increase the global capture rate to make encounters less frustrating
-  const difficultyMod = 1.3
   const dex = useShlagedexStore()
   const captureMod = 1 + dex.captureBonusPercent / 100
-  const chance = Math.min(100, hpChance * levelMod * ball.catchBonus * difficultyMod * captureMod)
+  const chance = Math.min(100, hpChance * levelMod * ball.catchBonus * captureMod)
   const dev = useDeveloperStore()
   if (dev.debug) {
     console.warn(

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -25,15 +25,14 @@ describe('capture mechanics', () => {
     expect(tryCapture(mon, balls[0])).toBe(false)
   })
 
-  it('hyper ball versus strong foe gives around 30% chance', () => {
+  it('hyper ball versus strong foe is guaranteed', () => {
     const mon = createDexShlagemon(carapouffe, false, 100)
     mon.hp = 100
     mon.hpCurrent = 10
     const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
     const levelMod = 1 / (1 + mon.lvl / 40)
-    const difficultyMod = 1.3
-    const chance = Math.min(100, hpChance * levelMod * balls[2].catchBonus * difficultyMod)
-    expect(chance).toBeCloseTo(30, 1)
+    const chance = Math.min(100, hpChance * levelMod * balls[2].catchBonus)
+    expect(chance).toBe(100)
   })
 
   it('regular ball against lvl1 foe at full HP is almost guaranteed', () => {
@@ -41,8 +40,7 @@ describe('capture mechanics', () => {
     mon.hpCurrent = mon.hp
     const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
     const levelMod = 1 / (1 + mon.lvl / 40)
-    const difficultyMod = 1.3
-    const chance = Math.min(100, hpChance * levelMod * balls[0].catchBonus * difficultyMod)
-    expect(chance).toBeGreaterThanOrEqual(95)
+    const chance = Math.min(100, hpChance * levelMod * balls[0].catchBonus)
+    expect(chance).toBeCloseTo(78, 0)
   })
 })


### PR DESCRIPTION
## Summary
- simplify `tryCapture` by removing difficulty coefficient
- update capture tests to reflect new probabilities

## Testing
- `pnpm test:unit` *(fails: Failed to resolve import '../src/data/items/items' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68868f0cecd8832a87cf771f1058104c