### PR TITLE
Fix minigame translation keys and cleanup

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -544,25 +544,7 @@ components:
             back: Back
             valid: Thanks!
   minigame:
-    MiniGameShlagMind:
-      messages:
-        - You're getting closer… or not.
-        - That's not it, but you're doing your best, little Shlag.
-        - Try again, champion of nothingness.
-        - You suck!
-        - You're one step away from a brain fart.
-        - Rarely seen someone so pathetic.
-      validate: Validate
-      attemptsLeft: '{n} attempts left'
-      win: You've cracked a Shlag's mind!
-      lose: Even a Grimer would have done it
-    MiniGameShlagPairs:
-      attempts: '{n} attempt | {n} attempts'
-    ShlagMindSelectionModal:
-      title: Choose a Shlagemon
     MasterMind:
-      SelectionModal:
-        title: Choose a Shlagemon
       messages:
         - You're getting closer… or not.
         - That's not it, but you're doing your best, little Shlag.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -569,25 +569,7 @@ components:
             back: Retour
             valid: Merci vieux !
   minigame:
-    MiniGameShlagMind:
-      messages:
-        - Tu te rapproches… ou pas.
-        - Ce n'est pas ça, mais tu fais de ton mieux, petit Shlag.
-        - Essaie encore, champion du néant.
-        - Tu es nul à chier !
-        - T'es à deux doigts de faire un pet cérébral.
-        - Rarement vu quelqu'un aussi merdique.
-      validate: Valider
-      attemptsLeft: '{n} tentatives restantes'
-      win: T'as percé le cerveau d'un Shlag !
-      lose: Même un Petmorv y serait arrivé
-    MiniGameShlagPairs:
-      attempts: '{n} tentative | {n} tentatives'
-    ShlagMindSelectionModal:
-      title: Choisis un Shlagémon
     MasterMind:
-      SelectionModal:
-        title: Choisis un Shlagémon
       messages:
         - Tu te rapproches… ou pas.
         - Ce n'est pas ça, mais tu fais de ton mieux, petit Shlag.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -85,7 +85,7 @@ declare module 'vue' {
     MinigameBattleship: typeof import('./components/minigame/Battleship.vue')['default']
     MinigameConnectFour: typeof import('./components/minigame/ConnectFour.vue')['default']
     MinigameMasterMind: typeof import('./components/minigame/MasterMind.vue')['default']
-    MinigameMasterMindSelectionModal: typeof import('./components/minigame/MasterMind/SelectionModal.vue')['default']
+    MinigameMasterMindSelectionModal: typeof import('./components/minigame/masterMind/SelectionModal.vue')['default']
     MinigamePairs: typeof import('./components/minigame/Pairs.vue')['default']
     MinigameSelectionModal: typeof import('./components/minigame/SelectionModal.vue')['default']
     MinigameShlagCard: typeof import('./components/minigame/ShlagCard.vue')['default']

--- a/src/components/minigame/Pairs.vue
+++ b/src/components/minigame/Pairs.vue
@@ -107,7 +107,7 @@ onMounted(reset)
       </div>
     </div>
     <div class="mt-2 text-center text-sm font-bold">
-      {{ t('components.minigame.MiniGameShlagPairs.attempts', attempts) }}
+      {{ t('components.minigame.Pairs.attempts', attempts) }}
     </div>
   </div>
 </template>

--- a/src/data/Minigame/MasterMind.ts
+++ b/src/data/Minigame/MasterMind.ts
@@ -17,11 +17,11 @@ export const shlagMindMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: i18n.global.t('data.Minigame.ShlagMind.startText'),
+        text: i18n.global.t('data.Minigame.MasterMind.startText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagMind.yes'), type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.MasterMind.yes'), type: 'primary', action: start },
           {
-            label: i18n.global.t('data.Minigame.ShlagMind.no'),
+            label: i18n.global.t('data.Minigame.MasterMind.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -36,9 +36,9 @@ export const shlagMindMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'win',
-        text: i18n.global.t('data.Minigame.ShlagMind.winText'),
+        text: i18n.global.t('data.Minigame.MasterMind.winText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagMind.super'), type: 'valid', action: done },
+          { label: i18n.global.t('data.Minigame.MasterMind.super'), type: 'valid', action: done },
         ],
       },
     ]
@@ -48,10 +48,10 @@ export const shlagMindMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: i18n.global.t('data.Minigame.ShlagMind.loseText'),
+        text: i18n.global.t('data.Minigame.MasterMind.loseText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagMind.restart'), type: 'primary', action: () => miniGame.play() },
-          { label: i18n.global.t('data.Minigame.ShlagMind.back'), type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.MasterMind.restart'), type: 'primary', action: () => miniGame.play() },
+          { label: i18n.global.t('data.Minigame.MasterMind.back'), type: 'danger', action: done },
         ],
       },
     ]

