### PR TITLE
Disable capture when mon is KO

### DIFF
--- a/src/components/battle/Capture.i18n.yml
+++ b/src/components/battle/Capture.i18n.yml
@@ -2,11 +2,13 @@ fr:
   cooldown: Patientez avant de capturer à nouveau
   noBall: Pas de Shlagéball, capture impossible
   ko: Impossible de capturer un Shlagémon K.O.
+  playerKo: Impossible de capturer avec un Shlagémon K.O.
   needBadge: Un badge est nécessaire pour capturer ce niveau
   capture: Capturer le Shlagémon
 en:
   cooldown: Wait before capturing again
   noBall: No Shlageball, capture impossible
   ko: Impossible to capture a fainted Shlagemon
+  playerKo: Can't capture with a fainted Shlagemon
   needBadge: A badge is required to capture this level
   capture: Capture the Shlagemon

--- a/src/components/battle/Capture.vue
+++ b/src/components/battle/Capture.vue
@@ -4,7 +4,7 @@ import { balls } from '~/data/items/shlageball'
 import { ballHues } from '~/utils/ball'
 import { tryCapture } from '~/utils/capture'
 
-const props = defineProps<{ enemy: DexShlagemon | null, enemyHp: number, stopBattle: () => void }>()
+const props = defineProps<{ enemy: DexShlagemon | null, enemyHp: number, playerHp: number, stopBattle: () => void }>()
 const emit = defineEmits<{ (e: 'finished', success: boolean): void }>()
 
 const inventory = useInventoryStore()
@@ -26,7 +26,8 @@ const captureCooldown = ref(false)
 const captureButtonDisabled = computed(() =>
   captureCooldown.value
   || (inventory.items[ballStore.current] || 0) <= 0
-  || props.enemyHp <= 0,
+  || props.enemyHp <= 0
+  || props.playerHp <= 0,
 )
 
 const captureButtonTooltip = computed(() => {
@@ -34,6 +35,8 @@ const captureButtonTooltip = computed(() => {
     return t('components.battle.Capture.cooldown')
   if ((inventory.items[ballStore.current] || 0) <= 0)
     return t('components.battle.Capture.noBall')
+  if (props.playerHp <= 0)
+    return t('components.battle.Capture.playerKo')
   if (props.enemyHp <= 0)
     return t('components.battle.Capture.ko')
   if (props.enemy && props.enemy.lvl > player.captureLevelCap)
@@ -56,7 +59,7 @@ function attempt(step: number) {
 
 function open() {
   const id = ballStore.current
-  if (!props.enemy || (inventory.items[id] || 0) <= 0 || props.enemyHp <= 0)
+  if (!props.enemy || (inventory.items[id] || 0) <= 0 || props.enemyHp <= 0 || props.playerHp <= 0)
     return
   if (props.enemy.lvl > player.captureLevelCap) {
     captureLimitModal.open(props.enemy.lvl)

--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -258,6 +258,7 @@ function onClick(_e: MouseEvent) {
     v-if="props.captureEnabled"
     :enemy="props.enemy"
     :enemy-hp="enemyHp"
+    :player-hp="playerHp"
     :stop-battle="stopBattle"
     @finished="onCaptureEnd"
   />


### PR DESCRIPTION
## Summary
- disable capture button if the player's or enemy's mon has 0 HP
- show tooltip when player's mon is KO

## Testing
- `pnpm test` *(fails: king-potion.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6888966b22d0832a933c4eff7fb3e3b8