### PR TITLE
Improve SaveTab UI

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -169,6 +169,7 @@ components:
       loaded: Save loaded
       copied: Copied
       generate: Generate
+      loadFile: Load from file
   shlagemon:
     Detail:
       equipItemTitle: Equip an item

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -171,6 +171,7 @@ components:
       loaded: Sauvegarde chargée
       copied: Copié
       generate: Générer
+      loadFile: Charger depuis un fichier
   shlagemon:
     Detail:
       equipItemTitle: Équiper un objet

--- a/src/components/settings/SaveTab.i18n.yml
+++ b/src/components/settings/SaveTab.i18n.yml
@@ -9,6 +9,7 @@ fr:
   invalid: Code invalide
   loaded: Sauvegarde chargée
   copied: Copié
+  loadFile: Charger depuis un fichier
 en:
   exportLabel: Save code
   generate: Generate
@@ -20,3 +21,4 @@ en:
   invalid: Invalid code
   loaded: Save loaded
   copied: Copied
+  loadFile: Load from file

--- a/src/components/settings/SaveTab.vue
+++ b/src/components/settings/SaveTab.vue
@@ -6,6 +6,9 @@ const emit = defineEmits<{ (e: 'remove'): void }>()
 const { t } = useI18n()
 const exportCode = ref('')
 const importCode = ref('')
+const showImport = ref(false)
+const copied = ref(false)
+const fileInput = ref<HTMLInputElement>()
 
 function generateExport() {
   exportCode.value = exportSave(collectSave())
@@ -15,7 +18,11 @@ function copyExport() {
   if (!exportCode.value)
     generateExport()
   navigator.clipboard.writeText(exportCode.value)
+  copied.value = true
   toast.success(t('components.settings.SaveTab.copied'))
+  setTimeout(() => {
+    copied.value = false
+  }, 1500)
 }
 
 function downloadExport() {
@@ -40,51 +47,100 @@ function loadImport() {
   toast.success(t('components.settings.SaveTab.loaded'))
   window.location.reload()
 }
+
+function triggerFileInput() {
+  fileInput.value?.click()
+}
+
+function loadFromFile(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file)
+    return
+  file.text().then((text) => {
+    importCode.value = text.trim()
+    showImport.value = true
+  })
+}
 </script>
 
 <template>
   <div class="flex flex-col gap-6">
-    <section class="flex flex-col gap-2">
-      <label class="font-bold">
+    <section class="flex flex-col items-center gap-2">
+      <label v-if="exportCode" class="font-bold">
         {{ t('components.settings.SaveTab.exportLabel') }}
       </label>
       <textarea
+        v-if="exportCode"
         :value="exportCode"
         readonly
         rows="4"
         class="w-full border border-gray-300 rounded bg-gray-100 p-2 text-xs font-mono dark:border-gray-700 dark:bg-gray-900"
         @focus="($event.target as HTMLTextAreaElement).select()"
       />
-      <div class="flex gap-2">
-        <UiButton class="flex-1" @click="generateExport">
+      <div v-if="exportCode" class="w-full flex gap-2">
+        <UiButton class="flex flex-1 items-center justify-center gap-1" @click="generateExport">
+          <div i-carbon-refresh />
           {{ t('components.settings.SaveTab.generate') }}
         </UiButton>
-        <UiButton class="flex-1" :disabled="!exportCode" @click="copyExport">
-          {{ t('components.settings.SaveTab.copy') }}
+        <UiButton class="flex flex-1 items-center justify-center gap-1" @click="copyExport">
+          <div :class="copied ? 'i-carbon-checkmark' : 'i-carbon-copy'" />
+          {{ copied ? t('components.settings.SaveTab.copied') : t('components.settings.SaveTab.copy') }}
         </UiButton>
-        <UiButton class="flex-1" :disabled="!exportCode" @click="downloadExport">
+        <UiButton class="flex flex-1 items-center justify-center gap-1" @click="downloadExport">
+          <div i-carbon-download />
           {{ t('components.settings.SaveTab.download') }}
         </UiButton>
       </div>
+      <UiButton
+        v-else
+        class="mx-auto flex items-center gap-1"
+        @click="generateExport"
+      >
+        <div i-carbon-play />
+        {{ t('components.settings.SaveTab.generate') }}
+      </UiButton>
     </section>
 
-    <section class="flex flex-col gap-2">
-      <label class="font-bold">
+    <section class="flex flex-col items-center gap-2">
+      <label v-if="showImport" class="font-bold">
         {{ t('components.settings.SaveTab.importLabel') }}
       </label>
       <textarea
+        v-if="showImport"
         v-model="importCode"
         rows="4"
         class="w-full border border-gray-300 rounded bg-white p-2 text-xs font-mono dark:border-gray-700 dark:bg-gray-800"
       />
-      <div class="flex gap-2">
-        <UiButton class="flex-1" @click="loadImport">
+      <div v-if="showImport" class="w-full flex gap-2">
+        <UiButton class="flex flex-1 items-center justify-center gap-1" @click="loadImport">
+          <div i-carbon-upload />
           {{ t('components.settings.SaveTab.load') }}
         </UiButton>
-        <UiButton type="danger" class="flex-1" @click="emit('remove')">
+        <UiButton type="default" class="flex flex-1 items-center justify-center gap-1" @click="triggerFileInput">
+          <div i-carbon-folder-open />
+          {{ t('components.settings.SaveTab.loadFile') }}
+        </UiButton>
+        <UiButton type="danger" class="flex flex-1 items-center justify-center gap-1" @click="emit('remove')">
+          <div i-carbon-trash-can />
           {{ t('components.settings.SaveTab.remove') }}
         </UiButton>
       </div>
+      <UiButton
+        v-else
+        class="mx-auto flex items-center gap-1"
+        @click="showImport = true"
+      >
+        <div i-carbon-upload />
+        {{ t('components.settings.SaveTab.load') }}
+      </UiButton>
+      <input
+        ref="fileInput"
+        type="file"
+        accept=".txt"
+        class="hidden"
+        :aria-label="t('components.settings.SaveTab.loadFile')"
+        @change="loadFromFile"
+      >
     </section>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- enhance SaveTab generation and import UX
- support file import
- update translations for new label

## Testing
- `pnpm exec vitest run` *(fails: test/capture.test.ts > level 33 halves capture chance)*

------
https://chatgpt.com/codex/tasks/task_e_6888fcc0fe1c832a8a7f014ecb45270f