### PR TITLE
refactor: externalize French strings

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -125,6 +125,7 @@ components:
       queen: queen
       king: king
       zoneKingChallenge: '{label} zone challenge'
+      reward: +{amount} Shlagidiamonds
   egg:
     BoxModal:
       title: Egg box
@@ -181,9 +182,25 @@ components:
       confirmText: Be careful, if you release it, it will shlage the whole land.
       yes: Yes
       no: No
+      hp: HP
+      attack: Attack
+      defense: Defense
+      smell: Smell
+      evolveByLevel: Can evolve at level {level}
+      evolveByItem: Can evolve with item {item}
+      rarityInfo: The rarer a Shlagemon is, the higher its potential power.
+      sick: sick
     WearableEquipModal:
       title: Choose an item to equip
       noAvailable: No item available.
+    EvolutionModal:
+      evolveTitle: '{name} is evolving'
+      question: >-
+        "{from}" wants to evolve into "{to}", will you allow it or stop the
+        spread of shlaguitude?
+      alreadyOwned: You already own this evolution
+      yes: Yes
+      no: No
   LanguageSelector:
     label: Language
     en: English
@@ -593,6 +610,11 @@ components:
       fight: Fight
       autoSelect: Automatic team selection
       choose: Choose a Shlagemon against {name}
+    EnemyStats:
+      hp: HP
+      attack: Attack
+      defense: Defense
+      smell: Smell
   audio:
     SettingsModal:
       title: Audio settings
@@ -602,6 +624,21 @@ components:
       sfxLabel: Sound effects
       sfxDisabledInfo: Warning, some audio feedback will be missing.
       sfxDisabledNote: (Especially shiny sounds, it'd be a shame to miss one!)
+  ball:
+    SelectionModal:
+      title: Shlageball selection
+      info: The Super and Hyper Shlageballs improve your capture odds (x1.5 and x2).
+  village:
+    ZoneActions:
+      shop: Shop
+      minigame: Minigame
+      arena: Arena
+      henhouse: Henhouse
+      fightKing: Challenge the {label} of the zone
+      kingDefeated: '{label} defeated!'
+  zone:
+    MonsModal:
+      title: '{zone} Shlagemons'
 data:
   shlagemons:
     01-05:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -127,6 +127,7 @@ components:
       queen: reine
       king: roi
       zoneKingChallenge: Défi du {label} de la zone
+      reward: +{amount} Shlagédiamonds
   egg:
     BoxModal:
       title: Boîte à œufs
@@ -183,9 +184,25 @@ components:
       confirmText: Attention, si vous le relâchez, il ira shlagiser tout le territoire.
       yes: Oui
       no: Non
+      hp: PV
+      attack: Attaque
+      defense: Défense
+      smell: Puanteur
+      evolveByLevel: Peut évoluer au niveau {level}
+      evolveByItem: Peut évoluer grâce à l'objet {item}
+      rarityInfo: Plus un Pokémon est rare, plus son potentiel de puissance est élevé.
+      sick: malade
     WearableEquipModal:
       title: Choisir un objet à équiper
       noAvailable: Aucun objet disponible.
+    EvolutionModal:
+      evolveTitle: '{name} évolue'
+      question: >-
+        « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou
+        l'empêcher de répandre sa shlaguitude ?
+      alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
+      yes: Oui
+      no: Non
   LanguageSelector:
     label: Langue
     en: Anglais
@@ -618,6 +635,11 @@ components:
       fight: Combattre
       autoSelect: Sélection automatique de l'équipe
       choose: Choisir un Shlagémon contre {name}
+    EnemyStats:
+      hp: PV
+      attack: Attaque
+      defense: Défense
+      smell: Puanteur
   audio:
     SettingsModal:
       title: Paramètres audio
@@ -629,6 +651,23 @@ components:
       sfxDisabledNote: >-
         (Notamment les sons liés au Shiny, ça serait dommage d'en rater un, sale
         connasse !)
+  ball:
+    SelectionModal:
+      title: Choix de la Shlagéball
+      info: >-
+        La Super et l'Hyper Shlagéball améliorent vos chances de capture (x1.5
+        et x2).
+  village:
+    ZoneActions:
+      shop: Magasin
+      minigame: Mini-jeu
+      arena: Arène
+      henhouse: Poulailler
+      fightKing: Défier la {label} de la zone
+      kingDefeated: '{label} vaincu{suffix} !'
+  zone:
+    MonsModal:
+      title: Shlagémons de {zone}
 data:
   shlagemons:
     01-05:

