### PR TITLE
Fix king potion activation logic

### DIFF
--- a/src/components/battle/KingPotionButton.vue
+++ b/src/components/battle/KingPotionButton.vue
@@ -6,43 +6,44 @@ import { useKingPotionStore } from '~/stores/kingPotion'
 const potion = useKingPotionStore()
 const { power } = storeToRefs(potion)
 
-const anim = ref(false)
+const holding = ref(false)
 let timer: ReturnType<typeof setTimeout> | null = null
 
-function endHold() {
+function cancelHold() {
   if (timer) {
     clearTimeout(timer)
     timer = null
   }
+  holding.value = false
 }
 
 function startHold() {
-  if (!power.value)
+  if (!power.value || potion.used)
     return
+  holding.value = true
   timer = setTimeout(() => {
-    anim.value = true
     potion.activate()
-    setTimeout(() => (anim.value = false), 600)
+    holding.value = false
   }, 1000)
 }
 </script>
 
 <template>
   <UiButton
-    v-if="power"
+    v-if="power && !potion.used"
     class="absolute right-50% top-12 aspect-square h-12 w-12 flex flex-col translate-x-1/2 items-center justify-center rounded-full text-xs"
     md="top-16 h-16 w-16"
     type="icon"
     @pointerdown="startHold"
-    @pointerup="endHold"
-    @pointerleave="endHold"
-    @pointercancel="endHold"
+    @pointerup="cancelHold"
+    @pointerleave="cancelHold"
+    @pointercancel="cancelHold"
   >
     <div
       class="relative flex items-center justify-center rounded-full p-1"
       :class="`rainbow-${power}`"
     >
-      <div class="potion-aura absolute inset-0 rounded-full" :class="{ 'scale-110': anim }" />
+      <div class="potion-aura absolute inset-0 rounded-full" :class="{ holding }" />
       <div class="i-game-icons:potion-ball relative z-1 h-8 w-8" />
     </div>
   </UiButton>
@@ -52,7 +53,12 @@ function startHold() {
 .potion-aura {
   background: conic-gradient(red, orange, yellow, lime, cyan, blue, purple, red);
   opacity: 0.6;
-  transition: transform 0.3s ease;
+  transform: scale(0);
+  transition: transform 0.2s ease;
+}
+.potion-aura.holding {
+  transform: scale(1.1);
+  transition: transform 1s linear;
 }
 .rainbow-15 .potion-aura {
   filter: brightness(0.8);

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -111,6 +111,7 @@ function startFight() {
   enemyIndex.value = 0
   if (dex.activeShlagemon.hpCurrent <= 0)
     dex.activeShlagemon.hpCurrent = dex.maxHp(dex.activeShlagemon)
+  kingPotion.reset()
   result.value = 'none'
   stage.value = 'battle'
   enemy.value = createEnemy()
@@ -121,6 +122,7 @@ watch(trainer, (t) => {
     stage.value = 'before'
     enemyIndex.value = 0
     result.value = 'none'
+    kingPotion.reset()
   }
 })
 

--- a/src/stores/kingPotion.ts
+++ b/src/stores/kingPotion.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { fabulousPotion, mysteriousPotion, specialPotion } from '~/data/items'
 import { useInventoryStore } from './inventory'
 import { useShlagedexStore } from './shlagedex'
@@ -10,6 +10,8 @@ export const useKingPotionStore = defineStore('kingPotion', () => {
   const inventory = useInventoryStore()
   const dex = useShlagedexStore()
 
+  const used = ref(false)
+
   const owned = computed(() =>
     potions.find(p => inventory.items[p.id] > 0) || null,
   )
@@ -17,6 +19,8 @@ export const useKingPotionStore = defineStore('kingPotion', () => {
   const power = computed(() => owned.value?.power ?? 0)
 
   function activate() {
+    if (used.value)
+      return false
     const potion = owned.value
     if (!potion || !dex.activeShlagemon)
       return false
@@ -26,8 +30,14 @@ export const useKingPotionStore = defineStore('kingPotion', () => {
       dex.healActive(amount)
     else
       dex.activeShlagemon.hpCurrent = Math.max(0, dex.activeShlagemon.hpCurrent - amount)
+    inventory.remove(potion.id)
+    used.value = true
     return true
   }
 
-  return { owned, power, activate }
+  function reset() {
+    used.value = false
+  }
+
+  return { owned, power, used, activate, reset }
 })

--- a/test/king-potion.test.ts
+++ b/test/king-potion.test.ts
@@ -24,8 +24,9 @@ describe('king potion', () => {
     expect(mon.hpCurrent).toBeGreaterThan(half)
     vi.spyOn(Math, 'random').mockReturnValue(1)
     const before = mon.hpCurrent
-    store.activate()
-    expect(mon.hpCurrent).toBeLessThan(before)
+    const result = store.activate()
+    expect(result).toBe(false)
+    expect(mon.hpCurrent).toBe(before)
     vi.useRealTimers()
   })
 


### PR DESCRIPTION
## Summary
- enlarge aura while holding down king potion button and trigger after 1s
- mark king potion as used, remove it from inventory and reset between battles
- update king potion unit test for single usage rule

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6887e57fe038832aa489b28d970f872e