### PR TITLE
Adjust type effectiveness to 50%

### DIFF
--- a/src/components/shlagemon/TypeChart.vue
+++ b/src/components/shlagemon/TypeChart.vue
@@ -25,9 +25,9 @@ onBeforeUnmount(() => {
 // --- Table logique
 function getMultiplier(att: typeof types[number], def: typeof types[number]) {
   if (def.weakness.some(w => w.id === att.id))
-    return 1.2
+    return 1.5
   if (def.resistance.some(r => r.id === att.id))
-    return 0.8
+    return 0.5
   return 1
 }
 </script>

--- a/src/utils/combat.ts
+++ b/src/utils/combat.ts
@@ -10,9 +10,9 @@ export function getTypeMultiplier(
   let base = 1
 
   if (targetType.weakness.some(w => w.id === attackType.id))
-    base = 1.2 // La cible est faible contre ce type
+    base = 1.5 // La cible est faible contre ce type
   else if (targetType.resistance.some(r => r.id === attackType.id))
-    base = 0.8 // La cible résiste à ce type
+    base = 0.5 // La cible résiste à ce type
 
   const effect: 'super' | 'not' | 'normal'
     = base > 1 ? 'super' : base < 1 ? 'not' : 'normal'

--- a/test/computeDamage.test.ts
+++ b/test/computeDamage.test.ts
@@ -6,7 +6,7 @@ describe('computeDamage dual type', () => {
   it('applies multipliers from both target types', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
     const result = computeDamage(100, shlagemonTypes.poison, [shlagemonTypes.fee, shlagemonTypes.normal])
-    expect(result.damage).toBe(120)
+    expect(result.damage).toBe(150)
     expect(result.effect).toBe('super')
     expect(result.crit).toBe('normal')
   })
@@ -14,7 +14,7 @@ describe('computeDamage dual type', () => {
   it('handles resistance and weakness', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
     const result = computeDamage(100, shlagemonTypes.combat, [shlagemonTypes.normal, shlagemonTypes.vol])
-    expect(result.damage).toBe(96)
+    expect(result.damage).toBe(75)
     expect(result.effect).toBe('not')
     expect(result.crit).toBe('normal')
   })


### PR DESCRIPTION
## Summary
- bump weakness damage bonus to x1.5 and resistance reduction to x0.5
- update type chart component to display new multipliers
- update computeDamage tests for new values

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688756c8bf0c832a8b51b8b303d79fae