### PR TITLE
Refactor shop panel

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -319,6 +319,8 @@ declare global {
   const useShare: typeof import('@vueuse/core')['useShare']
   const useShlagedexStore: typeof import('./stores/shlagedex')['useShlagedexStore']
   const useShopFilterStore: typeof import('./stores/shopFilter')['useShopFilterStore']
+  const useShopPurchase: typeof import('./composables/useShopPurchase')['useShopPurchase']
+  const useShopTabs: typeof import('./composables/useShopTabs')['useShopTabs']
   const useShortcutsStore: typeof import('./stores/shortcuts')['useShortcutsStore']
   const useSingleInterval: typeof import('./composables/battleEngine')['useSingleInterval']
   const useSlidingPuzzle: typeof import('./composables/useSlidingPuzzle')['useSlidingPuzzle']
@@ -764,6 +766,8 @@ declare module 'vue' {
     readonly useShare: UnwrapRef<typeof import('@vueuse/core')['useShare']>
     readonly useShlagedexStore: UnwrapRef<typeof import('./stores/shlagedex')['useShlagedexStore']>
     readonly useShopFilterStore: UnwrapRef<typeof import('./stores/shopFilter')['useShopFilterStore']>
+    readonly useShopPurchase: UnwrapRef<typeof import('./composables/useShopPurchase')['useShopPurchase']>
+    readonly useShopTabs: UnwrapRef<typeof import('./composables/useShopTabs')['useShopTabs']>
     readonly useShortcutsStore: UnwrapRef<typeof import('./stores/shortcuts')['useShortcutsStore']>
     readonly useSingleInterval: UnwrapRef<typeof import('./composables/battleEngine')['useSingleInterval']>
     readonly useSlidingPuzzle: UnwrapRef<typeof import('./composables/useSlidingPuzzle')['useSlidingPuzzle']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -85,7 +85,7 @@ declare module 'vue' {
     MinigameBattleship: typeof import('./components/minigame/Battleship.vue')['default']
     MinigameConnectFour: typeof import('./components/minigame/ConnectFour.vue')['default']
     MinigameMasterMind: typeof import('./components/minigame/MasterMind.vue')['default']
-    MinigameMasterMindSelectionModal: typeof import('./components/minigame/MasterMind/SelectionModal.vue')['default']
+    MinigameMasterMindSelectionModal: typeof import('./components/minigame/masterMind/SelectionModal.vue')['default']
     MinigamePairs: typeof import('./components/minigame/Pairs.vue')['default']
     MinigameSelectionModal: typeof import('./components/minigame/SelectionModal.vue')['default']
     MinigameShlagCard: typeof import('./components/minigame/ShlagCard.vue')['default']

--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -1,154 +1,24 @@
 <script setup lang="ts">
-import type { Item, ItemCategory } from '~/type/item'
-import { defineComponent, h } from 'vue'
-import { toast } from 'vue3-toastify'
 import ShopItemCard from '../shop/ItemCard.vue'
 import UiButton from '../ui/Button.vue'
 
 const panel = useMainPanelStore()
-const zone = useZoneStore()
-const game = useGameStore()
-const inventory = useInventoryStore()
-const audio = useAudioStore()
 const { t } = useI18n()
-const shopItems = computed(() => zone.current.village?.shop?.items || [])
-const filter = useShopFilterStore()
-const categoryOptions = [
-  { label: t('components.panel.Shop.category.active'), value: 'actif', icon: 'i-carbon-flash' },
-  { label: t('components.panel.Shop.category.passive'), value: 'passif', icon: 'i-carbon-timer' },
-  { label: t('components.panel.Shop.category.utility'), value: 'utilitaire', icon: 'i-carbon-tool-box' },
-  { label: t('components.panel.Shop.category.activable'), value: 'activable', icon: 'i-carbon-fire' },
-] as const
-const availableCategories = computed(() =>
-  categoryOptions
-    .filter(opt => shopItems.value.some(i => i.category === opt.value))
-    .map(opt => ({
-      label: { text: opt.label, icon: opt.icon },
-      value: opt.value,
-    })),
-)
 
-const activeTab = ref(0)
-const categories = computed(() => availableCategories.value)
+const {
+  selectedItem,
+  selectedQty,
+  canBuy,
+  selectItem,
+  buy,
+} = useShopPurchase()
 
-watch(() => filter.category, (val) => {
-  const idx = categories.value.findIndex(c => c.value === val)
-  if (idx !== -1 && idx !== activeTab.value)
-    activeTab.value = idx
-}, { immediate: true })
-
-watch(activeTab, (val) => {
-  const cat = categories.value[val]?.value
-  if (cat && cat !== filter.category)
-    filter.category = cat
-})
-
-watch(availableCategories, (cats) => {
-  if (!cats.length)
-    filter.category = 'all'
-  else if (!cats.some(c => c.value === filter.category))
-    filter.category = cats[0].value
-}, { immediate: true })
-
-function getList(category: ItemCategory | 'all') {
-  return computed(() => {
-    let list = shopItems.value.slice()
-    if (category !== 'all')
-      list = list.filter(item => item.category === category)
-    return list.sort((a, b) => {
-      const typeComp = (a.type || '').localeCompare(b.type || '')
-      if (typeComp !== 0)
-        return typeComp
-      return (a.power || 0) - (b.power || 0)
-    })
-  })
-}
-
-const tabs = computed(() =>
-  categories.value.map(cat => ({
-    label: cat.label,
-    component: defineComponent({
-      name: `ShopTab_${cat.value}`,
-      setup() {
-        const list = getList(cat.value)
-        return () => h('div', {
-          class: 'tiny-scrollbar flex flex-col gap-2 overflow-auto py-1',
-        }, list.value.map(item => h(ShopItemCard, {
-          item,
-          class: 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800',
-          onClick: () => selectItem(item),
-        }, {
-          default: () => h(UiButton, {
-            class: 'ml-auto text-xs',
-            onClick: (e: Event) => {
-              e.stopPropagation()
-              selectItem(item)
-            },
-          }, () => t('components.panel.Shop.details')),
-        })))
-      },
-    }),
-  })),
-)
-
-const filteredShopItems = getList('all')
-
-const selectedItem = ref<Item | null>(null)
-const selectedQty = ref(1)
-
-const maxQty = computed(() => {
-  if (!selectedItem.value)
-    return 1
-  const money = selectedItem.value.currency === 'shlagidiamond'
-    ? game.shlagidiamond
-    : game.shlagidolar
-  return Math.max(1, Math.floor(money / (selectedItem.value.price ?? 0)))
-})
-
-watch(selectedItem, () => {
-  selectedQty.value = 1
-})
-
-watch(selectedQty, (v) => {
-  if (v < 1)
-    selectedQty.value = 1
-  else if (v > maxQty.value)
-    selectedQty.value = maxQty.value
-})
-
-function selectItem(item: Item) {
-  selectedItem.value = item
-}
-
-const canBuy = computed(() => {
-  if (!selectedItem.value)
-    return false
-  const cost = (selectedItem.value.price ?? 0) * selectedQty.value
-  if (selectedItem.value.currency === 'shlagidiamond')
-    return game.shlagidiamond >= cost
-  return game.shlagidolar >= cost
-})
-
-function buy() {
-  if (!selectedItem.value)
-    return
-  const success = inventory.buy(selectedItem.value.id, selectedQty.value)
-  if (success) {
-    audio.playBuySfx()
-    const cost = (selectedItem.value.price ?? 0) * selectedQty.value
-    const currency = selectedItem.value.currency === 'shlagidiamond'
-      ? 'Shlagédiamant'
-      : 'Shlagédollar'
-    const currencyName = cost > 1 ? `${currency}s` : currency
-    toast.success(t('components.panel.Shop.bought', {
-      qty: selectedQty.value,
-      item: selectedItem.value.name,
-      cost: cost.toLocaleString(),
-      currency: currencyName,
-    }))
-    selectedItem.value = null
-  }
-}
+const {
+  activeTab,
+  availableCategories,
+  tabs,
+  filteredShopItems,
+} = useShopTabs(selectItem)
 
 function closeShop() {
   panel.showVillage()

--- a/src/composables/useShopPurchase.ts
+++ b/src/composables/useShopPurchase.ts
@@ -1,0 +1,77 @@
+/**
+ * Composable handling purchase logic in the shop panel.
+ */
+import type { Item } from '~/type/item'
+
+export function useShopPurchase() {
+  const game = useGameStore()
+  const inventory = useInventoryStore()
+  const audio = useAudioStore()
+  const { t } = useI18n()
+
+  const selectedItem = ref<Item | null>(null)
+  const selectedQty = ref(1)
+
+  const maxQty = computed(() => {
+    if (!selectedItem.value)
+      return 1
+    const money = selectedItem.value.currency === 'shlagidiamond'
+      ? game.shlagidiamond
+      : game.shlagidolar
+    return Math.max(1, Math.floor(money / (selectedItem.value.price ?? 0)))
+  })
+
+  watch(selectedItem, () => {
+    selectedQty.value = 1
+  })
+
+  watch(selectedQty, (v) => {
+    if (v < 1)
+      selectedQty.value = 1
+    else if (v > maxQty.value)
+      selectedQty.value = maxQty.value
+  })
+
+  function selectItem(item: Item) {
+    selectedItem.value = item
+  }
+
+  const canBuy = computed(() => {
+    if (!selectedItem.value)
+      return false
+    const cost = (selectedItem.value.price ?? 0) * selectedQty.value
+    if (selectedItem.value.currency === 'shlagidiamond')
+      return game.shlagidiamond >= cost
+    return game.shlagidolar >= cost
+  })
+
+  function buy() {
+    if (!selectedItem.value)
+      return
+    const success = inventory.buy(selectedItem.value.id, selectedQty.value)
+    if (success) {
+      audio.playBuySfx()
+      const cost = (selectedItem.value.price ?? 0) * selectedQty.value
+      const currency = selectedItem.value.currency === 'shlagidiamond'
+        ? 'Shlagédiamant'
+        : 'Shlagédollar'
+      const currencyName = cost > 1 ? `${currency}s` : currency
+      toast.success(t('components.panel.Shop.bought', {
+        qty: selectedQty.value,
+        item: selectedItem.value.name,
+        cost: cost.toLocaleString(),
+        currency: currencyName,
+      }))
+      selectedItem.value = null
+    }
+  }
+
+  return {
+    selectedItem,
+    selectedQty,
+    maxQty,
+    canBuy,
+    selectItem,
+    buy,
+  }
+}

--- a/src/composables/useShopTabs.ts
+++ b/src/composables/useShopTabs.ts
@@ -1,0 +1,110 @@
+/**
+ * Composable managing shop category tabs.
+ *
+ * It exposes the available categories, the active tab index and
+ * a list of tab descriptors used by UiTabs.
+ */
+import type { Item, ItemCategory } from '~/type/item'
+import ShopItemCard from '~/components/shop/ItemCard.vue'
+import UiButton from '~/components/ui/Button.vue'
+
+export function useShopTabs(selectItem: (item: Item) => void) {
+  const zone = useZoneStore()
+  const filter = useShopFilterStore()
+  const { t } = useI18n()
+
+  const shopItems = computed(() => zone.current.village?.shop?.items || [])
+
+  const categoryOptions = [
+    { label: t('components.panel.Shop.category.active'), value: 'actif', icon: 'i-carbon-flash' },
+    { label: t('components.panel.Shop.category.passive'), value: 'passif', icon: 'i-carbon-timer' },
+    { label: t('components.panel.Shop.category.utility'), value: 'utilitaire', icon: 'i-carbon-tool-box' },
+    { label: t('components.panel.Shop.category.activable'), value: 'activable', icon: 'i-carbon-fire' },
+  ] as const
+
+  const availableCategories = computed(() =>
+    categoryOptions
+      .filter(opt => shopItems.value.some(i => i.category === opt.value))
+      .map(opt => ({
+        label: { text: opt.label, icon: opt.icon },
+        value: opt.value,
+      })),
+  )
+
+  const activeTab = ref(0)
+  const categories = computed(() => availableCategories.value)
+
+  watch(() => filter.category, (val) => {
+    const idx = categories.value.findIndex(c => c.value === val)
+    if (idx !== -1 && idx !== activeTab.value)
+      activeTab.value = idx
+  }, { immediate: true })
+
+  watch(activeTab, (val) => {
+    const cat = categories.value[val]?.value
+    if (cat && cat !== filter.category)
+      filter.category = cat
+  })
+
+  watch(availableCategories, (cats) => {
+    if (!cats.length)
+      filter.category = 'all'
+    else if (!cats.some(c => c.value === filter.category))
+      filter.category = cats[0].value
+  }, { immediate: true })
+
+  function getList(category: ItemCategory | 'all') {
+    return computed(() => {
+      let list = shopItems.value.slice()
+      if (category !== 'all')
+        list = list.filter(item => item.category === category)
+      return list.sort((a, b) => {
+        const typeComp = (a.type || '').localeCompare(b.type || '')
+        if (typeComp !== 0)
+          return typeComp
+        return (a.power || 0) - (b.power || 0)
+      })
+    })
+  }
+
+  const tabs = computed(() =>
+    categories.value.map(cat => ({
+      label: cat.label,
+      component: defineComponent({
+        name: `ShopTab_${cat.value}`,
+        setup() {
+          const list = getList(cat.value)
+          return () => h(
+            'div',
+            { class: 'tiny-scrollbar flex flex-col gap-2 overflow-auto py-1' },
+            list.value.map(item => h(
+              ShopItemCard,
+              {
+                item,
+                class: 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800',
+                onClick: () => selectItem(item),
+              },
+              {
+                default: () => h(
+                  UiButton,
+                  {
+                    class: 'ml-auto text-xs',
+                    onClick: (e: Event) => {
+                      e.stopPropagation()
+                      selectItem(item)
+                    },
+                  },
+                  () => t('components.panel.Shop.details'),
+                ),
+              },
+            )),
+          )
+        },
+      }),
+    })),
+  )
+
+  const filteredShopItems = getList('all')
+
+  return { activeTab, availableCategories, tabs, filteredShopItems }
+}


### PR DESCRIPTION
## Summary
- add composables for shop tabs and purchase state
- use composables in Shop.vue for clearer logic

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Failed to resolve imports in some tests)*

------
https://chatgpt.com/codex/tasks/task_e_6888c43f2760832aa5b2841b0b6de8dd