### PR TITLE
Add rarity-based egg hatching

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -494,14 +494,24 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return mon
   }
 
-  function captureShlagemon(base: BaseShlagemon, shiny = false) {
+  function captureShlagemon(
+    base: BaseShlagemon,
+    shiny = false,
+    rarity?: number,
+  ) {
     const existing = shlagemons.value.find(mon => mon.base.id === base.id)
     if (existing) {
       if (existing.rarity >= 100) {
         toast('Vous avez déjà ce Shlagémon au maximum de sa rareté')
         return existing
       }
-      const incoming = createDexShlagemon(base, shiny, 1, wildLevel.highestWildLevel)
+      const incoming = createDexShlagemon(
+        base,
+        shiny,
+        1,
+        rarity ?? wildLevel.highestWildLevel,
+        rarity ?? 1,
+      )
       existing.captureCount += 1
       let rarityGain = 1
       let levelLoss = 1
@@ -528,7 +538,13 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       toast(rarityToastMessage(existing.base.name, rarityGain, levelLoss))
       return existing
     }
-    const incoming = createDexShlagemon(base, shiny, 1, wildLevel.highestWildLevel)
+    const incoming = createDexShlagemon(
+      base,
+      shiny,
+      1,
+      rarity ?? wildLevel.highestWildLevel,
+      rarity ?? 1,
+    )
     incoming.captureDate = new Date().toISOString()
     incoming.captureCount = 1
     addShlagemon(incoming)

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -92,7 +92,13 @@ export function createDexShlagemon(
   return mon
 }
 
-function generateRarity(max = 99, min = 1): number {
+/**
+ * Generate a rarity value with the same skew as used for battles.
+ *
+ * @param max - Maximum rarity (inclusive).
+ * @param min - Minimum rarity (inclusive).
+ */
+export function generateRarity(max = 99, min = 1): number {
   const x = Math.random()
   const skewed = x ** 2
   const value = Math.floor(1 + skewed * (max - 1))

--- a/src/utils/egg-serialize.ts
+++ b/src/utils/egg-serialize.ts
@@ -6,13 +6,14 @@ interface StoredEgg {
   id: number
   type: Egg['type']
   baseId: string
+  rarity: number
   startedAt: number
   hatchesAt: number
 }
 
 /**
  * Eggs are stored as a JSON array of plain objects containing only
- * `id`, `type`, `baseId`, `startedAt`, and `hatchesAt`.
+ * `id`, `type`, `baseId`, `rarity`, `startedAt`, and `hatchesAt`.
  */
 export const eggSerializer: Serializer = {
   serialize(data: { incubator: Egg[] }): string {
@@ -21,6 +22,7 @@ export const eggSerializer: Serializer = {
       id: e.id,
       type: e.type,
       baseId: e.base.id,
+      rarity: e.rarity,
       startedAt: e.startedAt,
       hatchesAt: e.hatchesAt,
     }))
@@ -35,6 +37,7 @@ export const eggSerializer: Serializer = {
       id: e.id,
       type: e.type,
       base: baseMap[e.baseId],
+      rarity: e.rarity,
       startedAt: e.startedAt,
       hatchesAt: e.hatchesAt,
     })).filter(e => e.base)

--- a/src/utils/egg.ts
+++ b/src/utils/egg.ts
@@ -1,0 +1,26 @@
+/**
+ * Utility helpers related to egg incubation.
+ */
+
+/** Minimum incubation duration in milliseconds for rarity 1. */
+export const MIN_HATCH_DURATION_MS = 60_000
+
+/** Maximum incubation duration in milliseconds for rarity 100. */
+export const MAX_HATCH_DURATION_MS = 3_600_000
+
+/**
+ * Compute the incubation duration for a given rarity.
+ * The mapping is linear between `MIN_HATCH_DURATION_MS` at rarity 1
+ * and `MAX_HATCH_DURATION_MS` at rarity 100.
+ *
+ * @param rarity - Egg rarity between 1 and 100.
+ * @returns Duration in milliseconds until the egg hatches.
+ */
+export function hatchDurationForRarity(rarity: number): number {
+  const clamped = Math.min(100, Math.max(1, Math.round(rarity)))
+  const ratio = (clamped - 1) / 99
+  return Math.round(
+    MIN_HATCH_DURATION_MS
+    + ratio * (MAX_HATCH_DURATION_MS - MIN_HATCH_DURATION_MS),
+  )
+}

--- a/test/egg-persist.test.ts
+++ b/test/egg-persist.test.ts
@@ -20,6 +20,7 @@ describe('egg persistence', () => {
           id: 1,
           type: 'feu',
           base: allShlagemons[0],
+          rarity: 42,
           startedAt: 1000,
           hatchesAt: 2000,
         },
@@ -32,6 +33,7 @@ describe('egg persistence', () => {
     const egg = eggs.incubator[0]
     expect(egg.startedAt).toBe(1000)
     expect(egg.hatchesAt).toBe(2000)
+    expect(egg.rarity).toBe(42)
     expect(egg.base.id).toBe(allShlagemons[0].id)
   })
 })

--- a/test/egg.test.ts
+++ b/test/egg.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { useEggStore } from '../src/stores/egg'
 import { useInventoryStore } from '../src/stores/inventory'
 import { useShlagedexStore } from '../src/stores/shlagedex'
+import { hatchDurationForRarity } from '../src/utils/egg'
 
 describe('egg workflow', () => {
   it('acquires and hatches eggs', () => {
@@ -19,11 +20,15 @@ describe('egg workflow', () => {
 
     const egg = eggs.incubator[0]
     const duration = egg.hatchesAt - egg.startedAt
+    expect(egg.rarity).toBeGreaterThanOrEqual(1)
+    expect(egg.rarity).toBeLessThanOrEqual(100)
+    expect(duration).toBe(hatchDurationForRarity(egg.rarity))
     expect(egg.startedAt).toBeLessThanOrEqual(Date.now())
     vi.advanceTimersByTime(duration + 1)
     expect(eggs.isReady(egg)).toBe(true)
-    const mon = eggs.hatchEgg(egg.id)
+    const mon = eggs.hatchEgg(egg.id)!
     expect(mon).not.toBeNull()
+    expect(mon.rarity).toBe(egg.rarity)
     expect(dex.shlagemons.length).toBe(1)
     vi.useRealTimers()
   })


### PR DESCRIPTION
## Summary
- export `generateRarity` helper
- compute egg rarity and hatch duration
- persist egg rarity in serializer
- allow specifying rarity when capturing
- add incubation duration helper
- adjust unit tests

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6888d77a8a8c832aa308b3009ac8c832