### PR TITLE
Add mandatory speciality field to Shlagemon data

### DIFF
--- a/src/data/shlagemons.ts
+++ b/src/data/shlagemons.ts
@@ -1,4 +1,4 @@
-import type { BaseShlagemon, Speciality } from '~/type'
+import type { BaseShlagemon } from '~/type'
 
 export const modules = import.meta.glob<{ default: BaseShlagemon }>('./shlagemons/**/*.ts', { eager: true })
 
@@ -6,10 +6,6 @@ export const allShlagemons: BaseShlagemon[] = Object.entries(modules)
   .filter(([path]) => !path.endsWith('index.ts'))
   .map(([path, m]) => {
     const base = m.default
-    if ((base as any).legendary) {
-      ;(base as any).speciality = 'legendary'
-      delete (base as any).legendary
-    }
     const rel = path
       .replace('./shlagemons/', '')
       .replace(/\.ts$/, '')
@@ -26,40 +22,6 @@ for (const mon of allShlagemons) {
     if (id)
       evolvedIds.add(id)
   })
-}
-
-function findPreEvolution(id: string): BaseShlagemon | undefined {
-  return allShlagemons.find((m) => {
-    const evos = m.evolutions ?? (m.evolution ? [m.evolution] : [])
-    return evos.some(e => e.base.id === id)
-  })
-}
-
-function evolutionDepth(id: string): number {
-  let depth = 0
-  let prev = findPreEvolution(id)
-  while (prev) {
-    depth += 1
-    prev = findPreEvolution(prev.id)
-  }
-  return depth
-}
-
-for (const mon of allShlagemons) {
-  if (mon.speciality === 'legendary')
-    continue
-  const depth = evolutionDepth(mon.id)
-  const hasEvolution = Boolean(mon.evolution || mon.evolutions?.length)
-  let speciality: Speciality
-  if (depth === 0 && !hasEvolution)
-    speciality = 'unique'
-  else if (depth === 0)
-    speciality = 'evolution0'
-  else if (depth === 1)
-    speciality = 'evolution1'
-  else
-    speciality = 'evolution2'
-  mon.speciality = speciality
 }
 
 export const baseShlagemons = allShlagemons.filter(m => !evolvedIds.has(m.id))

--- a/src/data/shlagemons/01-05/fantomanus.ts
+++ b/src/data/shlagemons/01-05/fantomanus.ts
@@ -19,6 +19,6 @@ On raconte qu’il rêve d’atteindre la perfection du prout astral, mais il ga
       value: 22,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default fantomanus

--- a/src/data/shlagemons/01-05/jeunebelette.ts
+++ b/src/data/shlagemons/01-05/jeunebelette.ts
@@ -19,6 +19,6 @@ On raconte qu'il pourrait évoluer s'il trouvait enfin une vraie motivation. Mai
       value: 5,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default jeunebelette

--- a/src/data/shlagemons/01-05/rouxPasCool.ts
+++ b/src/data/shlagemons/01-05/rouxPasCool.ts
@@ -9,6 +9,6 @@ export const rouxPasCool: BaseShlagemon = {
   descriptionKey: 'data.shlagemons.01-05.rouxPasCool.description',
   types: [shlagemonTypes.vol],
   evolution: { base: rouxScoop, condition: { type: 'lvl', value: 18 } },
+  speciality: 'evolution0',
 }
-
 export default rouxPasCool

--- a/src/data/shlagemons/01-05/sacdepates.ts
+++ b/src/data/shlagemons/01-05/sacdepates.ts
@@ -7,6 +7,6 @@ export const sacdepates: BaseShlagemon = {
   description: `Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser.`,
   descriptionKey: 'data.shlagemons.01-05.sacdepates.description',
   types: [shlagemonTypes.plante],
+  speciality: 'unique',
 }
-
 export default sacdepates

--- a/src/data/shlagemons/05-10/aspigros.ts
+++ b/src/data/shlagemons/05-10/aspigros.ts
@@ -23,6 +23,6 @@ Il ne parle pas, mais fait des bruits de mastication 100% du temps. Il adore les
 On le reconnaît à sa forme sphérique, ses yeux toujours mi-clos de satiété, et à sa devise gravée sur son ventre : "Si ça rentre, c’est que c’est bon."`,
   descriptionKey: 'data.shlagemons.05-10.aspigros.description',
   types: [shlagemonTypes.insecte],
+  speciality: 'evolution0',
 }
-
 export default aspigros

--- a/src/data/shlagemons/05-10/chenipaon.ts
+++ b/src/data/shlagemons/05-10/chenipaon.ts
@@ -21,6 +21,6 @@ Son cri officiel est enregistré dans les bases de données comme *"KRRRR-païï
 Il possède l’attaque spéciale *Roule Par Terre Coloré*, qui inflige des dégâts aléatoires et laisse des plumes toxiques sur le champ de bataille. Il peut également utiliser *Faux Charisme*, qui augmente brièvement son taux de critique en fonction du nombre de regards consternés qu’il reçoit.`,
   descriptionKey: 'data.shlagemons.05-10.chenipaon.description',
   types: [shlagemonTypes.insecte],
+  speciality: 'evolution0',
 }
-
 export default chenipaon

