### PR TITLE
Fix mobile view for shortcuts tab

### DIFF
--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import LanguageTab from './LanguageTab.vue'
 import SaveTab from './SaveTab.vue'
 import SettingsShortcutsTab from './ShortcutsTab.vue'
@@ -17,24 +18,37 @@ function removeSave() {
   close()
 }
 
-const tabs = [
-  {
-    label: { text: 'Sauvegarde', icon: 'i-carbon-save' },
-    component: defineComponent({
-      name: 'SettingsSaveTabWrapper',
-      setup() {
-        return () => h(SaveTab, { onRemove: removeSave })
-      },
-    }),
-  },
-  {
-    label: { text: 'Raccourcis', icon: 'i-carbon-keyboard' },
-    component: SettingsShortcutsTab,
-  },
-  { label: { text: 'Langue', icon: 'i-carbon-language' }, component: LanguageTab },
-] as const
+const { isMobile } = storeToRefs(useUIStore())
+
+const tabs = computed(() => {
+  const arr = [
+    {
+      label: { text: 'Sauvegarde', icon: 'i-carbon-save' },
+      component: defineComponent({
+        name: 'SettingsSaveTabWrapper',
+        setup() {
+          return () => h(SaveTab, { onRemove: removeSave })
+        },
+      }),
+    },
+    { label: { text: 'Langue', icon: 'i-carbon-language' }, component: LanguageTab },
+  ]
+
+  if (!isMobile.value) {
+    arr.splice(1, 0, {
+      label: { text: 'Raccourcis', icon: 'i-carbon-keyboard' },
+      component: SettingsShortcutsTab,
+    })
+  }
+
+  return arr
+})
 
 const activeTab = ref(0)
+watch(tabs, (val) => {
+  if (activeTab.value >= val.length)
+    activeTab.value = val.length - 1
+})
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- hide shortcuts tab in settings modal on mobile screens

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test failed message due to watcher exit but all tests passed)*
- `pnpm typecheck` *(fails: type errors)

------
https://chatgpt.com/codex/tasks/task_e_6888ffb61c64832ab0d2a6cca27c8288