### PR TITLE
Add activable king potions

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -251,6 +251,7 @@ declare global {
   const useItemUsageStore: typeof import('./stores/itemUsage')['useItemUsageStore']
   const useKeyModifier: typeof import('@vueuse/core')['useKeyModifier']
   const useKeyboardCaptureStore: typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']
+  const useKingPotionStore: typeof import('./stores/kingPotion')['useKingPotionStore']
   const useLastChanged: typeof import('@vueuse/core')['useLastChanged']
   const useLink: typeof import('vue-router/auto')['useLink']
   const useLocalStorage: typeof import('@vueuse/core')['useLocalStorage']
@@ -695,6 +696,7 @@ declare module 'vue' {
     readonly useItemUsageStore: UnwrapRef<typeof import('./stores/itemUsage')['useItemUsageStore']>
     readonly useKeyModifier: UnwrapRef<typeof import('@vueuse/core')['useKeyModifier']>
     readonly useKeyboardCaptureStore: UnwrapRef<typeof import('./stores/keyboardCapture')['useKeyboardCaptureStore']>
+    readonly useKingPotionStore: UnwrapRef<typeof import('./stores/kingPotion')['useKingPotionStore']>
     readonly useLastChanged: UnwrapRef<typeof import('@vueuse/core')['useLastChanged']>
     readonly useLink: UnwrapRef<typeof import('vue-router/auto')['useLink']>
     readonly useLocalStorage: UnwrapRef<typeof import('@vueuse/core')['useLocalStorage']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -23,6 +23,7 @@ declare module 'vue' {
     BattleEffectBadge: typeof import('./components/battle/EffectBadge.vue')['default']
     BattleFightKingButton: typeof import('./components/battle/FightKingButton.vue')['default']
     BattleHeader: typeof import('./components/battle/Header.vue')['default']
+    BattleKingPotionButton: typeof import('./components/battle/KingPotionButton.vue')['default']
     BattleMain: typeof import('./components/battle/Main.vue')['default']
     BattleRound: typeof import('./components/battle/Round.vue')['default']
     BattleShlagemon: typeof import('./components/battle/Shlagemon.vue')['default']

--- a/src/components/battle/KingPotionButton.vue
+++ b/src/components/battle/KingPotionButton.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { ref } from 'vue'
+import { useKingPotionStore } from '~/stores/kingPotion'
+
+const potion = useKingPotionStore()
+const { power } = storeToRefs(potion)
+
+const anim = ref(false)
+let timer: ReturnType<typeof setTimeout> | null = null
+
+function endHold() {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+}
+
+function startHold() {
+  if (!power.value)
+    return
+  timer = setTimeout(() => {
+    anim.value = true
+    potion.activate()
+    setTimeout(() => (anim.value = false), 600)
+  }, 1000)
+}
+</script>
+
+<template>
+  <UiButton
+    v-if="power"
+    class="absolute right-50% top-12 aspect-square h-12 w-12 flex flex-col translate-x-1/2 items-center justify-center rounded-full text-xs"
+    md="top-16 h-16 w-16"
+    type="icon"
+    @pointerdown="startHold"
+    @pointerup="endHold"
+    @pointerleave="endHold"
+    @pointercancel="endHold"
+  >
+    <div
+      class="relative flex items-center justify-center rounded-full p-1"
+      :class="`rainbow-${power}`"
+    >
+      <div class="potion-aura absolute inset-0 rounded-full" :class="{ 'scale-110': anim }" />
+      <div class="i-game-icons:potion-ball relative z-1 h-8 w-8" />
+    </div>
+  </UiButton>
+</template>
+
+<style scoped>
+.potion-aura {
+  background: conic-gradient(red, orange, yellow, lime, cyan, blue, purple, red);
+  opacity: 0.6;
+  transition: transform 0.3s ease;
+}
+.rainbow-15 .potion-aura {
+  filter: brightness(0.8);
+}
+.rainbow-30 .potion-aura {
+  filter: brightness(1);
+}
+.rainbow-50 .potion-aura {
+  filter: brightness(1.2);
+}
+</style>

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -2,9 +2,11 @@
 import type { DexShlagemon } from '~/type'
 import type { DialogNode } from '~/type/dialog'
 import { allShlagemons } from '~/data/shlagemons'
+import { useKingPotionStore } from '~/stores/kingPotion'
 import { useWildLevelStore } from '~/stores/wildLevel'
 import { createDexShlagemon } from '~/utils/dexFactory'
 import DialogBox from '../dialog/Box.vue'
+import KingPotionButton from './KingPotionButton.vue'
 
 const dex = useShlagedexStore()
 const trainerStore = useTrainerBattleStore()
@@ -16,6 +18,7 @@ const featureLock = useFeatureLockStore()
 const game = useGameStore()
 const mobile = useMobileTabStore()
 const wildLevel = useWildLevelStore()
+const kingPotion = useKingPotionStore()
 
 const trainer = computed(() => trainerStore.current)
 const isZoneKing = computed(() => trainer.value?.id.startsWith('king-'))
@@ -221,6 +224,7 @@ onUnmounted(featureLock.unlockAll)
           <BattleHeader :trainer="trainer" :defeated="enemyIndex" />
         </template>
       </BattleRound>
+      <KingPotionButton v-if="isZoneKing && kingPotion.power" />
     </template>
 
     <div v-else class="h-full flex flex-col items-center gap-2 text-center">

--- a/src/components/panel/Inventory.i18n.yml
+++ b/src/components/panel/Inventory.i18n.yml
@@ -7,6 +7,7 @@ fr:
     active: Actif
     passive: Passif
     utility: Utilitaire
+    activable: Activable
   equip: 'Vous avez équipé la {item}'
 en:
   sort:
@@ -17,4 +18,5 @@ en:
     active: Active
     passive: Passive
     utility: Utility
+    activable: Activable
   equip: 'You equipped the {item}'

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -25,6 +25,7 @@ const categoryOptions = [
   { label: t('components.panel.Inventory.category.active'), value: 'actif', icon: 'i-carbon-flash' },
   { label: t('components.panel.Inventory.category.passive'), value: 'passif', icon: 'i-carbon-timer' },
   { label: t('components.panel.Inventory.category.utility'), value: 'utilitaire', icon: 'i-carbon-tool-box' },
+  { label: t('components.panel.Inventory.category.activable'), value: 'activable', icon: 'i-carbon-fire' },
 ] as const
 
 const availableCategories = computed(() =>

--- a/src/components/panel/Shop.i18n.yml
+++ b/src/components/panel/Shop.i18n.yml
@@ -9,6 +9,7 @@ fr:
     active: Actif
     passive: Passif
     utility: Utilitaire
+    activable: Activable
 en:
   title: Shop
   details: Details
@@ -20,3 +21,4 @@ en:
     active: Active
     passive: Passive
     utility: Utility
+    activable: Activable

--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -17,6 +17,7 @@ const categoryOptions = [
   { label: t('components.panel.Shop.category.active'), value: 'actif', icon: 'i-carbon-flash' },
   { label: t('components.panel.Shop.category.passive'), value: 'passif', icon: 'i-carbon-timer' },
   { label: t('components.panel.Shop.category.utility'), value: 'utilitaire', icon: 'i-carbon-tool-box' },
+  { label: t('components.panel.Shop.category.activable'), value: 'activable', icon: 'i-carbon-fire' },
 ] as const
 const availableCategories = computed(() =>
   categoryOptions

--- a/src/constants/itemCategory.ts
+++ b/src/constants/itemCategory.ts
@@ -4,22 +4,26 @@ export const itemCategoryTabColors: Record<ItemCategory, string> = {
   actif: 'text-red-700 border-white/50',
   passif: 'text-green-700 border-white/50',
   utilitaire: 'text-orange-700 border-white/50',
+  activable: 'text-fuchsia-700 border-white/50',
 }
 
 export const itemCategoryTabBaseColors: Record<ItemCategory, string> = {
   actif: '',
   passif: '',
   utilitaire: '',
+  activable: '',
 }
 
 export const itemCategoryTabHoverColors: Record<ItemCategory, string> = {
   actif: 'hover:bg-red-200 dark:hover:bg-red-700',
   passif: 'hover:bg-green-200 dark:hover:bg-green-700',
   utilitaire: 'hover:bg-yellow-200 dark:hover:bg-yellow-700',
+  activable: 'hover:bg-fuchsia-200 dark:hover:bg-fuchsia-700',
 }
 
 export const itemCategoryPanelColors: Record<ItemCategory, string> = {
   actif: 'bg-red-50 dark:bg-red-900/20',
   passif: 'bg-green-50 dark:bg-green-900/20',
   utilitaire: 'bg-yellow-50 dark:bg-yellow-900/20',
+  activable: 'bg-fuchsia-50 dark:bg-fuchsia-900/20',
 }

--- a/src/data/items.i18n.yml
+++ b/src/data/items.i18n.yml
@@ -117,6 +117,18 @@ en:
   thunderEgg:
     name: Thunder Egg
     description: An egg crackling with sparks.
+  specialPotion:
+    name: Special Potion
+    description: Works only during king battles. Hold to unleash its effect.
+    details: During trainer fights against kings, hold the button to heal or damage your active Shlagémon by 15% of max HP.
+  mysteriousPotion:
+    name: Mysterious Potion
+    description: Works only during king battles. Hold to unleash its effect.
+    details: During trainer fights against kings, hold the button to heal or damage your active Shlagémon by 30% of max HP.
+  fabulousPotion:
+    name: Fabulous Potion
+    description: Works only during king battles. Hold to unleash its effect.
+    details: During trainer fights against kings, hold the button to heal or damage your active Shlagémon by 50% of max HP.
 fr:
   defensePotion:
     name: Potion de Défense
@@ -236,3 +248,15 @@ fr:
   thunderEgg:
     name: Œuf Foudre
     description: Un œuf parcouru d'étincelles.
+  specialPotion:
+    name: Potion Spéciale
+    description: S'utilise seulement contre les rois et se déclenche en maintenant le bouton.
+    details: Pendant les combats d'entraîneur face aux rois, maintenez le bouton pour soigner ou blesser de 15% des PV max.
+  mysteriousPotion:
+    name: Potion Mystérieuse
+    description: S'utilise seulement contre les rois et se déclenche en maintenant le bouton.
+    details: Pendant les combats d'entraîneur face aux rois, maintenez le bouton pour soigner ou blesser de 30% des PV max.
+  fabulousPotion:
+    name: Potion Fabuleuse
+    description: S'utilise seulement contre les rois et se déclenche en maintenant le bouton.
+    details: Pendant les combats d'entraîneur face aux rois, maintenez le bouton pour soigner ou blesser de 50% des PV max.

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -520,6 +520,57 @@ export const thunderEgg: Item = {
   iconClass: 'text-yellow-500 dark:text-yellow-400',
 }
 
+export const specialPotion: Item = {
+  id: 'special-potion',
+  nameKey: 'data.items.specialPotion.name',
+  name: 'Potion Spéciale',
+  descriptionKey: 'data.items.specialPotion.description',
+  description: 'Fonctionne uniquement contre les rois.',
+  detailsKey: 'data.items.specialPotion.details',
+  details:
+    'Tenue pendant un combat de roi, elle soigne ou blesse de 15% des PV max.',
+  type: 'heal',
+  power: 15,
+  category: 'activable',
+  wearable: true,
+  icon: 'i-game-icons:potion-ball',
+  iconClass: 'text-fuchsia-500 dark:text-fuchsia-400',
+}
+
+export const mysteriousPotion: Item = {
+  id: 'mysterious-potion',
+  nameKey: 'data.items.mysteriousPotion.name',
+  name: 'Potion Mystérieuse',
+  descriptionKey: 'data.items.mysteriousPotion.description',
+  description: 'Fonctionne uniquement contre les rois.',
+  detailsKey: 'data.items.mysteriousPotion.details',
+  details:
+    'Tenue pendant un combat de roi, elle soigne ou blesse de 30% des PV max.',
+  type: 'heal',
+  power: 30,
+  category: 'activable',
+  wearable: true,
+  icon: 'i-game-icons:potion-of-madness',
+  iconClass: 'text-fuchsia-600 dark:text-fuchsia-500',
+}
+
+export const fabulousPotion: Item = {
+  id: 'fabulous-potion',
+  nameKey: 'data.items.fabulousPotion.name',
+  name: 'Potion Fabuleuse',
+  descriptionKey: 'data.items.fabulousPotion.description',
+  description: 'Fonctionne uniquement contre les rois.',
+  detailsKey: 'data.items.fabulousPotion.details',
+  details:
+    'Tenue pendant un combat de roi, elle soigne ou blesse de 50% des PV max.',
+  type: 'heal',
+  power: 50,
+  category: 'activable',
+  wearable: true,
+  icon: 'i-game-icons:bubbling-flask',
+  iconClass: 'text-fuchsia-700 dark:text-fuchsia-600',
+}
+
 export const allItems = [
   shlageball,
   superShlageball,
@@ -567,6 +618,9 @@ export const allItems = [
   grassEgg,
   psyEgg,
   thunderEgg,
+  specialPotion,
+  mysteriousPotion,
+  fabulousPotion,
 ] as const satisfies Item[]
 
 export type ItemId = typeof allItems[number]['id']

--- a/src/stores/kingPotion.ts
+++ b/src/stores/kingPotion.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia'
+import { computed } from 'vue'
+import { fabulousPotion, mysteriousPotion, specialPotion } from '~/data/items'
+import { useInventoryStore } from './inventory'
+import { useShlagedexStore } from './shlagedex'
+
+const potions = [fabulousPotion, mysteriousPotion, specialPotion]
+
+export const useKingPotionStore = defineStore('kingPotion', () => {
+  const inventory = useInventoryStore()
+  const dex = useShlagedexStore()
+
+  const owned = computed(() =>
+    potions.find(p => inventory.items[p.id] > 0) || null,
+  )
+
+  const power = computed(() => owned.value?.power ?? 0)
+
+  function activate() {
+    const potion = owned.value
+    if (!potion || !dex.activeShlagemon)
+      return false
+    const max = dex.maxHp(dex.activeShlagemon)
+    const amount = Math.round((max * potion.power) / 100)
+    if (Math.random() < 0.5)
+      dex.healActive(amount)
+    else
+      dex.activeShlagemon.hpCurrent = Math.max(0, dex.activeShlagemon.hpCurrent - amount)
+    return true
+  }
+
+  return { owned, power, activate }
+})

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -1,6 +1,6 @@
 export type ItemCurrency = 'shlagidolar' | 'shlagidiamond'
 
-export type ItemCategory = 'actif' | 'passif' | 'utilitaire'
+export type ItemCategory = 'actif' | 'passif' | 'utilitaire' | 'activable'
 
 export interface Item {
   id: string

--- a/test/king-potion.test.ts
+++ b/test/king-potion.test.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import KingPotionButton from '../src/components/battle/KingPotionButton.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useKingPotionStore } from '../src/stores/kingPotion'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('king potion', () => {
+  it('heals or damages according to power', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const inventory = useInventoryStore()
+    const dex = useShlagedexStore()
+    const store = useKingPotionStore()
+    const mon = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(mon)
+    inventory.add('special-potion')
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const half = Math.round(dex.maxHp(mon) / 2)
+    mon.hpCurrent = half
+    store.activate()
+    expect(mon.hpCurrent).toBeGreaterThan(half)
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+    const before = mon.hpCurrent
+    store.activate()
+    expect(mon.hpCurrent).toBeLessThan(before)
+    vi.useRealTimers()
+  })
+
+  it('activates on hold', async () => {
+    vi.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const inventory = useInventoryStore()
+    const mon = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(mon)
+    inventory.add('special-potion')
+    const wrapper = mount(KingPotionButton, {
+      global: { plugins: [pinia], stubs: ['UiButton'] },
+    })
+    const store = useKingPotionStore()
+    const spy = vi.spyOn(store, 'activate')
+    await wrapper.trigger('pointerdown')
+    vi.advanceTimersByTime(1000)
+    await wrapper.trigger('pointerup')
+    expect(spy).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- introduce new activable items with translations
- add "activable" item category everywhere
- implement king potion store and button
- show button during king fights
- test king potion logic

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6887dd216188832a8bee6ffd57d6a001