### PR TITLE
Cap rarity based on zone

### DIFF
--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -36,7 +36,7 @@ function createEnemy(): DexShlagemon | null {
   const zoneMax = Number(zone.current.maxLevel ?? (min + 1))
   const max = Math.max(zoneMax - 1, min)
   const lvl = Math.floor(Math.random() * (max - min + 1)) + min
-  const created = createDexShlagemon(base, false, lvl)
+  const created = createDexShlagemon(base, false, lvl, zone.current.maxLevel ?? 99)
   if (created.isShiny) {
     audio.playSfx('/audio/sfx/shiny.ogg')
   }

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -83,7 +83,7 @@ function createEnemy(): DexShlagemon | null {
   const base = allShlagemons.find(b => b.id === spec.baseId)
   if (!base)
     return null
-  return createDexShlagemon(base, false, spec.level)
+  return createDexShlagemon(base, false, spec.level, zone.current.maxLevel ?? 99)
 }
 
 function startFight() {

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -53,8 +53,9 @@ export function createDexShlagemon(
   base: BaseShlagemon,
   shiny = false,
   level = 1,
+  maxRarity = 99,
 ): DexShlagemon {
-  const rarity = generateRarity()
+  const rarity = generateRarity(maxRarity)
   const mon: DexShlagemon = {
     id: crypto.randomUUID(),
     base,
@@ -84,10 +85,10 @@ export function createDexShlagemon(
   return mon
 }
 
-function generateRarity(): number {
+function generateRarity(max = 99): number {
   const x = Math.random()
   const skewed = x ** 2
-  return Math.floor(1 + skewed * 99)
+  return Math.floor(1 + skewed * (max - 1))
 }
 
 export function statWithRarity(base: number, rarity: number): number {


### PR DESCRIPTION
## Summary
- limit generated rarity by zone max level
- cap trainer and wild encounter rarities using the zone cap

## Testing
- `corepack pnpm exec vitest run --reporter verbose` *(fails: Test run cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6886b61a30d4832a9a07f75c728472f6