### PR TITLE
Add king loss tutorial dialog

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -43,6 +43,7 @@ declare module 'vue' {
     DialogFirstLossDialog: typeof import('./components/dialog/FirstLossDialog.vue')['default']
     DialogHalfDexDialog: typeof import('./components/dialog/HalfDexDialog.vue')['default']
     DialogInventoryIntroDialog: typeof import('./components/dialog/InventoryIntroDialog.vue')['default']
+    DialogKingLossDialog: typeof import('./components/dialog/KingLossDialog.vue')['default']
     DialogKingUnlockDialog: typeof import('./components/dialog/KingUnlockDialog.vue')['default']
     DialogLevel5Dialog: typeof import('./components/dialog/Level5Dialog.vue')['default']
     DialogNewZoneDialog: typeof import('./components/dialog/NewZoneDialog.vue')['default']

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -143,7 +143,10 @@ async function onEnd(type: 'capture' | 'win' | 'lose' | 'draw') {
     }
   }
   else if (type === 'lose') {
-    battleStats.addLoss()
+    if (isZoneKing.value)
+      battleStats.addKingLoss()
+    else
+      battleStats.addLoss()
     notifyAchievement({ type: 'battle-loss' })
     result.value = 'lose'
     stage.value = 'after'

--- a/src/components/dialog/KingLossDialog.i18n.yml
+++ b/src/components/dialog/KingLossDialog.i18n.yml
@@ -1,0 +1,40 @@
+fr:
+  steps:
+    step1:
+      text: Ouch... Ce roi t'a mis une sacrée raclée ! Ces monarques de zone sont bien plus coriaces que les dresseurs lambda.
+      responses:
+        next: Continuer
+    step2:
+      text: Rappelle-toi que chaque Shlagémon possède un type. Clique dessus pour ouvrir la table des types.
+      responses:
+        back: Retour
+        next: Continuer
+    step3:
+      text: Cette table indique les faiblesses et résistances de chaque type. Choisis le bon Shlagémon pour frapper plus fort et subir moins de dégâts.
+      responses:
+        back: Retour
+        next: Continuer
+    step4:
+      text: Utilise ce savoir pour humilier le roi la prochaine fois et faire honneur au Professeur Merdant !
+      responses:
+        valid: Merci Prof !
+en:
+  steps:
+    step1:
+      text: Ouch... That king gave you quite a beating! These rulers are tougher than regular trainers.
+      responses:
+        next: Continue
+    step2:
+      text: Remember every Shlagemon has a type. Click it to open the type chart.
+      responses:
+        back: Back
+        next: Continue
+    step3:
+      text: The chart shows each type's weaknesses and resistances. Pick the right Shlagemon to hit harder and take less damage.
+      responses:
+        back: Back
+        next: Continue
+    step4:
+      text: Use this knowledge to humiliate the king next time and make Professor Merdant proud!
+      responses:
+        valid: Thanks Prof!

--- a/src/components/dialog/KingLossDialog.vue
+++ b/src/components/dialog/KingLossDialog.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+
+const emit = defineEmits(['done'])
+const { t } = useI18n()
+
+const dialogTree = computed<DialogNode[]>(() => [
+  {
+    id: 'step1',
+    text: t('components.dialog.KingLossDialog.steps.step1.text'),
+    responses: [
+      { label: t('components.dialog.KingLossDialog.steps.step1.responses.next'), nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: t('components.dialog.KingLossDialog.steps.step2.text'),
+    responses: [
+      { label: t('components.dialog.KingLossDialog.steps.step2.responses.back'), nextId: 'step1', type: 'danger' },
+      { label: t('components.dialog.KingLossDialog.steps.step2.responses.next'), nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: t('components.dialog.KingLossDialog.steps.step3.text'),
+    responses: [
+      { label: t('components.dialog.KingLossDialog.steps.step3.responses.back'), nextId: 'step2', type: 'danger' },
+      { label: t('components.dialog.KingLossDialog.steps.step3.responses.next'), nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: t('components.dialog.KingLossDialog.steps.step4.text'),
+    responses: [
+      { label: t('components.dialog.KingLossDialog.steps.step4.responses.valid'), type: 'valid', action: () => emit('done', 'kingLoss') },
+    ],
+  },
+])
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :dialog-tree="dialogTree"
+  />
+</template>

--- a/src/stores/battleStats.ts
+++ b/src/stores/battleStats.ts
@@ -2,16 +2,23 @@ import { defineStore } from 'pinia'
 
 export const useBattleStatsStore = defineStore('battleStats', () => {
   const losses = ref(0)
+  const kingLosses = ref(0)
 
   function addLoss() {
     losses.value += 1
   }
 
-  function reset() {
-    losses.value = 0
+  function addKingLoss() {
+    kingLosses.value += 1
+    addLoss()
   }
 
-  return { losses, addLoss, reset }
+  function reset() {
+    losses.value = 0
+    kingLosses.value = 0
+  }
+
+  return { losses, kingLosses, addLoss, addKingLoss, reset }
 }, {
   persist: true,
 })

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -9,6 +9,7 @@ import EggBoxDialog from '~/components/dialog/EggBoxDialog.vue'
 import FirstLossDialog from '~/components/dialog/FirstLossDialog.vue'
 import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
 import InventoryIntroDialog from '~/components/dialog/InventoryIntroDialog.vue'
+import KingLossDialog from '~/components/dialog/KingLossDialog.vue'
 import KingUnlockDialog from '~/components/dialog/KingUnlockDialog.vue'
 import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import NewZoneDialog from '~/components/dialog/NewZoneDialog.vue'
@@ -205,6 +206,11 @@ export const useDialogStore = defineStore('dialog', () => {
       condition: () => arena.result === 'lose',
     },
     {
+      id: 'kingLoss',
+      component: markRaw(KingLossDialog),
+      condition: () => stats.kingLosses > 0,
+    },
+    {
       id: 'firstLoss',
       component: markRaw(FirstLossDialog),
       condition: () => stats.losses > 0,
@@ -215,9 +221,12 @@ export const useDialogStore = defineStore('dialog', () => {
     const firstLoss = dialogs.find(d => d.id === 'firstLoss')
     const showFirstLoss = firstLoss?.condition()
       && !done.value[firstLoss.id]
+    const kingLoss = dialogs.find(d => d.id === 'kingLoss')
+    const showKingLoss = kingLoss?.condition()
+      && !done.value[kingLoss.id]
 
     if (panel.current === 'trainerBattle')
-      return Boolean(showFirstLoss)
+      return Boolean(showFirstLoss || showKingLoss)
 
     return dialogs.some(d => d.condition() && !done.value[d.id])
   })


### PR DESCRIPTION
## Summary
- teach players about shlagemon types after the first defeat against a king
- track king losses in `battleStats`
- trigger new dialog in the dialog store
- display it on trainer defeats

## Testing
- `pnpm lint` *(fails: trailing spaces in unrelated files)*
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68877fe62428832a98a38f4808cc901b