--- a/src/data/shlagemons/05-10/metamorve.ts
+++ b/src/data/shlagemons/05-10/metamorve.ts
@@ -7,6 +7,6 @@ export const metamorve: BaseShlagemon = {
   description: `Une masse de boue nauséabonde qui se traîne lentement. Là où il passe, plus rien ne pousse à cause de sa toxicité. Il est fait d'une boue toxique. Il pollue tout ce qu’il touche, même le sol devient stérile. Il pue tellement que des gens s’évanouissent rien qu’en le croisant. Son corps est un concentré de toxines.`,
   descriptionKey: 'data.shlagemons.05-10.metamorve.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default metamorve

--- a/src/data/shlagemons/05-10/ptitocard.ts
+++ b/src/data/shlagemons/05-10/ptitocard.ts
@@ -15,6 +15,6 @@ export const ptitocard: BaseShlagemon = {
       value: 50,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default ptitocard

--- a/src/data/shlagemons/10-15/abraquemar.ts
+++ b/src/data/shlagemons/10-15/abraquemar.ts
@@ -15,6 +15,6 @@ export const abraquemar: BaseShlagemon = {
   description: `Abraquemar est adepte de la sieste transcendantale et de la fuite passive-agressive. À la moindre interaction sociale, il disparaît dans un nuage de poussière en marmonnant "j’te sens pas, j’me tire". Son taux de fuite est de 100%, sauf s’il entend une discussion sur les chakras ou les promos sur les tapis ethniques. On le trouve souvent assis en tailleur, les yeux mi-ouverts, entre deux posters de l’Univers collés avec du chewing-gum. Il porte toujours une capuche trop grande et une écharpe mal nouée, et prétend être "entre deux plans d’alignement stellaire". Sa capacité spéciale, *Téléportation du Malaise*, permet d’échanger de place avec une poubelle proche. Il possède aussi l’attaque *Sérénité Forcée*, qui fait baisser l’attaque ennemie par culpabilité énergétique. Abraquemar évolue uniquement quand il arrête de dire “j’ai pas envie de fight, moi je suis plus dans la vibe.”`,
   descriptionKey: 'data.shlagemons.10-15.abraquemar.description',
   types: [shlagemonTypes.psy],
+  speciality: 'evolution0',
 }
-
 export default abraquemar

--- a/src/data/shlagemons/10-15/amoche.ts
+++ b/src/data/shlagemons/10-15/amoche.ts
@@ -9,6 +9,6 @@ export const amoche: BaseShlagemon = {
   descriptionKey: 'data.shlagemons.10-15.amoche.description',
   types: [shlagemonTypes.poison],
   evolution: { base: barbok, condition: { type: 'lvl', value: 42 } },
+  speciality: 'evolution0',
 }
-
 export default amoche

--- a/src/data/shlagemons/10-15/emboli.ts
+++ b/src/data/shlagemons/10-15/emboli.ts
@@ -16,6 +16,6 @@ export const emboli: BaseShlagemon = {
     { base: salmoneli, condition: { type: 'item', value: pissBottle } },
     { base: tuberculi, condition: { type: 'item', value: defibrillator } },
   ],
+  speciality: 'evolution0',
 }
-
 export default emboli

--- a/src/data/shlagemons/10-15/nosferailleur.ts
+++ b/src/data/shlagemons/10-15/nosferailleur.ts
@@ -22,6 +22,6 @@ Il niche dans les toitures en fibrociment et collectionne les boulons comme des 
       value: 32,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default nosferailleur

--- a/src/data/shlagemons/15-20/goubite.ts
+++ b/src/data/shlagemons/15-20/goubite.ts
@@ -15,6 +15,6 @@ export const goubite: BaseShlagemon = {
       value: 80,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default goubite

--- a/src/data/shlagemons/15-20/nameouesh.ts
+++ b/src/data/shlagemons/15-20/nameouesh.ts
@@ -7,6 +7,6 @@ export const nanmeouesh: BaseShlagemon = {
   description: `Nanmeouesh passe ses journées à zoner devant la pharmacie en donnant des diagnostics à voix haute, sans qu’on lui demande. Il prétend avoir un diplôme "d’université de la street" et soigne surtout avec du sirop de tonton. Il communique uniquement en "wesh", "t'as capté" et "t’inquiète t’as rien". Malgré son allure nonchalante et ses lunettes trop stylées pour le reste de son corps, il ressent les bobos émotionnels mieux que n’importe quel Psy-type. Son attaque signature, Check-up Relou, oblige tous les ennemis à écouter une consultation de 3 minutes avec bilan complet, ce qui peut causer Sommeil ou Confusion.`,
   descriptionKey: 'data.shlagemons.15-20.nameouesh.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default nanmeouesh

--- a/src/data/shlagemons/15-20/pikachiant.ts
+++ b/src/data/shlagemons/15-20/pikachiant.ts
@@ -17,6 +17,6 @@ Il vit généralement dans des squats connectés où il recharge ses batteries a
       value: thunderStone,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default pikachiant

--- a/src/data/shlagemons/15-20/qulbudrogue.ts
+++ b/src/data/shlagemons/15-20/qulbudrogue.ts
@@ -7,6 +7,6 @@ export const qulbudrogue: BaseShlagemon = {
   description: `Qulbudrogué est connu pour son attitude détendue et sa démarche nonchalante. Il donne l’impression d’être dans un état de réflexion constante… ou complètement à l’ouest. Il se balade en sifflotant des sons qu’il est probablement le seul à comprendre. On raconte qu’il voit la vie en "slow motion" et qu’il communique avec les autres Pokémon par télépathie — mais uniquement quand il en a envie, c’est-à-dire rarement.`,
   descriptionKey: 'data.shlagemons.15-20.qulbudrogue.description',
   types: [shlagemonTypes.psy],
+  speciality: 'unique',
 }
-
 export default qulbudrogue

--- a/src/data/shlagemons/20-25/cacanus.ts
+++ b/src/data/shlagemons/20-25/cacanus.ts
@@ -23,6 +23,6 @@ Son flair est légendaire, mais son hygiène mentale, beaucoup moins.`,
       value: 54,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default cacanus

--- a/src/data/shlagemons/20-25/mystouffe.ts
+++ b/src/data/shlagemons/20-25/mystouffe.ts
@@ -24,6 +24,6 @@ Sa touffe le protège des coups directs, mais le rend lent et imprévisible. Son
       value: 62,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default mystouffe

--- a/src/data/shlagemons/20-25/plegique.ts
+++ b/src/data/shlagemons/20-25/plegique.ts
@@ -23,6 +23,6 @@ Il vit dans des zones Wi-Fi oubliées, collé contre des murs suintants. On dit 
       value: 45,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default plegique

--- a/src/data/shlagemons/20-25/ratonton.ts
+++ b/src/data/shlagemons/20-25/ratonton.ts
@@ -15,6 +15,6 @@ Il adore les coins d’ombre, les parasols Lidl, et les anecdotes gênantes. Si 
   descriptionKey: 'data.shlagemons.20-25.ratonton.description',
   types: [shlagemonTypes.normal],
   evolution: { base: ratartine, condition: { type: 'lvl', value: 45 } },
+  speciality: 'evolution0',
 }
-
 export default ratonton

--- a/src/data/shlagemons/25-30/grosmitoss.ts
+++ b/src/data/shlagemons/25-30/grosmitoss.ts
@@ -20,6 +20,6 @@ Sa compétence spéciale, *Mythobluff*, embrouille l’adversaire en lui faisant
     },
   },
 
+  speciality: 'evolution0',
 }
-
 export default grosmitoss

--- a/src/data/shlagemons/25-30/piafsansbec.ts
+++ b/src/data/shlagemons/25-30/piafsansbec.ts
@@ -17,6 +17,6 @@ Piafsansbec est souvent vu au bord des routes, essayant de siffler le vent ou de
   descriptionKey: 'data.shlagemons.25-30.piafsansbec.description',
   types: [shlagemonTypes.vol],
   evolution: { base: rapasdepisse, condition: { type: 'lvl', value: 50 } },
+  speciality: 'evolution0',
 }
-
 export default piafsansbec

--- a/src/data/shlagemons/25-30/taupicouze.ts
+++ b/src/data/shlagemons/25-30/taupicouze.ts
@@ -19,6 +19,6 @@ Son attaque signature, *Tricouze Saignante*, inflige des dégâts progressifs et
       value: 38,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default taupicouze

--- a/src/data/shlagemons/25-30/waouff.ts
+++ b/src/data/shlagemons/25-30/waouff.ts
@@ -19,6 +19,6 @@ Son attaque signature, *Croquette Mental*, inflige des dégâts aléatoires en f
       value: 38,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default waouff

--- a/src/data/shlagemons/30-35/canarchicon.ts
+++ b/src/data/shlagemons/30-35/canarchicon.ts
@@ -7,6 +7,6 @@ export const canarchicon: BaseShlagemon = {
   description: `Canarchicon est un cousin dégénéré du célèbre canard qu'on ne nommera pas pour des raisons juridiques. Toujours armé de son poireau fatigué (qu’il appelle tendrement “Jean-Chibre”), il chancelle d’un pas bancal, probablement à cause de ses soirées passées à picoler du bouillon cube fermenté. Son œil au beurre noir laisse deviner un mode de vie instable, fait de bastons derrière des bennes à frites et de paris perdus contre des Roucool. Il ne vole pas, il flotte à moitié — sans réelle direction — au gré des vents et des vapeurs d’alcool de cuisson. Sa capacité signature, *Coup de Poireau Tournoyant*, inflige peu de dégâts mais une honte durable. Il peut aussi utiliser *Flatulence de Gras*, une attaque à effet de zone olfactif. Canarchichon n’a jamais gagné un seul combat, mais il persiste... parce qu’il a oublié qu’il pouvait abandonner.`,
   descriptionKey: 'data.shlagemons.30-35.canarchicon.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
+  speciality: 'unique',
 }
-
 export default canarchicon

--- a/src/data/shlagemons/30-35/melofoutre.ts
+++ b/src/data/shlagemons/30-35/melofoutre.ts
@@ -20,6 +20,6 @@ Mélofoutre ne cherche pas le combat, mais s’y retrouve souvent par accident�
       value: 70,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default melofoutre

--- a/src/data/shlagemons/30-35/nidononbinaire-f.ts
+++ b/src/data/shlagemons/30-35/nidononbinaire-f.ts
@@ -17,6 +17,6 @@ Iel utilise souvent *Postillonnage Toxique*, une attaque à faible portée mais 
       value: 66,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default nidononbinaireF

--- a/src/data/shlagemons/30-35/nidononbinaire-m.ts
+++ b/src/data/shlagemons/30-35/nidononbinaire-m.ts
@@ -17,6 +17,6 @@ Sa capacité *Point-Virgule* inflige peu de dégâts mais perturbe l’ordre d�
       value: 66,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default nidononbinaireM

--- a/src/data/shlagemons/35-40/ferosang.ts
+++ b/src/data/shlagemons/35-40/ferosang.ts
@@ -21,6 +21,6 @@ Son attaque signature, *Jet Hémato*, projette un arc de sang corrosif et contam
       value: 44,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default ferosang

--- a/src/data/shlagemons/35-40/macho.ts
+++ b/src/data/shlagemons/35-40/macho.ts
@@ -22,6 +22,6 @@ Il évolue parfois... en pire.`,
       value: steroids,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default macho

--- a/src/data/shlagemons/35-40/psykonaute.ts
+++ b/src/data/shlagemons/35-40/psykonaute.ts
@@ -19,6 +19,6 @@ Son attaque signature, *Chichon Cosmique*, enveloppe l’arène d’un nuage den
       value: 85,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default psykonaute

--- a/src/data/shlagemons/35-40/rondonichon.ts
+++ b/src/data/shlagemons/35-40/rondonichon.ts
@@ -22,6 +22,6 @@ Ne pas le caresser. Jamais.`,
       value: 55,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default rondonichon

--- a/src/data/shlagemons/40-45/chetibranle.ts
+++ b/src/data/shlagemons/40-45/chetibranle.ts
@@ -19,6 +19,6 @@ On ne sait jamais vraiment ce qu’il absorbe, ni ce qu’il fait pousser, mais 
       value: 48,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default chetibranle

--- a/src/data/shlagemons/40-45/raboloss.ts
+++ b/src/data/shlagemons/40-45/raboloss.ts
@@ -21,6 +21,6 @@ On raconte qu’il rêve, dans ses rares moments d’éveil, de devenir populair
       value: 67,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default raboloss

--- a/src/data/shlagemons/40-45/racaillou.ts
+++ b/src/data/shlagemons/40-45/racaillou.ts
@@ -21,6 +21,6 @@ On raconte qu'il ne se d√©place jamais sans sa bande de Gravashlag, toujours pr√
       value: 76,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default racaillou

--- a/src/data/shlagemons/40-45/tatacool.ts
+++ b/src/data/shlagemons/40-45/tatacool.ts
@@ -22,6 +22,6 @@ On raconte que Tatacool collectionne les bouchons de bière et les vieux tickets
     },
   },
 
+  speciality: 'evolution0',
 }
-
 export default tatacool

--- a/src/data/shlagemons/45-50/dosolo.ts
+++ b/src/data/shlagemons/45-50/dosolo.ts
@@ -19,6 +19,6 @@ On raconte qu’il tente souvent de parler à son ombre, mais même elle a fini 
       value: 83,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default dosolo

--- a/src/data/shlagemons/45-50/magnubellule.ts
+++ b/src/data/shlagemons/45-50/magnubellule.ts
@@ -22,6 +22,6 @@ On raconte que chaque fois que Magnubellule passe en rase-motte, il laisse derri
       value: 61,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default magnubellule

--- a/src/data/shlagemons/45-50/otamere.ts
+++ b/src/data/shlagemons/45-50/otamere.ts
@@ -20,6 +20,6 @@ Personne n’a jamais vu Otamère sobre. Il aurait soi-disant un tatouage “MAM
       value: 90,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default otamere

--- a/src/data/shlagemons/45-50/pouleyta.ts
+++ b/src/data/shlagemons/45-50/pouleyta.ts
@@ -19,6 +19,6 @@ Malgré son allure, il rêve secrètement d'être la mascotte d’un fast-food d
       value: 53,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default pouleyta

--- a/src/data/shlagemons/50-55/cookieyas.ts
+++ b/src/data/shlagemons/50-55/cookieyas.ts
@@ -22,6 +22,6 @@ On raconte que Cookieyas ne rêve que d’une chose : qu’on le laisse tranquil
       value: 61,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default cookieyas

--- a/src/data/shlagemons/50-55/marginal.ts
+++ b/src/data/shlagemons/50-55/marginal.ts
@@ -12,6 +12,6 @@ export const marginal: BaseShlagemon = {
     base: leviaraison,
     condition: { type: 'lvl', value: 100 },
   },
+  speciality: 'evolution0',
 }
-
 export default marginal

--- a/src/data/shlagemons/50-55/tadsperm.ts
+++ b/src/data/shlagemons/50-55/tadsperm.ts
@@ -19,6 +19,6 @@ On raconte qu’il passe plus de temps à “méditer” qu’à se battre. Cert
       value: 59,
     },
   },
+  speciality: 'evolution0',
 }
-
 export default tadsperm

--- a/src/data/shlagemons/55-60/amonichiasse.ts
+++ b/src/data/shlagemons/55-60/amonichiasse.ts
@@ -12,6 +12,6 @@ export const amonichiasse: BaseShlagemon = {
     base: amonitrace,
     condition: { type: 'lvl', value: 72 },
   },
+  speciality: 'evolution0',
 }
-
 export default amonichiasse

--- a/src/data/shlagemons/55-60/kraputo.ts
+++ b/src/data/shlagemons/55-60/kraputo.ts
@@ -12,6 +12,6 @@ export const kraputo: BaseShlagemon = {
     base: kaputrak,
     condition: { type: 'lvl', value: 75 },
   },
+  speciality: 'evolution0',
 }
-
 export default kraputo