--- a/src/components/arena/EnemyStats.i18n.yml
+++ b/src/components/arena/EnemyStats.i18n.yml
@@ -1,0 +1,10 @@
+fr:
+  hp: PV
+  attack: Attaque
+  defense: Défense
+  smell: Puanteur
+en:
+  hp: HP
+  attack: Attack
+  defense: Defense
+  smell: Smell

--- a/src/components/arena/EnemyStats.vue
+++ b/src/components/arena/EnemyStats.vue
@@ -2,12 +2,13 @@
 import type { DexShlagemon } from '~/type/shlagemon'
 
 const props = defineProps<{ mon: DexShlagemon }>()
+const { t } = useI18n()
 
 const stats = computed(() => [
-  { label: 'HP', value: props.mon.hp },
-  { label: 'Attaque', value: props.mon.attack },
-  { label: 'Défense', value: props.mon.defense },
-  { label: 'Puanteur', value: props.mon.smelling },
+  { label: t('components.arena.EnemyStats.hp'), value: props.mon.hp },
+  { label: t('components.arena.EnemyStats.attack'), value: props.mon.attack },
+  { label: t('components.arena.EnemyStats.defense'), value: props.mon.defense },
+  { label: t('components.arena.EnemyStats.smell'), value: props.mon.smelling },
 ])
 </script>
 
