### PR TITLE
Fix egg box dialog order

### DIFF
--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -168,7 +168,10 @@ export const useDialogStore = defineStore('dialog', () => {
     {
       id: 'eggBox',
       component: markRaw(EggBoxDialog),
-      condition: () => !box.unlocked && ['oeuf-feu', 'oeuf-eau', 'oeuf-herbe', 'oeuf-foudre'].some(id => inventory.items[id]),
+      condition: () =>
+        !box.unlocked
+        && ['oeuf-feu', 'oeuf-eau', 'oeuf-herbe', 'oeuf-foudre'].some(id => inventory.items[id])
+        && panel.current !== 'miniGame',
     },
     {
       id: 'capturePotion',


### PR DESCRIPTION
## Summary
- delay egg box dialog until after the mini game ends

## Testing
- `pnpm test` *(fails: king potion > damages the enemy when unlucky)*

------
https://chatgpt.com/codex/tasks/task_e_68889ce7e8b0832ab2c3bca149a3e514