### PR TITLE
Fix apostrophes in music json generation

### DIFF
--- a/public/music-data.json
+++ b/public/music-data.json
@@ -156,16 +156,88 @@
     "image": null
   },
   {
+    "nom": "Afida Tourments",
+    "type": "character",
+    "url": null,
+    "image": null
+  },
+  {
+    "nom": "Alice Cordonbleu",
+    "type": "character",
+    "url": null,
+    "image": "/characters/alice-cordonbleu/alice-cordonbleu.png"
+  },
+  {
+    "nom": "Bouba",
+    "type": "character",
+    "url": null,
+    "image": "/characters/bouba/bouba.png"
+  },
+  {
     "nom": "Caillou",
     "type": "character",
     "url": "/audio/musics/character/caillou.ogg",
     "image": "/characters/caillou/caillou.png"
   },
   {
+    "nom": "Charles Manoir",
+    "type": "character",
+    "url": null,
+    "image": "/characters/charles-manoir/charles-manoir.png"
+  },
+  {
     "nom": "Donald Trompe",
     "type": "character",
     "url": "/audio/musics/character/donald-trompe.ogg",
     "image": "/characters/donald-trompe/donald-trompe.png"
+  },
+  {
+    "nom": "Élisabeth Borgne",
+    "type": "character",
+    "url": null,
+    "image": "/characters/elisabeth-borgne/elisabeth-borgne.png"
+  },
+  {
+    "nom": "Elizabeth Homeless",
+    "type": "character",
+    "url": null,
+    "image": "/characters/elizabeth-homeless/elizabeth-homeless.png"
+  },
+  {
+    "nom": "Émilie Louise",
+    "type": "character",
+    "url": null,
+    "image": "/characters/emilie-louise/emilie-louise.png"
+  },
+  {
+    "nom": "Étron Muscle",
+    "type": "character",
+    "url": null,
+    "image": "/characters/etron-muscle/etron-muscle.png"
+  },
+  {
+    "nom": "Glandhi",
+    "type": "character",
+    "url": null,
+    "image": "/characters/glandhi/glandhi.png"
+  },
+  {
+    "nom": "J.K. Râlwing",
+    "type": "character",
+    "url": null,
+    "image": "/characters/jk-ralwing/jk-ralwing.png"
+  },
+  {
+    "nom": "L'Abbé Bière",
+    "type": "character",
+    "url": null,
+    "image": "/characters/labbe-biere/labbe-biere.png"
+  },
+  {
+    "nom": "Magalie Bredouille",
+    "type": "character",
+    "url": null,
+    "image": null
   },
   {
     "nom": "Emmanuel Marcon",
@@ -180,10 +252,28 @@
     "image": "/characters/marine-lahaine/marine-lahaine.png"
   },
   {
+    "nom": "Monique Cerisier",
+    "type": "character",
+    "url": null,
+    "image": "/characters/monique-cerisier/monique-cerisier.png"
+  },
+  {
     "nom": "Norman le babysiter",
     "type": "character",
     "url": "/audio/musics/character/norman.ogg",
     "image": "/characters/norman/norman.png"
+  },
+  {
+    "nom": "Ondéjeune",
+    "type": "character",
+    "url": null,
+    "image": "/characters/ondejeune/ondejeune.png"
+  },
+  {
+    "nom": "Picassos",
+    "type": "character",
+    "url": null,
+    "image": "/characters/picassos/picassos.png"
   },
   {
     "nom": "Professeur Merdant",
@@ -202,6 +292,12 @@
     "type": "character",
     "url": "/audio/musics/character/siphanus.ogg",
     "image": "/characters/siphanus/siphanus.png"
+  },
+  {
+    "nom": "Thaïs d'Escufion",
+    "type": "character",
+    "url": null,
+    "image": "/characters/thais-descufion/thais-descufion.png"
   },
   {
     "nom": "Vladimir Putain",

--- a/scripts/generate-music-json.cjs
+++ b/scripts/generate-music-json.cjs
@@ -38,11 +38,12 @@ function parseVillages() {
   return files.map((f) => {
     const content = fs.readFileSync(path.join(dir, f), 'utf8')
     const id = content.match(/id:\s*'([^']+)'/)
-    const name = content.match(/name:\s*'([^']+)'/)
+    const name = content.match(/name:\s*'((?:\\'|[^'])+)'/)
     if (!id || !name)
       return null
+    const label = name[1].replace(/\\'/g, '\'')
     return {
-      nom: name[1],
+      nom: label,
       type: 'village',
       url: tracks[id[1]] || null,
       image: findImage('villages', id[1]),
@@ -56,11 +57,12 @@ function parseSavageZones() {
   return files.map((f) => {
     const content = fs.readFileSync(path.join(dir, f), 'utf8')
     const id = content.match(/id:\s*'([^']+)'/)
-    const name = content.match(/name:\s*'([^']+)'/)
+    const name = content.match(/name:\s*'((?:\\'|[^'])+)'/)
     if (!id || !name)
       return null
+    const label = name[1].replace(/\\'/g, '\'')
     return {
-      nom: name[1],
+      nom: label,
       type: 'sauvage',
       url: tracks[id[1]] || null,
       image: findImage('zones', id[1]),
@@ -75,12 +77,13 @@ function parseCharacters() {
   return files.map((f) => {
     const content = fs.readFileSync(path.join(dir, f), 'utf8')
     const id = content.match(/id:\s*'([^']+)'/)
-    const name = content.match(/name:\s*'([^']+)'/)
+    const name = content.match(/name:\s*'((?:\\'|[^'])+)'/)
     if (!id || !name)
       return null
+    const label = name[1].replace(/\\'/g, '\'')
     const key = alias[id[1]] || id[1]
     return {
-      nom: name[1],
+      nom: label,
       type: 'character',
       url: tracks[key] || null,
       image: findImage('characters', id[1]),

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -73,7 +73,7 @@ describe('zone panel', () => {
     for (let i = 0; i < 20; i++)
       progress.addWin('plaine-kekette')
     await wrapper.vm.$nextTick()
-    expect(wrapper.text()).toContain('Défier la roi de la zone')
+    expect(wrapper.text()).toContain('Défier la reine de la zone')
   })
 
   it('disables zone buttons during trainer battle', async () => {


### PR DESCRIPTION
## Summary
- handle escaped apostrophes when reading names in `generate-music-json.cjs`
- ensure label matches unescaped name
- fix failing test expectation
- update generated `music-data.json`

## Testing
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_688797769a08832aa42d31ba1d426fd9