@@ -20,7 +21,12 @@ const stats = computed(() => [
       <ShlagemonImage :id="props.mon.base.id" :alt="props.mon.base.name" class="object-contain" />
     </div>
     <div class="flex gap-1">
-      <ShlagemonType v-for="t in props.mon.base.types" :key="t.id" :value="t" open-on-click />
+      <ShlagemonType
+        v-for="typeItem in props.mon.base.types"
+        :key="typeItem.id"
+        :value="typeItem"
+        open-on-click
+      />
     </div>
     <ShlagemonStats :stats="stats" />
   </div>

--- a/src/components/ball/SelectionModal.i18n.yml
+++ b/src/components/ball/SelectionModal.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  title: Choix de la Shlagéball
+  info: La Super et l'Hyper Shlagéball améliorent vos chances de capture (x1.5 et x2).
+en:
+  title: Shlageball selection
+  info: The Super and Hyper Shlageballs improve your capture odds (x1.5 and x2).

--- a/src/components/ball/SelectionModal.vue
+++ b/src/components/ball/SelectionModal.vue
@@ -5,6 +5,7 @@ import { ballHues } from '~/utils/ball'
 
 const inventory = useInventoryStore()
 const ballStore = useBallStore()
+const { t } = useI18n()
 
 const options = computed(() =>
   balls.map(b => ({ ...b, qty: inventory.items[b.id] || 0 })),
@@ -19,11 +20,10 @@ function choose(id: BallId) {
   <UiModal v-model="ballStore.isVisible" footer-close>
     <div class="flex flex-col items-center gap-2">
       <h3 class="text-lg font-bold">
-        Choix de la Shlagéball
+        {{ t('components.ball.SelectionModal.title') }}
       </h3>
       <p class="text-center text-sm">
-        La Super et l'Hyper Shlagéball améliorent vos chances de capture
-        (x1.5 et x2).
+        {{ t('components.ball.SelectionModal.info') }}
       </p>
       <UiButton
         v-for="ball in options"

--- a/src/components/battle/Trainer.i18n.yml
+++ b/src/components/battle/Trainer.i18n.yml
@@ -6,6 +6,7 @@ fr:
   queen: reine
   king: roi
   zoneKingChallenge: 'Défi du {label} de la zone'
+  reward: '+{amount} Shlagédiamonds'
 en:
   startBattle: Start battle
   quit: Surrender
@@ -14,3 +15,4 @@ en:
   queen: queen
   king: king
   zoneKingChallenge: '{label} zone challenge'
+  reward: '+{amount} Shlagidiamonds'

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -63,7 +63,7 @@ const afterDialogTree = computed<DialogNode[]>(() => {
       },
       {
         id: 'reward',
-        text: `+${trainer.value.reward} Shlag\u00E9diamonds`,
+        text: t('components.battle.Trainer.reward', { amount: trainer.value.reward }),
         responses: [
           { label: t('components.battle.Trainer.continue'), type: 'valid', action: finish },
         ],

--- a/src/components/shlagemon/Detail.i18n.yml
+++ b/src/components/shlagemon/Detail.i18n.yml
@@ -9,6 +9,14 @@ fr:
   confirmText: Attention, si vous le relâchez, il ira shlagiser tout le territoire.
   yes: Oui
   no: Non
+  hp: PV
+  attack: Attaque
+  defense: Défense
+  smell: Puanteur
+  evolveByLevel: 'Peut évoluer au niveau {level}'
+  evolveByItem: "Peut évoluer grâce à l'objet {item}"
+  rarityInfo: Plus un Pokémon est rare, plus son potentiel de puissance est élevé.
+  sick: malade
 en:
   equipItemTitle: Equip an item
   allowEvolution: Allow this Shlagemon to evolve?
@@ -20,3 +28,11 @@ en:
   confirmText: Be careful, if you release it, it will shlage the whole land.
   yes: Yes
   no: No
+  hp: HP
+  attack: Attack
+  defense: Defense
+  smell: Smell
+  evolveByLevel: 'Can evolve at level {level}'
+  evolveByItem: 'Can evolve with item {item}'
+  rarityInfo: The rarer a Shlagemon is, the higher its potential power.
+  sick: sick

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -11,14 +11,15 @@ const emit = defineEmits<{
   (e: 'active'): void
 }>()
 
+const { t } = useI18n()
 const stats = computed(() => {
   if (!props.mon)
     return []
   return [
-    { label: 'HP', value: props.mon.hp },
-    { label: 'Attaque', value: props.mon.attack },
-    { label: 'Défense', value: props.mon.defense },
-    { label: 'Puanteur', value: props.mon.smelling },
+    { label: t('components.shlagemon.Detail.hp'), value: props.mon.hp },
+    { label: t('components.shlagemon.Detail.attack'), value: props.mon.attack },
+    { label: t('components.shlagemon.Detail.defense'), value: props.mon.defense },
+    { label: t('components.shlagemon.Detail.smell'), value: props.mon.smelling },
   ]
 })
 
@@ -36,7 +37,6 @@ const wearableItemStore = useWearableItemStore()
 const equipModal = useWearableEquipModalStore()
 const disease = useDiseaseStore()
 const detailModal = useDexDetailModalStore()
-const { t } = useI18n()
 const showConfirm = ref(false)
 
 const heldItem = computed(() => {
@@ -56,9 +56,9 @@ const evolutionInfo = computed(() => {
     return null
   const { condition } = props.mon.base.evolution
   if (condition.type === 'lvl')
-    return `Peut évoluer au niveau ${condition.value}`
+    return t('components.shlagemon.Detail.evolveByLevel', { level: condition.value })
   if (condition.type === 'item')
-    return `Peut évoluer grâce à l'objet ${condition.value.name}`
+    return t('components.shlagemon.Detail.evolveByItem', { item: condition.value.name })
   return null
 })
 
@@ -116,9 +116,9 @@ const captureInfo = computed(() => {
       <h2 class="flex items-center justify-between text-lg font-bold">
         <div class="flex items-center gap-1">
           <span :class="mon.isShiny ? 'shiny-text' : ''">{{ mon.base.name }}</span>
-          - lvl {{ mon.lvl }}<span v-if="isActiveAndSick"> (malade)</span>
+          - lvl {{ mon.lvl }}<span v-if="isActiveAndSick"> ({{ t('components.shlagemon.Detail.sick') }})</span>
         </div>
-        <UiTooltip text="Plus un Pokémon est rare, plus son potentiel de puissance est élevé.">
+        <UiTooltip :text="t('components.shlagemon.Detail.rarityInfo')">
           <ShlagemonRarity :rarity="mon.rarity" class="rounded-tr-0" />
         </UiTooltip>
       </h2>

--- a/src/components/shlagemon/EvolutionModal.i18n.yml
+++ b/src/components/shlagemon/EvolutionModal.i18n.yml
@@ -1,0 +1,12 @@
+fr:
+  evolveTitle: '{name} évolue'
+  question: "« {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou l'empêcher de répandre sa shlaguitude ?"
+  alreadyOwned: "Vous possédez déjà l'évolution de ce Shlagémon"
+  yes: Oui
+  no: Non
+en:
+  evolveTitle: '{name} is evolving'
+  question: '"{from}" wants to evolve into "{to}", will you allow it or stop the spread of shlaguitude?'
+  alreadyOwned: You already own this evolution
+  yes: Yes
+  no: No

--- a/src/components/shlagemon/EvolutionModal.vue
+++ b/src/components/shlagemon/EvolutionModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 const store = useEvolutionStore()
 const dex = useShlagedexStore()
+const { t } = useI18n()
 
 const hasEvolution = computed(() => {
   if (!store.pending)
@@ -20,25 +21,25 @@ const hasEvolution = computed(() => {
   >
     <div class="flex flex-col items-center gap-4">
       <h3 class="text-center text-lg font-bold">
-        {{ store.pending?.mon.base.name }} évolue
+        {{ t('components.shlagemon.EvolutionModal.evolveTitle', { name: store.pending?.mon.base.name }) }}
       </h3>
       <p class="text-center">
-        « {{ store.pending?.mon.base.name }} » veut évoluer en « {{ store.pending?.to.name }} », voulez-vous le laisser faire ou l'empêcher de répandre sa shlaguitude ?
+        {{ t('components.shlagemon.EvolutionModal.question', { from: store.pending?.mon.base.name, to: store.pending?.to.name }) }}
       </p>
       <p
         v-if="hasEvolution"
         class="text-center text-xs text-red-500 dark:text-red-400"
       >
-        Vous possédez déjà l'évolution de ce Shlagémon
+        {{ t('components.shlagemon.EvolutionModal.alreadyOwned') }}
       </p>
       <div class="flex gap-2">
         <UiButton type="valid" class="flex items-center gap-1" @click="store.accept">
           <div i-carbon-checkmark />
-          Oui
+          {{ t('components.shlagemon.EvolutionModal.yes') }}
         </UiButton>
         <UiButton type="danger" class="flex items-center gap-1" @click="store.reject">
           <div i-carbon-close />
-          Non
+          {{ t('components.shlagemon.EvolutionModal.no') }}
         </UiButton>
       </div>
     </div>

--- a/src/components/ui/CurrencyAmount.vue
+++ b/src/components/ui/CurrencyAmount.vue
@@ -8,8 +8,9 @@ const props = defineProps<{
   currency: 'shlagidolar' | 'shlagidiamond'
 }>()
 
+const { t } = useI18n()
 const currencyName = computed(() => {
-  const base = props.currency === 'shlagidiamond' ? 'Shlagédiamant' : 'Shlagédollar'
+  const base = t(`components.ui.CurrencyAmount.${props.currency}`)
   return props.amount > 1 ? `${base}s` : base
 })
 const icon = computed(() => props.currency === 'shlagidiamond' ? IconShlagidiamond : IconShlagidolar,

--- a/src/components/village/ZoneActions.i18n.yml
+++ b/src/components/village/ZoneActions.i18n.yml
@@ -1,0 +1,14 @@
+fr:
+  shop: Magasin
+  minigame: Mini-jeu
+  arena: Arène
+  henhouse: Poulailler
+  fightKing: 'Défier la {label} de la zone'
+  kingDefeated: '{label} vaincu{suffix} !'
+en:
+  shop: Shop
+  minigame: Minigame
+  arena: Arena
+  henhouse: Henhouse
+  fightKing: 'Challenge the {label} of the zone'
+  kingDefeated: '{label} defeated!'

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -9,6 +9,7 @@ const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
 const arena = useArenaStore()
 const dialog = useDialogStore()
+const { t } = useI18n()
 
 const hasKing = computed(() =>
   zone.current.hasKing ?? zone.current.type === 'sauvage',
@@ -87,7 +88,7 @@ function openPoulailler() {
     <UiNavigationButton
       v-if="zone.current.village?.shop"
       icon="i-carbon:shopping-bag"
-      label="Magasin"
+      :label="t('components.village.ZoneActions.shop')"
       class="bg-green-600 text-white dark:bg-green-700"
       hover="bg-green-700 dark:bg-green-800"
       :disabled="arena.inBattle"
@@ -106,7 +107,7 @@ function openPoulailler() {
     <UiNavigationButton
       v-if="zone.current.miniGame && !zone.current.actions.some(a => a.id === 'minigame')"
       icon="i-carbon:game-console"
-      label="Mini-jeu"
+      :label="t('components.village.ZoneActions.minigame')"
       class="bg-violet-600 text-white dark:bg-violet-700"
       hover="bg-violet-700 dark:bg-violet-800"
       :disabled="arena.inBattle"
@@ -115,7 +116,7 @@ function openPoulailler() {
     <UiNavigationButton
       v-if="hasArena && !arenaCompleted"
       icon="i-mdi:sword-cross"
-      label="Arène"
+      :label="t('components.village.ZoneActions.arena')"
       class="bg-red-600 text-white dark:bg-red-700"
       hover="bg-red-700 dark:bg-red-800"
       :disabled="arena.inBattle"
@@ -124,14 +125,14 @@ function openPoulailler() {
     <UiNavigationButton
       v-if="hasPoulailler"
       icon="i-game-icons:bird-house"
-      label="Poulailler"
+      :label="t('components.village.ZoneActions.henhouse')"
       :disabled="arena.inBattle"
       @click="openPoulailler"
     />
     <UiNavigationButton
       v-if="hasKing && !progress.isKingDefeated(zone.current.id) && progress.canFightKing(zone.current.id)"
       icon="i-game-icons:crown"
-      :label="`Défier la ${kingLabel} de la zone`"
+      :label="t('components.village.ZoneActions.fightKing', { label: kingLabel })"
       :disabled="arena.inBattle"
       @click="fightKing"
     />
@@ -139,8 +140,7 @@ function openPoulailler() {
       v-else-if="hasKing && progress.isKingDefeated(zone.current.id)"
       class="flex-center text-xs font-bold"
     >
-      {{ kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1) }}
-      vaincu{{ kingLabel === 'reine' ? 'e' : '' }} !
+      {{ t('components.village.ZoneActions.kingDefeated', { label: kingLabel.charAt(0).toUpperCase() + kingLabel.slice(1), suffix: kingLabel === 'reine' ? 'e' : '' }) }}
     </div>
   </div>
 </template>

--- a/src/components/zone/MonsModal.i18n.yml
+++ b/src/components/zone/MonsModal.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  title: 'Shlagémons de {zone}'
+en:
+  title: '{zone} Shlagemons'

--- a/src/components/zone/MonsModal.vue
+++ b/src/components/zone/MonsModal.vue
@@ -2,6 +2,7 @@
 const modal = useZoneMonsModalStore()
 const zone = useZoneStore()
 const dex = useShlagedexStore()
+const { t } = useI18n()
 
 const mons = computed(() => zone.current.shlagemons || [])
 function owned(id: string) {
@@ -11,7 +12,7 @@ function owned(id: string) {
 
 <template>
   <UiModal v-model="modal.isVisible" footer-close>
-    <UiPanelWrapper :title="`Shlagémons de ${zone.current.name}`" is-inline>
+    <UiPanelWrapper :title="t('components.zone.MonsModal.title', { zone: zone.current.name })" is-inline>
       <template #icon>
         <img src="/items/shlageball/shlageball.webp" alt="ball" class="h-4 w-4">
       </template>


### PR DESCRIPTION
## Summary
- move French UI text to translation files for evolution modal, zone actions, enemy stats and more
- use `useI18n()` in components and replace hardcoded strings with `t()`
- regenerate locale files

## Testing
- `pnpm lint`
- `pnpm test -- --run` *(fails: capture mechanics test assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6888fe7485cc832a984216956f19769a