### PR TITLE
Add Odor Elixir item and dialog

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -137,6 +137,9 @@ components:
     WearableItemModal:
       title: Choose the holder of {name}
       noAvailable: No Shlagemon available.
+    OdorElixirModal:
+      title: Choose the recipient of {name}
+      noAvailable: No Shlagemon needs this elixir.
   settings:
     ShortcutsTab:
       add: Add shortcut
@@ -513,6 +516,32 @@ components:
             Professor Merdant proud!
           responses:
             valid: Thanks Prof!
+    OdorElixirDialog:
+      steps:
+        step1:
+          text: Holy crap, your Shlagemon hit level 50!
+          responses:
+            next: Continue
+        step2:
+          text: Here's the Odor Elixir, a brew even my mom would sniff.
+          responses:
+            back: Back
+            next: Continue
+        step3:
+          text: Pour it on your favorite and its rarity will match its level.
+          responses:
+            back: Back
+            next: Continue
+        step4:
+          text: The higher it climbs, the more others will drool with envy.
+          responses:
+            back: Back
+            next: Continue
+        step5:
+          text: Take this bottle and don't waste it on a loser.
+          responses:
+            back: Back
+            valid: Thanks!
   minigame:
     MiniGameShlagMind:
       messages:
@@ -3204,16 +3233,22 @@ data:
       details: Needed for Emboli to evolve into Tuberculi.
     specialPotion:
       name: Special Potion
-      description: Works only during trainer battles. Hold to unleash its effect.
-      details: During trainer battles, hold the button to perform a special action.
+      description: Works only during king battles. Hold to unleash its effect.
+      details: During king battles, hold the button to perform a special action.
     mysteriousPotion:
       name: Mysterious Potion
-      description: Works only during trainer battles. Hold to unleash its effect.
-      details: During trainer battles, hold the button to perform a mysterious action.
+      description: Works only during king battles. Hold to unleash its effect.
+      details: During king battles, hold the button to perform a special action.
     fabulousPotion:
       name: Fabulous Potion
-      description: Works only during trainer battles. Hold to unleash its effect.
-      details: During trainer battles, hold the button to perform a fabulous action.
+      description: Works only during king battles. Hold to unleash its effect.
+      details: During king battles, hold the button to perform a special action.
+    odorElixir:
+      name: Odor Elixir
+      description: A rare scent to bond forever with a Shlagemon.
+      details: >-
+        Use it on a beloved Shlagemon so its rarity matches its level from now
+        on.
 pages:
   index:
     title: Shlagemon

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -139,6 +139,9 @@ components:
     WearableItemModal:
       title: Choisir le porteur de {name}
       noAvailable: Aucun Shlagémon disponible.
+    OdorElixirModal:
+      title: Choisir le bénéficiaire de {name}
+      noAvailable: Aucun Shlagémon n'a besoin de cet élixir.
   settings:
     ShortcutsTab:
       add: Ajouter un raccourci
@@ -536,6 +539,34 @@ components:
             honneur au Professeur Merdant !
           responses:
             valid: Merci Prof !
+    OdorElixirDialog:
+      steps:
+        step1:
+          text: Nom d'un slip, ton Shlagémon a atteint le niveau 50 !
+          responses:
+            next: Continuer
+        step2:
+          text: >-
+            Voilà l'Élixir d'Odeur, une mixture que même ma mère voudrait
+            sniffer.
+          responses:
+            back: Retour
+            next: Continuer
+        step3:
+          text: Verse ça sur ton chouchou et sa rareté collera à son niveau.
+          responses:
+            back: Retour
+            next: Continuer
+        step4:
+          text: Plus il progressera, plus il fera baver les autres d'envie.
+          responses:
+            back: Retour
+            next: Continuer
+        step5:
+          text: Tiens, j'te file la fiole. Gâche-la pas sur un tocard.
+          responses:
+            back: Retour
+            valid: Merci vieux !
   minigame:
     MiniGameShlagMind:
       messages:
@@ -3343,27 +3374,31 @@ data:
     specialPotion:
       name: Potion Spéciale
       description: >-
-        S'utilise seulement contre les dresseurs et se déclenche en maintenant le
+        S'utilise seulement contre les rois et se déclenche en maintenant le
         bouton.
       details: >-
-        Pendant les combats face aux dresseurs, maintenez le bouton pour effectuer
+        Pendant les combats face aux rois, maintenez le bouton pour effectuer
         une action spéciale.
     mysteriousPotion:
       name: Potion Mystérieuse
       description: >-
-        S'utilise seulement contre les dresseurs et se déclenche en maintenant le
+        S'utilise seulement contre les rois et se déclenche en maintenant le
         bouton.
       details: >-
