### PR TITLE
Implement rarity scaling on zone unlock

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -364,6 +364,7 @@ declare global {
   const useWebSocket: typeof import('@vueuse/core')['useWebSocket']
   const useWebWorker: typeof import('@vueuse/core')['useWebWorker']
   const useWebWorkerFn: typeof import('@vueuse/core')['useWebWorkerFn']
+  const useWildLevelStore: typeof import('./stores/wildLevel')['useWildLevelStore']
   const useWindowFocus: typeof import('@vueuse/core')['useWindowFocus']
   const useWindowScroll: typeof import('@vueuse/core')['useWindowScroll']
   const useWindowSize: typeof import('@vueuse/core')['useWindowSize']
@@ -800,6 +801,7 @@ declare module 'vue' {
     readonly useWebSocket: UnwrapRef<typeof import('@vueuse/core')['useWebSocket']>
     readonly useWebWorker: UnwrapRef<typeof import('@vueuse/core')['useWebWorker']>
     readonly useWebWorkerFn: UnwrapRef<typeof import('@vueuse/core')['useWebWorkerFn']>
+    readonly useWildLevelStore: UnwrapRef<typeof import('./stores/wildLevel')['useWildLevelStore']>
     readonly useWindowFocus: UnwrapRef<typeof import('@vueuse/core')['useWindowFocus']>
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>

--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -3,6 +3,7 @@ import type { DexShlagemon } from '~/type'
 import { storeToRefs } from 'pinia'
 import { multiExp } from '~/data/items'
 import { allShlagemons } from '~/data/shlagemons'
+import { useWildLevelStore } from '~/stores/wildLevel'
 import { createDexShlagemon } from '~/utils/dexFactory'
 import { pickByAlphabet } from '~/utils/spawn'
 
@@ -16,6 +17,7 @@ const game = useGameStore()
 const audio = useAudioStore()
 const battleStats = useBattleStatsStore()
 const zoneMonsModal = useZoneMonsModalStore()
+const wildLevel = useWildLevelStore()
 
 const enemy = ref(null as DexShlagemon | null)
 const { t } = useI18n()
@@ -36,7 +38,7 @@ function createEnemy(): DexShlagemon | null {
   const zoneMax = Number(zone.current.maxLevel ?? (min + 1))
   const max = Math.max(zoneMax - 1, min)
   const lvl = Math.floor(Math.random() * (max - min + 1)) + min
-  const created = createDexShlagemon(base, false, lvl, zone.current.maxLevel ?? 99)
+  const created = createDexShlagemon(base, false, lvl, wildLevel.highestWildLevel)
   if (created.isShiny) {
     audio.playSfx('/audio/sfx/shiny.ogg')
   }

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -2,6 +2,7 @@
 import type { DexShlagemon } from '~/type'
 import type { DialogNode } from '~/type/dialog'
 import { allShlagemons } from '~/data/shlagemons'
+import { useWildLevelStore } from '~/stores/wildLevel'
 import { createDexShlagemon } from '~/utils/dexFactory'
 import DialogBox from '../dialog/Box.vue'
 
@@ -14,6 +15,7 @@ const panel = useMainPanelStore()
 const featureLock = useFeatureLockStore()
 const game = useGameStore()
 const mobile = useMobileTabStore()
+const wildLevel = useWildLevelStore()
 
 const trainer = computed(() => trainerStore.current)
 const isZoneKing = computed(() => trainer.value?.id.startsWith('king-'))
@@ -83,7 +85,9 @@ function createEnemy(): DexShlagemon | null {
   const base = allShlagemons.find(b => b.id === spec.baseId)
   if (!base)
     return null
-  return createDexShlagemon(base, false, spec.level, zone.current.maxLevel ?? 99)
+  const max = wildLevel.highestWildLevel
+  const min = isZoneKing.value ? Math.max(1, max - 20) : 1
+  return createDexShlagemon(base, false, spec.level, max, min)
 }
 
 function startFight() {

--- a/src/stores/arena.ts
+++ b/src/stores/arena.ts
@@ -1,5 +1,6 @@
 import type { Arena, BaseShlagemon, DexShlagemon } from '~/type'
 import { defineStore } from 'pinia'
+import { useWildLevelStore } from '~/stores/wildLevel'
 import { createDexShlagemon } from '~/utils/dexFactory'
 
 export type ArenaResult = 'none' | 'win' | 'lose'
@@ -10,6 +11,7 @@ export const useArenaStore = defineStore('arena', () => {
   const lineup = ref<BaseShlagemon[]>([])
   const lineupDex = ref<DexShlagemon[]>([])
   const arenaData = ref<Arena | null>(null)
+  const wildLevel = useWildLevelStore()
   const selections = ref<(string | null)[]>([])
   const currentIndex = ref(0)
   const result = ref<ArenaResult>('none')
@@ -19,7 +21,7 @@ export const useArenaStore = defineStore('arena', () => {
   function setLineup(enemies: BaseShlagemon[], level: number) {
     lineup.value = enemies
     lineupDex.value = enemies.map(m =>
-      createDexShlagemon(m, false, level),
+      createDexShlagemon(m, false, level, wildLevel.highestWildLevel),
     )
     selections.value = Array.from({ length: enemies.length }).fill(null) as (string | null)[]
   }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -6,6 +6,7 @@ import { defineStore } from 'pinia'
 import { toast } from 'vue3-toastify'
 import { allItems } from '~/data/items'
 import { allShlagemons } from '~/data/shlagemons'
+import { useWildLevelStore } from '~/stores/wildLevel'
 import {
   applyCurrentStats,
   applyStats,
@@ -38,6 +39,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   const {
     accessibleZones,
   } = useZoneAccess(highestLevel)
+  const wildLevel = useWildLevelStore()
 
   const accessibleShopLevel = computed(() =>
     accessibleZones.value
@@ -470,7 +472,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   }
 
   function createShlagemon(base: BaseShlagemon, shiny = false) {
-    const mon = createDexShlagemon(base, shiny)
+    const mon = createDexShlagemon(base, shiny, 1, wildLevel.highestWildLevel)
     mon.captureDate = new Date().toISOString()
     mon.captureCount = 1
     addShlagemon(mon)
@@ -486,7 +488,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
         toast('Vous avez déjà ce Shlagémon au maximum de sa rareté')
         return existing
       }
-      const incoming = createDexShlagemon(base, shiny)
+      const incoming = createDexShlagemon(base, shiny, 1, wildLevel.highestWildLevel)
       existing.captureCount += 1
       let rarityGain = 1
       let levelLoss = 1
@@ -513,7 +515,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       toast(rarityToastMessage(existing.base.name, rarityGain, levelLoss))
       return existing
     }
-    const incoming = createDexShlagemon(base, shiny)
+    const incoming = createDexShlagemon(base, shiny, 1, wildLevel.highestWildLevel)
     incoming.captureDate = new Date().toISOString()
     incoming.captureCount = 1
     addShlagemon(incoming)

--- a/src/stores/wildLevel.ts
+++ b/src/stores/wildLevel.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+
+export const useWildLevelStore = defineStore('wildLevel', () => {
+  const dex = useShlagedexStore()
+  const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
+
+  const highestWildLevel = computed(() => {
+    const wildZones = accessibleZones.value
+      .filter(z => z.type === 'sauvage')
+    const last = wildZones[wildZones.length - 1]
+    return last?.maxLevel ?? 1
+  })
+
+  return { highestWildLevel }
+})

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -54,8 +54,9 @@ export function createDexShlagemon(
   shiny = false,
   level = 1,
   maxRarity = 99,
+  minRarity = 1,
 ): DexShlagemon {
-  const rarity = generateRarity(maxRarity)
+  const rarity = generateRarity(maxRarity, minRarity)
   const mon: DexShlagemon = {
     id: crypto.randomUUID(),
     base,
@@ -85,10 +86,11 @@ export function createDexShlagemon(
   return mon
 }
 
-function generateRarity(max = 99): number {
+function generateRarity(max = 99, min = 1): number {
   const x = Math.random()
   const skewed = x ** 2
-  return Math.floor(1 + skewed * (max - 1))
+  const value = Math.floor(1 + skewed * (max - 1))
+  return Math.min(max, Math.max(min, value))
 }
 
 export function statWithRarity(base: number, rarity: number): number {


### PR DESCRIPTION
## Summary
- compute highest accessible wild level via new store
- clamp rarity generation using this value
- give kings stronger rarity
- pass max rarity everywhere new Shlagemons are generated

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68873bbf3bd8832ab6458014399f7669