### PR TITLE
Add i18n support for panel grid and battle panels

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -35,6 +35,11 @@ components:
       title: Shlagemon
       home: Home
       dex: Shlagedex
+    GameGrid:
+      inventory: Inventory
+      achievements: Achievements
+      zones: Zones
+      dex: Shlagedex
   panel:
     Achievements:
       all: All
@@ -125,6 +130,16 @@ components:
       queen: queen
       king: king
       zoneKingChallenge: '{label} zone challenge'
+    CaptureLimitModal:
+      text: >-
+        To capture this level {level} Shlagemon, you need a badge. Visit the
+        village to challenge the arena and earn this right.
+    FightKingButton:
+      challenge: Challenge {label}
+    Round:
+      vs: VS
+    Shlagemon:
+      ownedTooltip: You already own this Shlagemon
   egg:
     BoxModal:
       title: Egg box

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -36,6 +36,11 @@ components:
       title: Shlagémon
       home: Accueil
       dex: Shlagédex
+    GameGrid:
+      inventory: Inventaire
+      achievements: Succès
+      zones: Zones
+      dex: Shlagédex
   panel:
     Achievements:
       all: Tous
@@ -127,6 +132,17 @@ components:
       queen: reine
       king: roi
       zoneKingChallenge: Défi du {label} de la zone
+    CaptureLimitModal:
+      text: >-
+        Pour pouvoir attraper ce Shlagémon de niveau {level}, il vous faut un
+        badge. Rendez-vous dans le village pour défier l'arène et remporter ce
+        droit.
+    FightKingButton:
+      challenge: Défier {label}
+    Round:
+      vs: VS
+    Shlagemon:
+      ownedTooltip: Vous possédez déjà ce Shlagémon
   egg:
     BoxModal:
       title: Boîte à œufs

--- a/src/components/battle/CaptureLimitModal.i18n.yml
+++ b/src/components/battle/CaptureLimitModal.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  text: "Pour pouvoir attraper ce Shlagémon de niveau {level}, il vous faut un badge. Rendez-vous dans le village pour défier l'arène et remporter ce droit."
+en:
+  text: 'To capture this level {level} Shlagemon, you need a badge. Visit the village to challenge the arena and earn this right.'

--- a/src/components/battle/CaptureLimitModal.vue
+++ b/src/components/battle/CaptureLimitModal.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 const modal = useCaptureLimitModalStore()
+const { t } = useI18n()
 </script>
 
 <template>
   <UiModal v-model="modal.isVisible" footer-close>
     <div class="flex flex-col items-center gap-2">
       <p class="text-center text-sm">
-        Pour pouvoir attraper ce Shlagémon de niveau {{ modal.requiredLevel }}, il vous faut un badge.
-        Rendez-vous dans le village pour défier l'arène et remporter ce droit.
+        {{ t('components.battle.CaptureLimitModal.text', { level: modal.requiredLevel }) }}
       </p>
     </div>
   </UiModal>

--- a/src/components/battle/FightKingButton.i18n.yml
+++ b/src/components/battle/FightKingButton.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  challenge: 'Défier {label}'
+en:
+  challenge: 'Challenge {label}'

--- a/src/components/battle/FightKingButton.vue
+++ b/src/components/battle/FightKingButton.vue
@@ -6,6 +6,7 @@ const trainerBattle = useTrainerBattleStore()
 const zone = useZoneStore()
 const progress = useZoneProgressStore()
 const dev = useDeveloperStore()