--- a/src/data/Minigame/Pairs.ts
+++ b/src/data/Minigame/Pairs.ts
@@ -17,11 +17,11 @@ export const shlagPairsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: i18n.global.t('data.Minigame.ShlagPairs.startText'),
+        text: i18n.global.t('data.Minigame.Pairs.startText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagPairs.yes'), type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.Pairs.yes'), type: 'primary', action: start },
           {
-            label: i18n.global.t('data.Minigame.ShlagPairs.no'),
+            label: i18n.global.t('data.Minigame.Pairs.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -36,9 +36,9 @@ export const shlagPairsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'win',
-        text: i18n.global.t('data.Minigame.ShlagPairs.winText'),
+        text: i18n.global.t('data.Minigame.Pairs.winText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagPairs.super'), type: 'valid', action: done },
+          { label: i18n.global.t('data.Minigame.Pairs.super'), type: 'valid', action: done },
         ],
       },
     ]
@@ -48,10 +48,10 @@ export const shlagPairsMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: i18n.global.t('data.Minigame.ShlagPairs.loseText'),
+        text: i18n.global.t('data.Minigame.Pairs.loseText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagPairs.restart'), type: 'primary', action: () => miniGame.play() },
-          { label: i18n.global.t('data.Minigame.ShlagPairs.back'), type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.Pairs.restart'), type: 'primary', action: () => miniGame.play() },
+          { label: i18n.global.t('data.Minigame.Pairs.back'), type: 'danger', action: done },
         ],
       },
     ]

--- a/src/data/Minigame/Taquin.ts
+++ b/src/data/Minigame/Taquin.ts
@@ -17,11 +17,11 @@ export const shlagTaquinMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'start',
-        text: i18n.global.t('data.Minigame.ShlagTaquin.startText'),
+        text: i18n.global.t('data.Minigame.Taquin.startText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagTaquin.yes'), type: 'primary', action: start },
+          { label: i18n.global.t('data.Minigame.Taquin.yes'), type: 'primary', action: start },
           {
-            label: i18n.global.t('data.Minigame.ShlagTaquin.no'),
+            label: i18n.global.t('data.Minigame.Taquin.no'),
             type: 'danger',
             action: () => {
               miniGame.quit()
@@ -36,9 +36,9 @@ export const shlagTaquinMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'win',
-        text: i18n.global.t('data.Minigame.ShlagTaquin.winText'),
+        text: i18n.global.t('data.Minigame.Taquin.winText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagTaquin.super'), type: 'valid', action: done },
+          { label: i18n.global.t('data.Minigame.Taquin.super'), type: 'valid', action: done },
         ],
       },
     ]
@@ -48,10 +48,10 @@ export const shlagTaquinMiniGame: MiniGameDefinition = {
     return [
       {
         id: 'fail',
-        text: i18n.global.t('data.Minigame.ShlagTaquin.loseText'),
+        text: i18n.global.t('data.Minigame.Taquin.loseText'),
         responses: [
-          { label: i18n.global.t('data.Minigame.ShlagTaquin.restart'), type: 'primary', action: () => miniGame.play() },
-          { label: i18n.global.t('data.Minigame.ShlagTaquin.back'), type: 'danger', action: done },
+          { label: i18n.global.t('data.Minigame.Taquin.restart'), type: 'primary', action: () => miniGame.play() },
+          { label: i18n.global.t('data.Minigame.Taquin.back'), type: 'danger', action: done },
         ],
       },
     ]

--- a/test/shlagmind-component.test.ts
+++ b/test/shlagmind-component.test.ts
@@ -1,10 +1,10 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import MiniGameShlagMind from '../src/components/minigame/MiniGameShlagMind.vue'
+import MasterMind from '../src/components/minigame/MasterMind.vue'
 
 describe('shlagmind component', () => {
   it('renders without crashing', () => {
-    const wrapper = mount(MiniGameShlagMind, { props: {} })
+    const wrapper = mount(MasterMind, { props: {} })
     expect(wrapper.exists()).toBe(true)
   })
 })

--- a/test/taquin-component.test.ts
+++ b/test/taquin-component.test.ts
@@ -1,10 +1,10 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import MiniGameShlagTaquin from '../src/components/minigame/MiniGameShlagTaquin.vue'
+import Taquin from '../src/components/minigame/Taquin.vue'
 
 describe('taquin component', () => {
   it('renders without crashing', () => {
-    const wrapper = mount(MiniGameShlagTaquin)
+    const wrapper = mount(Taquin)
     expect(wrapper.exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- use correct translation keys for Pairs, Taquin and MasterMind minigames
- update components to consume the proper keys
- clean obsolete keys from locale files
- fix broken unit tests after file renames

## Testing
- `pnpm test:unit --run`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6888ca80c5e8832aae9c41adfae9f9e0