### PR TITLE
Fix minigame translation keys

### DIFF
--- a/src/components/minigame/Pairs.vue
+++ b/src/components/minigame/Pairs.vue
@@ -107,7 +107,7 @@ onMounted(reset)
       </div>
     </div>
     <div class="mt-2 text-center text-sm font-bold">
-      {{ t('components.minigame.MiniGameShlagPairs.attempts', attempts) }}
+      {{ t('components.minigame.Pairs.attempts', attempts) }}
     </div>
   </div>
 </template>

--- a/test/shlagmind-component.test.ts
+++ b/test/shlagmind-component.test.ts
@@ -1,10 +1,10 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import MiniGameShlagMind from '../src/components/minigame/MiniGameShlagMind.vue'
+import MasterMind from '../src/components/minigame/MasterMind.vue'
 
 describe('shlagmind component', () => {
   it('renders without crashing', () => {
-    const wrapper = mount(MiniGameShlagMind, { props: {} })
+    const wrapper = mount(MasterMind, { props: {} })
     expect(wrapper.exists()).toBe(true)
   })
 })

--- a/test/taquin-component.test.ts
+++ b/test/taquin-component.test.ts
@@ -1,10 +1,10 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import MiniGameShlagTaquin from '../src/components/minigame/MiniGameShlagTaquin.vue'
+import Taquin from '../src/components/minigame/Taquin.vue'
 
 describe('taquin component', () => {
   it('renders without crashing', () => {
-    const wrapper = mount(MiniGameShlagTaquin)
+    const wrapper = mount(Taquin)
     expect(wrapper.exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- fix translation key used in Pairs component
- update tests to import correct components

## Testing
- `pnpm test --run test/shlagmind-component.test.ts test/taquin-component.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6888c209add8832aa03b97eadc275290