### PR TITLE
Add auto-equip tests for potions and balls

### DIFF
--- a/test/ball-store.test.ts
+++ b/test/ball-store.test.ts
@@ -1,0 +1,42 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import { useBallStore } from '../src/stores/ball'
+import { useInventoryStore } from '../src/stores/inventory'
+
+/**
+ * Ensures the ball store automatically equips balls based on inventory changes.
+ */
+describe('ball store', () => {
+  it('auto-equips a ball when bought without one equipped', async () => {
+    setActivePinia(createPinia())
+    const inventory = useInventoryStore()
+    const store = useBallStore()
+
+    expect(store.current).toBeNull()
+
+    inventory.add('super-shlageball')
+    await nextTick()
+
+    expect(store.current).toBe('super-shlageball')
+  })
+
+  it('equips the next best ball after using the last one', async () => {
+    setActivePinia(createPinia())
+    const inventory = useInventoryStore()
+    const store = useBallStore()
+
+    inventory.add('hyper-shlageball')
+    inventory.add('shlageball')
+    await nextTick()
+    expect(store.current).toBe('hyper-shlageball')
+
+    inventory.remove('hyper-shlageball')
+    await nextTick()
+    expect(store.current).toBe('shlageball')
+
+    inventory.remove('shlageball')
+    await nextTick()
+    expect(store.current).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- extend `king-potion.test.ts` to check auto-equip when buying a potion and when the equipped one is consumed
- fix existing test by awaiting reactive updates
- add `ball-store.test.ts` covering the same auto-equip logic for balls

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6888a0b3daec832ab41907bec1f440cf