### PR TITLE
Implement speciality bonus for Shlagemons

### DIFF
--- a/src/constants/speciality.ts
+++ b/src/constants/speciality.ts
@@ -1,0 +1,9 @@
+import type { Speciality } from '~/type'
+
+export const specialityBonus: Record<Speciality, number> = {
+  legendary: 20,
+  unique: 10,
+  evolution0: 0,
+  evolution1: 10,
+  evolution2: 15,
+}

--- a/src/data/shlagemons.ts
+++ b/src/data/shlagemons.ts
@@ -1,4 +1,4 @@
-import type { BaseShlagemon } from '~/type'
+import type { BaseShlagemon, Speciality } from '~/type'
 
 export const modules = import.meta.glob<{ default: BaseShlagemon }>('./shlagemons/**/*.ts', { eager: true })
 
@@ -6,6 +6,10 @@ export const allShlagemons: BaseShlagemon[] = Object.entries(modules)
   .filter(([path]) => !path.endsWith('index.ts'))
   .map(([path, m]) => {
     const base = m.default
+    if ((base as any).legendary) {
+      ;(base as any).speciality = 'legendary'
+      delete (base as any).legendary
+    }
     const rel = path
       .replace('./shlagemons/', '')
       .replace(/\.ts$/, '')
@@ -22,6 +26,40 @@ for (const mon of allShlagemons) {
     if (id)
       evolvedIds.add(id)
   })
+}
+
+function findPreEvolution(id: string): BaseShlagemon | undefined {
+  return allShlagemons.find((m) => {
+    const evos = m.evolutions ?? (m.evolution ? [m.evolution] : [])
+    return evos.some(e => e.base.id === id)
+  })
+}
+
+function evolutionDepth(id: string): number {
+  let depth = 0
+  let prev = findPreEvolution(id)
+  while (prev) {
+    depth += 1
+    prev = findPreEvolution(prev.id)
+  }
+  return depth
+}
+
+for (const mon of allShlagemons) {
+  if (mon.speciality === 'legendary')
+    continue
+  const depth = evolutionDepth(mon.id)
+  const hasEvolution = Boolean(mon.evolution || mon.evolutions?.length)
+  let speciality: Speciality
+  if (depth === 0 && !hasEvolution)
+    speciality = 'unique'
+  else if (depth === 0)
+    speciality = 'evolution0'
+  else if (depth === 1)
+    speciality = 'evolution1'
+  else
+    speciality = 'evolution2'
+  mon.speciality = speciality
 }
 
 export const baseShlagemons = allShlagemons.filter(m => !evolvedIds.has(m.id))

--- a/src/data/shlagemons/artichaud.ts
+++ b/src/data/shlagemons/artichaud.ts
@@ -14,7 +14,7 @@ Aujourd’hui, Artichaud veille sur les zones de non-droit climatiques, où il i
   descriptionKey: 'data.shlagemons.artichaud.description',
 
   types: [shlagemonTypes.glace, shlagemonTypes.vol],
-  legendary: true,
+  speciality: 'legendary',
 }
 
 export default artichaud

--- a/src/data/shlagemons/electhordu.ts
+++ b/src/data/shlagemons/electhordu.ts
@@ -16,7 +16,7 @@ Aujourd’hui, il erre, tordu du bec au voltage, parlant seul dans les fils éle
   descriptionKey: 'data.shlagemons.electhordu.description',
 
   types: [shlagemonTypes.electrique, shlagemonTypes.vol],
-  legendary: true,
+  speciality: 'legendary',
 }
 
 export default electhordu

--- a/src/data/shlagemons/mairiousse.ts
+++ b/src/data/shlagemons/mairiousse.ts
@@ -14,7 +14,7 @@ On dit que Mairiousse n’aboie pas : il fait des discours interminables qui end
   descriptionKey: 'data.shlagemons.mairiousse.description',
 
   types: [shlagemonTypes.sol, shlagemonTypes.eau],
-  legendary: true,
+  speciality: 'legendary',
 }
 
 export default mairiousse

