### PR TITLE
Add starter rarity sync with level

### DIFF
--- a/src/components/dialog/Starter.vue
+++ b/src/components/dialog/Starter.vue
@@ -59,7 +59,8 @@ const dialogTree = computed((): DialogNode[] => [
         type: 'valid' as ButtonType,
         action: () => {
           gameState.setStarterId(s.id)
-          dex.createShlagemon(s)
+          const mon = dex.createShlagemon(s)
+          mon.rarityFollowsLevel = true
           gameState.setHasPokemon(true)
           emit('done', 'starter')
         },

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -459,8 +459,12 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     while (mon.lvl < maxLevel && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)
       mon.lvl += 1
+      if (mon.rarityFollowsLevel)
+        mon.rarity = mon.lvl
       audio.playSfx('/audio/sfx/lvl-up.ogg')
       const prevHp = mon.hpCurrent
+      if (mon.rarityFollowsLevel)
+        applyStats(mon)
       applyCurrentStats(mon)
       const healAmount = Math.round((mon.hp * healPercent) / 100)
       mon.hpCurrent = Math.min(mon.hp, prevHp + healAmount)

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -58,4 +58,10 @@ export interface DexShlagemon extends Stats {
    * ID of the item currently held by the Shlagémon, if any.
    */
   heldItemId?: string | null
+
+  /**
+   * When true, the rarity of this Shlagémon will always match its level.
+   * Useful for the starter whose rarity scales with leveling.
+   */
+  rarityFollowsLevel?: boolean
 }

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -80,6 +80,7 @@ export function createDexShlagemon(
     hpCurrent: 0,
     allowEvolution: true,
     heldItemId: null,
+    rarityFollowsLevel: false,
   }
   applyStats(mon)
   applyCurrentStats(mon)

--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -90,6 +90,7 @@ export const shlagedexSerializer = {
           captureDate: mon.captureDate ?? new Date().toISOString(),
           captureCount: mon.captureCount ?? 1,
           heldItemId: mon.heldItemId ?? null,
+          rarityFollowsLevel: mon.rarityFollowsLevel ?? false,
         }
       })
       .filter((m): m is DexShlagemon => Boolean(m))
@@ -114,6 +115,7 @@ export const shlagedexSerializer = {
           captureDate: activeData.captureDate ?? new Date().toISOString(),
           captureCount: activeData.captureCount ?? 1,
           heldItemId: activeData.heldItemId ?? null,
+          rarityFollowsLevel: activeData.rarityFollowsLevel ?? false,
         }
       }
       else {


### PR DESCRIPTION
## Summary
- add `rarityFollowsLevel` to `DexShlagemon`
- persist this new flag in the save serializer
- ensure Dex factory initializes the flag
- update XP gain so rarity matches level when enabled
- mark starter's Pokémon with this flag

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688756615a88832aa73f0c863c83e249