### PR TITLE
Externalize French strings to i18n files

### DIFF
--- a/src/components/arena/Panel.i18n.yml
+++ b/src/components/arena/Panel.i18n.yml
@@ -1,0 +1,14 @@
+fr:
+  selectSix: Vous devez sélectionner 6 Shlagémons pour combattre dans l'arène
+  autoBattleInfo: Le combat est automatique et se déroule sans clics.
+  quit: Abandonner
+  fight: Combattre
+  autoSelect: Sélection automatique de l'équipe
+  choose: 'Choisir un Shlagémon contre {name}'
+en:
+  selectSix: You must select 6 Shlagemon to fight in the arena
+  autoBattleInfo: The battle is automatic and proceeds without clicks.
+  quit: Give up
+  fight: Fight
+  autoSelect: Automatic team selection
+  choose: 'Choose a Shlagemon against {name}'

--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -10,6 +10,7 @@ const arena = useArenaStore()
 const featureLock = useFeatureLockStore()
 const panel = useMainPanelStore()
 const savedActive = ref<DexShlagemon | null>(null)
+const { t } = useI18n()
 
 const enemyTeam = computed(() => arena.lineup)
 const enemyDexTeam = computed(() => arena.lineupDex)
@@ -162,11 +163,11 @@ onUnmounted(() => {
 
       <div class="col-span-6 flex flex-col gap-2">
         <UiInfo v-if="playerSelection.some(m => !m)" color="danger" class="text-center text-xs">
-          Vous devez sélectionner 6 Shlagémons pour combattre dans l'arène
+          {{ t('components.arena.Panel.selectSix') }}
         </UiInfo>
         <div class="col-span-6 flex flex-col gap-2">
           <UiInfo color="alert" class="text-center text-xs">
-            Le combat est automatique et se déroule sans clics.
+            {{ t('components.arena.Panel.autoBattleInfo') }}
           </UiInfo>
           <div class="flex gap-2">
             <UiButton
@@ -174,7 +175,7 @@ onUnmounted(() => {
               variant="outline"
               @click="quit"
             >
-              Abandonner
+              {{ t('components.arena.Panel.quit') }}
             </UiButton>
             <UiButton
               type="primary"
@@ -182,9 +183,9 @@ onUnmounted(() => {
               :disabled="playerSelection.some(m => !m)"
               @click="startBattle"
             >
-              Combattre
+              {{ t('components.arena.Panel.fight') }}
             </UiButton>
-            <UiTooltip text="Sélection automatique de l'équipe" is-button>
+            <UiTooltip :text="t('components.arena.Panel.autoSelect')" is-button>
               <UiButton
                 type="icon"
                 class="bottom-0 left-0 z-10 rounded-full"
@@ -197,7 +198,7 @@ onUnmounted(() => {
         </div>
         <UiModal v-model="showDex" footer-close>
           <h3 v-if="activeSlot !== null" class="mb-2 text-center text-lg font-bold">
-            Choisir un Shlagémon contre {{ enemyTeam[activeSlot].name }}
+            {{ t('components.arena.Panel.choose', { name: enemyTeam[activeSlot].name }) }}
           </h3>
           <ShlagemonQuickSelect
             :selected="arena.selections.filter(Boolean) as string[]"

--- a/src/components/audio/SettingsModal.i18n.yml
+++ b/src/components/audio/SettingsModal.i18n.yml
@@ -1,0 +1,16 @@
+fr:
+  title: Paramètres audio
+  musicLabel: Musique
+  musicDisabledInfo: Désactiver la musique réduit les dégâts de vos Shlagémons de 10%.
+  musicDisabledNote: '(Ba oui, je me suis pas cassé le cul à faire une bande-son pour rien !)'
+  sfxLabel: Effets sonores
+  sfxDisabledInfo: Attention, certains feedbacks sonores seront absents.
+  sfxDisabledNote: "(Notamment les sons liés au Shiny, ça serait dommage d'en rater un, sale connasse !)"
+en:
+  title: Audio settings
+  musicLabel: Music
+  musicDisabledInfo: Disabling music reduces your Shlagemons' damage by 10%.
+  musicDisabledNote: '(Hey, I did not compose a soundtrack for nothing!)'
+  sfxLabel: Sound effects
+  sfxDisabledInfo: Warning, some audio feedback will be missing.
+  sfxDisabledNote: "(Especially shiny sounds, it'd be a shame to miss one!)"

--- a/src/components/audio/SettingsModal.vue
+++ b/src/components/audio/SettingsModal.vue
@@ -13,6 +13,7 @@ const show = computed<boolean>({
 })
 
 const audio = useAudioStore()
+const { t } = useI18n()
 </script>
 
 <template>
@@ -27,7 +28,7 @@ const audio = useAudioStore()
     <template #default>
       <div id="audio-modal-desc" class="flex flex-col gap-5 p-2 sm:p-4">
         <h3 id="audio-modal-title" class="text-center text-lg font-bold">
-          Paramètres audio
+          {{ t('components.audio.SettingsModal.title') }}
         </h3>
 
         <section
@@ -45,7 +46,7 @@ const audio = useAudioStore()
 
           <!-- Ligne 1, colonne 2 : Label -->
           <label for="music-checkbox" class="col-start-2 row-start-1 cursor-pointer select-none font-medium">
-            Musique
+            {{ t('components.audio.SettingsModal.musicLabel') }}
           </label>
 
           <!-- Ligne 2, colonne 1 : Input number (volume direct) -->
@@ -79,8 +80,8 @@ const audio = useAudioStore()
             color="alert"
             class="col-span-2 row-start-3 mt-2"
           >
-            Désactiver la musique réduit les dégâts de vos Shlagémons de 10%.<br>
-            <small class="opacity-80">(Ba oui, je me suis pas cassé le cul à faire une bande-son pour rien !)</small>
+            {{ t('components.audio.SettingsModal.musicDisabledInfo') }}<br>
+            <small class="opacity-80">{{ t('components.audio.SettingsModal.musicDisabledNote') }}</small>
           </UiInfo>
         </section>
         <!-- Bloc effets -->
@@ -100,7 +101,7 @@ const audio = useAudioStore()
 
           <!-- Ligne 1, colonne 2 : Label -->
           <label for="sfx-checkbox" class="col-start-2 row-start-1 cursor-pointer select-none font-medium">
-            Effets sonores
+            {{ t('components.audio.SettingsModal.sfxLabel') }}
           </label>
 
           <!-- Ligne 2, colonne 1 : Input number (volume direct) -->
@@ -135,8 +136,8 @@ const audio = useAudioStore()
             color="alert"
             class="col-span-2 row-start-3 mt-2"
           >
-            Attention, certains feedbacks sonores seront absents.<br>
-            <small class="opacity-80">(Notamment les sons liés au Shiny, ça serait dommage d'en rater un, sale connasse !)</small>
+            {{ t('components.audio.SettingsModal.sfxDisabledInfo') }}<br>
+            <small class="opacity-80">{{ t('components.audio.SettingsModal.sfxDisabledNote') }}</small>
           </UiInfo>
         </section>
       </div>

--- a/src/components/battle/CaptureMenu.i18n.yml
+++ b/src/components/battle/CaptureMenu.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  captured: 'Vous avez capturé {name} !'
+  fail: Raté !
+en:
+  captured: 'You captured {name}!'
+  fail: Missed!

--- a/src/components/battle/CaptureMenu.vue
+++ b/src/components/battle/CaptureMenu.vue
@@ -10,6 +10,7 @@ const emit = defineEmits<{ (e: 'capture', success: boolean): void }>()
 const inventory = useInventoryStore()
 const dex = useShlagedexStore()
 const audio = useAudioStore()
+const { t } = useI18n()
 const animBall = ref<string | null>(null)
 
 const availableBalls = computed(() =>
@@ -29,12 +30,12 @@ function useBall(ball: Ball) {
     dex.captureEnemy(props.enemy)
     emit('capture', true)
     audio.playSfx('capture-success')
-    toast(`Vous avez capturé ${props.enemy.base.name} !`)
+    toast(t('components.battle.CaptureMenu.captured', { name: props.enemy.base.name }))
   }
   else {
     emit('capture', false)
     audio.playSfx('capture-fail')
-    toast('Raté !')
+    toast(t('components.battle.CaptureMenu.fail'))
   }
 }
 </script>

--- a/src/components/battle/Trainer.i18n.yml
+++ b/src/components/battle/Trainer.i18n.yml
@@ -1,0 +1,16 @@
+fr:
+  startBattle: Démarrer le combat
+  quit: Abandonner
+  continue: Continuer
+  defeat: Défaite...
+  queen: reine
+  king: roi
+  zoneKingChallenge: 'Défi du {label} de la zone'
+en:
+  startBattle: Start battle
+  quit: Surrender
+  continue: Continue
+  defeat: Defeat...
+  queen: queen
+  king: king
+  zoneKingChallenge: '{label} zone challenge'

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -19,10 +19,15 @@ const game = useGameStore()
 const mobile = useMobileTabStore()
 const wildLevel = useWildLevelStore()
 const kingPotion = useKingPotionStore()
+const { t } = useI18n()
 
 const trainer = computed(() => trainerStore.current)
 const isZoneKing = computed(() => trainer.value?.id.startsWith('king-'))
-const kingLabel = computed(() => trainer.value?.character.gender === 'female' ? 'reine' : 'roi')
+const kingLabel = computed(() =>
+  trainer.value?.character.gender === 'female'
+    ? t('components.battle.Trainer.queen')
+    : t('components.battle.Trainer.king'),
+)
 
 const stage = ref<'before' | 'battle' | 'after'>('before')
 const result = ref<'none' | 'win' | 'lose'>('none')
@@ -37,8 +42,8 @@ const beforeDialogTree = computed<DialogNode[]>(() => {
       id: 'start',
       text: trainer.value.dialogBefore,
       responses: [
-        { label: 'D\u00E9marrer le combat', type: 'primary', action: startFight },
-        { label: 'Abandonner', type: 'danger', action: cancelFight },
+        { label: t('components.battle.Trainer.startBattle'), type: 'primary', action: startFight },
+        { label: t('components.battle.Trainer.quit'), type: 'danger', action: cancelFight },
       ],
     },
   ]
@@ -53,14 +58,14 @@ const afterDialogTree = computed<DialogNode[]>(() => {
         id: 'start',
         text: trainer.value.dialogAfter,
         responses: [
-          { label: 'Continuer', nextId: 'reward', type: 'primary' },
+          { label: t('components.battle.Trainer.continue'), nextId: 'reward', type: 'primary' },
         ],
       },
       {
         id: 'reward',
         text: `+${trainer.value.reward} Shlag\u00E9diamonds`,
         responses: [
-          { label: 'Continuer', type: 'valid', action: finish },
+          { label: t('components.battle.Trainer.continue'), type: 'valid', action: finish },
         ],
       },
     ]
@@ -69,9 +74,9 @@ const afterDialogTree = computed<DialogNode[]>(() => {
     return [
       {
         id: 'start',
-        text: trainer.value.dialogDefeat || 'D\u00E9faite...',
+        text: trainer.value.dialogDefeat || t('components.battle.Trainer.defeat'),
         responses: [
-          { label: 'Continuer', type: 'valid', action: finish },
+          { label: t('components.battle.Trainer.continue'), type: 'valid', action: finish },
         ],
       },
     ]
@@ -206,7 +211,7 @@ onUnmounted(featureLock.unlockAll)
     <div v-if="stage === 'before'" class="h-full flex flex-col items-center gap-2 text-center">
       <template v-if="isZoneKing">
         <div class="font-bold capitalize">
-          Défi du {{ kingLabel }} de la zone
+          {{ t('components.battle.Trainer.zoneKingChallenge', { label: kingLabel }) }}
         </div>
       </template>
       <DialogBox

--- a/src/components/egg/HatchModal.i18n.yml
+++ b/src/components/egg/HatchModal.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  message: Vous avez obtenu {name} !
+en:
+  message: You obtained {name}!

--- a/src/components/egg/HatchModal.vue
+++ b/src/components/egg/HatchModal.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 const modal = useEggHatchModalStore()
+const { t } = useI18n()
 </script>
 
 <template>
   <UiModal v-model="modal.isVisible" footer-close>
     <div class="flex flex-col items-center gap-2">
       <h3 class="text-center text-lg font-bold">
-        Vous avez obtenu {{ modal.mon?.base.name }} !
+        {{ t('components.egg.HatchModal.message', { name: modal.mon?.base.name }) }}
       </h3>
       <div
         class="h-24 w-24"


### PR DESCRIPTION
## Summary
- move hard-coded French UI strings to component translation files
- reference translations in HatchModal, Arena Panel, CaptureMenu, Trainer battle view, and SettingsModal

## Testing
- `pnpm test:unit` *(fails: AssertionError in capture mechanic)*

------
https://chatgpt.com/codex/tasks/task_e_6888ee8445d4832ab58139fe0676e399