### PR TITLE
Replace pickRandomByCoefficient with uniform pickRandom

### DIFF
--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia'
 import { multiExp } from '~/data/items'
 import { allShlagemons } from '~/data/shlagemons'
 import { createDexShlagemon } from '~/utils/dexFactory'
-import { pickRandomByCoefficient } from '~/utils/spawn'
+import { pickRandom } from '~/utils/spawn'
 
 const dex = useShlagedexStore()
 const zone = useZoneStore()
@@ -29,7 +29,7 @@ function createEnemy(): DexShlagemon | null {
     if (filtered.length)
       pool = filtered
   }
-  const base = pickRandomByCoefficient(pool)
+  const base = pickRandom(pool)
   progress.registerEncounter(zone.current.id, base.id)
   const min = Number(zone.current.minLevel ?? 1)
   const zoneMax = Number(zone.current.maxLevel ?? (min + 1))

--- a/src/stores/egg.ts
+++ b/src/stores/egg.ts
@@ -4,7 +4,7 @@ import type { BaseShlagemon } from '~/type'
 import { defineStore } from 'pinia'
 import { baseShlagemons } from '~/data/shlagemons'
 import { eggSerializer } from '~/utils/egg-serialize'
-import { pickRandomByCoefficient } from '~/utils/spawn'
+import { pickRandom } from '~/utils/spawn'
 
 export type EggType = TypeName
 
@@ -26,7 +26,7 @@ export const useEggStore = defineStore('egg', () => {
     const candidates = baseShlagemons
       .filter(b => b.types.some(t => t.id === type))
       .filter(b => !b.legendary)
-    const base = pickRandomByCoefficient(candidates)
+    const base = pickRandom(candidates)
     const duration = 60_000
     const startedAt = Date.now()
     const id = startedAt + Math.random()

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -4,7 +4,7 @@ import type { BaseShlagemon } from '~/type'
  * Pick a random Shlagemon from the list preserving the
  * original item type.
  */
-export function pickRandomByCoefficient<T extends BaseShlagemon>(list: T[]): T {
+export function pickRandom<T extends BaseShlagemon>(list: T[]): T {
   const r = Math.floor(Math.random() * list.length)
   return list[r]
 }

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { pickRandomByCoefficient } from '../src/utils/spawn'
+import { pickRandom } from '../src/utils/spawn'
 
 const list = [
   { id: 'm1', name: 'm1', description: '', types: [] },
@@ -9,7 +9,7 @@ const list = [
 
 describe('spawn selection', () => {
   it('returns a monster from the list', () => {
-    const result = pickRandomByCoefficient(list)
+    const result = pickRandom(list)
     expect(list).toContain(result)
   })
 })


### PR DESCRIPTION
## Summary
- rename `pickRandomByCoefficient` to `pickRandom`
- update uses in battle, egg store and tests
- keep random selection logic without weighting

## Testing
- `pnpm test` *(fails: missing imports and snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68869287c6b4832a90be2f3b54da9d79