--- a/src/data/shlagemons/mewteub.ts
+++ b/src/data/shlagemons/mewteub.ts
@@ -8,7 +8,7 @@ export const mewteub: BaseShlagemon = {
 Mewteub est rare. Trop rare. Et franchement, c’est peut-être mieux ainsi.`,
   descriptionKey: 'data.shlagemons.mewteub.description',
   types: [shlagemonTypes.psy],
-  legendary: true,
+  speciality: 'legendary',
 }
 
 export default mewteub

--- a/src/data/shlagemons/sulfusouris.ts
+++ b/src/data/shlagemons/sulfusouris.ts
@@ -14,7 +14,7 @@ Vénéré par une secte de rats crasseux, Sulfusouris est considéré comme le �
   descriptionKey: 'data.shlagemons.sulfusouris.description',
 
   types: [shlagemonTypes.feu, shlagemonTypes.vol],
-  legendary: true,
+  speciality: 'legendary',
 }
 
 export default sulfusouris

--- a/src/data/shlagemons/zebrapoisbleu.ts
+++ b/src/data/shlagemons/zebrapoisbleu.ts
@@ -18,7 +18,7 @@ Ce Shlagémon n’attaque jamais directement. Il infuse le terrain d’une paix 
   descriptionKey: 'data.shlagemons.electhordu.description',
 
   types: [shlagemonTypes.psy, shlagemonTypes.vol],
-  legendary: true,
+  speciality: 'legendary',
 }
 
 export default zebrapoisbleu

--- a/src/stores/egg.ts
+++ b/src/stores/egg.ts
@@ -25,7 +25,7 @@ export const useEggStore = defineStore('egg', () => {
       return false
     const candidates = baseShlagemons
       .filter(b => b.types.some(t => t.id === type))
-      .filter(b => !b.legendary)
+      .filter(b => b.speciality !== 'legendary')
     const base = pickRandomByCoefficient(candidates)
     const duration = 60_000
     const startedAt = Date.now()

--- a/src/stores/eggMonsModal.ts
+++ b/src/stores/eggMonsModal.ts
@@ -16,7 +16,7 @@ export const useEggMonsModalStore = defineStore('eggMonsModal', () => {
       return []
     return baseShlagemons
       .filter(b => b.types.some(t => t.id === type.value))
-      .filter(b => !b.legendary)
+      .filter(b => b.speciality !== 'legendary')
   })
 
   function open(id: EggItemId, eggItem: Item) {

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -4,6 +4,13 @@ import type { Stats } from './stats'
 
 export type Sex = 'male' | 'female'
 
+export type Speciality
+  = 'legendary'
+    | 'unique'
+    | 'evolution0'
+    | 'evolution1'
+    | 'evolution2'
+
 export interface BaseShlagemon {
   id: string
   name: string
@@ -22,7 +29,7 @@ export interface BaseShlagemon {
    * Multiple options can be provided.
    */
   evolutions?: ShlagemonEvolution[]
-  legendary?: boolean
+  speciality?: Speciality
 }
 
 export interface DexShlagemon extends Stats {

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -1,5 +1,6 @@
 import type { Stats } from '~/type'
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
+import { specialityBonus } from '~/constants/speciality'
 import marginal from '~/data/shlagemons/50-55/marginal'
 
 export const baseStats: Stats = {
@@ -34,11 +35,13 @@ export function applyStats(mon: DexShlagemon) {
 
 export function applyCurrentStats(mon: DexShlagemon) {
   const levelBoost = 1.04 ** (mon.lvl - 1)
+  const specialityBoost = 1
+    + (specialityBonus[mon.base.speciality ?? 'evolution0'] || 0) / 100
 
   const hpBase = Math.floor(mon.baseStats.hp / 5) * 5
   mon.hp = Math.floor(hpBase * levelBoost)
-  mon.attack = Math.floor(mon.baseStats.attack * levelBoost)
-  mon.defense = Math.floor(mon.baseStats.defense * levelBoost)
+  mon.attack = Math.floor(mon.baseStats.attack * levelBoost * specialityBoost)
+  mon.defense = Math.floor(mon.baseStats.defense * levelBoost * specialityBoost)
   mon.smelling = Math.floor(mon.baseStats.smelling * levelBoost)
   mon.hpCurrent = mon.hp
 


### PR DESCRIPTION
## Summary
- replace `legendary` flag with `speciality` field
- compute speciality for all Shlagemons at load time
- add speciality bonus constants and apply them to stats
- filter legendary monsters in egg features using `speciality`
- update legendary data files to use the new field

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot mismatch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886948ed448832ab4ddd0e6242da39f