### PR TITLE
Ensure speciality for all monsters

### DIFF
--- a/src/data/shlagemons.ts
+++ b/src/data/shlagemons.ts
@@ -1,21 +1,26 @@
 import type { BaseShlagemon, Speciality } from '~/type'
 
-export const modules = import.meta.glob<{ default: BaseShlagemon }>('./shlagemons/**/*.ts', { eager: true })
+interface RawShlagemon extends Omit<BaseShlagemon, 'speciality'> {
+  speciality?: Speciality
+  /** Temporary property for backwards compatibility */
+  legendary?: boolean
+}
+export const modules = import.meta.glob<{ default: RawShlagemon }>('./shlagemons/**/*.ts', { eager: true })
 
 export const allShlagemons: BaseShlagemon[] = Object.entries(modules)
   .filter(([path]) => !path.endsWith('index.ts'))
   .map(([path, m]) => {
-    const base = m.default
-    if ((base as any).legendary) {
-      ;(base as any).speciality = 'legendary'
-      delete (base as any).legendary
+    const raw = m.default
+    if (raw.legendary) {
+      raw.speciality = 'legendary'
+      delete raw.legendary
     }
     const rel = path
       .replace('./shlagemons/', '')
       .replace(/\.ts$/, '')
     const key = rel.replace(/\//g, '.')
-    base.descriptionKey = `data.shlagemons.${key}.description`
-    return base
+    raw.descriptionKey = `data.shlagemons.${key}.description`
+    return raw as BaseShlagemon
   })
 
 const evolvedIds = new Set<string>()

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -29,7 +29,10 @@ export interface BaseShlagemon {
    * Multiple options can be provided.
    */
   evolutions?: ShlagemonEvolution[]
-  speciality?: Speciality
+  /**
+   * Classification of the Shlagémon based on its evolution stage.
+   */
+  speciality: Speciality
 }
 
 export interface DexShlagemon extends Stats {

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -36,7 +36,7 @@ export function applyStats(mon: DexShlagemon) {
 export function applyCurrentStats(mon: DexShlagemon) {
   const levelBoost = 1.04 ** (mon.lvl - 1)
   const specialityBoost = 1
-    + (specialityBonus[mon.base.speciality ?? 'evolution0'] || 0) / 100
+    + (specialityBonus[mon.base.speciality] || 0) / 100
 
   const hpBase = Math.floor(mon.baseStats.hp / 5) * 5
   mon.hp = Math.floor(hpBase * levelBoost)


### PR DESCRIPTION
## Summary
- make `speciality` mandatory in `BaseShlagemon`
- allow shlagemon data files to omit it at import time
- compute `speciality` for each shlagemon
- use required `speciality` when applying stats

## Testing
- `pnpm vitest run` *(fails: pickRandomByCoefficient is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68869cf57c04832a9442defe9fcf06ed