### PR TITLE
Adjust king battle music

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -212,6 +212,7 @@ onUnmounted(featureLock.unlockAll)
       <DialogBox
         :character="trainer.character"
         :dialog-tree="beforeDialogTree"
+        :keep-music-on-exit="isZoneKing"
       />
     </div>
     <template v-else-if="stage === 'battle' && dex.activeShlagemon && enemy">
@@ -233,6 +234,7 @@ onUnmounted(featureLock.unlockAll)
       <DialogBox
         :character="trainer.character"
         :dialog-tree="afterDialogTree"
+        :keep-music-on-exit="isZoneKing"
       />
     </div>
   </div>

--- a/src/components/ui/InputTipRange.vue
+++ b/src/components/ui/InputTipRange.vue
@@ -31,7 +31,9 @@ const displayValue = computed(() =>
 
 const bubblePercent = ref(percent.value)
 watch(percent, (val) => {
-  requestAnimationFrame(() => { bubblePercent.value = val })
+  requestAnimationFrame(() => {
+    bubblePercent.value = val
+  })
 })
 </script>
 


### PR DESCRIPTION
## Summary
- ensure king battle music keeps playing across dialogues
- fix style error in InputTipRange

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6888d034ebf4832a99f2ddf756854d5c