### PR TITLE
Update capture mechanics

### DIFF
--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -2,25 +2,50 @@ import type { Ball, DexShlagemon } from '~/type'
 
 export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
   const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
-  const levelMod = 1 / (1 + enemy.lvl / 40)
+  const levelBonus = ballLevelMultiplier(ball, enemy.lvl)
+  if (levelBonus <= 0)
+    return false
+  const rarityMod = rarityModifier(enemy.rarity)
   const dex = useShlagedexStore()
   const captureMod = 1 + dex.captureBonusPercent / 100
-  const chance = Math.min(100, hpChance * levelMod * ball.catchBonus * captureMod)
+  const chance = Math.min(100, hpChance * levelBonus * rarityMod * captureMod)
   const dev = useDeveloperStore()
   if (dev.debug) {
     console.warn(
       `Capture chance: ${chance.toFixed(2)}%`,
-      { level: enemy.lvl, ballBonus: ball.catchBonus, hpChance, levelMod, captureMod },
+      { level: enemy.lvl, hpChance, levelBonus, rarityMod, captureMod },
     )
   }
   return Math.random() * 100 < chance
 }
 
+function ballLevelMultiplier(ball: Ball, level: number): number {
+  switch (ball.id) {
+    case 'shlageball':
+      return level <= 33 ? 1 : 0
+    case 'super-shlageball':
+      if (level > 66)
+        return 0
+      return level < 33 ? 2 : 1
+    case 'hyper-shlageball':
+      if (level < 33)
+        return 3
+      if (level < 66)
+        return 2
+      return 1
+    default:
+      return ball.catchBonus || 1
+  }
+}
+
+function rarityModifier(rarity: number): number {
+  const r = Math.min(100, Math.max(1, rarity))
+  return 1 - (r - 1) * 0.75 / 99
+}
+
 export function captureChanceFromHp(ratio: number): number {
   const r = Math.min(1, Math.max(0, ratio))
-  const baseChance = 80
-  const multiplier = 3 ** (1 - r)
-  return baseChance * multiplier
+  return 89 * (1 - r)
 }
 
 export function simpleCapture(enemy: DexShlagemon): boolean {

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -9,38 +9,31 @@ describe('capture mechanics', () => {
     vi.restoreAllMocks()
   })
 
-  it('succeeds when random is low', () => {
-    const mon = createDexShlagemon(carapouffe)
-    mon.hpCurrent = 0
-    mon.rarity = 50
-    vi.spyOn(Math, 'random').mockReturnValue(0)
-    expect(tryCapture(mon, balls[0])).toBe(true)
+  it('capture chance from hp is linear', () => {
+    expect(captureChanceFromHp(0.5)).toBeCloseTo(44.5, 1)
   })
 
-  it('fails when random is high', () => {
-    const mon = createDexShlagemon(carapouffe)
-    mon.hpCurrent = mon.hp
-    mon.rarity = 100
-    vi.spyOn(Math, 'random').mockReturnValue(0.99)
+  it('basic ball cannot capture high level foe', () => {
+    const mon = createDexShlagemon(carapouffe, false, 40)
+    mon.hpCurrent = 0
+    vi.spyOn(Math, 'random').mockReturnValue(0)
     expect(tryCapture(mon, balls[0])).toBe(false)
   })
 
-  it('hyper ball versus strong foe is guaranteed', () => {
-    const mon = createDexShlagemon(carapouffe, false, 100)
+  it('super ball doubles chance for low level foe', () => {
+    const mon = createDexShlagemon(carapouffe, false, 20)
     mon.hp = 100
-    mon.hpCurrent = 10
-    const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
-    const levelMod = 1 / (1 + mon.lvl / 40)
-    const chance = Math.min(100, hpChance * levelMod * balls[2].catchBonus)
-    expect(chance).toBe(100)
+    mon.hpCurrent = 1
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    expect(tryCapture(mon, balls[1])).toBe(true)
   })
 
-  it('regular ball against lvl1 foe at full HP is almost guaranteed', () => {
-    const mon = createDexShlagemon(carapouffe, false, 1)
-    mon.hpCurrent = mon.hp
-    const hpChance = captureChanceFromHp(mon.hpCurrent / mon.hp)
-    const levelMod = 1 / (1 + mon.lvl / 40)
-    const chance = Math.min(100, hpChance * levelMod * balls[0].catchBonus)
-    expect(chance).toBeCloseTo(78, 0)
+  it('rarity reduces capture probability', () => {
+    const mon = createDexShlagemon(carapouffe, false, 70)
+    mon.hp = 100
+    mon.hpCurrent = 1
+    mon.rarity = 100
+    vi.spyOn(Math, 'random').mockReturnValue(0.3)
+    expect(tryCapture(mon, balls[2])).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- tweak capture chance formula and adjust by level and rarity
- update related capture tests

## Testing
- `pnpm exec vitest run test/capture.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6886b5a73988832aa1aa69bae9cec1ae