--- a/src/data/shlagemons/55-60/pauvreetcon.ts
+++ b/src/data/shlagemons/55-60/pauvreetcon.ts
@@ -7,6 +7,6 @@ export const pauvreetcon: BaseShlagemon = {
   description: `Pauvreetcon est un amas de polygones bancals issu d’un bug informatique. Il flotte maladroitement en cherchant sa connexion Wi-Fi et affiche de temps en temps un écran bleu en guise de cri.`,
   descriptionKey: 'data.shlagemons.55-60.pauvreetcon.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default pauvreetcon

--- a/src/data/shlagemons/55-60/ptitrat.ts
+++ b/src/data/shlagemons/55-60/ptitrat.ts
@@ -7,6 +7,6 @@ export const ptitrat: BaseShlagemon = {
   description: `Ancien régne fossile au museau pointu, Ptitrat se prend pour un rongeur volant. Sa peau grisâtre s’effrite un peu plus à chaque battement d’aile.`,
   descriptionKey: 'data.shlagemons.55-60.ptitrat.description',
   types: [shlagemonTypes.roche, shlagemonTypes.vol],
+  speciality: 'unique',
 }
-
 export default ptitrat

--- a/src/data/shlagemons/60-65/carreflex.ts
+++ b/src/data/shlagemons/60-65/carreflex.ts
@@ -9,6 +9,6 @@ export const carreflex: BaseShlagemon = {
   description: CARREFLEX_DESCRIPTION,
   descriptionKey: 'data.shlagemons.60-65.carreflex.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default carreflex

--- a/src/data/shlagemons/60-65/coksale.ts
+++ b/src/data/shlagemons/60-65/coksale.ts
@@ -12,6 +12,6 @@ export const coksale: BaseShlagemon = {
     base: coksnif,
     condition: { type: 'lvl', value: 75 },
   },
+  speciality: 'evolution0',
 }
-
 export default coksale

--- a/src/data/shlagemons/60-65/houlard.ts
+++ b/src/data/shlagemons/60-65/houlard.ts
@@ -12,6 +12,6 @@ export const houlard: BaseShlagemon = {
     base: noctedard,
     condition: { type: 'lvl', value: 80 },
   },
+  speciality: 'evolution0',
 }
-
 export default houlard

--- a/src/data/shlagemons/60-65/kaiminable.ts
+++ b/src/data/shlagemons/60-65/kaiminable.ts
@@ -12,6 +12,6 @@ export const kaiminable: BaseShlagemon = {
     base: croconaze,
     condition: { type: 'lvl', value: 78 },
   },
+  speciality: 'evolution0',
 }
-
 export default kaiminable

--- a/src/data/shlagemons/65-70/glandignon.ts
+++ b/src/data/shlagemons/65-70/glandignon.ts
@@ -12,6 +12,6 @@ export const glandignon: BaseShlagemon = {
     base: beuleef,
     condition: { type: 'lvl', value: 78 },
   },
+  speciality: 'evolution0',
 }
-
 export default glandignon

--- a/src/data/shlagemons/65-70/hericouille.ts
+++ b/src/data/shlagemons/65-70/hericouille.ts
@@ -12,6 +12,6 @@ export const hericouille: BaseShlagemon = {
     base: heriplouf,
     condition: { type: 'lvl', value: 81 },
   },
+  speciality: 'evolution0',
 }
-
 export default hericouille

--- a/src/data/shlagemons/65-70/minidrapcon.ts
+++ b/src/data/shlagemons/65-70/minidrapcon.ts
@@ -12,6 +12,6 @@ export const minidrapcon: BaseShlagemon = {
     base: drapcon,
     condition: { type: 'lvl', value: 90 },
   },
+  speciality: 'evolution0',
 }
-
 export default minidrapcon

--- a/src/data/shlagemons/65-70/qwiflash.ts
+++ b/src/data/shlagemons/65-70/qwiflash.ts
@@ -12,6 +12,6 @@ export const qwiflash: BaseShlagemon = {
     base: qwiflouch,
     condition: { type: 'lvl', value: 82 },
   },
+  speciality: 'evolution0',
 }
-
 export default qwiflash

--- a/src/data/shlagemons/70-75/krabbyjaccob.ts
+++ b/src/data/shlagemons/70-75/krabbyjaccob.ts
@@ -12,6 +12,6 @@ export const krabbyjaccob: BaseShlagemon = {
     base: krabbolosse,
     condition: { type: 'lvl', value: 79 },
   },
+  speciality: 'evolution0',
 }
-
 export default krabbyjaccob

--- a/src/data/shlagemons/70-75/onixtamere.ts
+++ b/src/data/shlagemons/70-75/onixtamere.ts
@@ -7,6 +7,6 @@ export const onixtamere: BaseShlagemon = {
   description: `Onixtamere est un gigantesque serpent de pierre qui se prend pour une reine tout en se déguisant en ta maman. Il parade au milieu des canyons en vantant ses conquêtes de papas comme d’autres collectionnent les cailloux. Son corps segmenté résonne à chaque mouvement, histoire d’annoncer son arrivée bien avant qu’il ouvre la bouche.`,
   descriptionKey: 'data.shlagemons.70-75.onixtamere.description',
   types: [shlagemonTypes.sol, shlagemonTypes.roche],
+  speciality: 'unique',
 }
-
 export default onixtamere

--- a/src/data/shlagemons/70-75/soporifiak.ts
+++ b/src/data/shlagemons/70-75/soporifiak.ts
@@ -12,6 +12,6 @@ export const soporifiak: BaseShlagemon = {
     base: hypsedentaire,
     condition: { type: 'lvl', value: 78 },
   },
+  speciality: 'evolution0',
 }
-
 export default soporifiak

--- a/src/data/shlagemons/70-75/voltamere.ts
+++ b/src/data/shlagemons/70-75/voltamere.ts
@@ -13,6 +13,6 @@ export const voltamere: BaseShlagemon = {
     base: electrobeauf,
     condition: { type: 'item', value: thunderStone },
   },
+  speciality: 'evolution0',
 }
-
 export default voltamere

--- a/src/data/shlagemons/75-80/chignon.ts
+++ b/src/data/shlagemons/75-80/chignon.ts
@@ -7,6 +7,6 @@ export const chignon: BaseShlagemon = {
   description: `Toujours tiré à quatre épingles, Chignon se bat avec des attaques de coiffure redoutables. Il lance ses épingles comme des shurikens et s'arrange pour que tout le monde admire sa queue-de-cheval.`,
   descriptionKey: 'data.shlagemons.75-80.chignon.description',
   types: [shlagemonTypes.combat],
+  speciality: 'unique',
 }
-
 export default chignon

--- a/src/data/shlagemons/75-80/dentlait.ts
+++ b/src/data/shlagemons/75-80/dentlait.ts
@@ -14,6 +14,6 @@ export const dentlait: BaseShlagemon = {
     base: hosoltueur,
     condition: { type: 'lvl', value: 83 },
   },
+  speciality: 'evolution0',
 }
-
 export default dentlait

--- a/src/data/shlagemons/75-80/huithuit.ts
+++ b/src/data/shlagemons/75-80/huithuit.ts
@@ -12,6 +12,6 @@ export const huithuit: BaseShlagemon = {
     base: noadcajou,
     condition: { type: 'lvl', value: 82 },
   },
+  speciality: 'evolution0',
 }
-
 export default huithuit

--- a/src/data/shlagemons/75-80/kistlee.ts
+++ b/src/data/shlagemons/75-80/kistlee.ts
@@ -7,6 +7,6 @@ export const kistlee: BaseShlagemon = {
   description: `Kistlee possède un énorme kyste qui sert autant d'arme que de chaise. Il frappe ses ennemis à coups de pied tout en se plaignant que ça tire un peu.`,
   descriptionKey: 'data.shlagemons.75-80.kistlee.description',
   types: [shlagemonTypes.combat],
+  speciality: 'unique',
 }
-
 export default kistlee

--- a/src/data/shlagemons/80-85/languedepute.ts
+++ b/src/data/shlagemons/80-85/languedepute.ts
@@ -7,6 +7,6 @@ export const languedepute: BaseShlagemon = {
   description: `Sa langue interminable traîne partout et sert principalement à médire. Il aime critiquer ses adversaires jusqu'à ce qu'ils abandonnent par lassitude.`,
   descriptionKey: 'data.shlagemons.80-85.languedepute.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default languedepute

--- a/src/data/shlagemons/80-85/lecocu.ts
+++ b/src/data/shlagemons/80-85/lecocu.ts
@@ -7,6 +7,6 @@ export const lecocu: BaseShlagemon = {
   description: `Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.`,
   descriptionKey: 'data.shlagemons.80-85.lecocu.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default lecocu

--- a/src/data/shlagemons/80-85/rhinofaringite.ts
+++ b/src/data/shlagemons/80-85/rhinofaringite.ts
@@ -12,6 +12,6 @@ export const rhinofaringite: BaseShlagemon = {
     base: rhinoplastie,
     condition: { type: 'lvl', value: 89 },
   },
+  speciality: 'evolution0',
 }
-
 export default rhinofaringite

--- a/src/data/shlagemons/80-85/smongol.ts
+++ b/src/data/shlagemons/80-85/smongol.ts
@@ -12,6 +12,6 @@ export const smongol: BaseShlagemon = {
     base: smongogol,
     condition: { type: 'lvl', value: 88 },
   },
+  speciality: 'evolution0',
 }
-
 export default smongol

--- a/src/data/shlagemons/85-90/hypotrompe.ts
+++ b/src/data/shlagemons/85-90/hypotrompe.ts
@@ -12,6 +12,6 @@ export const hypotrompe: BaseShlagemon = {
     base: hyporuisseau,
     condition: { type: 'lvl', value: 92 },
   },
+  speciality: 'evolution0',
 }
-
 export default hypotrompe

--- a/src/data/shlagemons/85-90/kandurex.ts
+++ b/src/data/shlagemons/85-90/kandurex.ts
@@ -7,6 +7,6 @@ export const kandurex: BaseShlagemon = {
   description: `Toujours équipé de préservatifs fluo, Kandurex vante ses prouesses au lit à qui veut l'entendre. Il distribue des conseils douteux sur la reproduction entre deux uppercuts.`,
   descriptionKey: 'data.shlagemons.85-90.kandurex.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default kandurex

--- a/src/data/shlagemons/85-90/poissaucisse.ts
+++ b/src/data/shlagemons/85-90/poissaucisse.ts
@@ -12,6 +12,6 @@ export const poissaucisse: BaseShlagemon = {
     base: poissomerguez,
     condition: { type: 'lvl', value: 94 },
   },
+  speciality: 'evolution0',
 }
-
 export default poissaucisse

--- a/src/data/shlagemons/85-90/strabisme.ts
+++ b/src/data/shlagemons/85-90/strabisme.ts
@@ -13,6 +13,6 @@ export const strabisme: BaseShlagemon = {
     base: stabiscarosse,
     condition: { type: 'item', value: thunderStone },
   },
+  speciality: 'evolution0',
 }
-
 export default strabisme