+const { t } = useI18n()
 
 const currentKing = computed(() => zone.getKing(zone.current.id as SavageZoneId))
 const kingLabel = computed(() =>
@@ -35,7 +36,7 @@ function fightKing() {
     type="danger"
     @click="fightKing"
   >
-    <div>Défier {{ kingLabel }}</div>
+    <div>{{ t('components.battle.FightKingButton.challenge', { label: kingLabel }) }}</div>
 
     <div class="i-mdi:sword" />
   </UiButton>

--- a/src/components/battle/Round.i18n.yml
+++ b/src/components/battle/Round.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  vs: VS
+en:
+  vs: VS

--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -23,6 +23,8 @@ const emit = defineEmits<{
   (e: 'capture'): void
 }>()
 
+const { t } = useI18n()
+
 const dex = useShlagedexStore()
 const disease = useDiseaseStore()
 const zone = useZoneStore()
@@ -215,7 +217,7 @@ function onClick(_e: MouseEvent) {
         </BattleShlagemon>
       </Transition>
       <div class="vs font-bold">
-        VS
+        {{ t('components.battle.Round.vs') }}
       </div>
       <div
         class="relative h-full w-full flex-1"

--- a/src/components/battle/Shlagemon.i18n.yml
+++ b/src/components/battle/Shlagemon.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  ownedTooltip: Vous possédez déjà ce Shlagémon
+en:
+  ownedTooltip: You already own this Shlagemon

--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -4,6 +4,23 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import DiseaseBadge from './DiseaseBadge.vue'
 import EffectBadge from './EffectBadge.vue'
 
+const props = withDefaults(defineProps<Props>(), {
+  color: undefined,
+  flipped: false,
+  fainted: false,
+  flash: false,
+  levelPosition: 'bottom',
+  showBall: false,
+  owned: false,
+  effects: () => [],
+  disease: false,
+  diseaseRemaining: 0,
+})
+
+const emit = defineEmits<{ (e: 'faintEnd'): void }>()
+
+const { t } = useI18n()
+
 interface Props {
   mon: DexShlagemon
   hp: number
@@ -19,20 +36,6 @@ interface Props {
   diseaseRemaining?: number
 }
 
-const props = withDefaults(defineProps<Props>(), {
-  color: undefined,
-  flipped: false,
-  fainted: false,
-  flash: false,
-  levelPosition: 'bottom',
-  showBall: false,
-  owned: false,
-  effects: () => [],
-  disease: false,
-  diseaseRemaining: 0,
-})
-
-const emit = defineEmits<{ (e: 'faintEnd'): void }>()
 const typeChart = useTypeChartModalStore()
 const dex = useShlagedexStore()
 
@@ -100,7 +103,7 @@ const maxHp = computed(() => dex.maxHp(props.mon))
       lvl {{ props.mon.lvl }}
     </div>
     <div class="mt-1 flex items-center gap-1">
-      <UiTooltip text="Vous possédez déjà ce Shlagémon">
+      <UiTooltip :text="t('components.battle.Shlagemon.ownedTooltip')">
         <img
           v-if="props.showBall && props.owned"
           src="/items/shlageball/shlageball.webp"

--- a/src/components/layout/GameGrid.i18n.yml
+++ b/src/components/layout/GameGrid.i18n.yml
@@ -1,0 +1,10 @@
+fr:
+  inventory: Inventaire
+  achievements: Succès
+  zones: Zones
+  dex: Shlagédex
+en:
+  inventory: Inventory
+  achievements: Achievements
+  zones: Zones
+  dex: Shlagedex

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -23,6 +23,8 @@ const {
 
 const { current: activeTab } = storeToRefs(mobileTab)
 
+const { t } = useI18n()
+
 const bottomComponent = computed(() => {
   switch (activeTab.value) {
     case 'achievements':
@@ -41,13 +43,13 @@ const bottomComponent = computed(() => {
 const bottomTitle = computed(() => {
   switch (activeTab.value) {
     case 'achievements':
-      return 'Succès'
+      return t('components.layout.GameGrid.achievements')
     case 'zones':
-      return 'Zones'
+      return t('components.layout.GameGrid.zones')
     case 'dex':
-      return 'Shlagédex'
+      return t('components.layout.GameGrid.dex')
     case 'inventory':
-      return 'Inventaire'
+      return t('components.layout.GameGrid.inventory')
     default:
       return ''
   }
@@ -76,14 +78,14 @@ const bottomLocked = computed(() => {
       md="flex-row justify-between"
     >
       <div v-if="!isMobile && (displayInventory || displayAchievements || displayDex)" class="panel-group flex-1 overflow-hidden" md="max-w-80 basis-1/4">
-        <UiPanelWrapper v-if="displayInventory" title="Inventaire" class="overflow-hidden" :is-locked="lockStore.isInventoryLocked">
+        <UiPanelWrapper v-if="displayInventory" :title="t('components.layout.GameGrid.inventory')" class="overflow-hidden" :is-locked="lockStore.isInventoryLocked">
           <template #icon>
             <div class="i-carbon-inventory-management" />
           </template>
           <PanelInventory />
         </UiPanelWrapper>
 
-        <UiPanelWrapper v-if="displayAchievements" title="Succès" class="overflow-hidden" :is-locked="lockStore.areAchievementsLocked">
+        <UiPanelWrapper v-if="displayAchievements" :title="t('components.layout.GameGrid.achievements')" class="overflow-hidden" :is-locked="lockStore.areAchievementsLocked">
           <template #icon>
             <div class="i-carbon-trophy" />
           </template>
@@ -100,7 +102,7 @@ const bottomLocked = computed(() => {
           <PanelMain class="flex-1" />
         </UiPanelWrapper>
 
-        <UiPanelWrapper v-if="displayZonePanel" title="Zones" class="overflow-hidden" is-mobile-hidable :is-locked="lockStore.areZonesLocked">
+        <UiPanelWrapper v-if="displayZonePanel" :title="t('components.layout.GameGrid.zones')" class="overflow-hidden" is-mobile-hidable :is-locked="lockStore.areZonesLocked">
           <template #icon>
             <div class="i-carbon-map" />
           </template>
@@ -109,7 +111,7 @@ const bottomLocked = computed(() => {
       </div>
 
       <div v-if="!isMobile && displayDex" class="panel-group flex-1 overflow-hidden" md="max-w-80 basis-1/4 flex-1 max-h-none">
-        <UiPanelWrapper title="Shlagédex" class="overflow-hidden" is-mobile-hidable :is-locked="lockStore.isShlagedexLocked">
+        <UiPanelWrapper :title="t('components.layout.GameGrid.dex')" class="overflow-hidden" is-mobile-hidable :is-locked="lockStore.isShlagedexLocked">
           <template #icon>
             <IconShlagedex class="h-4 w-4" />
           </template>


### PR DESCRIPTION
## Summary
- translate all panel names in `GameGrid` using new i18n file
- internationalize various battle panels
- regenerate locale files
- update tests to run once

## Testing
- `pnpm i18n`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6888fb5fabbc832a8b17173a9acbd120