### PR TITLE
Update mobile behavior for mini-games and leaving village

### DIFF
--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import ZoneActions from '../village/ZoneActions.vue'
 
+const mobile = useMobileTabStore()
+
 const zone = useZoneStore()
 const panel = useMainPanelStore()
 const { t } = useI18n()
@@ -9,6 +11,7 @@ function leaveVillage() {
   if (zone.current.attachedTo)
     zone.setZone(zone.current.attachedTo)
   panel.showBattle()
+  mobile.set('zones')
 }
 </script>
 

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -4,6 +4,7 @@ import type { SavageZoneId } from '~/type'
 const zone = useZoneStore()
 const panel = useMainPanelStore()
 const mini = useMiniGameStore()
+const mobile = useMobileTabStore()
 const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
 const arena = useArenaStore()
@@ -48,6 +49,7 @@ function onAction(id: string) {
     if (zone.current.miniGame)
       mini.select(zone.current.miniGame)
     panel.showMiniGame()
+    mobile.set('game')
   }
 }
 


### PR DESCRIPTION
## Summary
- hide the bottom panel when launching a mini-game on mobile so the game panel uses the full screen
- automatically show the map panel after leaving a village on mobile

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68873ec39fac832a942a3ce5d4cdc975