### PR TITLE
Fix achievements progress and update test

### DIFF
--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -433,7 +433,7 @@ export const useAchievementsStore = defineStore('achievements', () => {
 
       const zoneWin = prefix.match(/^zone-(.*)-win$/)
       if (zoneWin)
-        return { value: progress.wins.value[zoneWin[1]] || 0, max }
+        return { value: progress.wins[zoneWin[1]] || 0, max }
     }
 
     const zoneComplete = id.match(/^zone-(.*)-complete$/)

--- a/test/connectfour-component.test.ts
+++ b/test/connectfour-component.test.ts
@@ -11,7 +11,7 @@ describe('connect four component', () => {
 
   it('renders correct number of cells', () => {
     const wrapper = mount(MiniGamePuissance4)
-    const cells = wrapper.findAll('button')
+    const cells = wrapper.findAll('.aspect-square')
     expect(cells.length).toBe(ROWS * COLS)
   })
 })


### PR DESCRIPTION
## Summary
- fix zone win progress calculation in achievements store
- update connect four test selector

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_688747c875b8832a898da8b9adf74f93