-        Pendant les combats face aux dresseurs, maintenez le bouton pour effectuer
+        Pendant les combats face aux rois, maintenez le bouton pour effectuer
         une action mystérieuse.
     fabulousPotion:
       name: Potion Fabuleuse
       description: >-
-        S'utilise seulement contre les dresseurs et se déclenche en maintenant le
+        S'utilise seulement contre les rois et se déclenche en maintenant le
         bouton.
       details: >-
-        Pendant les combats face aux dresseurs, maintenez le bouton pour effectuer
+        Pendant les combats face aux rois, maintenez le bouton pour effectuer
         une action fabuleuse.
+    odorElixir:
+      name: Élixir d'Odeur
+      description: Un élixir très rare à offrir à un Shlagémon qu'on adore.
+      details: Utilisé sur un Shlagémon, sa rareté suivra désormais son niveau.
 pages:
   index:
     title: Shlagémon

--- a/src/components/dialog/OdorElixirDialog.i18n.yml
+++ b/src/components/dialog/OdorElixirDialog.i18n.yml
@@ -1,0 +1,52 @@
+fr:
+  steps:
+    step1:
+      text: "Nom d'un slip, ton Shlagémon a atteint le niveau 50 !"
+      responses:
+        next: Continuer
+    step2:
+      text: "Voilà l'Élixir d'Odeur, une mixture que même ma mère voudrait sniffer."
+      responses:
+        back: Retour
+        next: Continuer
+    step3:
+      text: Verse ça sur ton chouchou et sa rareté collera à son niveau.
+      responses:
+        back: Retour
+        next: Continuer
+    step4:
+      text: "Plus il progressera, plus il fera baver les autres d'envie."
+      responses:
+        back: Retour
+        next: Continuer
+    step5:
+      text: "Tiens, j'te file la fiole. Gâche-la pas sur un tocard."
+      responses:
+        back: Retour
+        valid: Merci vieux !
+en:
+  steps:
+    step1:
+      text: 'Holy crap, your Shlagemon hit level 50!'
+      responses:
+        next: Continue
+    step2:
+      text: "Here's the Odor Elixir, a brew even my mom would sniff."
+      responses:
+        back: Back
+        next: Continue
+    step3:
+      text: Pour it on your favorite and its rarity will match its level.
+      responses:
+        back: Back
+        next: Continue
+    step4:
+      text: 'The higher it climbs, the more others will drool with envy.'
+      responses:
+        back: Back
+        next: Continue
+    step5:
+      text: "Take this bottle and don't waste it on a loser."
+      responses:
+        back: Back
+        valid: Thanks!

