### PR TITLE
Fix bottom panel closing on dialog

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -19,14 +19,6 @@ const dexDisabled = computed(() => menuDisabled.value || shlagedex.shlagemons.le
 const achievementsDisabled = computed(() => menuDisabled.value || !achievements.hasAny)
 const inventoryDisabled = computed(() => menuDisabled.value || inventory.list.length === 0 || arena.inBattle || lockStore.isInventoryLocked)
 
-watch(
-  () => dialog.isDialogVisible,
-  (val) => {
-    if (val)
-      mobile.set('game')
-  },
-)
-
 function toggleInventory() {
   mobile.toggle('inventory')
 }


### PR DESCRIPTION
## Summary
- ensure mobile bottom panel stays open when dialogs appear

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b2145060832a8bacdf1893055926