--- a/src/data/shlagemons/90-95/elektektonik.ts
+++ b/src/data/shlagemons/90-95/elektektonik.ts
@@ -7,6 +7,6 @@ export const elektektonik: BaseShlagemon = {
   description: `Toujours en train de danser la tecktonik, il électrise l'air autour de lui. Ses mouvements saccadés déclenchent de petites décharges qui font sauter les plombs partout où il passe.`,
   descriptionKey: 'data.shlagemons.90-95.elektektonik.description',
   types: [shlagemonTypes.electrique],
+  speciality: 'unique',
 }
-
 export default elektektonik

--- a/src/data/shlagemons/90-95/insinerateur.ts
+++ b/src/data/shlagemons/90-95/insinerateur.ts
@@ -7,6 +7,6 @@ export const insinerateur: BaseShlagemon = {
   description: `Armé de lames insectes, il a surtout envie de mettre le feu à tout ce qui bouge. Sa passion pour la combustion le rend particulièrement dangereux dans les forêts.`,
   descriptionKey: 'data.shlagemons.90-95.insinerateur.description',
   types: [shlagemonTypes.insecte],
+  speciality: 'unique',
 }
-
 export default insinerateur

--- a/src/data/shlagemons/90-95/lipposucsion.ts
+++ b/src/data/shlagemons/90-95/lipposucsion.ts
@@ -7,6 +7,6 @@ export const lipposucsion: BaseShlagemon = {
   description: `Après une liposuccion ratée, ce Shlagémon a la peau toute fripée et un tempérament glacial. Il embrasse ses ennemis pour les geler sur place avant de se plaindre de ses kilos en trop.`,
   descriptionKey: 'data.shlagemons.90-95.lipposucsion.description',
   types: [shlagemonTypes.glace, shlagemonTypes.psy],
+  speciality: 'unique',
 }
-
 export default lipposucsion

--- a/src/data/shlagemons/90-95/m-ventriloque.ts
+++ b/src/data/shlagemons/90-95/m-ventriloque.ts
@@ -7,6 +7,6 @@ export const mVentriloque: BaseShlagemon = {
   description: `C'est le sosie raté d'un célèbre humoriste et il passe son temps à discuter avec sa propre main. Ses tours de ventriloquie mettent mal à l'aise plus qu'ils ne font rire.`,
   descriptionKey: 'data.shlagemons.90-95.m-ventriloque.description',
   types: [shlagemonTypes.psy],
+  speciality: 'unique',
 }
-
 export default mVentriloque

--- a/src/data/shlagemons/95-99/lokhlash.ts
+++ b/src/data/shlagemons/95-99/lokhlash.ts
@@ -7,6 +7,6 @@ export const lokhlash: BaseShlagemon = {
   description: `Lokhlash adore participer à des battles de rap improvisées sur son dos. Il navigue de scène en scène, lâchant des punchlines glaciales qui font frissonner l'auditoire.`,
   descriptionKey: 'data.shlagemons.95-99.lokhlash.description',
   types: [shlagemonTypes.eau, shlagemonTypes.glace],
+  speciality: 'unique',
 }
-
 export default lokhlash

--- a/src/data/shlagemons/95-99/magmaretfred.ts
+++ b/src/data/shlagemons/95-99/magmaretfred.ts
@@ -9,6 +9,6 @@ export const magmaretfred: BaseShlagemon = {
   description: MAGMARETFRED_DESCRIPTION,
   descriptionKey: 'data.shlagemons.95-99.magmaretfred.description',
   types: [shlagemonTypes.feu],
+  speciality: 'unique',
 }
-
 export default magmaretfred

--- a/src/data/shlagemons/95-99/scarapute.ts
+++ b/src/data/shlagemons/95-99/scarapute.ts
@@ -7,6 +7,6 @@ export const scarapute: BaseShlagemon = {
   description: `Cet insecte adore sucer le sang des voyageurs imprudents. On le voit souvent roder près des campings à la recherche d'un mollet juteux.`,
   descriptionKey: 'data.shlagemons.95-99.scarapute.description',
   types: [shlagemonTypes.insecte],
+  speciality: 'unique',
 }
-
 export default scarapute

--- a/src/data/shlagemons/95-99/taurus.ts
+++ b/src/data/shlagemons/95-99/taurus.ts
@@ -7,6 +7,6 @@ export const taurus: BaseShlagemon = {
   description: `Taurus est littéralement un taureau géométrique. Ses angles parfaits le rendent difficile à approcher sans se prendre une arrête dans les côtes.`,
   descriptionKey: 'data.shlagemons.95-99.taurus.description',
   types: [shlagemonTypes.normal],
+  speciality: 'unique',
 }
-
 export default taurus

--- a/src/data/shlagemons/bulgrosboule.ts
+++ b/src/data/shlagemons/bulgrosboule.ts
@@ -9,6 +9,6 @@ export const bulgrosboule: BaseShlagemon = {
   descriptionKey: 'data.shlagemons.bulgrosboule.description',
   types: [shlagemonTypes.plante],
   evolution: { base: barbeBizarre, condition: { type: 'lvl', value: 16 } },
+  speciality: 'evolution0',
 }
-
 export default bulgrosboule

--- a/src/data/shlagemons/carapouffe.ts
+++ b/src/data/shlagemons/carapouffe.ts
@@ -9,6 +9,6 @@ export const carapouffe: BaseShlagemon = {
   descriptionKey: 'data.shlagemons.carapouffe.description',
   types: [shlagemonTypes.eau],
   evolution: { base: carabifle, condition: { type: 'lvl', value: 16 } },
+  speciality: 'evolution0',
 }
-
 export default carapouffe

--- a/src/data/shlagemons/evolutions/accrocrack.ts
+++ b/src/data/shlagemons/evolutions/accrocrack.ts
@@ -11,6 +11,6 @@ Avec ses plumes en vrac, son regard halluciné et son bec fendu par les rires ne
 Il porte parfois un sac plastique en guise de cape et marmonne des théories cosmologiques incompréhensibles à des lampadaires. Son attaque signature, *Flashback Violent*, plonge tous les combattants dans une confusion intense pendant plusieurs tours. Il utilise aussi *Tirage d’Urgence*, qui lui permet de rejouer un tour au prix de la moitié de sa santé mentale.`,
   descriptionKey: 'data.shlagemons.evolutions.accrocrack.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default accrocrack

--- a/src/data/shlagemons/evolutions/aerobite.ts
+++ b/src/data/shlagemons/evolutions/aerobite.ts
@@ -11,6 +11,6 @@ D’une impudeur sans faille, Aérobite adore surgir sans prévenir dans des lie
 Son attaque signature *Claqueburnes* inflige des dégâts sonores et psychologiques, tandis que *Vent Glacial* laisse souvent les adversaires tétanisés — pas à cause du froid, mais du traumatisme visuel. On dit qu’aucun dresseur n’est jamais vraiment prêt à le voir voler au ralenti… jambes écartées.`,
   descriptionKey: 'data.shlagemons.evolutions.aerobite.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
+  speciality: 'evolution1',
 }
-
 export default aerobite

--- a/src/data/shlagemons/evolutions/alakalbar.ts
+++ b/src/data/shlagemons/evolutions/alakalbar.ts
@@ -7,6 +7,6 @@ export const alakalbar: BaseShlagemon = {
   description: `Considéré comme un sage dans son quartier... du moins par lui-même. Il prétend maîtriser les arts mystiques du *Contrôle du Destin* mais confond souvent télékinésie et procrastination. On le reconnaît à ses deux grosses cuillères de cantine, tordues à force de remuer du thé aux herbes chelou dans des bouteilles de soda. Vêtu d’une djellaba délavée et d’un regard qui voit à travers toi (mais pas très loin), il marmonne des incantations approximatives pendant qu’il fait tourner sa sacoche à bandoulière en plastique doré. Il prétend méditer, mais il dort à 80%. Sa capacité spéciale, *Chakra Perimé*, déséquilibre l’ennemi avec une odeur de patchouli acide et une attaque psychique floue. Il peut aussi invoquer son attaque signature, *Projection Spirituelle*, qui consiste à lancer une cuillère sur son adversaire en hurlant “vision sacrée !” sans grand effet. On le croise souvent assis sur un banc, seul, en train de discuter avec ses propres Pokéball vides.`,
   descriptionKey: 'data.shlagemons.evolutions.alakalbar.description',
   types: [shlagemonTypes.psy],
+  speciality: 'evolution2',
 }
-
 export default alakalbar

--- a/src/data/shlagemons/evolutions/alligastro.ts
+++ b/src/data/shlagemons/evolutions/alligastro.ts
@@ -7,6 +7,6 @@ export const alligastro: BaseShlagemon = {
   description: `Géant torse nu avec une gueule de travers. Pue la bière et le vomi, et vomit la bière. Parle que en borborygmes.`,
   descriptionKey: 'data.shlagemons.evolutions.alligastro.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution2',
 }
-
 export default alligastro

--- a/src/data/shlagemons/evolutions/amonitrace.ts
+++ b/src/data/shlagemons/evolutions/amonitrace.ts
@@ -7,6 +7,6 @@ export const amonitrace: BaseShlagemon = {
   description: `Amonitrace est la forme décadente d’Amonichiasse. Sa coquille porte des traces suspectes et il tente de glisser loin des regards embarrassés.`,
   descriptionKey: 'data.shlagemons.evolutions.amonitrace.description',
   types: [shlagemonTypes.roche, shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default amonitrace

--- a/src/data/shlagemons/evolutions/barbe-bizarre.ts
+++ b/src/data/shlagemons/evolutions/barbe-bizarre.ts
@@ -12,6 +12,6 @@ Il parle en citations absurdes qu’il invente sur le moment (“si l’eau mont
 
   types: [shlagemonTypes.plante],
   evolution: { base: floripute, condition: { type: 'lvl', value: 36 } },
+  speciality: 'evolution0',
 }
-
 export default barbeBizarre

--- a/src/data/shlagemons/evolutions/barbok.ts
+++ b/src/data/shlagemons/evolutions/barbok.ts
@@ -9,6 +9,6 @@ export const barbok: BaseShlagemon = {
 Ancien joueur de Iop sur un vieux serveur oublié, il croit toujours qu’il a un rôle crucial dans le combat, même s’il passe plus de temps à commenter les tours qu’à les jouer. Ses attaques sont bruyantes et peu efficaces, comme *Coup d'Barbe*, qui inflige des dégâts très moyens mais provoque parfois un saignement de honte chez l’adversaire.`,
   descriptionKey: 'data.shlagemons.evolutions.barbok.description',
   types: [shlagemonTypes.poison],
+  speciality: 'evolution1',
 }
-
 export default barbok

--- a/src/data/shlagemons/evolutions/beuleef.ts
+++ b/src/data/shlagemons/evolutions/beuleef.ts
@@ -12,6 +12,6 @@ export const beuleef: BaseShlagemon = {
     base: moisanium,
     condition: { type: 'lvl', value: 92 },
   },
+  speciality: 'evolution1',
 }
-
 export default beuleef

--- a/src/data/shlagemons/evolutions/boustiflemme.ts
+++ b/src/data/shlagemons/evolutions/boustiflemme.ts
@@ -21,6 +21,6 @@ En résumé, Boustiflemme ne fait jamais rien... et il le fait très bien.`,
       value: 62,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default boustiflemme

--- a/src/data/shlagemons/evolutions/carabifle.ts
+++ b/src/data/shlagemons/evolutions/carabifle.ts
@@ -15,6 +15,6 @@ On dit que si l’on regarde ses cils pailletés trop longtemps, on devient infl
   descriptionKey: 'data.shlagemons.evolutions.carabifle.description',
   types: [shlagemonTypes.eau],
   evolution: { base: tordturc, condition: { type: 'lvl', value: 36 } },
+  speciality: 'evolution1',
 }
-
 export default carabifle

--- a/src/data/shlagemons/evolutions/chrysachier.ts
+++ b/src/data/shlagemons/evolutions/chrysachier.ts
@@ -21,6 +21,6 @@ Son cri ressemble à *"BLU-PFRT-GAAAAAAAAAAAAH"*, mélange d’effort intestinal
 Chrysachier ne vole pas : il s’élève un peu, puis redescend avec le bruit d’un sac de linge sale. Il est cependant très respecté dans certains cercles underground pour sa capacité à ruiner l’ambiance instantanément.`,
   descriptionKey: 'data.shlagemons.evolutions.chrysachier.description',
   types: [shlagemonTypes.insecte],
+  speciality: 'evolution1',
 }
