### PR TITLE
Refine egg and dex serializers

### DIFF
--- a/src/utils/egg-serialize.ts
+++ b/src/utils/egg-serialize.ts
@@ -10,7 +10,11 @@ interface StoredEgg {
   hatchesAt: number
 }
 
-export const eggSerializer = {
+/**
+ * Eggs are stored as a JSON array of plain objects containing only
+ * `id`, `type`, `baseId`, `startedAt`, and `hatchesAt`.
+ */
+export const eggSerializer: Serializer = {
   serialize(data: { incubator: Egg[] }): string {
     const eggs = data.incubator || []
     const list: StoredEgg[] = eggs.map(e => ({
@@ -36,4 +40,4 @@ export const eggSerializer = {
     })).filter(e => e.base)
     return { incubator }
   },
-} as unknown as Serializer
+} as const

--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -34,7 +34,12 @@ interface StoredDex extends Omit<SerializedDex, 'shlagemons' | 'activeShlagemon'
   activeShlagemon: StoredDexMon | null
 }
 
-export const shlagedexSerializer = {
+/**
+ * Data is stored as a JSON object containing the dex arrays and effects.
+ * Each monster includes `baseId` and `heldItemId` so older saves remain
+ * readable even if the schema evolves.
+ */
+export const shlagedexSerializer: Serializer = {
   serialize(data: SerializedDex): string {
     return JSON.stringify({
       ...data,
@@ -144,4 +149,4 @@ export const shlagedexSerializer = {
       effects,
     }
   },
-} as unknown as Serializer
+} as const


### PR DESCRIPTION
## Summary
- document egg serializer format
- expose typed constants for egg and shlagedex serializers

## Testing
- `pnpm exec vitest run` *(fails: cannot resolve MiniGameShlagMind.vue)*

------
https://chatgpt.com/codex/tasks/task_e_6888c42f20c0832ab6586b2f8ef5e005