### PR TITLE
Refactor kings to use id arrays

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -82,12 +82,17 @@ function createEnemy(): DexShlagemon | null {
   const spec = t.shlagemons[enemyIndex.value]
   if (!spec)
     return null
-  const base = allShlagemons.find(b => b.id === spec.baseId)
+  const baseId = typeof spec === 'string' ? spec : spec.baseId
+  const base = allShlagemons.find(b => b.id === baseId)
   if (!base)
     return null
   const max = wildLevel.highestWildLevel
   const min = isZoneKing.value ? Math.max(1, max - 20) : 1
-  return createDexShlagemon(base, false, spec.level, max, min)
+  const zoneMax = zone.current.maxLevel ?? 1
+  const level = typeof spec === 'string'
+    ? zoneMax + 1 - (t.shlagemons.length - 1 - enemyIndex.value)
+    : spec.level
+  return createDexShlagemon(base, false, level, max, min)
 }
 
 function startFight() {

--- a/src/data/kings.ts
+++ b/src/data/kings.ts
@@ -1,121 +1,113 @@
 import type { Character } from '~/type/character'
 import type { SavageZoneId } from '~/type/zone'
 import type { BaseShlagemon, Trainer } from '~/types'
+import { aliceCordonbleu } from './characters/alice-cordonbleu'
+import { bouba } from './characters/bouba'
 import { caillou } from './characters/caillou'
+import { charlesManoir } from './characters/charles-manoir'
 import { donaldTrompe } from './characters/donald-trompe'
+import { elisabethBorgne } from './characters/elisabeth-borgne'
+import { elizabethHomeless } from './characters/elizabeth-homeless'
+import { etronMuscle } from './characters/etron-muscle'
+import { glandhi } from './characters/glandhi'
+import { jkRalwing } from './characters/jk-ralwing'
+import { labbeBiere } from './characters/labbe-biere'
 import { marcon } from './characters/marcon'
 import { marineLahaine } from './characters/marine-lahaine'
+import { moniqueCerisier } from './characters/monique-cerisier'
 import { norman } from './characters/norman'
 import { ondejeune } from './characters/ondejeune'
-import { profMerdant } from './characters/prof-merdant'
-import { sachatte } from './characters/sachatte'
-import { siphanus } from './characters/siphanus'
-import { vladimirPutain } from './characters/vladimir-putain'
-import mystouffe from './shlagemons/20-25/mystouffe'
-import melofoutre from './shlagemons/30-35/melofoutre'
-import racaillou from './shlagemons/40-45/racaillou'
-import houlard from './shlagemons/60-65/houlard'
-import onixtamere from './shlagemons/70-75/onixtamere'
-import huithuit from './shlagemons/75-80/huithuit'
-import poissaucisse from './shlagemons/85-90/poissaucisse'
-import gravaglaire from './shlagemons/evolutions/gravaglaire'
-import hyporuisseau from './shlagemons/evolutions/hyporuisseau'
-import rafflamby from './shlagemons/evolutions/rafflamby'
-import tordturc from './shlagemons/evolutions/tord-turc'
-import { zonesData } from './zones'
-import goubite from './shlagemons/15-20/goubite'
-import vieuxBlaireau from './shlagemons/evolutions/vieuxblaireau'
-import chetibranle from './shlagemons/40-45/chetibranle'
-import coconnul from './shlagemons/evolutions/coconnul'
-import rapasdepisse from './shlagemons/evolutions/rapasdepisse'
-import glandignon from './shlagemons/65-70/glandignon'
-import orchibre from './shlagemons/evolutions/orchibre'
-import barbeBizarre from './shlagemons/evolutions/barbe-bizarre'
-import macho from './shlagemons/35-40/macho'
-import ferosang from './shlagemons/35-40/ferosang'
-import masschopeur from './shlagemons/evolutions/masschopeur'
-import taupicouze from './shlagemons/25-30/taupicouze'
-import rhinoplastie from './shlagemons/evolutions/rhinoplastie'
-import { aliceCordonbleu } from './characters/alice-cordonbleu'
-import pyrolise from './shlagemons/evolutions/pyrolise'
-import cacanus from './shlagemons/20-25/cacanus'
-import ricardnin from './shlagemons/evolutions/ricardnin'
-import kraputo from './shlagemons/55-60/kraputo'
 import { picassos } from './characters/picassos'
-import piafsansbec from './shlagemons/25-30/piafsansbec'
-import hericouille from './shlagemons/65-70/hericouille'
-import ptitrat from './shlagemons/55-60/ptitrat'
-import hosoltueur from './shlagemons/evolutions/hosoltueur'
-import coloscopie from './shlagemons/evolutions/coloscopie'
-import { moniqueCerisier } from './characters/monique-cerisier'
-import heristrash from './shlagemons/evolutions/heristrash'
-import amonichiasse from './shlagemons/55-60/amonichiasse'
-import grosseflemme from './shlagemons/evolutions/grosseflemme'
-import magnubellule from './shlagemons/45-50/magnubellule'
-import { labbeBiere } from './characters/labbe-biere'
-import dentlait from './shlagemons/75-80/dentlait'
-import { jkRalwing } from './characters/jk-ralwing'
-import coksale from './shlagemons/60-65/coksale'
-import coksnif from './shlagemons/evolutions/coksnif'
-import coxymort from './shlagemons/evolutions/coxymort'
-import aerobite from './shlagemons/evolutions/aerobite'
-import papysucon from './shlagemons/evolutions/papi-sucon'
-import nidononbinaireF from './shlagemons/30-35/nidononbinaire-f'
-import nidononbinaireM from './shlagemons/30-35/nidononbinaire-m'
-import nidoteub from './shlagemons/evolutions/nidoteub'
-import nidoschneck from './shlagemons/evolutions/nidoschneck'
-import kadavrebras from './shlagemons/evolutions/kadavrebras'
-import sperectum from './shlagemons/evolutions/sperectum'
-import ectroudbal from './shlagemons/evolutions/ectroudbal'
-import fantomanus from './shlagemons/01-05/fantomanus'
-import qulbudrogue from './shlagemons/15-20/qulbudrogue'
-import smongol from './shlagemons/80-85/smongol'
-import { charlesManoir } from './characters/charles-manoir'
-import { glandhi } from './characters/glandhi'
-import marginal from './shlagemons/50-55/marginal'
-import lamantinedu38 from './shlagemons/evolutions/lamantinedu38'
-import krabbolosse from './shlagemons/evolutions/krabbolosse'
-import grossetarte from './shlagemons/evolutions/grossetarte'
-import qwiflash from './shlagemons/65-70/qwiflash'
-import qwiflouch from './shlagemons/evolutions/qwiflouch'
+import { siphanus } from './characters/siphanus'
 import { thaisDescufion } from './characters/thais-descufion'
+import { vladimirPutain } from './characters/vladimir-putain'
+import fantomanus from './shlagemons/01-05/fantomanus'
 import metamorve from './shlagemons/05-10/metamorve'
-import ratartine from './shlagemons/evolutions/ratartine'
+import goubite from './shlagemons/15-20/goubite'
+import qulbudrogue from './shlagemons/15-20/qulbudrogue'
+import cacanus from './shlagemons/20-25/cacanus'
 import ratonton from './shlagemons/20-25/ratonton'
+import grosmitoss from './shlagemons/25-30/grosmitoss'
+import piafsansbec from './shlagemons/25-30/piafsansbec'
+import taupicouze from './shlagemons/25-30/taupicouze'
 import waouff from './shlagemons/25-30/waouff'
 import canarchicon from './shlagemons/30-35/canarchicon'
-import dosolo from './shlagemons/45-50/dosolo'
-import { elizabethHomeless } from './characters/elizabeth-homeless'
-import flaclodoss from './shlagemons/evolutions/flaclodoss'
-import poissomerguez from './shlagemons/evolutions/poissomerguez'
-import carreflex from './shlagemons/60-65/carreflex'
-import kandurex from './shlagemons/85-90/kandurex'
-import pauvreetcon from './shlagemons/55-60/pauvreetcon'
-import grosmitoss from './shlagemons/25-30/grosmitoss'
-import { bouba } from './characters/bouba'
-import chignon from './shlagemons/75-80/chignon'
-import kistlee from './shlagemons/75-80/kistlee'
-import drapcon from './shlagemons/evolutions/drapcon'
-import minidrapcon from './shlagemons/65-70/minidrapcon'
-import drapcoloscopie from './shlagemons/evolutions/drapcoloscopie'
-import electrobeauf from './shlagemons/evolutions/electrobeauf'
-import voltamere from './shlagemons/70-75/voltamere'
-import magnementon from './shlagemons/evolutions/magnementon'
-import { elisabethBorgne } from './characters/elisabeth-borgne'
-import { etronMuscle } from './characters/etron-muscle'
-import rouxPasCool from './shlagemons/01-05/rouxPasCool'
-import noctedard from './shlagemons/evolutions/noctedard'
-import lecocu from './shlagemons/80-85/lecocu'
-import electhordu from './shlagemons/electhordu'
-import meladolphe from './shlagemons/evolutions/meladolphe'
+import melofoutre from './shlagemons/30-35/melofoutre'
+import nidononbinaireF from './shlagemons/30-35/nidononbinaire-f'
+import nidononbinaireM from './shlagemons/30-35/nidononbinaire-m'
+import ferosang from './shlagemons/35-40/ferosang'
+import macho from './shlagemons/35-40/macho'
 import psykonaute from './shlagemons/35-40/psykonaute'
-import nosferasta from './shlagemons/evolutions/nosferasta'
-import kaputrak from './shlagemons/evolutions/kaputrak'
-import raptorincel from './shlagemons/evolutions/raptorincel'
-import sulfusouris from './shlagemons/sulfusouris'
-import floripute from './shlagemons/evolutions/floripute'
+import chetibranle from './shlagemons/40-45/chetibranle'
+import racaillou from './shlagemons/40-45/racaillou'
+import dosolo from './shlagemons/45-50/dosolo'
+import magnubellule from './shlagemons/45-50/magnubellule'
+import marginal from './shlagemons/50-55/marginal'
+import amonichiasse from './shlagemons/55-60/amonichiasse'
+import kraputo from './shlagemons/55-60/kraputo'
+import pauvreetcon from './shlagemons/55-60/pauvreetcon'
+import ptitrat from './shlagemons/55-60/ptitrat'
+import carreflex from './shlagemons/60-65/carreflex'
+import coksale from './shlagemons/60-65/coksale'
+import houlard from './shlagemons/60-65/houlard'
+import glandignon from './shlagemons/65-70/glandignon'
+import hericouille from './shlagemons/65-70/hericouille'
+import minidrapcon from './shlagemons/65-70/minidrapcon'
+import qwiflash from './shlagemons/65-70/qwiflash'
+import onixtamere from './shlagemons/70-75/onixtamere'
+import voltamere from './shlagemons/70-75/voltamere'
+import dentlait from './shlagemons/75-80/dentlait'
+import huithuit from './shlagemons/75-80/huithuit'
+import lecocu from './shlagemons/80-85/lecocu'
+import smongol from './shlagemons/80-85/smongol'
+import kandurex from './shlagemons/85-90/kandurex'
+import poissaucisse from './shlagemons/85-90/poissaucisse'
+import electhordu from './shlagemons/electhordu'
+import aerobite from './shlagemons/evolutions/aerobite'
+import barbeBizarre from './shlagemons/evolutions/barbe-bizarre'
+import coconnul from './shlagemons/evolutions/coconnul'
+import coksnif from './shlagemons/evolutions/coksnif'
+import coloscopie from './shlagemons/evolutions/coloscopie'
+import coxymort from './shlagemons/evolutions/coxymort'
 import dracoCon from './shlagemons/evolutions/draco-con'
+import drapcoloscopie from './shlagemons/evolutions/drapcoloscopie'
+import drapcon from './shlagemons/evolutions/drapcon'
+import ectroudbal from './shlagemons/evolutions/ectroudbal'
+import electrobeauf from './shlagemons/evolutions/electrobeauf'
+import flaclodoss from './shlagemons/evolutions/flaclodoss'
+import floripute from './shlagemons/evolutions/floripute'
+import gravaglaire from './shlagemons/evolutions/gravaglaire'
+import grosseflemme from './shlagemons/evolutions/grosseflemme'
+import grossetarte from './shlagemons/evolutions/grossetarte'
+import heristrash from './shlagemons/evolutions/heristrash'
+import hosoltueur from './shlagemons/evolutions/hosoltueur'
+import hyporuisseau from './shlagemons/evolutions/hyporuisseau'
+import kadavrebras from './shlagemons/evolutions/kadavrebras'
+import kaputrak from './shlagemons/evolutions/kaputrak'
+import krabbolosse from './shlagemons/evolutions/krabbolosse'
+import lamantinedu38 from './shlagemons/evolutions/lamantinedu38'
+import magnementon from './shlagemons/evolutions/magnementon'
+import masschopeur from './shlagemons/evolutions/masschopeur'
+import meladolphe from './shlagemons/evolutions/meladolphe'
+import nidoschneck from './shlagemons/evolutions/nidoschneck'
+import nidoteub from './shlagemons/evolutions/nidoteub'
+import nosferasta from './shlagemons/evolutions/nosferasta'
+import orchibre from './shlagemons/evolutions/orchibre'
+import papysucon from './shlagemons/evolutions/papi-sucon'
+import poissomerguez from './shlagemons/evolutions/poissomerguez'
+import pyrolise from './shlagemons/evolutions/pyrolise'
+import qwiflouch from './shlagemons/evolutions/qwiflouch'
+import rafflamby from './shlagemons/evolutions/rafflamby'
 import raichiotte from './shlagemons/evolutions/raichiotte'
+import rapasdepisse from './shlagemons/evolutions/rapasdepisse'
+import ratartine from './shlagemons/evolutions/ratartine'
+import rhinoplastie from './shlagemons/evolutions/rhinoplastie'
+import ricardnin from './shlagemons/evolutions/ricardnin'
+import sperectum from './shlagemons/evolutions/sperectum'
+import tordturc from './shlagemons/evolutions/tord-turc'
+import vieuxBlaireau from './shlagemons/evolutions/vieuxblaireau'
+import sulfusouris from './shlagemons/sulfusouris'
+import { zonesData } from './zones'
 
 function _createKing(
   zoneId: SavageZoneId,
@@ -129,8 +121,6 @@ function _createKing(
   if (!zone) {
     throw new Error(`Zone ${zoneId} not found`)
   }
-  const levelMax = (zone.maxLevel ?? 1) + 1
-
   // Gather base shlagemons and their first evolution stage
   const available = zone.shlagemons!
     .flatMap(b => b.evolution?.base ? [b, b.evolution.base] : [b])
@@ -151,10 +141,7 @@ function _createKing(
   const selectedEvols = evolvedMons.slice(0, evolCount)
   const selected = [...selectedBases, ...selectedEvols]
 
-  const shlagemons: { baseId: string, level: number }[] = selected.map((b, idx) => ({
-    baseId: b.id,
-    level: levelMax - (selected.length - 1 - idx),
-  }))
+  const shlagemons: string[] = selected.map(b => b.id)
 
   return {
     id: `king-${zoneId}`,
@@ -169,9 +156,8 @@ function _createKing(
 
 type Kings = Record<SavageZoneId, Trainer>
 
-function createStaticShlags(zoneId: SavageZoneId) {
-  const level = (zonesData.find(z => z.id === zoneId)?.maxLevel ?? 1) + 1
-  return Array.from({ length: 4 }, () => ({ baseId: 'wem', level }))
+function _createStaticShlags(_zoneId: SavageZoneId) {
+  return Array.from({ length: 4 }, () => 'wem')
 }
 
 export const kings: Kings = {
@@ -183,8 +169,8 @@ export const kings: Kings = {
     dialogAfter: 'Ok, ok, tu as gagné, je vais t\'inviter pour ce petit déj !',
     dialogDefeat: 'Mais quel grosse merde, tu vas me payer un petit déj\' de ouf !',
     shlagemons: [
-      { baseId: poissaucisse.id, level: 5 },
-      { baseId: hyporuisseau.id, level: 6 },
+      poissaucisse.id,
+      hyporuisseau.id,
     ],
   },
   'bois-de-bouffon': {
@@ -195,9 +181,9 @@ export const kings: Kings = {
     dialogDefeat: 'Je vais te faire bouffer tes cheveux espèce de sous merde !',
     reward: zonesData.find(z => z.id === 'bois-de-bouffon')?.maxLevel || 1,
     shlagemons: [
-      { baseId: racaillou.id, level: 8 },
-      { baseId: onixtamere.id, level: 9 },
-      { baseId: gravaglaire.id, level: 11 },
+      racaillou.id,
+      onixtamere.id,
+      gravaglaire.id,
     ],
   },
   'chemin-du-slip': {
@@ -208,9 +194,9 @@ export const kings: Kings = {
     dialogDefeat: 'Tu pues la lose, file te laver !',
     reward: zonesData.find(z => z.id === 'chemin-du-slip')?.maxLevel || 1,
     shlagemons: [
-      { baseId: melofoutre.id, level: 14 },
-      { baseId: huithuit.id, level: 15 },
-      { baseId: taupicouze.id, level: 16 },
+      melofoutre.id,
+      huithuit.id,
+      taupicouze.id,
     ],
   },
   'ravin-fesse-molle': {
@@ -221,9 +207,9 @@ export const kings: Kings = {
     dialogDefeat: 'Dégage ! Retourne dans ton pays !',
     reward: zonesData.find(z => z.id === 'ravin-fesse-molle')?.maxLevel || 1,
     shlagemons: [
-      { baseId: houlard.id, level: 19 },
-      { baseId: rafflamby.id, level: 20 },
-      { baseId: tordturc.id, level: 21 },
+      houlard.id,
+      rafflamby.id,
+      tordturc.id,
     ],
   },
   'precipice-nanard': {
@@ -234,10 +220,10 @@ export const kings: Kings = {
     dialogDefeat: 'T\'es une merde, t\'as toujours été une merde, tu resteras une merde toute ta vie.',
     reward: zonesData.find(z => z.id === 'precipice-nanard')?.maxLevel || 1,
     shlagemons: [
-      { baseId: goubite.id, level: 23 },
-      { baseId: vieuxBlaireau.id, level: 24 },
-      { baseId: chetibranle.id, level: 25 },
-      { baseId: coconnul.id, level: 26 },
+      goubite.id,
+      vieuxBlaireau.id,
+      chetibranle.id,
+      coconnul.id,
     ],
   },
   'marais-moudugenou': {
@@ -248,10 +234,10 @@ export const kings: Kings = {
     dialogDefeat: 'Je t\'éclabousse de ma boue, retourne barboter ailleurs.',
     reward: zonesData.find(z => z.id === 'marais-moudugenou')?.maxLevel || 1,
     shlagemons: [
-      { baseId: orchibre.id, level: 28 },
-      { baseId: barbeBizarre.id, level: 39 },
-      { baseId: glandignon.id, level: 30 },
-      { baseId: rapasdepisse.id, level: 31 },
+      orchibre.id,
+      barbeBizarre.id,
+      glandignon.id,
+      rapasdepisse.id,
     ],
   },
   'forteresse-petmoalfiak': {
@@ -262,129 +248,129 @@ export const kings: Kings = {
     dialogDefeat: 'Boum ! Ma forteresse t\'écrase, petit looser de mort ! J\'te baise !',
     reward: zonesData.find(z => z.id === 'forteresse-petmoalfiak')?.maxLevel || 1,
     shlagemons: [
-      { baseId: macho.id, level: 33 },
-      { baseId: ferosang.id, level: 34 },
-      { baseId: rhinoplastie.id, level: 35 },
-      { baseId: masschopeur.id, level: 36 },
+      macho.id,
+      ferosang.id,
+      rhinoplastie.id,
+      masschopeur.id,
     ],
   },
   'route-du-nawak': {
     id: 'king-route-du-nawak',
     character: aliceCordonbleu,
-    dialogBefore: "Je n'aime ni la couleur de tes cheveux, ni la forme de ton nez, ni la taille de tes pieds. Prépare toi à perdre tes couilles !",
+    dialogBefore: 'Je n\'aime ni la couleur de tes cheveux, ni la forme de ton nez, ni la taille de tes pieds. Prépare toi à perdre tes couilles !',
     dialogAfter: 'Tu t\'en sors, pour l\'instant.',
-    dialogDefeat: "Je suis obligée de quitter le territoire, mais je reviendrai pour te bouffer le cul, enculé de ta race !",
+    dialogDefeat: 'Je suis obligée de quitter le territoire, mais je reviendrai pour te bouffer le cul, enculé de ta race !',
     reward: zonesData.find(z => z.id === 'route-du-nawak')?.maxLevel || 1,
     shlagemons: [
-      { baseId: pyrolise.id, level: 38 },
-      { baseId: cacanus.id, level: 39 },
-      { baseId: kraputo.id, level: 40 },
-      { baseId: ricardnin.id, level: 41 },
+      pyrolise.id,
+      cacanus.id,
+      kraputo.id,
+      ricardnin.id,
     ],
   },
   'mont-dracatombe': {
     id: 'king-mont-dracatombe',
     character: picassos,
-    dialogBefore: "Salut, j'aime beaucoup les couleurs mais également tabasser des meufs.",
-    dialogAfter: "Tu as réussi à me vaincre, je te peindrait tout de même en looser.",
-    dialogDefeat: "Tu pues la merde, je te nique tes morts !",
+    dialogBefore: 'Salut, j\'aime beaucoup les couleurs mais également tabasser des meufs.',
+    dialogAfter: 'Tu as réussi à me vaincre, je te peindrait tout de même en looser.',
+    dialogDefeat: 'Tu pues la merde, je te nique tes morts !',
     reward: zonesData.find(z => z.id === 'mont-dracatombe')?.maxLevel || 1,
     shlagemons: [
-      { baseId: piafsansbec.id, level: 42 },
-      { baseId: hericouille.id, level: 43 },
-      { baseId: ptitrat.id, level: 44 },
-      { baseId: hosoltueur.id, level: 45 },
-      { baseId: coloscopie.id, level: 46 },
+      piafsansbec.id,
+      hericouille.id,
+      ptitrat.id,
+      hosoltueur.id,
+      coloscopie.id,
     ],
   },
   'catacombes-merdifientes': {
     id: 'king-catacombes-merdifientes',
     character: moniqueCerisier,
-    dialogBefore: "Peux tu m'aider à descendre ce sac dans ma cave, s'il te plaît ?",
+    dialogBefore: 'Peux tu m\'aider à descendre ce sac dans ma cave, s\'il te plaît ?',
     dialogAfter: 'Je sombre dans l\'ombre des catacombes avec mon terrible secret.',
     dialogDefeat: 'Remonte donc à la surface, larve.',
     reward: zonesData.find(z => z.id === 'catacombes-merdifientes')?.maxLevel || 1,
     shlagemons: [
-      { baseId: amonichiasse.id, level: 47 },
-      { baseId: dentlait.id, level: 48 },
-      { baseId: magnubellule.id, level: 49 },
-      { baseId: grosseflemme.id, level: 50 },
-      { baseId: heristrash.id, level: 51 },
+      amonichiasse.id,
+      dentlait.id,
+      magnubellule.id,
+      grosseflemme.id,
+      heristrash.id,
     ],
   },
   'route-aguicheuse': {
     id: 'king-route-aguicheuse',
     character: labbeBiere,
-    dialogBefore: "Moi j'aide les pauvre mais je les baises aussi. Avec ou sans consentement.",
-    dialogAfter: "Bien joué, voyageur, tu m'as bien enculé.",
-    dialogDefeat: "Et je te baise toi aussi, espèce de trou de balle informe !",
+    dialogBefore: 'Moi j\'aide les pauvre mais je les baises aussi. Avec ou sans consentement.',
+    dialogAfter: 'Bien joué, voyageur, tu m\'as bien enculé.',
+    dialogDefeat: 'Et je te baise toi aussi, espèce de trou de balle informe !',
     reward: zonesData.find(z => z.id === 'route-aguicheuse')?.maxLevel || 1,
     shlagemons: [
-      { baseId: coksale.id, level: 52 },
-      { baseId: aerobite.id, level: 53 },
-      { baseId: coksnif.id, level: 54 },
-      { baseId: papysucon.id, level: 55 },
-      { baseId: coxymort.id, level: 56 },
+      coksale.id,
+      aerobite.id,
+      coksnif.id,
+      papysucon.id,
+      coxymort.id,
     ],
   },
   'vallee-des-chieurs': {
     id: 'king-vallee-des-chieurs',
     character: jkRalwing,
     dialogBefore: 'Tu es plutôt un garçon ou une fille ? Décide toi car je ne veux pas perdre mon temps avec les indécis.',
-    dialogAfter: "Tu m'as ovuert les yeux, je vais t'accepter comme tu es : un vagin à tête de gland.",
-    dialogDefeat: "Je t'ai violenté aussi fort qu'un expéliermus, tu es un vrai loser.",
+    dialogAfter: 'Tu m\'as ovuert les yeux, je vais t\'accepter comme tu es : un vagin à tête de gland.',
+    dialogDefeat: 'Je t\'ai violenté aussi fort qu\'un expéliermus, tu es un vrai loser.',
     reward: zonesData.find(z => z.id === 'vallee-des-chieurs')?.maxLevel || 1,
     shlagemons: [
-      { baseId: nidononbinaireF.id, level: 57 },
-      { baseId: nidononbinaireM.id, level: 58 },
-      { baseId: nidoteub.id, level: 59 },
-      { baseId: nidoschneck.id, level: 60 },
-      { baseId: kadavrebras.id, level: 61 },
+      nidononbinaireF.id,
+      nidononbinaireM.id,
+      nidoteub.id,
+      nidoschneck.id,
+      kadavrebras.id,
     ],
   },
   'trou-du-bide': {
     id: 'king-trou-du-bide',
     character: charlesManoir,
     dialogBefore: 'Helllo !  Veux tu goutter à ma nouvelle beuh ?',
-    dialogAfter: "Je vais te faire subir ma colère, personne ne me manque de respect !",
-    dialogDefeat: "Viens avec moi, je t'accompagne mon Loulou...",
+    dialogAfter: 'Je vais te faire subir ma colère, personne ne me manque de respect !',
+    dialogDefeat: 'Viens avec moi, je t\'accompagne mon Loulou...',
     reward: zonesData.find(z => z.id === 'trou-du-bide')?.maxLevel || 1,
     shlagemons: [
-      { baseId: fantomanus.id, level: 62 },
-      { baseId: qulbudrogue.id, level: 63 },
-      { baseId: sperectum.id, level: 64 },
-      { baseId: smongol.id, level: 65 },
-      { baseId: ectroudbal.id, level: 66 },
+      fantomanus.id,
+      qulbudrogue.id,
+      sperectum.id,
+      smongol.id,
+      ectroudbal.id,
     ],
   },
   'zone-giga-zob': {
     id: 'king-zone-giga-zob',
     character: glandhi,
-    dialogBefore: "Je suis paix, je suis amour, tu n'as qu'à m'écouter et tu seras sauvé !",
+    dialogBefore: 'Je suis paix, je suis amour, tu n\'as qu\'à m\'écouter et tu seras sauvé !',
     dialogAfter: 'Je te hais, toi et tes idées de merde !',
     dialogDefeat: 'Je suis ta haine, je suis ta colère, je suis ton désespoir !',
     reward: zonesData.find(z => z.id === 'zone-giga-zob')?.maxLevel || 1,
     shlagemons: [
-      { baseId: marginal.id, level: 67 },
-      { baseId: marginal.id, level: 68 },
-      { baseId: marginal.id, level: 69 },
-      { baseId: marginal.id, level: 70 },
-      { baseId: marginal.id, level: 71 },
+      marginal.id,
+      marginal.id,
+      marginal.id,
+      marginal.id,
+      marginal.id,
     ],
   },
   'route-so-dom': {
     id: 'king-route-so-dom',
     character: thaisDescufion,
-    dialogBefore: "Les meufs, c'est toutes des putes, alors que moi j'adoooorrrreee faire la vaiselle !",
+    dialogBefore: 'Les meufs, c\'est toutes des putes, alors que moi j\'adoooorrrreee faire la vaiselle !',
     dialogAfter: `Tu me l'as mise bien profonde, mais je reviendrai plus forte !`,
     dialogDefeat: `T'es ma pute, je fais ce que je veux de toi !`,
     reward: zonesData.find(z => z.id === 'route-so-dom')?.maxLevel || 1,
     shlagemons: [
-      { baseId: krabbolosse.id, level: 72 },
-      { baseId: grossetarte.id, level: 73 },
-      { baseId: qwiflash.id, level: 74 },
-      { baseId: qwiflouch.id, level: 75 },
-      { baseId: lamantinedu38.id, level: 76 },
+      krabbolosse.id,
+      grossetarte.id,
+      qwiflash.id,
+      qwiflouch.id,
+      lamantinedu38.id,
     ],
   },
   'lac-aux-relous': {
@@ -395,28 +381,28 @@ export const kings: Kings = {
     dialogDefeat: 'Я засунул свой палец тебе в задницу',
     reward: zonesData.find(z => z.id === 'lac-aux-relous')?.maxLevel || 1,
     shlagemons: [
-      { baseId: metamorve.id, level: 76 },
-      { baseId: ratonton.id, level: 77 },
-      { baseId: ratartine.id, level: 78 },
-      { baseId: waouff.id, level: 79 },
-      { baseId: canarchicon.id, level: 80 },
-      { baseId: dosolo.id, level: 81 },
+      metamorve.id,
+      ratonton.id,
+      ratartine.id,
+      waouff.id,
+      canarchicon.id,
+      dosolo.id,
     ],
   },
   'canyon-a-la-derp': {
     id: 'king-canyon-a-la-derp',
     character: elizabethHomeless,
-    dialogBefore: "Bienvenue au Canyon-a-la-derp™, le seul endroit où une simple goutte de sueur suffit à prouver ta grandeur... enfin, en théorie.",
-    dialogAfter: "Incroyable, tu as survécu à ma technologie révolutionnaire 100% inefficace. Tu mériterais presque un brevet.",
-    dialogDefeat: "Échec critique détecté. Mais t’inquiète, avec un bon PowerPoint, tu pourrais faire croire que t'as gagné.",
-  reward: zonesData.find(z => z.id === 'canyon-a-la-derp')?.maxLevel || 1,
+    dialogBefore: 'Bienvenue au Canyon-a-la-derp™, le seul endroit où une simple goutte de sueur suffit à prouver ta grandeur... enfin, en théorie.',
+    dialogAfter: 'Incroyable, tu as survécu à ma technologie révolutionnaire 100% inefficace. Tu mériterais presque un brevet.',
+    dialogDefeat: 'Échec critique détecté. Mais t’inquiète, avec un bon PowerPoint, tu pourrais faire croire que t\'as gagné.',
+    reward: zonesData.find(z => z.id === 'canyon-a-la-derp')?.maxLevel || 1,
     shlagemons: [
-      { baseId: pauvreetcon.id, level: 81 },
-      { baseId: kandurex.id, level: 82 },
-      { baseId: carreflex.id, level: 83 },
-      { baseId: poissomerguez.id, level: 84 },
-      { baseId: grosmitoss.id, level: 85 },
-      { baseId: flaclodoss.id, level: 86 },
+      pauvreetcon.id,
+      kandurex.id,
+      carreflex.id,
+      poissomerguez.id,
+      grosmitoss.id,
+      flaclodoss.id,
     ],
   },
   'cratere-des-legends': {
@@ -427,28 +413,28 @@ export const kings: Kings = {
     dialogDefeat: 'Tu es un perdant, tu ne mérites pas de traverser ce cratère ! Baise ton frère.',
     reward: zonesData.find(z => z.id === 'cratere-des-legends')?.maxLevel || 1,
     shlagemons: [
-      { baseId: minidrapcon.id, level: 86 },
-      { baseId: voltamere.id, level: 87 },
-      { baseId: magnementon.id, level: 88 },
-      { baseId: drapcon.id, level: 89 },
-      { baseId: electrobeauf.id, level: 90 },
-      { baseId: drapcoloscopie.id, level: 91 },
+      minidrapcon.id,
+      voltamere.id,
+      magnementon.id,
+      drapcon.id,
+      electrobeauf.id,
+      drapcoloscopie.id,
     ],
   },
   'mont-kouillasse': {
     id: 'king-mont-kouillasse',
     character: etronMuscle,
-    dialogBefore: "Bonjour, en tant que Roi du Mont Kouillasse, j'ai une liberté d'expression TOTALE ! Je peux dire ce que je veux et sucer des petits moustachus Allemands sans aucune censure !",
-    dialogAfter: "Vas te faire foutre, je t'enverrai dans une fusée pour que t'ailles sucer des couilles sur Mars !",
-    dialogDefeat: "T'es aussi con que ta mère, tu ne mérites pas de traverser le Mont Kouillasse !",
+    dialogBefore: 'Bonjour, en tant que Roi du Mont Kouillasse, j\'ai une liberté d\'expression TOTALE ! Je peux dire ce que je veux et sucer des petits moustachus Allemands sans aucune censure !',
+    dialogAfter: 'Vas te faire foutre, je t\'enverrai dans une fusée pour que t\'ailles sucer des couilles sur Mars !',
+    dialogDefeat: 'T\'es aussi con que ta mère, tu ne mérites pas de traverser le Mont Kouillasse !',
     reward: zonesData.find(z => z.id === 'mont-kouillasse')?.maxLevel || 1,
     shlagemons: [
-      { baseId: lecocu.id, level: 91 },
-      { baseId: meladolphe.id, level: 92 },
-      { baseId: psykonaute.id, level: 93 },
-      { baseId: nosferasta.id, level: 94 },
-      { baseId: rapasdepisse.id, level: 95 },
-      { baseId: electhordu.id, level: 96 },
+      lecocu.id,
+      meladolphe.id,
+      psykonaute.id,
+      nosferasta.id,
+      rapasdepisse.id,
+      electhordu.id,
     ],
   },
   'paturage-crado': {
@@ -459,12 +445,12 @@ export const kings: Kings = {
     dialogDefeat: 'Je vais imposer une loi pour interdire les losers comme toi de se balader dans les pâturages !',
     reward: zonesData.find(z => z.id === 'paturage-crado')?.maxLevel || 1,
     shlagemons: [
-      { baseId: floripute.id, level: 99 },
-      { baseId: dracoCon.id, level: 99 },
-      { baseId: tordturc.id, level: 99 },
-      { baseId: raichiotte.id, level: 99 },
-      { baseId: kaputrak.id, level: 99 },
-      { baseId: sulfusouris.id, level: 99 },
+      floripute.id,
+      dracoCon.id,
+      tordturc.id,
+      raichiotte.id,
+      kaputrak.id,
+      sulfusouris.id,
     ],
   },
 }

--- a/src/type/trainer.ts
+++ b/src/type/trainer.ts
@@ -12,5 +12,5 @@ export interface Trainer {
   dialogAfter: string
   dialogDefeat?: string
   reward: number
-  shlagemons: TrainerShlagemon[]
+  shlagemons: (TrainerShlagemon | string)[]
 }


### PR DESCRIPTION
## Summary
- update Trainer type to support string-based king rosters
- compute king shlagémon levels dynamically in `Trainer.vue`
- store only shlagémon ids for all kings

## Testing
- `pnpm test` *(fails: zone panel > shows king button after 20 wins)*

------
https://chatgpt.com/codex/tasks/task_e_6887910ea35c832ab75a2b6a7a9b2fab