### PR TITLE
Ensure starter rarity handling

### DIFF
--- a/src/components/dialog/Starter.vue
+++ b/src/components/dialog/Starter.vue
@@ -61,6 +61,7 @@ const dialogTree = computed((): DialogNode[] => [
           gameState.setStarterId(s.id)
           const mon = dex.createShlagemon(s)
           mon.rarityFollowsLevel = true
+          mon.rarity = 1
           gameState.setHasPokemon(true)
           emit('done', 'starter')
         },

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -56,7 +56,12 @@ export function createDexShlagemon(
   maxRarity = 99,
   minRarity = 1,
 ): DexShlagemon {
-  const rarity = generateRarity(maxRarity, minRarity)
+  let rarity = generateRarity(maxRarity, minRarity)
+  let rarityFollowsLevel = false
+  if (base.id === 'wem') {
+    rarity = level
+    rarityFollowsLevel = true
+  }
   const mon: DexShlagemon = {
     id: crypto.randomUUID(),
     base,
@@ -80,7 +85,7 @@ export function createDexShlagemon(
     hpCurrent: 0,
     allowEvolution: true,
     heldItemId: null,
-    rarityFollowsLevel: false,
+    rarityFollowsLevel,
   }
   applyStats(mon)
   applyCurrentStats(mon)


### PR DESCRIPTION
## Summary
- ensure the chosen starter always starts at rarity 1
- treat `wem` as a special case whose rarity follows level automatically

## Testing
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_688769713108832aa1a6289275a2faea