### PR TITLE
Persist achievements progress

### DIFF
--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -451,7 +451,15 @@ export const useAchievementsStore = defineStore('achievements', () => {
     return null
   }
 
-  return { list, unlockedList, hasAny, handleEvent, reset, getProgress }
+  return {
+    list,
+    unlockedList,
+    hasAny,
+    handleEvent,
+    reset,
+    getProgress,
+    counters,
+  }
 }, {
   persist: {
     pick: ['counters'],

--- a/test/achievements-progress-persist.test.ts
+++ b/test/achievements-progress-persist.test.ts
@@ -1,0 +1,22 @@
+import { createPinia, setActivePinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
+import { useAchievementsStore } from '../src/stores/achievements'
+
+describe('achievements progress persistence', () => {
+  it('restores counters from storage', () => {
+    const pinia = createPinia()
+    pinia.use(piniaPluginPersistedstate)
+    const app = createApp({})
+    app.use(pinia)
+    setActivePinia(pinia)
+
+    // simulate saved counters
+    window.localStorage.setItem('achievements', JSON.stringify({ counters: { wins: 5 } }))
+
+    const achievements = useAchievementsStore()
+    const progress = achievements.getProgress('win-10')
+    expect(progress?.value).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- persist counters in achievements store
- test that counters restore from localStorage

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68875332adc4832a94862f2f6c4a5d0a