-
 export default chrysachier

--- a/src/data/shlagemons/evolutions/coconnul.ts
+++ b/src/data/shlagemons/evolutions/coconnul.ts
@@ -25,6 +25,6 @@ Sa capacité passive, *Auto-Sabotage*, lui fait perdre 1 point de vie à chaque 
 Il traîne dans les buissons, évite les regards et se planque dès qu’il entend le mot "match". Une icône de la lose, une légende de l’échec.`,
   descriptionKey: 'data.shlagemons.evolutions.coconnul.description',
   types: [shlagemonTypes.insecte],
+  speciality: 'evolution1',
 }
-
 export default coconnul

--- a/src/data/shlagemons/evolutions/coksnif.ts
+++ b/src/data/shlagemons/evolutions/coksnif.ts
@@ -12,6 +12,6 @@ export const coksnif: BaseShlagemon = {
     base: coxymort,
     condition: { type: 'lvl', value: 90 },
   },
+  speciality: 'evolution1',
 }
-
 export default coksnif

--- a/src/data/shlagemons/evolutions/coloscopie.ts
+++ b/src/data/shlagemons/evolutions/coloscopie.ts
@@ -11,6 +11,6 @@ Son obsession est simple : trifouiller. Que ce soit le sien ou celui des autres 
 Il n’a plus vraiment de force physique : tout est dans l’analyse, la perfusion mentale, la gêne. Son attaque *Tactile Rectal* inflige un effet de malaise profond qui désarme les ennemis. Il dispose aussi de *Grand Nettoyage*, une attaque en AOE qui provoque une panique collective et laisse un goût de savonnette mentale.`,
   descriptionKey: 'data.shlagemons.evolutions.coloscopie.description',
   types: [shlagemonTypes.combat],
+  speciality: 'evolution1',
 }
-
 export default coloscopie

--- a/src/data/shlagemons/evolutions/coxymort.ts
+++ b/src/data/shlagemons/evolutions/coxymort.ts
@@ -7,6 +7,6 @@ export const coxymort: BaseShlagemon = {
   description: `Immense insecte décrépi, recouvert de résidus douteux, avec des tatouages au blanco et un regard perdu. Il claque des ailes sans raison.`,
   descriptionKey: 'data.shlagemons.evolutions.coxymort.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default coxymort

--- a/src/data/shlagemons/evolutions/croconaze.ts
+++ b/src/data/shlagemons/evolutions/croconaze.ts
@@ -12,6 +12,6 @@ export const croconaze: BaseShlagemon = {
     base: alligastro,
     condition: { type: 'lvl', value: 92 },
   },
+  speciality: 'evolution1',
 }
-
 export default croconaze

--- a/src/data/shlagemons/evolutions/crustabridou.ts
+++ b/src/data/shlagemons/evolutions/crustabridou.ts
@@ -13,6 +13,6 @@ Attitude : Crustabridou est persuadé qu’il est la star de tous les apéros, a
 Anecdote : On raconte que Crustabridou rêve secrètement de devenir ambassadeur du saucisson, mais il confond toujours les plateaux de fromages avec les arènes Pokémon.`,
   descriptionKey: 'data.shlagemons.evolutions.crustabridou.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default crustabridou

--- a/src/data/shlagemons/evolutions/dartagnan.ts
+++ b/src/data/shlagemons/evolutions/dartagnan.ts
@@ -7,6 +7,6 @@ export const dartagnan: BaseShlagemon = {
   description: `D\'Art Tagnan est un Mousquépique de type panache combatif. Toujours prêt à pérorer avant de piquer, il surgit d’un nuage de poussière dramatique en criant « En garde, manant ! », alors que personne ne l’a regardé. Avec ses dards en forme de rapières et ses antennes sculptées en bouclettes, il enchaîne les moulinets dans le vide juste pour le style. Sa moustache n’existe pas, mais il la twiste régulièrement du bout des griffes, persuadé que ça le rend irrésistible. Son chapeau à plume est greffé directement sur son crâne depuis sa naissance — selon la légende, il serait sorti de son cocon en criant « À l’attaque pour l’honneur et les gaufres ! » Il défie les Pokémon sauvages à des duels de poésie, vole au secours des baies tombées au sol, et fond en larmes si on lui abîme sa cape. Sa technique signature, Tournoyement Galant, consiste à piquer son adversaire après avoir tourné sur lui-même au moins huit fois, tout en citant du théâtre. Son flair pour le drame est tel que certains chercheurs pensent qu’il est en fait mi-insecte, mi-acteur raté.`,
   descriptionKey: 'data.shlagemons.evolutions.dartagnan.description',
   types: [shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default dartagnan

--- a/src/data/shlagemons/evolutions/dopluspersonne.ts
+++ b/src/data/shlagemons/evolutions/dopluspersonne.ts
@@ -10,6 +10,6 @@ Son attaque signature, *Vide Sidéral*, aspire toute volonté de combattre, lais
 On dit que parfois, une petite brise fait tourner Dopluspersonne sur lui-même, mais personne ne sait si c’est la honte, l’ennui ou juste le vent.`,
   descriptionKey: 'data.shlagemons.evolutions.dopluspersonne.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
+  speciality: 'evolution1',
 }
-
 export default dopluspersonne

--- a/src/data/shlagemons/evolutions/draco-con.ts
+++ b/src/data/shlagemons/evolutions/draco-con.ts
@@ -15,6 +15,6 @@ Il possède la capacité *Combo Kéké*, qui mélange toutes ses attaques en un 
 On dit que même le Professeur Merdant a arrêté d’essayer de l’étudier : "trop con pour la science", selon ses notes.`,
   descriptionKey: 'data.shlagemons.evolutions.draco-con.description',
   types: [shlagemonTypes.feu, shlagemonTypes.vol],
+  speciality: 'unique',
 }
-
 export default dracoCon

--- a/src/data/shlagemons/evolutions/drapcoloscopie.ts
+++ b/src/data/shlagemons/evolutions/drapcoloscopie.ts
@@ -7,6 +7,6 @@ export const drapcoloscopie: BaseShlagemon = {
   description: `Forme finale du DrapCon, ce drap géant se prend pour un médecin de l’obscur et fouille tout ce qui passe à sa portée.`,
   descriptionKey: 'data.shlagemons.evolutions.drapcoloscopie.description',
   types: [shlagemonTypes.dragon, shlagemonTypes.vol],
+  speciality: 'evolution2',
 }
-
 export default drapcoloscopie

--- a/src/data/shlagemons/evolutions/drapcon.ts
+++ b/src/data/shlagemons/evolutions/drapcon.ts
@@ -12,6 +12,6 @@ export const drapcon: BaseShlagemon = {
     base: drapcoloscopie,
     condition: { type: 'lvl', value: 100 },
   },
+  speciality: 'evolution1',
 }
-
 export default drapcon

--- a/src/data/shlagemons/evolutions/ectroudbal.ts
+++ b/src/data/shlagemons/evolutions/ectroudbal.ts
@@ -13,6 +13,6 @@ Son attaque signature, *Souffle de Troudbal*, relâche un jet gazeux issu de l�
 On raconte qu’Ectroudbal peut apparaître dans tes chiottes si tu dis “Papier triple épaisseur” trois fois devant ton miroir après un kebab trop épicé.`,
   descriptionKey: 'data.shlagemons.evolutions.ectroudbal.description',
   types: [shlagemonTypes.spectre, shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default ectroudbal

--- a/src/data/shlagemons/evolutions/electrobeauf.ts
+++ b/src/data/shlagemons/evolutions/electrobeauf.ts
@@ -7,6 +7,6 @@ export const electrobeauf: BaseShlagemon = {
   description: `DJ de soirée miteuse, Électrobeauf fait exploser les watts et les tympans à coups de beats ringards. Il se prend pour la star des discothèques de camping.`,
   descriptionKey: 'data.shlagemons.evolutions.electrobeauf.description',
   types: [shlagemonTypes.electrique],
+  speciality: 'evolution1',
 }
-
 export default electrobeauf

--- a/src/data/shlagemons/evolutions/empifouette.ts
+++ b/src/data/shlagemons/evolutions/empifouette.ts
@@ -13,6 +13,6 @@ Empifouette s’en sert aussi comme d’un leurre : attirant l’ennemi avec un 
 Si vous croisez un Empifouette, courez… ou retenez votre souffle, et espérez qu’il n’a pas décidé de sortir le grand jeu.`,
   descriptionKey: 'data.shlagemons.evolutions.empifouette.description',
   types: [shlagemonTypes.poison, shlagemonTypes.plante],
+  speciality: 'evolution2',
 }
-
 export default empifouette

--- a/src/data/shlagemons/evolutions/feunouille.ts
+++ b/src/data/shlagemons/evolutions/feunouille.ts
@@ -14,6 +14,6 @@ Il est persuadé d’être l’élu d’une prophétie inventée par lui-même. 
   descriptionKey: 'data.shlagemons.evolutions.feunouille.description',
 
   types: [shlagemonTypes.feu],
+  speciality: 'evolution1',
 }
-
 export default feunouille

