### PR TITLE
Equip king potions

### DIFF
--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
 import { storeToRefs } from 'pinia'
-import { eggBox } from '~/data/items'
+import {
+  eggBox,
+  fabulousPotion,
+  mysteriousPotion,
+  specialPotion,
+} from '~/data/items'
 import { ballHues } from '~/utils/ball'
 
 const props = defineProps<{ item: Item, qty: number, disabled?: boolean }>()
@@ -13,6 +18,7 @@ const { t } = useI18n()
 
 const showInfo = ref(false)
 const usage = useItemUsageStore()
+const kingPotionIds = [fabulousPotion.id, mysteriousPotion.id, specialPotion.id]
 const isUnused = computed(() => !usage.used[props.item.id])
 const zoom = ref(false)
 function onCardClick() {
@@ -28,11 +34,12 @@ const ballFilter = computed(() =>
 
 const isEgg = computed(() => props.item.id.startsWith('oeuf-'))
 const isEggBox = computed(() => props.item.id === eggBox.id)
+const isKingPotion = computed(() => kingPotionIds.includes(props.item.id))
 
 const actionLabel = computed(() => {
   if (isEggBox.value)
     return t('components.inventory.ItemCard.action.open')
-  if ('catchBonus' in props.item || props.item.wearable)
+  if ('catchBonus' in props.item || props.item.wearable || isKingPotion.value)
     return props.disabled ? t('components.inventory.ItemCard.action.equipped') : t('components.inventory.ItemCard.action.equip')
   return t('components.inventory.ItemCard.action.use')
 })

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -4,7 +4,13 @@ import type { BallId } from '~/data/items/shlageball'
 import type { Item, ItemCategory } from '~/type/item'
 import { defineComponent, h } from 'vue'
 import { toast } from 'vue3-toastify'
-import { eggBox as eggBoxItem } from '~/data/items'
+import {
+  eggBox as eggBoxItem,
+  fabulousPotion,
+  mysteriousPotion,
+  specialPotion,
+} from '~/data/items'
+import { useKingPotionStore } from '~/stores/kingPotion'
 import InventoryItemCard from '../inventory/ItemCard.vue'
 
 const inventory = useInventoryStore()
@@ -12,6 +18,8 @@ const eggBox = useEggBoxStore()
 const ballStore = useBallStore()
 const evoItemStore = useEvolutionItemStore()
 const wearableStore = useWearableItemStore()
+const kingPotion = useKingPotionStore()
+const kingPotionIds = [fabulousPotion.id, mysteriousPotion.id, specialPotion.id]
 const filter = useInventoryFilterStore()
 const featureLock = useFeatureLockStore()
 const usage = useItemUsageStore()
@@ -137,6 +145,8 @@ function isDisabled(item: Item) {
     return true
   if ('catchBonus' in item)
     return ballStore.current === item.id
+  if (kingPotionIds.includes(item.id))
+    return kingPotion.current === item.id
   return item.type === 'evolution' && !evoItemStore.canUse(item)
 }
 
@@ -145,6 +155,11 @@ function onUse(item: Item) {
     return
   if ('catchBonus' in item) {
     ballStore.setBall(item.id as BallId)
+    usage.markUsed(item.id)
+    toast(t('components.panel.Inventory.equip', { item: t(item.nameKey || item.name) }))
+  }
+  else if (kingPotionIds.includes(item.id)) {
+    kingPotion.equip(item.id)
     usage.markUsed(item.id)
     toast(t('components.panel.Inventory.equip', { item: t(item.nameKey || item.name) }))
   }

--- a/src/stores/kingPotion.ts
+++ b/src/stores/kingPotion.ts
@@ -11,17 +11,27 @@ export const useKingPotionStore = defineStore('kingPotion', () => {
   const dex = useShlagedexStore()
 
   const used = ref(false)
+  const current = ref<string | null>(null)
 
   const owned = computed(() =>
-    potions.find(p => inventory.items[p.id] > 0) || null,
+    potions.filter(p => (inventory.items[p.id] || 0) > 0),
   )
 
-  const power = computed(() => owned.value?.power ?? 0)
+  const equipped = computed(() =>
+    current.value ? potions.find(p => p.id === current.value) || null : null,
+  )
+
+  const power = computed(() => equipped.value?.power ?? 0)
+
+  function equip(id: string) {
+    if (owned.value.some(p => p.id === id))
+      current.value = id
+  }
 
   function activate() {
     if (used.value)
       return false
-    const potion = owned.value
+    const potion = equipped.value
     if (!potion || !dex.activeShlagemon)
       return false
     const max = dex.maxHp(dex.activeShlagemon)
@@ -32,6 +42,7 @@ export const useKingPotionStore = defineStore('kingPotion', () => {
       dex.activeShlagemon.hpCurrent = Math.max(0, dex.activeShlagemon.hpCurrent - amount)
     inventory.remove(potion.id)
     used.value = true
+    current.value = null
     return true
   }
 
@@ -39,5 +50,7 @@ export const useKingPotionStore = defineStore('kingPotion', () => {
     used.value = false
   }
 
-  return { owned, power, used, activate, reset }
+  return { owned, current, equipped, power, used, equip, activate, reset }
+}, {
+  persist: { pick: ['current'] },
 })

--- a/test/king-potion.test.ts
+++ b/test/king-potion.test.ts
@@ -17,6 +17,7 @@ describe('king potion', () => {
     const mon = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(mon)
     inventory.add('special-potion')
+    store.equip('special-potion')
     vi.spyOn(Math, 'random').mockReturnValue(0)
     const half = Math.round(dex.maxHp(mon) / 2)
     mon.hpCurrent = half
@@ -39,10 +40,11 @@ describe('king potion', () => {
     const mon = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(mon)
     inventory.add('special-potion')
+    const store = useKingPotionStore()
+    store.equip('special-potion')
     const wrapper = mount(KingPotionButton, {
       global: { plugins: [pinia], stubs: ['UiButton'] },
     })
-    const store = useKingPotionStore()
     const spy = vi.spyOn(store, 'activate')
     await wrapper.trigger('pointerdown')
     vi.advanceTimersByTime(1000)


### PR DESCRIPTION
## Summary
- allow selecting a king potion before battle
- show equip action for king potions in inventory
- equip potions via store and disable button when already equipped
- adjust tests for new equip behavior

## Testing
- `pnpm lint`
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6887f8bda5dc832a92a7b915e3b889ac