### PR TITLE
Ensure starter rarity follows level after hydration

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -640,6 +640,14 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
         if (typeof effect.timeout?.stop !== 'function')
           effect.timeout = useTimeoutFn(() => store.removeEffect(effect.id), effect.expiresAt - now)
       })
+      const oldest = [...store.shlagemons]
+        .sort((a, b) => new Date(a.captureDate).getTime() - new Date(b.captureDate).getTime())[0]
+      if (oldest && !oldest.rarityFollowsLevel) {
+        oldest.rarityFollowsLevel = true
+        oldest.rarity = oldest.lvl
+        applyStats(oldest)
+        applyCurrentStats(oldest)
+      }
     },
   } as PersistedStateOptions,
 })


### PR DESCRIPTION
## Summary
- update shlagedex store hydration to ensure first captured monster's rarity follows level

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68888b2c7fe4832a9e1e7c229d5d505d