--- a/src/components/dialog/OdorElixirDialog.vue
+++ b/src/components/dialog/OdorElixirDialog.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { odorElixir } from '~/data/items'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+const { t } = useI18n()
+
+const dialogTree = computed<DialogNode[]>(() => [
+  {
+    id: 'start',
+    text: t('components.dialog.OdorElixirDialog.steps.step1.text'),
+    responses: [
+      { label: t('components.dialog.OdorElixirDialog.steps.step1.responses.next'), nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: t('components.dialog.OdorElixirDialog.steps.step2.text'),
+    responses: [
+      { label: t('components.dialog.OdorElixirDialog.steps.step2.responses.back'), nextId: 'start', type: 'danger' },
+      { label: t('components.dialog.OdorElixirDialog.steps.step2.responses.next'), nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: t('components.dialog.OdorElixirDialog.steps.step3.text'),
+    responses: [
+      { label: t('components.dialog.OdorElixirDialog.steps.step3.responses.back'), nextId: 'step2', type: 'danger' },
+      { label: t('components.dialog.OdorElixirDialog.steps.step3.responses.next'), nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: t('components.dialog.OdorElixirDialog.steps.step4.text'),
+    responses: [
+      { label: t('components.dialog.OdorElixirDialog.steps.step4.responses.back'), nextId: 'step3', type: 'danger' },
+      { label: t('components.dialog.OdorElixirDialog.steps.step4.responses.next'), nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: t('components.dialog.OdorElixirDialog.steps.step5.text'),
+    responses: [
+      { label: t('components.dialog.OdorElixirDialog.steps.step5.responses.back'), nextId: 'step4', type: 'danger' },
+      {
+        label: t('components.dialog.OdorElixirDialog.steps.step5.responses.valid'),
+        type: 'valid',
+        action: () => {
+          inventory.add(odorElixir.id, 1)
+          emit('done', 'odorElixir')
+        },
+      },
+    ],
+  },
+])
+</script>
+
+<template>
+  <DialogBox :character="profMerdant" :dialog-tree="dialogTree" orientation="col" />
+</template>

--- a/src/components/inventory/OdorElixirModal.i18n.yml
+++ b/src/components/inventory/OdorElixirModal.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  title: 'Choisir le bénéficiaire de {name}'
+  noAvailable: Aucun Shlagémon n'a besoin de cet élixir.
+en:
+  title: 'Choose the recipient of {name}'
+  noAvailable: No Shlagemon needs this elixir.

--- a/src/components/inventory/OdorElixirModal.vue
+++ b/src/components/inventory/OdorElixirModal.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+
+const store = useOdorElixirStore()
+const { t } = useI18n()
+
+function select(mon: DexShlagemon) {
+  store.useOn(mon)
+}
+</script>
+
+<template>
+  <UiModal v-model="store.isVisible" footer-close>
+    <div class="flex flex-col gap-2">
+      <h3 class="text-center text-lg font-bold">
+        {{ t('components.inventory.OdorElixirModal.title', { name: store.current?.name }) }}
+      </h3>
+      <ShlagemonQuickSelect
+        v-if="store.availableMons.length"
+        class="max-h-60vh"
+        @select="select"
+      />
+      <p v-else class="text-center text-sm">
+        {{ t('components.inventory.OdorElixirModal.noAvailable') }}
+      </p>
+    </div>
+  </UiModal>
+</template>

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -8,6 +8,7 @@ import {
   eggBox as eggBoxItem,
   fabulousPotion,
   mysteriousPotion,
+  odorElixir,
   specialPotion,
 } from '~/data/items'
 import { useKingPotionStore } from '~/stores/kingPotion'
@@ -20,6 +21,7 @@ const evoItemStore = useEvolutionItemStore()
 const wearableStore = useWearableItemStore()
 const kingPotion = useKingPotionStore()
 const kingPotionIds = [fabulousPotion.id, mysteriousPotion.id, specialPotion.id]
+const odorElixirStore = useOdorElixirStore()
 const filter = useInventoryFilterStore()
 const featureLock = useFeatureLockStore()
 const usage = useItemUsageStore()
@@ -169,6 +171,9 @@ function onUse(item: Item) {
   else if (item.wearable) {
     wearableStore.open(item)
   }
+  else if (item.id === odorElixir.id) {
+    odorElixirStore.open(item)
+  }
   else if (item.id === eggBoxItem.id) {
     eggBox.open()
     usage.markUsed(item.id)
@@ -214,6 +219,7 @@ function onUse(item: Item) {
   </section>
   <InventoryEvolutionItemModal />
   <InventoryWearableItemModal />
+  <InventoryOdorElixirModal />
   <InventoryItemShortcutModal />
   <EggBoxModal />
 </template>

--- a/src/data/items.i18n.yml
+++ b/src/data/items.i18n.yml
@@ -129,6 +129,10 @@ en:
     name: Fabulous Potion
     description: Works only during king battles. Hold to unleash its effect.
     details: During king battles, hold the button to perform a special action.
+  odorElixir:
+    name: Odor Elixir
+    description: A rare scent to bond forever with a Shlagemon.
+    details: Use it on a beloved Shlagemon so its rarity matches its level from now on.
 fr:
   defensePotion:
     name: Potion de Défense
@@ -260,3 +264,7 @@ fr:
     name: Potion Fabuleuse
     description: S'utilise seulement contre les rois et se déclenche en maintenant le bouton.
     details: Pendant les combats face aux rois, maintenez le bouton pour effectuer une action fabuleuse.
+  odorElixir:
+    name: Élixir d'Odeur
+    description: Un élixir très rare à offrir à un Shlagémon qu'on adore.
+    details: Utilisé sur un Shlagémon, sa rareté suivra désormais son niveau.

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -228,6 +228,20 @@ export const hyperXpPotion: Item = {
   iconClass: 'text-green-800 dark:text-green-600',
 }
 
+export const odorElixir: Item = {
+  id: 'elixir-odeur',
+  nameKey: 'data.items.odorElixir.name',
+  name: 'Élixir d\'Odeur',
+  descriptionKey: 'data.items.odorElixir.description',
+  description: 'Un parfum si rare qu\'il rend jaloux les collectionneurs.',
+  detailsKey: 'data.items.odorElixir.details',
+  details:
+    'À offrir à un Shlagémon adoré : sa rareté suivra désormais son niveau.',
+  category: 'actif',
+  icon: 'i-game-icons:delicate-perfume',
+  iconClass: 'text-yellow-500 dark:text-yellow-300',
+}
+
 export const capturePotion: Item = {
   id: 'capture-potion',
   nameKey: 'data.items.capturePotion.name',
@@ -594,6 +608,7 @@ export const allItems = [
   xpPotion,
   superXpPotion,
   hyperXpPotion,
+  odorElixir,
   multiExp,
   vitalityRing,
   advancedVitalityRing,

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -13,6 +13,7 @@ import KingLossDialog from '~/components/dialog/KingLossDialog.vue'
 import KingUnlockDialog from '~/components/dialog/KingUnlockDialog.vue'
 import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import NewZoneDialog from '~/components/dialog/NewZoneDialog.vue'
+import OdorElixirDialog from '~/components/dialog/OdorElixirDialog.vue'
 import PotionInfoDialog from '~/components/dialog/PotionInfoDialog.vue'
 import DialogStarter from '~/components/dialog/Starter.vue'
 import WearableItemDialog from '~/components/dialog/WearableItemDialog.vue'
@@ -173,6 +174,11 @@ export const useDialogStore = defineStore('dialog', () => {
     {
       id: 'capturePotion',
       component: markRaw(CapturePotionDialog),
+      condition: () => dex.highestLevel >= 50,
+    },
+    {
+      id: 'odorElixir',
+      component: markRaw(OdorElixirDialog),
       condition: () => dex.highestLevel >= 50,
     },
     {

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -4,9 +4,11 @@ import { defineStore } from 'pinia'
 import {
   allItems,
   eggBox as eggBoxItem,
+  odorElixir,
 } from '~/data/items'
 import { hyperShlageball, shlageball, superShlageball } from '~/data/items/shlageball'
 import { allShlagemons } from '~/data/shlagemons'
+import { useOdorElixirStore } from './odorElixir'
 
 export const useInventoryStore = defineStore('inventory', () => {
   const items = ref<Partial<Record<ItemId, number>>>({})
@@ -17,6 +19,7 @@ export const useInventoryStore = defineStore('inventory', () => {
   const captureLimitModal = useCaptureLimitModalStore()
   const itemUsage = useItemUsageStore()
   const eggBox = useEggBoxStore()
+  const odorElixirStore = useOdorElixirStore()
 
   interface ListedItem {
     item: Item
@@ -113,6 +116,10 @@ export const useInventoryStore = defineStore('inventory', () => {
       [shlageball.id]: capture,
       [superShlageball.id]: capture,
       [hyperShlageball.id]: capture,
+      [odorElixir.id]: () => {
+        odorElixirStore.open(item)
+        return true
+      },
     }
 
     const typeHandlers: Record<string, (power: number) => boolean> = {

--- a/src/stores/odorElixir.ts
+++ b/src/stores/odorElixir.ts
@@ -1,0 +1,41 @@
+import type { Item } from '~/type/item'
+import type { DexShlagemon } from '~/type/shlagemon'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { useInventoryStore } from './inventory'
+import { useItemUsageStore } from './itemUsage'
+import { useShlagedexStore } from './shlagedex'
+
+export const useOdorElixirStore = defineStore('odorElixir', () => {
+  const current = ref<Item | null>(null)
+  const isVisible = ref(false)
+  const dex = useShlagedexStore()
+  const inventory = useInventoryStore()
+  const usage = useItemUsageStore()
+
+  const availableMons = computed(() =>
+    dex.shlagemons.filter(m => !m.rarityFollowsLevel),
+  )
+
+  function open(item: Item) {
+    current.value = item
+    isVisible.value = true
+  }
+
+  function close() {
+    isVisible.value = false
+    current.value = null
+  }
+
+  function useOn(mon: DexShlagemon) {
+    if (!current.value)
+      return false
+    dex.applyOdorElixir(mon)
+    inventory.remove(current.value.id)
+    usage.markUsed(current.value.id)
+    close()
+    return true
+  }
+
+  return { current, isVisible, availableMons, open, close, useOn }
+})

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -374,6 +374,15 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     effects.value.push(effect)
   }
 
+  function applyOdorElixir(mon: DexShlagemon) {
+    if (mon.rarityFollowsLevel)
+      return
+    mon.rarityFollowsLevel = true
+    mon.rarity = mon.lvl
+    applyStats(mon)
+    applyCurrentStats(mon)
+  }
+
   const evolutionStore = useEvolutionStore()
 
   function applyEvolution(mon: DexShlagemon, to: BaseShlagemon) {
@@ -615,6 +624,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     boostVitality,
     boostXp,
     boostCapture,
+    applyOdorElixir,
     effectiveAttack,
     effectiveDefense,
     maxHp,

--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 import {
   allItems,
   hyperPotion,
+  odorElixir,
   potion,
   superPotion,
 } from '~/data/items'
@@ -82,6 +83,9 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
         }
         else if (item.wearable) {
           useWearableItemStore().open(item)
+        }
+        else if (item.id === odorElixir.id) {
+          useOdorElixirStore().open(item)
         }
         else {
           if (inventory.useItem(item.id))


### PR DESCRIPTION
## Summary
- add new active item `Élixir d'Odeur`
- include translations and add the item to item list
- provide modal to select a target shlagémon
- add store logic and dialog from Professeur Merdant
- wire up inventory, shortcuts and shlagedex logic

## Testing
- `pnpm test` *(fails: king potion damage test)*

------
https://chatgpt.com/codex/tasks/task_e_688898add08c832aa9844c5f6ab79123