### PR TITLE
Update king music handling

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -212,6 +212,7 @@ onUnmounted(featureLock.unlockAll)
       <DialogBox
         :character="trainer.character"
         :dialog-tree="beforeDialogTree"
+        :keep-music="isZoneKing"
       />
     </div>
     <template v-else-if="stage === 'battle' && dex.activeShlagemon && enemy">
@@ -233,6 +234,7 @@ onUnmounted(featureLock.unlockAll)
       <DialogBox
         :character="trainer.character"
         :dialog-tree="afterDialogTree"
+        :keep-music="isZoneKing"
       />
     </div>
   </div>

--- a/src/components/dialog/Box.vue
+++ b/src/components/dialog/Box.vue
@@ -3,14 +3,16 @@ import type { Character } from '~/type/character'
 import type { DialogNode, DialogResponse } from '~/type/dialog'
 import { getCharacterTrack, getZoneTrack } from '~/data/music'
 
-const { dialogTree, character, orientation, exitTrack }
+const { dialogTree, character, orientation, exitTrack, keepMusic }
   = withDefaults(defineProps<{
     dialogTree: DialogNode[]
     character: Character
     orientation?: 'row' | 'col'
     exitTrack?: string
+    keepMusic?: boolean
   }>(), {
     orientation: 'row',
+    keepMusic: false,
   })
 
 const avatarUrl = computed(() => `/characters/${character.id}/${character.id}.webp`)
@@ -38,6 +40,8 @@ watch(currentNode, () => {
 })
 
 onUnmounted(() => {
+  if (keepMusic)
+    return
   const track = exitTrack || getZoneTrack(zone.current.id, zone.current.type)
   if (track)
     audio.fadeToMusic(track)


### PR DESCRIPTION
## Summary
- let `DialogBox` optionally keep current music when leaving
- keep character music throughout king battles

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6888c1799aa0832a9a8851cca106a56c