### PR TITLE
Compute save code on demand

### DIFF
--- a/src/components/settings/SaveTab.i18n.yml
+++ b/src/components/settings/SaveTab.i18n.yml
@@ -1,5 +1,6 @@
 fr:
   exportLabel: Code de sauvegarde
+  generate: Générer
   copy: Copier
   download: Télécharger
   importLabel: Importer une sauvegarde
@@ -10,6 +11,7 @@ fr:
   copied: Copié
 en:
   exportLabel: Save code
+  generate: Generate
   copy: Copy
   download: Download
   importLabel: Import save

--- a/src/components/settings/SaveTab.vue
+++ b/src/components/settings/SaveTab.vue
@@ -7,16 +7,20 @@ const { t } = useI18n()
 const exportCode = ref('')
 const importCode = ref('')
 
-onMounted(() => {
+function generateExport() {
   exportCode.value = exportSave(collectSave())
-})
+}
 
 function copyExport() {
+  if (!exportCode.value)
+    generateExport()
   navigator.clipboard.writeText(exportCode.value)
   toast.success(t('components.settings.SaveTab.copied'))
 }
 
 function downloadExport() {
+  if (!exportCode.value)
+    generateExport()
   const blob = new Blob([exportCode.value], { type: 'text/plain;charset=utf-8' })
   const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
@@ -52,10 +56,13 @@ function loadImport() {
         @focus="($event.target as HTMLTextAreaElement).select()"
       />
       <div class="flex gap-2">
-        <UiButton class="flex-1" @click="copyExport">
+        <UiButton class="flex-1" @click="generateExport">
+          {{ t('components.settings.SaveTab.generate') }}
+        </UiButton>
+        <UiButton class="flex-1" :disabled="!exportCode" @click="copyExport">
           {{ t('components.settings.SaveTab.copy') }}
         </UiButton>
-        <UiButton class="flex-1" @click="downloadExport">
+        <UiButton class="flex-1" :disabled="!exportCode" @click="downloadExport">
           {{ t('components.settings.SaveTab.download') }}
         </UiButton>
       </div>


### PR DESCRIPTION
## Summary
- avoid heavy save code generation on mount
- add a button to manually generate save code
- translate new `generate` label

## Testing
- `pnpm lint`
- `pnpm exec vitest run` *(fails: capture mechanics test)*

------
https://chatgpt.com/codex/tasks/task_e_6888e77b6d08832a882423f94d4f12e4