--- a/src/data/shlagemons/evolutions/flaclodoss.ts
+++ b/src/data/shlagemons/evolutions/flaclodoss.ts
@@ -13,6 +13,6 @@ Son attaque signature, *Nuage de Misère*, dégage une aura de fatigue et de vie
 On raconte que Flaclodoss possède le secret pour ouvrir toutes les poubelles à un seul doigt, et qu’il médite souvent sur la vie en fixant les pigeons. Sa philosophie ? “Tant qu’il y a un banc, y’a de l’espoir…”`,
   descriptionKey: 'data.shlagemons.evolutions.flaclodoss.description',
   types: [shlagemonTypes.eau, shlagemonTypes.psy],
+  speciality: 'evolution1',
 }
-
 export default flaclodoss

--- a/src/data/shlagemons/evolutions/floripute.ts
+++ b/src/data/shlagemons/evolutions/floripute.ts
@@ -11,6 +11,6 @@ Elle tire ses pouvoirs d’un potager qu’elle cultive sur son dos, mélange do
 On raconte qu’elle peut invoquer des cercles de danse autour d’un feu sacré fait de palettes et de sacs Leclerc. Si elle grogne en récitant des mantras, cours. Elle s’apprête à t’offrir une purification... ou un sandwich au houmous moisi.`,
   descriptionKey: 'data.shlagemons.evolutions.floripute.description',
   types: [shlagemonTypes.plante],
+  speciality: 'evolution1',
 }
-
 export default floripute

--- a/src/data/shlagemons/evolutions/galopard.ts
+++ b/src/data/shlagemons/evolutions/galopard.ts
@@ -11,6 +11,6 @@ Son attaque signature, *Jet de Binouze*, consiste à asperger ses adversaires de
 Il n’aime qu’une seule chose : quand la France gagne au tiercé.`,
   descriptionKey: 'data.shlagemons.evolutions.galopard.description',
   types: [shlagemonTypes.feu],
+  speciality: 'evolution1',
 }
-
 export default galopard

--- a/src/data/shlagemons/evolutions/gravaglaire.ts
+++ b/src/data/shlagemons/evolutions/gravaglaire.ts
@@ -21,6 +21,6 @@ On dit que plus personne ne veut s’asseoir à côté de lui, même dans les sq
       value: 89,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default gravaglaire

--- a/src/data/shlagemons/evolutions/grochichon.ts
+++ b/src/data/shlagemons/evolutions/grochichon.ts
@@ -16,6 +16,6 @@ On ignore s’il a une évolution. Certains parlent d’un “Tontonchichon” t
   descriptionKey: 'data.shlagemons.evolutions.grochichon.description',
 
   types: [shlagemonTypes.normal, shlagemonTypes.poison],
+  speciality: 'evolution1',
 }
-
 export default grochichon

--- a/src/data/shlagemons/evolutions/grosseflemme.ts
+++ b/src/data/shlagemons/evolutions/grosseflemme.ts
@@ -13,6 +13,6 @@ Son visage affiche un mélange de lassitude et d’aigreur, les yeux mi-clos, ce
 On raconte que personne n’a jamais vu Grosseflemme se lever de son canapé, sauf une fois, pour atteindre une télécommande tombée trop loin. Même là, il a préféré lancer une pantoufle plutôt que de faire l’effort de bouger.`,
   descriptionKey: 'data.shlagemons.evolutions.grosseflemme.description',
   types: [shlagemonTypes.roche, shlagemonTypes.sol],
+  speciality: 'evolution2',
 }
-
 export default grosseflemme

--- a/src/data/shlagemons/evolutions/grossetarte.ts
+++ b/src/data/shlagemons/evolutions/grossetarte.ts
@@ -11,6 +11,6 @@ Il ne se bat pas : il *sert*. À répétition. Son attaque *Service Trois Parts*
 Certains Shlagémons l’évitent non pas par peur, mais par goût. On raconte qu’un seul fragment de sa Tarte Ultime peut bloquer une mâchoire pendant 3 jours.`,
   descriptionKey: 'data.shlagemons.evolutions.grossetarte.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default grossetarte

--- a/src/data/shlagemons/evolutions/grostadsperm.ts
+++ b/src/data/shlagemons/evolutions/grostadsperm.ts
@@ -11,6 +11,6 @@ Son attaque fétiche, *MasturBave*, recouvre le terrain d’une vague glissante 
 Anecdote : Il paraît qu’en période de reproduction, il faut désinfecter toute la zone après son passage…`,
   descriptionKey: 'data.shlagemons.evolutions.grostadsperm.description',
   types: [shlagemonTypes.poison],
+  speciality: 'evolution1',
 }
-
 export default grostadsperm

--- a/src/data/shlagemons/evolutions/heriplouf.ts
+++ b/src/data/shlagemons/evolutions/heriplouf.ts
@@ -12,6 +12,6 @@ export const heriplouf: BaseShlagemon = {
     base: heristrash,
     condition: { type: 'lvl', value: 95 },
   },
+  speciality: 'evolution1',
 }
-
 export default heriplouf

