### PR TITLE
Implement deterministic spawn system

### DIFF
--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -4,7 +4,7 @@ import { storeToRefs } from 'pinia'
 import { multiExp } from '~/data/items'
 import { allShlagemons } from '~/data/shlagemons'
 import { createDexShlagemon } from '~/utils/dexFactory'
-import { pickRandom } from '~/utils/spawn'
+import { pickByAlphabet } from '~/utils/spawn'
 
 const dex = useShlagedexStore()
 const zone = useZoneStore()
@@ -29,7 +29,8 @@ function createEnemy(): DexShlagemon | null {
     if (filtered.length)
       pool = filtered
   }
-  const base = pickRandom(pool)
+  const count = progress.getEncounterCount(zone.current.id)
+  const base = pickByAlphabet(pool, count)
   progress.registerEncounter(zone.current.id, base.id)
   const min = Number(zone.current.minLevel ?? 1)
   const zoneMax = Number(zone.current.maxLevel ?? (min + 1))

--- a/src/stores/zoneProgress.ts
+++ b/src/stores/zoneProgress.ts
@@ -6,6 +6,7 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
   const kingsDefeated = ref<Record<string, boolean>>({})
   const arenasCompleted = ref<Record<string, boolean>>({})
   const lastEncounters = ref<Record<string, string[]>>({})
+  const encounterCounts = ref<Record<string, number>>({})
 
   function addWin(id: string) {
     wins.value[id] = (wins.value[id] || 0) + 1
@@ -32,11 +33,16 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
   }
 
   function registerEncounter(zoneId: string, monId: string) {
+    encounterCounts.value[zoneId] = (encounterCounts.value[zoneId] || 0) + 1
     const list = lastEncounters.value[zoneId] || []
     list.push(monId)
     while (list.length > 3)
       list.shift()
     lastEncounters.value[zoneId] = list
+  }
+
+  function getEncounterCount(zoneId: string) {
+    return encounterCounts.value[zoneId] || 0
   }
 
   function streakExceeded(zoneId: string, monId: string) {
@@ -62,6 +68,7 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
     kingsDefeated,
     fightsBeforeKing,
     arenasCompleted,
+    encounterCounts,
     lastEncounters,
     addWin,
     getWins,
@@ -71,6 +78,7 @@ export const useZoneProgressStore = defineStore('zoneProgress', () => {
     completeArena,
     isArenaCompleted,
     registerEncounter,
+    getEncounterCount,
     streakExceeded,
     reset,
   }

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -8,3 +8,35 @@ export function pickRandom<T extends BaseShlagemon>(list: T[]): T {
   const r = Math.floor(Math.random() * list.length)
   return list[r]
 }
+
+/**
+ * Deterministically pick a Shlagemon from the list using a counter.
+ * The list is sorted alphabetically and weights are applied so the
+ * first monster appears rarely, the second appears occasionally and
+ * the rest appear normally.
+ */
+export function pickByAlphabet<T extends BaseShlagemon>(
+  list: T[],
+  counter: number,
+): T {
+  const sorted = [...list].sort((a, b) => a.name.localeCompare(b.name))
+  if (sorted.length <= 1)
+    return sorted[0]
+
+  const weights = sorted.map((_, idx) => {
+    if (idx === 0)
+      return 1
+    if (idx === 1)
+      return 2
+    return 3
+  })
+  const total = weights.reduce((a, w) => a + w, 0)
+  const idx = counter % total
+  let acc = 0
+  for (let i = 0; i < weights.length; i++) {
+    acc += weights[i]
+    if (idx < acc)
+      return sorted[i]
+  }
+  return sorted[sorted.length - 1]
+}

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,31 +1,21 @@
 import { describe, expect, it } from 'vitest'
-import { pickRandom } from '../src/utils/spawn'
+import { pickByAlphabet } from '../src/utils/spawn'
 
 const list = [
-  { id: 'm1', name: 'm1', description: '', types: [] },
-  { id: 'm2', name: 'm2', description: '', types: [] },
-  { id: 'm3', name: 'm3', description: '', types: [] },
+  { id: 'a', name: 'a', description: '', types: [] },
+  { id: 'b', name: 'b', description: '', types: [] },
+  { id: 'c', name: 'c', description: '', types: [] },
+  { id: 'd', name: 'd', description: '', types: [] },
 ]
 
-describe('spawn selection', () => {
-  it('returns a monster from the list', () => {
-    const result = pickRandom(list)
-    expect(list).toContain(result)
-  })
-
-  it('picks each monster with roughly equal probability', () => {
-    const counts = {
-      m1: 0,
-      m2: 0,
-      m3: 0,
-    }
-    const runs = 3000
-    for (let i = 0; i < runs; i++) {
-      const pick = pickRandomByCoefficient(list)
-      counts[pick.id as keyof typeof counts]++
-    }
-    const expected = runs / list.length
-    for (const c of Object.values(counts))
-      expect(c).toBeGreaterThan(expected * 0.8)
+describe('alphabetical spawn', () => {
+  it('uses the counter to pick deterministically', () => {
+    expect(pickByAlphabet(list, 0).id).toBe('a')
+    expect(pickByAlphabet(list, 1).id).toBe('b')
+    expect(pickByAlphabet(list, 2).id).toBe('b')
+    expect(pickByAlphabet(list, 3).id).toBe('c')
+    expect(pickByAlphabet(list, 4).id).toBe('c')
+    expect(pickByAlphabet(list, 5).id).toBe('c')
+    expect(pickByAlphabet(list, 6).id).toBe('d')
   })
 })


### PR DESCRIPTION
## Summary
- spawn pokémon deterministically with `pickByAlphabet`
- track encounter counts in `zoneProgress` store
- use new spawn logic in battles
- update unit tests for deterministic spawns

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6886a5e1d154832ab137dc8d46d6a6c3