### PR TITLE
Maintain character music during minigames

### DIFF
--- a/src/components/dialog/Box.vue
+++ b/src/components/dialog/Box.vue
@@ -3,14 +3,24 @@ import type { Character } from '~/type/character'
 import type { DialogNode, DialogResponse } from '~/type/dialog'
 import { getCharacterTrack, getZoneTrack } from '~/data/music'
 
-const { dialogTree, character, orientation, exitTrack }
+/**
+ * Props for {@link DialogBox}. Handles dialog tree and music behavior.
+ */
+const { dialogTree, character, orientation, exitTrack, keepMusicOnExit }
   = withDefaults(defineProps<{
     dialogTree: DialogNode[]
     character: Character
     orientation?: 'row' | 'col'
+    /** Track to play when the dialog closes. If omitted, the zone track is used. */
     exitTrack?: string
+    /**
+     * If true, the currently playing music continues when the dialog closes.
+     * Useful when a following scene should keep the character track.
+     */
+    keepMusicOnExit?: boolean
   }>(), {
     orientation: 'row',
+    keepMusicOnExit: false,
   })
 
 const avatarUrl = computed(() => `/characters/${character.id}/${character.id}.webp`)
@@ -38,6 +48,8 @@ watch(currentNode, () => {
 })
 
 onUnmounted(() => {
+  if (keepMusicOnExit)
+    return
   const track = exitTrack || getZoneTrack(zone.current.id, zone.current.type)
   if (track)
     audio.fadeToMusic(track)

--- a/src/components/panel/MiniGame.vue
+++ b/src/components/panel/MiniGame.vue
@@ -21,7 +21,6 @@ watchEffect(async () => {
 
 function start() {
   mini.play()
-  audio.fadeToMusic(miniGameMusic)
 }
 function leaveGame() {
   mini.quit()
@@ -56,7 +55,7 @@ const failure = computed(() => gameDef.value?.createFailure(leaveGame))
         v-if="mini.phase === 'intro'"
         :character="gameDef.character"
         :dialog-tree="intro!"
-        :exit-track="miniGameMusic"
+        keep-music-on-exit
         orientation="col"
       />
       <component

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -57,11 +57,6 @@ export const useUIStore = defineStore('ui', () => {
         return
       }
 
-      if (panel === 'miniGame') {
-        audio.fadeToMusic('/audio/musics/games/mini-game.ogg')
-        return
-      }
-
       if (panel === 'battle') {
         const track = getZoneBattleTrack(zoneId)
         if (track)


### PR DESCRIPTION
## Summary
- add `keepMusicOnExit` option to `DialogBox`
- ensure minigame intro dialog keeps character music
- remove automatic switch to minigame music in UI store

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6888c07c2bb8832aac5f09c9da6ed528