--- a/src/data/shlagemons/evolutions/heristrash.ts
+++ b/src/data/shlagemons/evolutions/heristrash.ts
@@ -7,6 +7,6 @@ export const heristrash: BaseShlagemon = {
   description: `Ressemble à un raton-laveur carbonisé. Les flammes sont vertes et sentent l’œuf pourri.`,
   descriptionKey: 'data.shlagemons.evolutions.heristrash.description',
   types: [shlagemonTypes.feu, shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default heristrash

--- a/src/data/shlagemons/evolutions/hosoltueur.ts
+++ b/src/data/shlagemons/evolutions/hosoltueur.ts
@@ -7,6 +7,6 @@ export const hosoltueur: BaseShlagemon = {
   description: `Armé d'un os gigantesque, Hosoltueur règle ses comptes en une seule frappe. Il garde pourtant un air mélancolique en pensant à son enfance perdue.`,
   descriptionKey: 'data.shlagemons.evolutions.hosoltueur.description',
   types: [shlagemonTypes.sol],
+  speciality: 'evolution1',
 }
-
 export default hosoltueur

--- a/src/data/shlagemons/evolutions/hyporuisseau.ts
+++ b/src/data/shlagemons/evolutions/hyporuisseau.ts
@@ -7,6 +7,6 @@ export const hyporuisseau: BaseShlagemon = {
   description: `Hyporuisseau ne nage que dans les petits ruisseaux par peur des grandes eaux. Son courage grandit à mesure que le débit augmente, mais pas trop quand même.`,
   descriptionKey: 'data.shlagemons.evolutions.hyporuisseau.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default hyporuisseau

--- a/src/data/shlagemons/evolutions/hypsedentaire.ts
+++ b/src/data/shlagemons/evolutions/hypsedentaire.ts
@@ -7,6 +7,6 @@ export const hypsedentaire: BaseShlagemon = {
   description: `Hypsedentaire a développé un pouvoir hypnotique tellement fort qu'il préfère rester affalé chez lui. Il endort ses ennemis à distance pour ne jamais avoir à se lever.`,
   descriptionKey: 'data.shlagemons.evolutions.hypsedentaire.description',
   types: [shlagemonTypes.psy],
+  speciality: 'evolution1',
 }
-
 export default hypsedentaire

--- a/src/data/shlagemons/evolutions/kadavrebras.ts
+++ b/src/data/shlagemons/evolutions/kadavrebras.ts
@@ -21,6 +21,6 @@ On dit que Kadavrebras ne dort jamais. Il se contente de bercer ses cadavres en 
       value: 95,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default kadavrebras

--- a/src/data/shlagemons/evolutions/kaputrak.ts
+++ b/src/data/shlagemons/evolutions/kaputrak.ts
@@ -7,6 +7,6 @@ export const kaputrak: BaseShlagemon = {
   description: `Issu de Kraputo, ce guerrier fossile manie des lames rouillées et vit dans la paranoïa permanente.`,
   descriptionKey: 'data.shlagemons.evolutions.kaputrak.description',
   types: [shlagemonTypes.roche, shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default kaputrak

--- a/src/data/shlagemons/evolutions/krabbolosse.ts
+++ b/src/data/shlagemons/evolutions/krabbolosse.ts
@@ -7,6 +7,6 @@ export const krabbolosse: BaseShlagemon = {
   description: `Krabbolosse est un crabe massif mais un peu benêt. Il écrase tout sur son passage en bredouillant des prières en vieux dialecte.`,
   descriptionKey: 'data.shlagemons.evolutions.krabbolosse.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default krabbolosse

--- a/src/data/shlagemons/evolutions/lamantinedu38.ts
+++ b/src/data/shlagemons/evolutions/lamantinedu38.ts
@@ -11,6 +11,6 @@ Son attaque signature, *Roule-Galoche Givrée*, consiste à te rouler une pelle 
 On dit que même les autres shlagémons du 38 évitent de s’asseoir à côté de lui, de peur de repartir avec des morpions polaires.`,
   descriptionKey: 'data.shlagemons.evolutions.lamantinedu38.description',
   types: [shlagemonTypes.eau, shlagemonTypes.glace],
+  speciality: 'evolution1',
 }
-
 export default lamantinedu38

--- a/src/data/shlagemons/evolutions/leviaraison.ts
+++ b/src/data/shlagemons/evolutions/leviaraison.ts
@@ -7,6 +7,6 @@ export const leviaraison: BaseShlagemon = {
   description: `Toujours persuadé d'avoir raison, ce serpent de mer géant fulmine dès qu'on le contredit. Ses colères déclenchent des tempêtes monumentales.`,
   descriptionKey: 'data.shlagemons.evolutions.leviaraison.description',
   types: [shlagemonTypes.eau, shlagemonTypes.vol],
+  speciality: 'evolution1',
 }
-
 export default leviaraison

--- a/src/data/shlagemons/evolutions/macintosh.ts
+++ b/src/data/shlagemons/evolutions/macintosh.ts
@@ -13,6 +13,6 @@ Il attaque avec *Clavier Rageur*, qui spam des insultes mal orthographiées, et 
 On raconte qu’il a installé un fond d’écran de lui torse nu en noir et blanc avec marqué “GRIND” en majuscules. Aucun Shlagémon ne veut le combattre : pas par peur… par pitié.`,
   descriptionKey: 'data.shlagemons.evolutions.macintosh.description',
   types: [shlagemonTypes.combat],
+  speciality: 'evolution2',
 }
-
 export default macintosh

--- a/src/data/shlagemons/evolutions/magnementon.ts
+++ b/src/data/shlagemons/evolutions/magnementon.ts
@@ -14,6 +14,6 @@ Son attaque signature, *Menton Omnipotent*, consiste à donner un coup de menton
 On raconte que croiser un Magnementon, c’est risquer de finir avec “8 mentons, 6 bosses” et une bonne excuse bidon pour rentrer au camping.`,
   descriptionKey: 'data.shlagemons.evolutions.magnementon.description',
   types: [shlagemonTypes.electrique, shlagemonTypes.insecte],
+  speciality: 'evolution1',
 }
-
 export default magnementon

--- a/src/data/shlagemons/evolutions/masschopeur.ts
+++ b/src/data/shlagemons/evolutions/masschopeur.ts
@@ -24,6 +24,6 @@ On raconte qu’il s’auto-like sur Pokégram avec des faux comptes et laisse d
       value: ultraSteroid,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default masschopeur

--- a/src/data/shlagemons/evolutions/meladolphe.ts
+++ b/src/data/shlagemons/evolutions/meladolphe.ts
@@ -12,6 +12,6 @@ Son aura autoritaire et son parfum de naphtaline lui valent d’être banni de p
   descriptionKey: 'data.shlagemons.evolutions.meladolphe.description',
 
   types: [shlagemonTypes.fee],
+  speciality: 'evolution1',
 }
-
 export default meladolphe

--- a/src/data/shlagemons/evolutions/moisanium.ts
+++ b/src/data/shlagemons/evolutions/moisanium.ts
@@ -7,6 +7,6 @@ export const moisanium: BaseShlagemon = {
   description: `Géante plante décrépite, tachetée de moisissure, avec des spores hallucinogènes. Elle rigole toute seule dans les champs.`,
   descriptionKey: 'data.shlagemons.evolutions.moisanium.description',
   types: [shlagemonTypes.plante, shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default moisanium

--- a/src/data/shlagemons/evolutions/nidodragqueen.ts
+++ b/src/data/shlagemons/evolutions/nidodragqueen.ts
@@ -11,6 +11,6 @@ Son attaque signature *Talons de la Mort* inflige des dégâts massifs tout en r
 On reconnaît Nidodragqueen à sa corne pailletée, son sceptre cosmique et son cri de guerre : “T'ES PAS PRÊT BÉBÉ 💅”. Iel ? On ne pose pas la question. Nidodragqueen EST. Et c’est bien assez.`,
   descriptionKey: 'data.shlagemons.evolutions.nidodragqueen.description',
   types: [shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default nidodragqueen

--- a/src/data/shlagemons/evolutions/nidoqueer.ts
+++ b/src/data/shlagemons/evolutions/nidoqueer.ts
@@ -11,6 +11,6 @@ Son attaque signature *Marche de la Fierté* lui permet de traverser n’importe
 Nidoqueer est un pilier des zones communautaires de Shlagémon, toujours là pour défendre les plus petit·e·s, corriger les propos déplacés avec élégance, et lâcher un *wink* bien placé. On reconnaît Nidoqueer à ses épines colorées, son regard fardé et sa démarche impeccable. Iel n'est pas là pour se battre... mais si iel le fait, ce sera avec **panache**.`,
   descriptionKey: 'data.shlagemons.evolutions.nidoqueer.description',
   types: [shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default nidoqueer

--- a/src/data/shlagemons/evolutions/nidoschneck.ts
+++ b/src/data/shlagemons/evolutions/nidoschneck.ts
@@ -20,6 +20,6 @@ Iel s’entoure souvent de Nidononbinaire♀ ou d’autres Shlagémons influenç
       value: 88,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default nidoschneck

--- a/src/data/shlagemons/evolutions/nidoteub.ts
+++ b/src/data/shlagemons/evolutions/nidoteub.ts
@@ -20,6 +20,6 @@ Iel est bruyant·e, inefficace, et persuadé·e qu’iel est “trop stylé”. 
       value: 88,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default nidoteub

--- a/src/data/shlagemons/evolutions/noadcajou.ts
+++ b/src/data/shlagemons/evolutions/noadcajou.ts
@@ -7,6 +7,6 @@ export const noadcajou: BaseShlagemon = {
   description: `Cet arbre sur pattes produit des noix de cajou grillées à chaque attaque. Il préfère le climat tropical et se moque des régimes alimentaires de ses adversaires.`,
   descriptionKey: 'data.shlagemons.evolutions.noadcajou.description',
   types: [shlagemonTypes.plante, shlagemonTypes.psy],
+  speciality: 'evolution1',
 }
-
 export default noadcajou

--- a/src/data/shlagemons/evolutions/noctedard.ts
+++ b/src/data/shlagemons/evolutions/noctedard.ts
@@ -7,6 +7,6 @@ export const noctedard: BaseShlagemon = {
   description: `Grand hibou insomniaque, chauve par endroits, avec des seringues plantées dans les plumes et une clope toujours au bec. Parle seul.`,
   descriptionKey: 'data.shlagemons.evolutions.noctedard.description',
   types: [shlagemonTypes.vol, shlagemonTypes.psy],
+  speciality: 'evolution1',
 }
-
 export default noctedard

--- a/src/data/shlagemons/evolutions/nosferasta.ts
+++ b/src/data/shlagemons/evolutions/nosferasta.ts
@@ -12,6 +12,6 @@ Son attaque signature *Chant de Jah* étourdit tous les ennemis dans un large ra
   descriptionKey: 'data.shlagemons.evolutions.nosferasta.description',
 
   types: [shlagemonTypes.poison, shlagemonTypes.vol],
+  speciality: 'evolution1',
 }
-
 export default nosferasta

--- a/src/data/shlagemons/evolutions/orchibre.ts
+++ b/src/data/shlagemons/evolutions/orchibre.ts
@@ -22,6 +22,6 @@ Il n’évolue plus, car selon la légende : “Quand un chibre atteint la flora
       value: 90,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default orchibre

--- a/src/data/shlagemons/evolutions/papi-sucon.ts
+++ b/src/data/shlagemons/evolutions/papi-sucon.ts
@@ -15,6 +15,6 @@ Sa capacité passive, *Salive Persistante*, ralentit les adversaires qui l’ont
 Papy Suçon est un type crasse par excellence, mais il est aussi classé *affection*, car il prétend toujours "faire ça avec tendresse".`,
   descriptionKey: 'data.shlagemons.evolutions.papi-sucon.description',
   types: [shlagemonTypes.insecte],
+  speciality: 'evolution2',
 }
-
 export default papysucon

--- a/src/data/shlagemons/evolutions/parasecte.ts
+++ b/src/data/shlagemons/evolutions/parasecte.ts
@@ -15,6 +15,6 @@ Son attaque signature, *Révélation Sporale*, libère une explosion de spores q
 Parasecte ne cherche pas la victoire. Il cherche *l’humidité universelle*. Et toi, es-tu prêt à entendre l’appel du Champi Total ?`,
   descriptionKey: 'data.shlagemons.evolutions.parasecte.description',
   types: [shlagemonTypes.poison, shlagemonTypes.spectre],
+  speciality: 'evolution1',
 }
-
 export default parasecte

--- a/src/data/shlagemons/evolutions/perchiste.ts
+++ b/src/data/shlagemons/evolutions/perchiste.ts
@@ -11,6 +11,6 @@ Il prend très à cœur son rôle, quitte à interrompre une scène pour recadre
 Son attaque signature, *Grésil du Désespoir*, inflige un bruit statique à l’ennemi pendant 3 tours, tandis que *Silence Plateau !* le fait disparaître temporairement du combat, le temps d’un long plan fixe inutile.`,
   descriptionKey: 'data.shlagemons.evolutions.perchiste.description',
   types: [shlagemonTypes.normal],
+  speciality: 'evolution1',
 }
-
 export default perchiste

--- a/src/data/shlagemons/evolutions/poissomerguez.ts
+++ b/src/data/shlagemons/evolutions/poissomerguez.ts
@@ -7,6 +7,6 @@ export const poissomerguez: BaseShlagemon = {
   description: `Poissomerguez dégage une forte odeur de barbecue. Il fait frire l'eau autour de lui et provoque des fringales incontrôlables chez ses adversaires.`,
   descriptionKey: 'data.shlagemons.evolutions.poissomerguez.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default poissomerguez

--- a/src/data/shlagemons/evolutions/pyrolise.ts
+++ b/src/data/shlagemons/evolutions/pyrolise.ts
@@ -7,6 +7,6 @@ export const pyrolise: BaseShlagemon = {
   description: `Toujours entouré d’une fumée douteuse, Pyrolise adore brûler tout ce qu’il touche et sentir les vapeurs toxiques.`,
   descriptionKey: 'data.shlagemons.evolutions.pyrolise.description',
   types: [shlagemonTypes.feu],
+  speciality: 'evolution1',
 }
-
 export default pyrolise

--- a/src/data/shlagemons/evolutions/qwiflouch.ts
+++ b/src/data/shlagemons/evolutions/qwiflouch.ts
@@ -7,6 +7,6 @@ export const qwiflouch: BaseShlagemon = {
   description: `Enflé comme une boule à mites, recouvert de pics rouillés. Il lâche du gaz au moindre stress et fait fuir les autres Shlagémons.`,
   descriptionKey: 'data.shlagemons.evolutions.qwiflouch.description',
   types: [shlagemonTypes.eau, shlagemonTypes.poison],
+  speciality: 'evolution1',
 }
-
 export default qwiflouch

--- a/src/data/shlagemons/evolutions/rafflamby.ts
+++ b/src/data/shlagemons/evolutions/rafflamby.ts
@@ -14,6 +14,6 @@ Rafflamby n’évolue plus, mais reste malgré tout présent dans de nombreux d�
   descriptionKey: 'data.shlagemons.evolutions.rafflamby.description',
 
   types: [shlagemonTypes.plante, shlagemonTypes.poison],
+  speciality: 'evolution2',
 }
-
 export default rafflamby

--- a/src/data/shlagemons/evolutions/raichiotte.ts
+++ b/src/data/shlagemons/evolutions/raichiotte.ts
@@ -11,6 +11,6 @@ Sa queue est devenue un paratonnerre inversé qui attire les problèmes, et son 
 Même les bornes de recharge refusent de le connecter. Il est considéré comme un bug vivant du Pokédex, et certains dresseurs le fuient, non pas pour sa puissance… mais pour sa conversation.`,
   descriptionKey: 'data.shlagemons.evolutions.raichiotte.description',
   types: [shlagemonTypes.electrique],
+  speciality: 'evolution1',
 }
-
 export default raichiotte

--- a/src/data/shlagemons/evolutions/rapasdepisse.ts
+++ b/src/data/shlagemons/evolutions/rapasdepisse.ts
@@ -15,6 +15,6 @@ Rapasdepisse ne vole pas vraiment. Il fait des sauts nerveux et humides. Son cri
 On le garde par compassion, ou par erreur. Mais même s’il fait un peu pitié, certains affirment qu’il est doux, affectueux... et toujours tiède.`,
   descriptionKey: 'data.shlagemons.evolutions.rapasdepisse.description',
   types: [shlagemonTypes.vol],
+  speciality: 'evolution1',
 }
-
 export default rapasdepisse

--- a/src/data/shlagemons/evolutions/raptorincel.ts
+++ b/src/data/shlagemons/evolutions/raptorincel.ts
@@ -15,6 +15,6 @@ On le trouve souvent dans des grottes sombres, en train de taper sur des clavier
   descriptionKey: 'data.shlagemons.evolutions.raptorincel.description',
   types: [shlagemonTypes.feu],
   evolution: { base: dracoCon, condition: { type: 'lvl', value: 36 } },
+  speciality: 'evolution1',
 }
-
 export default raptorincel

--- a/src/data/shlagemons/evolutions/ratartine.ts
+++ b/src/data/shlagemons/evolutions/ratartine.ts
@@ -13,6 +13,6 @@ Ratartine vit dans les placards, dort dans les grille-pains abandonnés, et rêv
 On dit qu’il a tenté d’évoluer en "Croquemonsieur", mais qu’il a trop fondu avant la dernière étape.`,
   descriptionKey: 'data.shlagemons.evolutions.ratartine.description',
   types: [shlagemonTypes.normal],
+  speciality: 'evolution1',
 }
-
 export default ratartine

--- a/src/data/shlagemons/evolutions/rhinoplastie.ts
+++ b/src/data/shlagemons/evolutions/rhinoplastie.ts
@@ -7,6 +7,6 @@ export const rhinoplastie: BaseShlagemon = {
   description: `Après une chirurgie esthétique ratée, Rhinoplastie a la face entièrement remodelée. Il fait peur à tout le monde mais se trouve magnifique.`,
   descriptionKey: 'data.shlagemons.evolutions.rhinoplastie.description',
   types: [shlagemonTypes.sol, shlagemonTypes.roche],
+  speciality: 'evolution1',
 }
-
 export default rhinoplastie

--- a/src/data/shlagemons/evolutions/ricardnin.ts
+++ b/src/data/shlagemons/evolutions/ricardnin.ts
@@ -7,6 +7,6 @@ export const ricardnin: BaseShlagemon = {
   description: `Ricardnin n’apparaît que lors des barbecues familiaux prolongés. On le reconnaît à sa casquette délavée à l'odeur suspecte et à la fiole sacrée qu’il garde en pendentif, qu’il appelle sa réserve tactique. Il aboie dès qu’il entend les mots "pétanque", "saucisson" ou "c’est qui qui a pris ma chaise là ?". Son haleine inflige des dégâts sur la durée, surtout s’il a mangé de l’aïoli. Son attaque signature, Souffle Anisé, embrume le terrain dans un nuage jaunâtre qui réduit la précision de tous les Pokémon adverses. Il peut aussi lancer Provoquapéro, qui oblige les dresseurs à faire une pause et à sortir les chips.`,
   descriptionKey: 'data.shlagemons.evolutions.ricardnin.description',
   types: [shlagemonTypes.feu, shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default ricardnin

--- a/src/data/shlagemons/evolutions/roux-pignolage.ts
+++ b/src/data/shlagemons/evolutions/roux-pignolage.ts
@@ -13,6 +13,6 @@ Sa capacité signature, *Stimulation Solitaire*, le soigne légèrement à chaqu
 On le croise rarement en public, sauf dans des commentaires de vidéos floues ou à 3h du matin dans des zones Wi-Fi libres. Il prétend être incompris, mais en vérité, tout le monde le comprend très bien… et c’est ça le problème.`,
   descriptionKey: 'data.shlagemons.evolutions.roux-pignolage.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
+  speciality: 'unique',
 }
-
 export default rouxPignolage

--- a/src/data/shlagemons/evolutions/roux-scoop.ts
+++ b/src/data/shlagemons/evolutions/roux-scoop.ts
@@ -9,6 +9,6 @@ export const rouxScoop: BaseShlagemon = {
   descriptionKey: 'data.shlagemons.evolutions.roux-scoop.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
   evolution: { base: rouxPignolage, condition: { type: 'lvl', value: 36 } },
+  speciality: 'evolution0',
 }
-
 export default rouxScoop

--- a/src/data/shlagemons/evolutions/salmoneli.ts
+++ b/src/data/shlagemons/evolutions/salmoneli.ts
@@ -7,6 +7,6 @@ export const salmoneli: BaseShlagemon = {
   description: `Ce poisson aux couleurs ternes traîne des germes partout où il passe et préfère l’eau croupie.`,
   descriptionKey: 'data.shlagemons.evolutions.salmoneli.description',
   types: [shlagemonTypes.eau],
+  speciality: 'evolution1',
 }
-
 export default salmoneli

--- a/src/data/shlagemons/evolutions/smongogol.ts
+++ b/src/data/shlagemons/evolutions/smongogol.ts
@@ -7,6 +7,6 @@ export const smongogol: BaseShlagemon = {
   description: `Toujours plus imbécile et plus toxique que Smongol, Smongogol libère un nuage épais qui empeste la débilité. On le confond souvent avec un vieux pneu en feu.`,
   descriptionKey: 'data.shlagemons.evolutions.smongogol.description',
   types: [shlagemonTypes.poison],
+  speciality: 'evolution1',
 }
-
 export default smongogol

--- a/src/data/shlagemons/evolutions/sperectum.ts
+++ b/src/data/shlagemons/evolutions/sperectum.ts
@@ -15,6 +15,6 @@ export const sperectum: BaseShlagemon = {
       value: 52,
     },
   },
+  speciality: 'evolution1',
 }
-
 export default sperectum

--- a/src/data/shlagemons/evolutions/stabiscarosse.ts
+++ b/src/data/shlagemons/evolutions/stabiscarosse.ts
@@ -7,6 +7,6 @@ export const stabiscarosse: BaseShlagemon = {
   description: `Parti s'installer à Biscarrosse pour profiter des vagues, ce Shlagémon se pavane désormais avec une planche de surf sous chaque bras.`,
   descriptionKey: 'data.shlagemons.evolutions.stabiscarosse.description',
   types: [shlagemonTypes.eau, shlagemonTypes.psy],
+  speciality: 'evolution1',
 }
-
 export default stabiscarosse

--- a/src/data/shlagemons/evolutions/tatacruelle.ts
+++ b/src/data/shlagemons/evolutions/tatacruelle.ts
@@ -13,6 +13,6 @@ Tatacruelle adore faire la morale en jetant du vinaigre partout, piquer les bisc
 On raconte qu’elle hante les cuisines après 22h, prête à punir ceux qui osent ouvrir le frigo. Son rêve ? Être immortalisée en portrait sur chaque pot de cornichons du coin. Même les plus téméraires n’osent pas traîner près d’elle quand la nuit tombe.`,
   descriptionKey: 'data.shlagemons.evolutions.tatacruelle.description',
   types: [shlagemonTypes.eau, shlagemonTypes.poison],
+  speciality: 'evolution1',
 }
-
 export default tatacruelle

--- a/src/data/shlagemons/evolutions/tord-turc.ts
+++ b/src/data/shlagemons/evolutions/tord-turc.ts
@@ -13,6 +13,6 @@ Son dos est devenu un trône en spirale, incrusté de miroirs concaves qui renvo
 On dit que même les légendaires évitent de le croiser : pas par peur de la défaite, mais par peur de se faire juger en silence.`,
   descriptionKey: 'data.shlagemons.evolutions.tord-turc.description',
   types: [shlagemonTypes.eau],
+  speciality: 'unique',
 }
-
 export default tordturc

--- a/src/data/shlagemons/evolutions/triopikouze.ts
+++ b/src/data/shlagemons/evolutions/triopikouze.ts
@@ -11,6 +11,6 @@ Composé de trois têtes aux regards fuyants, il discute souvent avec lui-même 
 Son attaque signature, *Injection Festive*, inflige un statut aléatoire à tous les ennemis présents. Il peut aussi déclencher *Soirée Non Consentante*, une capacité qui interrompt toutes les actions ennemies pendant un tour, le temps de créer un malaise palpable.`,
   descriptionKey: 'data.shlagemons.evolutions.triopikouze.description',
   types: [shlagemonTypes.poison, shlagemonTypes.spectre],
+  speciality: 'evolution1',
 }
-
 export default triopikouze

--- a/src/data/shlagemons/evolutions/tuberculi.ts
+++ b/src/data/shlagemons/evolutions/tuberculi.ts
@@ -7,6 +7,6 @@ export const tuberculi: BaseShlagemon = {
   description: `Permanemment parcouru d’étincelles maladives, Tuberculi tousse des arcs électriques sur ses adversaires.`,
   descriptionKey: 'data.shlagemons.evolutions.tuberculi.description',
   types: [shlagemonTypes.electrique],
+  speciality: 'evolution1',
 }
-
 export default tuberculi

--- a/src/data/shlagemons/evolutions/vieuxblaireau.ts
+++ b/src/data/shlagemons/evolutions/vieuxblaireau.ts
@@ -11,6 +11,6 @@ Il n’a pas vraiment de technique, mais beaucoup d'expérience : son attaque *R
 On dit qu’il a autrefois gagné un tournoi interzonier, mais la légende reste floue. Aujourd’hui, il râle, il grogne, et parfois, il dort en plein combat. Mais attention : sous la couche de rhumatismes, il reste dangereux… surtout pour les nerfs.`,
   descriptionKey: 'data.shlagemons.evolutions.vieuxblaireau.description',
   types: [shlagemonTypes.sol],
+  speciality: 'unique',
 }
