### PR TITLE
Implement capture difficulty by level

### DIFF
--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -24,7 +24,7 @@ describe('capture mechanics', () => {
     const mon = createDexShlagemon(carapouffe, false, 20)
     mon.hp = 100
     mon.hpCurrent = 1
-    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    vi.spyOn(Math, 'random').mockReturnValue(0.3)
     expect(tryCapture(mon, balls[1])).toBe(true)
   })
 
@@ -34,6 +34,14 @@ describe('capture mechanics', () => {
     mon.hpCurrent = 1
     mon.rarity = 100
     vi.spyOn(Math, 'random').mockReturnValue(0.3)
+    expect(tryCapture(mon, balls[2])).toBe(false)
+  })
+
+  it('level 33 halves capture chance', () => {
+    const mon = createDexShlagemon(carapouffe, false, 33)
+    mon.hp = 100
+    mon.hpCurrent = 1
+    vi.spyOn(Math, 'random').mockReturnValue(0.6)
     expect(tryCapture(mon, balls[2])).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- adjust capture mechanics to apply level-based penalty
- document level difficulty multiplier
- test capture probability adjustments

## Testing
- `pnpm lint`
- `pnpm vitest run`
- `pnpm typecheck` *(fails: Type errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6888d8755f34832a8ccf0da4b7f7675e