-
 export default vieuxBlaireau

--- a/src/data/shlagemons/salamiches.ts
+++ b/src/data/shlagemons/salamiches.ts
@@ -9,6 +9,6 @@ export const salamiches: BaseShlagemon = {
   descriptionKey: 'data.shlagemons.salamiches.description',
   types: [shlagemonTypes.feu],
   evolution: { base: raptorincel, condition: { type: 'lvl', value: 16 } },
+  speciality: 'evolution0',
 }
-
 export default salamiches

--- a/src/data/shlagemons/wem.ts
+++ b/src/data/shlagemons/wem.ts
@@ -13,6 +13,6 @@ Son attaque signature, *Raté Critique*, inflige 0 dégâts mais provoque un inc
 On ne le trouve pas : c’est lui qui reste, par erreur, au fond d’un sac. Son rêve ? Être ignoré parfaitement, comme un ticket de caisse mouillé.`,
   descriptionKey: 'data.shlagemons.wem.description',
   types: [shlagemonTypes.psy],
+  speciality: 'unique',
 }
-
 export default wem

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -29,7 +29,7 @@ export interface BaseShlagemon {
    * Multiple options can be provided.
    */
   evolutions?: ShlagemonEvolution[]
-  speciality?: Speciality
+  speciality: Speciality
 }
 
 export interface DexShlagemon extends Stats {


### PR DESCRIPTION
## Summary
- make `speciality` required in `BaseShlagemon`
- store `speciality` directly in each shlagemon record
- simplify shlagemon data loader

## Testing
- `pnpm test` *(fails: pickRandomByCoefficient is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68869fd87bd4832aa559d712071a25a9