### PR TITLE
Refactor data i18n keys

### DIFF
--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -91,7 +91,7 @@ function remaining(egg: { hatchesAt: number }) {
                 :class="[entry.item.icon, entry.item.iconClass]"
               />
               <span class="truncate text-sm font-medium">
-                {{ t(entry.item.nameKey || entry.item.name) }}
+                {{ t(entry.item.name) }}
               </span>
             </div>
 

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -26,12 +26,9 @@ export { hyperShlageball, shlageball, superShlageball } from './items/shlageball
 // @unocss-include
 export const defensePotion: Item = {
   id: 'defense-potion',
-  nameKey: 'data.items.defensePotion.name',
-  name: 'Potion de Défense',
-  descriptionKey: 'data.items.defensePotion.description',
-  description: 'Augmente temporairement la défense.',
-  detailsKey: 'data.items.defensePotion.details',
-  details: 'Renforce brièvement la défense de votre Shlagémon actif.',
+  name: 'data.items.defensePotion.name',
+  description: 'data.items.defensePotion.description',
+  details: 'data.items.defensePotion.details',
   type: 'defense',
   power: 10,
   price: 50,
@@ -43,12 +40,9 @@ export const defensePotion: Item = {
 
 export const superDefensePotion: Item = {
   id: 'super-defense-potion',
-  nameKey: 'data.items.superDefensePotion.name',
-  name: 'Super Potion de Défense',
-  descriptionKey: 'data.items.superDefensePotion.description',
-  description: 'Augmente beaucoup la défense.',
-  detailsKey: 'data.items.superDefensePotion.details',
-  details: 'Renforce considérablement la défense de votre Shlagémon actif.',
+  name: 'data.items.superDefensePotion.name',
+  description: 'data.items.superDefensePotion.description',
+  details: 'data.items.superDefensePotion.details',
   type: 'defense',
   power: 25,
   price: 500,
@@ -60,12 +54,9 @@ export const superDefensePotion: Item = {
 
 export const hyperDefensePotion: Item = {
   id: 'hyper-defense-potion',
-  nameKey: 'data.items.hyperDefensePotion.name',
-  name: 'Hyper Potion de Défense',
-  descriptionKey: 'data.items.hyperDefensePotion.description',
-  description: 'Maximise temporairement la défense.',
-  detailsKey: 'data.items.hyperDefensePotion.details',
-  details: 'Booste énormément la défense de votre Shlagémon actif.',
+  name: 'data.items.hyperDefensePotion.name',
+  description: 'data.items.hyperDefensePotion.description',
+  details: 'data.items.hyperDefensePotion.details',
   type: 'defense',
   power: 50,
   price: 55000,
@@ -77,12 +68,9 @@ export const hyperDefensePotion: Item = {
 
 export const attackPotion: Item = {
   id: 'attack-potion',
-  nameKey: 'data.items.attackPotion.name',
-  name: 'Potion d\'Attaque',
-  descriptionKey: 'data.items.attackPotion.description',
-  description: 'Augmente temporairement l\'attaque.',
-  detailsKey: 'data.items.attackPotion.details',
-  details: 'Renforce brièvement l\'attaque de votre Shlagémon actif.',
+  name: 'data.items.attackPotion.name',
+  description: 'data.items.attackPotion.description',
+  details: 'data.items.attackPotion.details',
   type: 'attack',
   power: 10,
   price: 60,
@@ -94,12 +82,9 @@ export const attackPotion: Item = {
 
 export const superAttackPotion: Item = {
   id: 'super-attack-potion',
-  nameKey: 'data.items.superAttackPotion.name',
-  name: 'Super Potion d\'Attaque',
-  descriptionKey: 'data.items.superAttackPotion.description',
-  description: 'Augmente beaucoup l\'attaque.',
-  detailsKey: 'data.items.superAttackPotion.details',
-  details: 'Renforce considérablement l\'attaque de votre Shlagémon actif.',
+  name: 'data.items.superAttackPotion.name',
+  description: 'data.items.superAttackPotion.description',
+  details: 'data.items.superAttackPotion.details',
   type: 'attack',
   power: 25,
   price: 600,
@@ -111,12 +96,9 @@ export const superAttackPotion: Item = {
 
 export const hyperAttackPotion: Item = {
   id: 'hyper-attack-potion',
-  nameKey: 'data.items.hyperAttackPotion.name',
-  name: 'Hyper Potion d\'Attaque',
-  descriptionKey: 'data.items.hyperAttackPotion.description',
-  description: 'Maximise temporairement l\'attaque.',
-  detailsKey: 'data.items.hyperAttackPotion.details',
-  details: 'Booste énormément l\'attaque de votre Shlagémon actif.',
+  name: 'data.items.hyperAttackPotion.name',
+  description: 'data.items.hyperAttackPotion.description',
+  details: 'data.items.hyperAttackPotion.details',
   type: 'attack',
   power: 50,
   price: 65000,
@@ -128,12 +110,9 @@ export const hyperAttackPotion: Item = {
 
 export const vitalityPotion: Item = {
   id: 'vitality-potion',
-  nameKey: 'data.items.vitalityPotion.name',
-  name: 'Potion de Vitalité',
-  descriptionKey: 'data.items.vitalityPotion.description',
-  description: 'Augmente temporairement les PV.',
-  detailsKey: 'data.items.vitalityPotion.details',
-  details: 'Augmente les PV de votre Shlagémon actif de 10% pendant quelques minutes.',
+  name: 'data.items.vitalityPotion.name',
+  description: 'data.items.vitalityPotion.description',
+  details: 'data.items.vitalityPotion.details',
   type: 'vitality',
   power: 10,
   price: 70,
@@ -145,12 +124,9 @@ export const vitalityPotion: Item = {
 
 export const superVitalityPotion: Item = {
   id: 'super-vitality-potion',
-  nameKey: 'data.items.superVitalityPotion.name',
-  name: 'Super Potion de Vitalité',
-  descriptionKey: 'data.items.superVitalityPotion.description',
-  description: 'Augmente beaucoup les PV.',
-  detailsKey: 'data.items.superVitalityPotion.details',
-  details: 'Augmente les PV de votre Shlagémon actif de 25% pendant quelques minutes.',
+  name: 'data.items.superVitalityPotion.name',
+  description: 'data.items.superVitalityPotion.description',
+  details: 'data.items.superVitalityPotion.details',
   type: 'vitality',
   power: 25,
   price: 700,
@@ -162,12 +138,9 @@ export const superVitalityPotion: Item = {
 
 export const hyperVitalityPotion: Item = {
   id: 'hyper-vitality-potion',
-  nameKey: 'data.items.hyperVitalityPotion.name',
-  name: 'Hyper Potion de Vitalité',
-  descriptionKey: 'data.items.hyperVitalityPotion.description',
-  description: 'Maximise temporairement les PV.',
-  detailsKey: 'data.items.hyperVitalityPotion.details',
-  details: 'Augmente les PV de votre Shlagémon actif de 50% pendant quelques minutes.',
+  name: 'data.items.hyperVitalityPotion.name',
+  description: 'data.items.hyperVitalityPotion.description',
+  details: 'data.items.hyperVitalityPotion.details',
   type: 'vitality',
   power: 50,
   price: 75000,
@@ -179,12 +152,9 @@ export const hyperVitalityPotion: Item = {
 
 export const xpPotion: Item = {
   id: 'xp-potion',
-  nameKey: 'data.items.xpPotion.name',
-  name: 'Potion d\'Expérience',
-  descriptionKey: 'data.items.xpPotion.description',
-  description: 'Augmente temporairement les gains d\'XP.',
-  detailsKey: 'data.items.xpPotion.details',
-  details: 'Améliore l\'XP gagnée de 10% pendant quelques minutes.',
+  name: 'data.items.xpPotion.name',
+  description: 'data.items.xpPotion.description',
+  details: 'data.items.xpPotion.details',
   type: 'xp',
   power: 10,
   price: 40,
@@ -196,12 +166,9 @@ export const xpPotion: Item = {
 
 export const superXpPotion: Item = {
   id: 'super-xp-potion',
-  nameKey: 'data.items.superXpPotion.name',
-  name: 'Super Potion d\'Expérience',
-  descriptionKey: 'data.items.superXpPotion.description',
-  description: 'Augmente beaucoup les gains d\'XP.',
-  detailsKey: 'data.items.superXpPotion.details',
-  details: 'Améliore l\'XP gagnée de 25% pendant quelques minutes.',
+  name: 'data.items.superXpPotion.name',
+  description: 'data.items.superXpPotion.description',
+  details: 'data.items.superXpPotion.details',
   type: 'xp',
   power: 25,
   price: 400,
@@ -213,12 +180,9 @@ export const superXpPotion: Item = {
 
 export const hyperXpPotion: Item = {
   id: 'hyper-xp-potion',
-  nameKey: 'data.items.hyperXpPotion.name',
-  name: 'Hyper Potion d\'Expérience',
-  descriptionKey: 'data.items.hyperXpPotion.description',
-  description: 'Maximise temporairement les gains d\'XP.',
-  detailsKey: 'data.items.hyperXpPotion.details',
-  details: 'Améliore l\'XP gagnée de 50% pendant quelques minutes.',
+  name: 'data.items.hyperXpPotion.name',
+  description: 'data.items.hyperXpPotion.description',
+  details: 'data.items.hyperXpPotion.details',
   type: 'xp',
   power: 50,
   price: 45000,
@@ -230,13 +194,9 @@ export const hyperXpPotion: Item = {
 
 export const odorElixir: Item = {
   id: 'elixir-odeur',
-  nameKey: 'data.items.odorElixir.name',
-  name: 'Élixir d\'Odeur',
-  descriptionKey: 'data.items.odorElixir.description',
-  description: 'Un parfum si rare qu\'il rend jaloux les collectionneurs.',
-  detailsKey: 'data.items.odorElixir.details',
-  details:
-    'À offrir à un Shlagémon adoré : sa rareté suivra désormais son niveau.',
+  name: 'data.items.odorElixir.name',
+  description: 'data.items.odorElixir.description',
+  details: 'data.items.odorElixir.details',
   category: 'actif',
   icon: 'i-game-icons:delicate-perfume',
   iconClass: 'text-yellow-500 dark:text-yellow-300',
@@ -244,12 +204,9 @@ export const odorElixir: Item = {
 
 export const capturePotion: Item = {
   id: 'capture-potion',
-  nameKey: 'data.items.capturePotion.name',
-  name: 'Potion de Capture',
-  descriptionKey: 'data.items.capturePotion.description',
-  description: 'Augmente légèrement les chances de capture.',
-  detailsKey: 'data.items.capturePotion.details',
-  details: 'Améliore la probabilité de capture de 10% pendant quelques minutes.',
+  name: 'data.items.capturePotion.name',
+  description: 'data.items.capturePotion.description',
+  details: 'data.items.capturePotion.details',
   type: 'capture',
   power: 10,
   price: 40,
@@ -261,12 +218,9 @@ export const capturePotion: Item = {
 
 export const superCapturePotion: Item = {
   id: 'super-capture-potion',
-  nameKey: 'data.items.superCapturePotion.name',
-  name: 'Super Potion de Capture',
-  descriptionKey: 'data.items.superCapturePotion.description',
-  description: 'Augmente beaucoup les chances de capture.',
-  detailsKey: 'data.items.superCapturePotion.details',
-  details: 'Améliore la probabilité de capture de 25% pendant quelques minutes.',
+  name: 'data.items.superCapturePotion.name',
+  description: 'data.items.superCapturePotion.description',
+  details: 'data.items.superCapturePotion.details',
   type: 'capture',
   power: 25,
   price: 400,
@@ -278,12 +232,9 @@ export const superCapturePotion: Item = {
 
 export const hyperCapturePotion: Item = {
   id: 'hyper-capture-potion',
-  nameKey: 'data.items.hyperCapturePotion.name',
-  name: 'Hyper Potion de Capture',
-  descriptionKey: 'data.items.hyperCapturePotion.description',
-  description: 'Maximise les chances de capture.',
-  detailsKey: 'data.items.hyperCapturePotion.details',
-  details: 'Améliore la probabilité de capture de 50% pendant quelques minutes.',
+  name: 'data.items.hyperCapturePotion.name',
+  description: 'data.items.hyperCapturePotion.description',
+  details: 'data.items.hyperCapturePotion.details',
   type: 'capture',
   power: 50,
   price: 45000,
@@ -295,12 +246,9 @@ export const hyperCapturePotion: Item = {
 
 export const potion: Item = {
   id: 'potion',
-  nameKey: 'data.items.potion.name',
-  name: 'Potion Dégueulasse',
-  descriptionKey: 'data.items.potion.description',
-  description: 'Soigne 50 HP de votre Shlagémon.',
-  detailsKey: 'data.items.potion.details',
-  details: 'Redonne 50 points de vie à votre Shlagémon actif pendant le combat.',
+  name: 'data.items.potion.name',
+  description: 'data.items.potion.description',
+  details: 'data.items.potion.details',
   type: 'heal',
   power: 50,
   price: 10,
@@ -312,12 +260,9 @@ export const potion: Item = {
 
 export const superPotion: Item = {
   id: 'super-potion',
-  nameKey: 'data.items.superPotion.name',
-  name: 'Super Potion',
-  descriptionKey: 'data.items.superPotion.description',
-  description: 'Soigne 100 HP de votre Shlagémon.',
-  detailsKey: 'data.items.superPotion.details',
-  details: 'Redonne 100 points de vie à votre Shlagémon actif pendant le combat.',
+  name: 'data.items.superPotion.name',
+  description: 'data.items.superPotion.description',
+  details: 'data.items.superPotion.details',
   type: 'heal',
   power: 100,
   price: 100,
@@ -329,12 +274,9 @@ export const superPotion: Item = {
 
 export const hyperPotion: Item = {
   id: 'hyper-potion',
-  nameKey: 'data.items.hyperPotion.name',
-  name: 'Hyper Potion',
-  descriptionKey: 'data.items.hyperPotion.description',
-  description: 'Soigne 200 HP de votre Shlagémon.',
-  detailsKey: 'data.items.hyperPotion.details',
-  details: 'Redonne 200 points de vie à votre Shlagémon actif pendant le combat.',
+  name: 'data.items.hyperPotion.name',
+  description: 'data.items.hyperPotion.description',
+  details: 'data.items.hyperPotion.details',
   type: 'heal',
   power: 200,
   price: 1000,
@@ -346,13 +288,9 @@ export const hyperPotion: Item = {
 
 export const multiExp: Item = {
   id: 'multi-exp',
-  nameKey: 'data.items.multiExp.name',
-  name: 'Multi-EXP',
-  descriptionKey: 'data.items.multiExp.description',
-  description: 'Partage l\'XP avec un Shlagémon.',
-  detailsKey: 'data.items.multiExp.details',
-  details:
-    'Permet de partager 50% de l\'XP gagnée en combat avec le Shlagémon porteur.',
+  name: 'data.items.multiExp.name',
+  description: 'data.items.multiExp.description',
+  details: 'data.items.multiExp.details',
   price: 20,
   currency: 'shlagidiamond',
   category: 'utilitaire',
@@ -364,12 +302,9 @@ export const multiExp: Item = {
 
 export const thunderStone: Item = {
   id: 'pierre-foutre',
-  nameKey: 'data.items.thunderStone.name',
-  name: 'Pierre Foutre',
-  descriptionKey: 'data.items.thunderStone.description',
-  description: 'Permet certaines évolutions de type électrique.',
-  detailsKey: 'data.items.thunderStone.details',
-  details: 'À des effets foutrement intéressants.',
+  name: 'data.items.thunderStone.name',
+  description: 'data.items.thunderStone.description',
+  details: 'data.items.thunderStone.details',
   price: 10,
   currency: 'shlagidiamond',
   category: 'actif',
@@ -379,12 +314,9 @@ export const thunderStone: Item = {
 
 export const steroids: Item = {
   id: 'steroides',
-  nameKey: 'data.items.steroids.name',
-  name: 'Stéroïdes',
-  descriptionKey: 'data.items.steroids.description',
-  description: 'Permet certaines évolutions de type "gros beauf bodybuildé toxique".',
-  detailsKey: 'data.items.steroids.details',
-  details: `Fait évoluer Macho en Masschopeur, à condition qu’il ait passé au moins 3h à la salle, sans jambes, évidemment.`,
+  name: 'data.items.steroids.name',
+  description: 'data.items.steroids.description',
+  details: 'data.items.steroids.details',
   price: 50,
   currency: 'shlagidiamond',
   category: 'actif',
@@ -395,12 +327,9 @@ export const steroids: Item = {
 
 export const ultraSteroid: Item = {
   id: 'ultra-steroide',
-  nameKey: 'data.items.ultraSteroid.name',
-  name: 'Ultra-Stéroïde',
-  descriptionKey: 'data.items.ultraSteroid.description',
-  description: `Une substance interdite dans 97 pays, 2 dimensions et au moins une timeline.`,
-  detailsKey: 'data.items.ultraSteroid.details',
-  details: `Fait évoluer Masschopeur en Macintosh, une forme d’hypertrophie critique atteignant le point de non-retour. À manipuler avec des gants, une perche, et un avocat.`,
+  name: 'data.items.ultraSteroid.name',
+  description: 'data.items.ultraSteroid.description',
+  details: 'data.items.ultraSteroid.details',
   price: 100,
   currency: 'shlagidiamond',
   category: 'actif',
@@ -411,12 +340,9 @@ export const ultraSteroid: Item = {
 
 export const lighter: Item = {
   id: 'briquet',
-  nameKey: 'data.items.lighter.name',
-  name: 'Briquet',
-  descriptionKey: 'data.items.lighter.description',
-  description: 'Fait briller la pyromanie chez certains Shlagémons.',
-  detailsKey: 'data.items.lighter.details',
-  details: 'Permet à Emboli de se changer en Pyrolise pour tout cramer.',
+  name: 'data.items.lighter.name',
+  description: 'data.items.lighter.description',
+  details: 'data.items.lighter.details',
   price: 25,
   currency: 'shlagidiamond',
   category: 'actif',
@@ -427,12 +353,9 @@ export const lighter: Item = {
 
 export const pissBottle: Item = {
   id: 'bouteille-pisse',
-  nameKey: 'data.items.pissBottle.name',
-  name: 'Bouteille de Pisse',
-  descriptionKey: 'data.items.pissBottle.description',
-  description: 'Un breuvage douteux qui dégouline de germes.',
-  detailsKey: 'data.items.pissBottle.details',
-  details: 'Transforme Emboli en Salmoneli après une bonne rasade.',
+  name: 'data.items.pissBottle.name',
+  description: 'data.items.pissBottle.description',
+  details: 'data.items.pissBottle.details',
   price: 25,
   currency: 'shlagidiamond',
   category: 'actif',
@@ -443,12 +366,9 @@ export const pissBottle: Item = {
 
 export const defibrillator: Item = {
   id: 'defibrilateur',
-  nameKey: 'data.items.defibrillator.name',
-  name: 'Défibrillateur',
-  descriptionKey: 'data.items.defibrillator.description',
-  description: 'Un coup de jus pour repartir de travers.',
-  detailsKey: 'data.items.defibrillator.details',
-  details: 'Nécessaire pour qu\'Emboli évolue en Tuberculi.',
+  name: 'data.items.defibrillator.name',
+  description: 'data.items.defibrillator.description',
+  details: 'data.items.defibrillator.details',
   price: 25,
   currency: 'shlagidiamond',
   category: 'actif',
@@ -459,10 +379,8 @@ export const defibrillator: Item = {
 
 export const eggBox: Item = {
   id: 'egg-box',
-  nameKey: 'data.items.eggBox.name',
-  name: 'Boîte à œufs',
-  descriptionKey: 'data.items.eggBox.description',
-  description: 'Permet de stocker tous tes œufs sans encombrer l\'inventaire. C\'est super pour collectionner les œufs, mais tu n\'as aucune idée de ce qu\'il peut y avoir à l\'intérieur.',
+  name: 'data.items.eggBox.name',
+  description: 'data.items.eggBox.description',
   category: 'utilitaire',
   unique: true,
   icon: 'i-game-icons:nest-eggs',
@@ -471,10 +389,8 @@ export const eggBox: Item = {
 
 export const fireEgg: Item = {
   id: 'oeuf-feu',
-  nameKey: 'data.items.fireEgg.name',
-  name: 'Œuf Feu',
-  descriptionKey: 'data.items.fireEgg.description',
-  description: 'Un œuf chaud bouillant.',
+  name: 'data.items.fireEgg.name',
+  description: 'data.items.fireEgg.description',
   price: 30,
   currency: 'shlagidolar',
   category: 'utilitaire',
@@ -484,10 +400,8 @@ export const fireEgg: Item = {
 
 export const waterEgg: Item = {
   id: 'oeuf-eau',
-  nameKey: 'data.items.waterEgg.name',
-  name: 'Œuf Eau',
-  descriptionKey: 'data.items.waterEgg.description',
-  description: 'Un œuf qui ruisselle.',
+  name: 'data.items.waterEgg.name',
+  description: 'data.items.waterEgg.description',
   price: 30,
   currency: 'shlagidolar',
   category: 'utilitaire',
@@ -497,10 +411,8 @@ export const waterEgg: Item = {
 
 export const grassEgg: Item = {
   id: 'oeuf-herbe',
-  nameKey: 'data.items.grassEgg.name',
-  name: 'Œuf Herbe',
-  descriptionKey: 'data.items.grassEgg.description',
-  description: 'Un œuf qui sent la pelouse.',
+  name: 'data.items.grassEgg.name',
+  description: 'data.items.grassEgg.description',
   price: 30,
   currency: 'shlagidolar',
   category: 'utilitaire',
@@ -510,10 +422,8 @@ export const grassEgg: Item = {
 
 export const psyEgg: Item = {
   id: 'oeuf-psy',
-  nameKey: 'data.items.psyEgg.name',
-  name: 'Œuf Psy',
-  descriptionKey: 'data.items.psyEgg.description',
-  description: 'Un œuf qui te fixe intensément.',
+  name: 'data.items.psyEgg.name',
+  description: 'data.items.psyEgg.description',
   price: 30,
   currency: 'shlagidolar',
   category: 'utilitaire',
@@ -523,10 +433,8 @@ export const psyEgg: Item = {
 
 export const thunderEgg: Item = {
   id: 'oeuf-foudre',
-  nameKey: 'data.items.thunderEgg.name',
-  name: 'Œuf Foudre',
-  descriptionKey: 'data.items.thunderEgg.description',
-  description: 'Un œuf parcouru d\'étincelles.',
+  name: 'data.items.thunderEgg.name',
+  description: 'data.items.thunderEgg.description',
   price: 30,
   currency: 'shlagidolar',
   category: 'utilitaire',
@@ -536,13 +444,9 @@ export const thunderEgg: Item = {
 
 export const specialPotion: Item = {
   id: 'special-potion',
-  nameKey: 'data.items.specialPotion.name',
-  name: 'Potion Spéciale',
-  descriptionKey: 'data.items.specialPotion.description',
-  description: 'Fonctionne uniquement contre les rois.',
-  detailsKey: 'data.items.specialPotion.details',
-  details:
-    'Tenue pendant un combat de roi, elle peut avoir un pouvoir surprenant !',
+  name: 'data.items.specialPotion.name',
+  description: 'data.items.specialPotion.description',
+  details: 'data.items.specialPotion.details',
   type: 'heal',
   power: 50,
   price: 11111,
@@ -553,13 +457,9 @@ export const specialPotion: Item = {
 
 export const mysteriousPotion: Item = {
   id: 'mysterious-potion',
-  nameKey: 'data.items.mysteriousPotion.name',
-  name: 'Potion Mystérieuse',
-  descriptionKey: 'data.items.mysteriousPotion.description',
-  description: 'Fonctionne uniquement contre les rois.',
-  detailsKey: 'data.items.mysteriousPotion.details',
-  details:
-    'Tenue pendant un combat de roi, elle peut avoir un pouvoir très surprenant !',
+  name: 'data.items.mysteriousPotion.name',
+  description: 'data.items.mysteriousPotion.description',
+  details: 'data.items.mysteriousPotion.details',
   type: 'heal',
   power: 75,
   price: 111111,
@@ -570,13 +470,9 @@ export const mysteriousPotion: Item = {
 
 export const fabulousPotion: Item = {
   id: 'fabulous-potion',
-  nameKey: 'data.items.fabulousPotion.name',
-  name: 'Potion Fabuleuse',
-  descriptionKey: 'data.items.fabulousPotion.description',
-  description: 'Fonctionne uniquement contre les rois.',
-  detailsKey: 'data.items.fabulousPotion.details',
-  details:
-    'Tenue pendant un combat de roi, elle peut avoir un pouvoir extrêmement surprenant !',
+  name: 'data.items.fabulousPotion.name',
+  description: 'data.items.fabulousPotion.description',
+  details: 'data.items.fabulousPotion.details',
   type: 'heal',
   power: 100,
   price: 1111111,

--- a/src/data/items/wearables/defenseRing.ts
+++ b/src/data/items/wearables/defenseRing.ts
@@ -2,13 +2,9 @@ import type { WearableItem } from '~/type/item'
 
 export const defenseRing: WearableItem = {
   id: 'defense-ring',
-  nameKey: 'data.items.wearables.defenseRing.defenseRing.name',
-  name: 'Bague de défense',
-  descriptionKey: 'data.items.wearables.defenseRing.defenseRing.description',
-  description: 'Augmente la défense du porteur.',
-  detailsKey: 'data.items.wearables.defenseRing.defenseRing.details',
-  details:
-    'Portée par un Shlagémon, elle augmente sa défense de 15%. Effet cumulable avec les potions de défense.',
+  name: 'data.items.wearables.defenseRing.defenseRing.name',
+  description: 'data.items.wearables.defenseRing.defenseRing.description',
+  details: 'data.items.wearables.defenseRing.defenseRing.details',
   price: 20,
   currency: 'shlagidiamond',
   category: 'utilitaire',
@@ -22,13 +18,9 @@ export const defenseRing: WearableItem = {
 
 export const advancedDefenseRing: WearableItem = {
   id: 'advanced-defense-ring',
-  nameKey: 'data.items.wearables.defenseRing.advancedDefenseRing.name',
-  name: 'Bague de défense avancée',
-  descriptionKey: 'data.items.wearables.defenseRing.advancedDefenseRing.description',
-  description: 'Augmente fortement la défense du porteur.',
-  detailsKey: 'data.items.wearables.defenseRing.advancedDefenseRing.details',
-  details:
-    'Portée par un Shlagémon, elle augmente sa défense de 25%. Effet cumulable avec les potions de défense.',
+  name: 'data.items.wearables.defenseRing.advancedDefenseRing.name',
+  description: 'data.items.wearables.defenseRing.advancedDefenseRing.description',
+  details: 'data.items.wearables.defenseRing.advancedDefenseRing.details',
   price: 50,
   currency: 'shlagidiamond',
   category: 'utilitaire',
@@ -42,13 +34,9 @@ export const advancedDefenseRing: WearableItem = {
 
 export const defenseAmulet: WearableItem = {
   id: 'defense-amulet',
-  nameKey: 'data.items.wearables.defenseRing.defenseAmulet.name',
-  name: 'Amulette de défense',
-  descriptionKey: 'data.items.wearables.defenseRing.defenseAmulet.description',
-  description: 'Augmente grandement la défense du porteur.',
-  detailsKey: 'data.items.wearables.defenseRing.defenseAmulet.details',
-  details:
-    'Portée par un Shlagémon, elle augmente sa défense de 33%. Effet cumulable avec les potions de défense.',
+  name: 'data.items.wearables.defenseRing.defenseAmulet.name',
+  description: 'data.items.wearables.defenseRing.defenseAmulet.description',
+  details: 'data.items.wearables.defenseRing.defenseAmulet.details',
   price: 100,
   currency: 'shlagidiamond',
   category: 'utilitaire',

--- a/src/data/items/wearables/vitalityRing.ts
+++ b/src/data/items/wearables/vitalityRing.ts
@@ -2,13 +2,9 @@ import type { WearableItem } from '~/type/item'
 
 export const vitalityRing: WearableItem = {
   id: 'vitality-ring',
-  nameKey: 'data.items.wearables.vitalityRing.vitalityRing.name',
-  name: 'Bague Vitalesque',
-  descriptionKey: 'data.items.wearables.vitalityRing.vitalityRing.description',
-  description: 'Augmente les PV max du porteur.',
-  detailsKey: 'data.items.wearables.vitalityRing.vitalityRing.details',
-  details:
-    'Portée par un Shlagémon, elle augmente ses PV maximum de 15%. Effet cumulable avec les potions de vitalité.',
+  name: 'data.items.wearables.vitalityRing.vitalityRing.name',
+  description: 'data.items.wearables.vitalityRing.vitalityRing.description',
+  details: 'data.items.wearables.vitalityRing.vitalityRing.details',
   price: 20,
   currency: 'shlagidiamond',
   category: 'utilitaire',
@@ -22,13 +18,9 @@ export const vitalityRing: WearableItem = {
 
 export const advancedVitalityRing: WearableItem = {
   id: 'advanced-vitality-ring',
-  nameKey: 'data.items.wearables.vitalityRing.advancedVitalityRing.name',
-  name: 'Bague Vitalesque avancée',
-  descriptionKey: 'data.items.wearables.vitalityRing.advancedVitalityRing.description',
-  description: 'Augmente fortement les PV max du porteur.',
-  detailsKey: 'data.items.wearables.vitalityRing.advancedVitalityRing.details',
-  details:
-    'Portée par un Shlagémon, elle augmente ses PV maximum de 25%. Effet cumulable avec les potions de vitalité.',
+  name: 'data.items.wearables.vitalityRing.advancedVitalityRing.name',
+  description: 'data.items.wearables.vitalityRing.advancedVitalityRing.description',
+  details: 'data.items.wearables.vitalityRing.advancedVitalityRing.details',
   price: 50,
   currency: 'shlagidiamond',
   category: 'utilitaire',
@@ -42,13 +34,9 @@ export const advancedVitalityRing: WearableItem = {
 
 export const vitalityAmulet: WearableItem = {
   id: 'vitality-amulet',
-  nameKey: 'data.items.wearables.vitalityRing.vitalityAmulet.name',
-  name: 'Amulette Vitalesque',
-  descriptionKey: 'data.items.wearables.vitalityRing.vitalityAmulet.description',
-  description: 'Augmente grandement les PV max du porteur.',
-  detailsKey: 'data.items.wearables.vitalityRing.vitalityAmulet.details',
-  details:
-    'Portée par un Shlagémon, elle augmente ses PV maximum de 33%. Effet cumulable avec les potions de vitalité.',
+  name: 'data.items.wearables.vitalityRing.vitalityAmulet.name',
+  description: 'data.items.wearables.vitalityRing.vitalityAmulet.description',
+  details: 'data.items.wearables.vitalityRing.vitalityAmulet.details',
   price: 100,
   currency: 'shlagidiamond',
   category: 'utilitaire',

--- a/src/data/items/wearables/xpRing.ts
+++ b/src/data/items/wearables/xpRing.ts
@@ -2,13 +2,9 @@ import type { WearableItem } from '~/type/item'
 
 export const xpRing: WearableItem = {
   id: 'xp-ring',
-  nameKey: 'data.items.wearables.xpRing.xpRing.name',
-  name: 'Anneau d\'expérience',
-  descriptionKey: 'data.items.wearables.xpRing.xpRing.description',
-  description: 'Augmente l\'XP du porteur.',
-  detailsKey: 'data.items.wearables.xpRing.xpRing.details',
-  details:
-    'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 15%. Effet cumulable avec les potions d\'expérience.',
+  name: 'data.items.wearables.xpRing.xpRing.name',
+  description: 'data.items.wearables.xpRing.xpRing.description',
+  details: 'data.items.wearables.xpRing.xpRing.details',
   price: 20,
   currency: 'shlagidiamond',
   category: 'utilitaire',
@@ -22,13 +18,9 @@ export const xpRing: WearableItem = {
 
 export const advancedXpRing: WearableItem = {
   id: 'advanced-xp-ring',
-  nameKey: 'data.items.wearables.xpRing.advancedXpRing.name',
-  name: 'Anneau d\'expérience avancé',
-  descriptionKey: 'data.items.wearables.xpRing.advancedXpRing.description',
-  description: 'Augmente fortement l\'XP du porteur.',
-  detailsKey: 'data.items.wearables.xpRing.advancedXpRing.details',
-  details:
-    'Porté par un Shlagémon, il augmente l\'expérience gagnée en combat de 25%. Effet cumulable avec les potions d\'expérience.',
+  name: 'data.items.wearables.xpRing.advancedXpRing.name',
+  description: 'data.items.wearables.xpRing.advancedXpRing.description',
+  details: 'data.items.wearables.xpRing.advancedXpRing.details',
   price: 50,
   currency: 'shlagidiamond',
   category: 'utilitaire',
@@ -42,13 +34,9 @@ export const advancedXpRing: WearableItem = {
 
 export const xpAmulet: WearableItem = {
   id: 'xp-amulet',
-  nameKey: 'data.items.wearables.xpRing.xpAmulet.name',
-  name: 'Amulette d\'expérience',
-  descriptionKey: 'data.items.wearables.xpRing.xpAmulet.description',
-  description: 'Augmente grandement l\'XP du porteur.',
-  detailsKey: 'data.items.wearables.xpRing.xpAmulet.details',
-  details:
-    'Portée par un Shlagémon, elle augmente l\'expérience gagnée en combat de 33%. Effet cumulable avec les potions d\'expérience.',
+  name: 'data.items.wearables.xpRing.xpAmulet.name',
+  description: 'data.items.wearables.xpRing.xpAmulet.description',
+  details: 'data.items.wearables.xpRing.xpAmulet.details',
   price: 100,
   currency: 'shlagidiamond',
   category: 'utilitaire',

--- a/src/data/kings.ts
+++ b/src/data/kings.ts
@@ -1,6 +1,6 @@
 import type { Character } from '~/type/character'
 import type { SavageZoneId } from '~/type/zone'
-import type { BaseShlagemon, Trainer } from '~/types'
+import type { BaseShlagemon, I18nKey, Trainer } from '~/types'
 import { aliceCordonbleu } from './characters/alice-cordonbleu'
 import { bouba } from './characters/bouba'
 import { caillou } from './characters/caillou'
@@ -113,12 +113,9 @@ function _createKing(
   zoneId: SavageZoneId,
   character: Character,
   qteShlagemons: number,
-  dialogBefore: string,
-  dialogBeforeKey: string,
-  dialogAfter: string,
-  dialogAfterKey: string,
-  dialogDefeat: string,
-  dialogDefeatKey: string,
+  dialogBefore: I18nKey,
+  dialogAfter: I18nKey,
+  dialogDefeat: I18nKey,
 ): Trainer {
   const zone = zonesData.find(z => z.id === zoneId)
   if (!zone) {
@@ -150,11 +147,8 @@ function _createKing(
     id: `king-${zoneId}`,
     character,
     dialogBefore,
-    dialogBeforeKey,
     dialogAfter,
-    dialogAfterKey,
     dialogDefeat,
-    dialogDefeatKey,
     reward: zone.maxLevel || 1,
     shlagemons,
   }
@@ -171,12 +165,9 @@ export const kings: Kings = {
     id: 'king-plaine-kekette',
     character: ondejeune,
     reward: zonesData.find(z => z.id === 'plaine-kekette')?.maxLevel || 1,
-    dialogBefore: 'Coucou, si tu gagnes, je te paye le petit déjeuné !',
-    dialogBeforeKey: 'data.kings.plaine-kekette.dialogBefore',
-    dialogAfter: 'Ok, ok, tu as gagné, je vais t\'inviter pour ce petit déj !',
-    dialogAfterKey: 'data.kings.plaine-kekette.dialogAfter',
-    dialogDefeat: 'Mais quel grosse merde, tu vas me payer un petit déj\' de ouf !',
-    dialogDefeatKey: 'data.kings.plaine-kekette.dialogDefeat',
+    dialogBefore: 'data.kings.plaine-kekette.dialogBefore',
+    dialogAfter: 'data.kings.plaine-kekette.dialogAfter',
+    dialogDefeat: 'data.kings.plaine-kekette.dialogDefeat',
     shlagemons: [
       poissaucisse.id,
       hyporuisseau.id,
@@ -185,12 +176,9 @@ export const kings: Kings = {
   'bois-de-bouffon': {
     id: 'king-bois-de-bouffon',
     character: caillou,
-    dialogBefore: 'Ici, c\'est ma street, et tu as trop de cheveux pour pouvoir continuer ton chemin.',
-    dialogBeforeKey: 'data.kings.bois-de-bouffon.dialogBefore',
-    dialogAfter: 'Tu m\'as bien déglingué, bravo ! Je vais aller me faire un shampoing et je reviendrai bien plus fort !',
-    dialogAfterKey: 'data.kings.bois-de-bouffon.dialogAfter',
-    dialogDefeat: 'Je vais te faire bouffer tes cheveux espèce de sous merde !',
-    dialogDefeatKey: 'data.kings.bois-de-bouffon.dialogDefeat',
+    dialogBefore: 'data.kings.bois-de-bouffon.dialogBefore',
+    dialogAfter: 'data.kings.bois-de-bouffon.dialogAfter',
+    dialogDefeat: 'data.kings.bois-de-bouffon.dialogDefeat',
     reward: zonesData.find(z => z.id === 'bois-de-bouffon')?.maxLevel || 1,
     shlagemons: [
       racaillou.id,
@@ -201,12 +189,9 @@ export const kings: Kings = {
   'chemin-du-slip': {
     id: 'king-chemin-du-slip',
     character: norman,
-    dialogBefore: 'Entres dans ma grotte si tu l\'oses.',
-    dialogBeforeKey: 'data.kings.chemin-du-slip.dialogBefore',
-    dialogAfter: 'Ta victoire ne sera que temporaire, je retourne en garde à vue.',
-    dialogAfterKey: 'data.kings.chemin-du-slip.dialogAfter',
-    dialogDefeat: 'Tu pues la lose, file te laver !',
-    dialogDefeatKey: 'data.kings.chemin-du-slip.dialogDefeat',
+    dialogBefore: 'data.kings.chemin-du-slip.dialogBefore',
+    dialogAfter: 'data.kings.chemin-du-slip.dialogAfter',
+    dialogDefeat: 'data.kings.chemin-du-slip.dialogDefeat',
     reward: zonesData.find(z => z.id === 'chemin-du-slip')?.maxLevel || 1,
     shlagemons: [
       melofoutre.id,
@@ -217,12 +202,9 @@ export const kings: Kings = {
   'ravin-fesse-molle': {
     id: 'king-ravin-fesse-molle',
     character: marineLahaine,
-    dialogBefore: 'Yo, j\'suis raciste.',
-    dialogBeforeKey: 'data.kings.ravin-fesse-molle.dialogBefore',
-    dialogAfter: 'Incroyable... tu as gagné. Je vais donc arrêter d\'être raciste. Merci de m\'avoir ouvert les yeux !',
-    dialogAfterKey: 'data.kings.ravin-fesse-molle.dialogAfter',
-    dialogDefeat: 'Dégage ! Retourne dans ton pays !',
-    dialogDefeatKey: 'data.kings.ravin-fesse-molle.dialogDefeat',
+    dialogBefore: 'data.kings.ravin-fesse-molle.dialogBefore',
+    dialogAfter: 'data.kings.ravin-fesse-molle.dialogAfter',
+    dialogDefeat: 'data.kings.ravin-fesse-molle.dialogDefeat',
     reward: zonesData.find(z => z.id === 'ravin-fesse-molle')?.maxLevel || 1,
     shlagemons: [
       houlard.id,
@@ -233,12 +215,9 @@ export const kings: Kings = {
   'precipice-nanard': {
     id: 'king-precipice-nanard',
     character: marcon,
-    dialogBefore: 'Je suis prêt à te mettre une sacrée rouste espèce de cassos ! Je déteste les pauvres comme toi, sale bâtard !',
-    dialogBeforeKey: 'data.kings.precipice-nanard.dialogBefore',
-    dialogAfter: 'Tu m\'as explosé le fiak, je vais te foutre une grosse loi dans ta gueule, ça va te calmer.',
-    dialogAfterKey: 'data.kings.precipice-nanard.dialogAfter',
-    dialogDefeat: 'T\'es une merde, t\'as toujours été une merde, tu resteras une merde toute ta vie.',
-    dialogDefeatKey: 'data.kings.precipice-nanard.dialogDefeat',
+    dialogBefore: 'data.kings.precipice-nanard.dialogBefore',
+    dialogAfter: 'data.kings.precipice-nanard.dialogAfter',
+    dialogDefeat: 'data.kings.precipice-nanard.dialogDefeat',
     reward: zonesData.find(z => z.id === 'precipice-nanard')?.maxLevel || 1,
     shlagemons: [
       goubite.id,
@@ -250,12 +229,9 @@ export const kings: Kings = {
   'marais-moudugenou': {
     id: 'king-marais-moudugenou',
     character: siphanus,
-    dialogBefore: 'J\'ai des infos sur la sortie de la prochaine Switch !',
-    dialogBeforeKey: 'data.kings.marais-moudugenou.dialogBefore',
-    dialogAfter: 'Tu t\'extirpes du marais victorieux, tu ne sauras donc jamais quand la prochaine Switch va sortir...',
-    dialogAfterKey: 'data.kings.marais-moudugenou.dialogAfter',
-    dialogDefeat: 'Je t\'éclabousse de ma boue, retourne barboter ailleurs.',
-    dialogDefeatKey: 'data.kings.marais-moudugenou.dialogDefeat',
+    dialogBefore: 'data.kings.marais-moudugenou.dialogBefore',
+    dialogAfter: 'data.kings.marais-moudugenou.dialogAfter',
+    dialogDefeat: 'data.kings.marais-moudugenou.dialogDefeat',
     reward: zonesData.find(z => z.id === 'marais-moudugenou')?.maxLevel || 1,
     shlagemons: [
       orchibre.id,
@@ -268,12 +244,9 @@ export const kings: Kings = {
     id: 'king-forteresse-petmoalfiak',
     reward: zonesData.find(z => z.id === 'forteresse-petmoalfiak')?.maxLevel || 1,
     character: charlesManoir,
-    dialogBefore: 'Tu entends cette petite voix dans ta tête ? Elle te dit de perdre... C’est moi. Bienvenue dans mon trip, tu ne t’en sortiras pas indemne !',
-    dialogBeforeKey: 'data.kings.forteresse-petmoalfiak.dialogBefore',
-    dialogAfter: 'Quoi ?! Même mes discours tordus ne t’ont pas fait perdre pied ? Tu dois être vraiment perché, toi aussi…',
-    dialogAfterKey: 'data.kings.forteresse-petmoalfiak.dialogAfter',
-    dialogDefeat: 'Wow… tu pues la loose ! Attention, les vraies hallucinations commencent à la prochaine pleine lune…',
-    dialogDefeatKey: 'data.kings.forteresse-petmoalfiak.dialogDefeat',
+    dialogBefore: 'data.kings.forteresse-petmoalfiak.dialogBefore',
+    dialogAfter: 'data.kings.forteresse-petmoalfiak.dialogAfter',
+    dialogDefeat: 'data.kings.forteresse-petmoalfiak.dialogDefeat',
     shlagemons: [
       macho.id,
       ferosang.id,
@@ -284,12 +257,9 @@ export const kings: Kings = {
   'route-du-nawak': {
     id: 'king-route-du-nawak',
     character: aliceCordonbleu,
-    dialogBefore: 'Je n\'aime ni la couleur de tes cheveux, ni la forme de ton nez, ni la taille de tes pieds. Prépare toi à perdre tes couilles !',
-    dialogBeforeKey: 'data.kings.route-du-nawak.dialogBefore',
-    dialogAfter: 'Tu t\'en sors, pour l\'instant.',
-    dialogAfterKey: 'data.kings.route-du-nawak.dialogAfter',
-    dialogDefeat: 'Je suis obligée de quitter le territoire, mais je reviendrai pour te bouffer le cul, enculé de ta race !',
-    dialogDefeatKey: 'data.kings.route-du-nawak.dialogDefeat',
+    dialogBefore: 'data.kings.route-du-nawak.dialogBefore',
+    dialogAfter: 'data.kings.route-du-nawak.dialogAfter',
+    dialogDefeat: 'data.kings.route-du-nawak.dialogDefeat',
     reward: zonesData.find(z => z.id === 'route-du-nawak')?.maxLevel || 1,
     shlagemons: [
       pyrolise.id,
@@ -301,12 +271,9 @@ export const kings: Kings = {
   'mont-dracatombe': {
     id: 'king-mont-dracatombe',
     character: picassos,
-    dialogBefore: 'Salut, j\'aime beaucoup les couleurs mais également tabasser des meufs.',
-    dialogBeforeKey: 'data.kings.mont-dracatombe.dialogBefore',
-    dialogAfter: 'Tu as réussi à me vaincre, je te peindrait tout de même en looser.',
-    dialogAfterKey: 'data.kings.mont-dracatombe.dialogAfter',
-    dialogDefeat: 'Tu pues la merde, je te nique tes morts !',
-    dialogDefeatKey: 'data.kings.mont-dracatombe.dialogDefeat',
+    dialogBefore: 'data.kings.mont-dracatombe.dialogBefore',
+    dialogAfter: 'data.kings.mont-dracatombe.dialogAfter',
+    dialogDefeat: 'data.kings.mont-dracatombe.dialogDefeat',
     reward: zonesData.find(z => z.id === 'mont-dracatombe')?.maxLevel || 1,
     shlagemons: [
       piafsansbec.id,
@@ -319,12 +286,9 @@ export const kings: Kings = {
   'catacombes-merdifientes': {
     id: 'king-catacombes-merdifientes',
     character: moniqueCerisier,
-    dialogBefore: 'Peux tu m\'aider à descendre ce sac dans ma cave, s\'il te plaît ?',
-    dialogBeforeKey: 'data.kings.catacombes-merdifientes.dialogBefore',
-    dialogAfter: 'Je sombre dans l\'ombre des catacombes avec mon terrible secret.',
-    dialogAfterKey: 'data.kings.catacombes-merdifientes.dialogAfter',
-    dialogDefeat: 'Remonte donc à la surface, larve.',
-    dialogDefeatKey: 'data.kings.catacombes-merdifientes.dialogDefeat',
+    dialogBefore: 'data.kings.catacombes-merdifientes.dialogBefore',
+    dialogAfter: 'data.kings.catacombes-merdifientes.dialogAfter',
+    dialogDefeat: 'data.kings.catacombes-merdifientes.dialogDefeat',
     reward: zonesData.find(z => z.id === 'catacombes-merdifientes')?.maxLevel || 1,
     shlagemons: [
       amonichiasse.id,
@@ -337,12 +301,9 @@ export const kings: Kings = {
   'route-aguicheuse': {
     id: 'king-route-aguicheuse',
     character: labbeBiere,
-    dialogBefore: 'Moi j\'aide les pauvre mais je les baises aussi. Avec ou sans consentement.',
-    dialogBeforeKey: 'data.kings.route-aguicheuse.dialogBefore',
-    dialogAfter: 'Bien joué, voyageur, tu m\'as bien enculé.',
-    dialogAfterKey: 'data.kings.route-aguicheuse.dialogAfter',
-    dialogDefeat: 'Et je te baise toi aussi, espèce de trou de balle informe !',
-    dialogDefeatKey: 'data.kings.route-aguicheuse.dialogDefeat',
+    dialogBefore: 'data.kings.route-aguicheuse.dialogBefore',
+    dialogAfter: 'data.kings.route-aguicheuse.dialogAfter',
+    dialogDefeat: 'data.kings.route-aguicheuse.dialogDefeat',
     reward: zonesData.find(z => z.id === 'route-aguicheuse')?.maxLevel || 1,
     shlagemons: [
       coksale.id,
@@ -355,12 +316,9 @@ export const kings: Kings = {
   'vallee-des-chieurs': {
     id: 'king-vallee-des-chieurs',
     character: jkRalwing,
-    dialogBefore: 'Tu es plutôt un garçon ou une fille ? Décide toi car je ne veux pas perdre mon temps avec les indécis.',
-    dialogBeforeKey: 'data.kings.vallee-des-chieurs.dialogBefore',
-    dialogAfter: 'Tu m\'as ovuert les yeux, je vais t\'accepter comme tu es : un vagin à tête de gland.',
-    dialogAfterKey: 'data.kings.vallee-des-chieurs.dialogAfter',
-    dialogDefeat: 'Je t\'ai violenté aussi fort qu\'un expéliermus, tu es un vrai loser.',
-    dialogDefeatKey: 'data.kings.vallee-des-chieurs.dialogDefeat',
+    dialogBefore: 'data.kings.vallee-des-chieurs.dialogBefore',
+    dialogAfter: 'data.kings.vallee-des-chieurs.dialogAfter',
+    dialogDefeat: 'data.kings.vallee-des-chieurs.dialogDefeat',
     reward: zonesData.find(z => z.id === 'vallee-des-chieurs')?.maxLevel || 1,
     shlagemons: [
       nidononbinaireF.id,
@@ -373,12 +331,9 @@ export const kings: Kings = {
   'trou-du-bide': {
     id: 'king-trou-du-bide',
     character: donaldTrompe,
-    dialogBefore: 'Bienvenue dans mon trou, il est imprenable, j\'y ai construit un mur titanesque !',
-    dialogBeforeKey: 'data.kings.trou-du-bide.dialogBefore',
-    dialogAfter: 'Tu as brisé mon trou... je vais te niquer ton père et construire un mur tout autour !',
-    dialogAfterKey: 'data.kings.trou-du-bide.dialogAfter',
-    dialogDefeat: 'Boum ! Mon trou t\'écrase, petit looser de mort ! J\'te baise !',
-    dialogDefeatKey: 'data.kings.trou-du-bide.dialogDefeat',
+    dialogBefore: 'data.kings.trou-du-bide.dialogBefore',
+    dialogAfter: 'data.kings.trou-du-bide.dialogAfter',
+    dialogDefeat: 'data.kings.trou-du-bide.dialogDefeat',
     reward: zonesData.find(z => z.id === 'trou-du-bide')?.maxLevel || 1,
     shlagemons: [
       fantomanus.id,
@@ -391,12 +346,9 @@ export const kings: Kings = {
   'zone-giga-zob': {
     id: 'king-zone-giga-zob',
     character: glandhi,
-    dialogBefore: 'Je suis paix, je suis amour, tu n\'as qu\'à m\'écouter et tu seras sauvé !',
-    dialogBeforeKey: 'data.kings.zone-giga-zob.dialogBefore',
-    dialogAfter: 'Je te hais, toi et tes idées de merde !',
-    dialogAfterKey: 'data.kings.zone-giga-zob.dialogAfter',
-    dialogDefeat: 'Je suis ta haine, je suis ta colère, je suis ton désespoir !',
-    dialogDefeatKey: 'data.kings.zone-giga-zob.dialogDefeat',
+    dialogBefore: 'data.kings.zone-giga-zob.dialogBefore',
+    dialogAfter: 'data.kings.zone-giga-zob.dialogAfter',
+    dialogDefeat: 'data.kings.zone-giga-zob.dialogDefeat',
     reward: zonesData.find(z => z.id === 'zone-giga-zob')?.maxLevel || 1,
     shlagemons: [
       marginal.id,
@@ -409,12 +361,9 @@ export const kings: Kings = {
   'route-so-dom': {
     id: 'king-route-so-dom',
     character: thaisDescufion,
-    dialogBefore: 'Les meufs, c\'est toutes des putes, alors que moi j\'adoooorrrreee faire la vaiselle !',
-    dialogBeforeKey: 'data.kings.route-so-dom.dialogBefore',
-    dialogAfter: `Tu me l'as mise bien profonde, mais je reviendrai plus forte !`,
-    dialogAfterKey: 'data.kings.route-so-dom.dialogAfter',
-    dialogDefeat: `T'es ma pute, je fais ce que je veux de toi !`,
-    dialogDefeatKey: 'data.kings.route-so-dom.dialogDefeat',
+    dialogBefore: 'data.kings.route-so-dom.dialogBefore',
+    dialogAfter: 'data.kings.route-so-dom.dialogAfter',
+    dialogDefeat: 'data.kings.route-so-dom.dialogDefeat',
     reward: zonesData.find(z => z.id === 'route-so-dom')?.maxLevel || 1,
     shlagemons: [
       krabbolosse.id,
@@ -427,12 +376,9 @@ export const kings: Kings = {
   'lac-aux-relous': {
     id: 'king-lac-aux-relous',
     character: vladimirPutain,
-    dialogBefore: 'Я люблю хорошие ясли из кулей',
-    dialogBeforeKey: 'data.kings.lac-aux-relous.dialogBefore',
-    dialogAfter: 'Я люблю тебя, хочешь pойти со мной на свидание?',
-    dialogAfterKey: 'data.kings.lac-aux-relous.dialogAfter',
-    dialogDefeat: 'Я засунул свой палец тебе в задницу',
-    dialogDefeatKey: 'data.kings.lac-aux-relous.dialogDefeat',
+    dialogBefore: 'data.kings.lac-aux-relous.dialogBefore',
+    dialogAfter: 'data.kings.lac-aux-relous.dialogAfter',
+    dialogDefeat: 'data.kings.lac-aux-relous.dialogDefeat',
     reward: zonesData.find(z => z.id === 'lac-aux-relous')?.maxLevel || 1,
     shlagemons: [
       metamorve.id,
@@ -446,12 +392,9 @@ export const kings: Kings = {
   'canyon-a-la-derp': {
     id: 'king-canyon-a-la-derp',
     character: elizabethHomeless,
-    dialogBefore: 'Bienvenue au Canyon-a-la-derp™, le seul endroit où une simple goutte de sueur suffit à prouver ta grandeur... enfin, en théorie.',
-    dialogBeforeKey: 'data.kings.canyon-a-la-derp.dialogBefore',
-    dialogAfter: 'Incroyable, tu as survécu à ma technologie révolutionnaire 100% inefficace. Tu mériterais presque un brevet.',
-    dialogAfterKey: 'data.kings.canyon-a-la-derp.dialogAfter',
-    dialogDefeat: 'Échec critique détecté. Mais t’inquiète, avec un bon PowerPoint, tu pourrais faire croire que t\'as gagné.',
-    dialogDefeatKey: 'data.kings.canyon-a-la-derp.dialogDefeat',
+    dialogBefore: 'data.kings.canyon-a-la-derp.dialogBefore',
+    dialogAfter: 'data.kings.canyon-a-la-derp.dialogAfter',
+    dialogDefeat: 'data.kings.canyon-a-la-derp.dialogDefeat',
     reward: zonesData.find(z => z.id === 'canyon-a-la-derp')?.maxLevel || 1,
     shlagemons: [
       pauvreetcon.id,
@@ -465,12 +408,9 @@ export const kings: Kings = {
   'cratere-des-legends': {
     id: 'king-cratere-des-legends',
     character: bouba,
-    dialogBefore: 'Wesh fdp.',
-    dialogBeforeKey: 'data.kings.cratere-des-legends.dialogBefore',
-    dialogAfter: 'Je vais retourner a Los Angeles, et je serai beaucoup plus fort enculé !',
-    dialogAfterKey: 'data.kings.cratere-des-legends.dialogAfter',
-    dialogDefeat: 'Tu es un perdant, tu ne mérites pas de traverser ce cratère ! Baise ton frère.',
-    dialogDefeatKey: 'data.kings.cratere-des-legends.dialogDefeat',
+    dialogBefore: 'data.kings.cratere-des-legends.dialogBefore',
+    dialogAfter: 'data.kings.cratere-des-legends.dialogAfter',
+    dialogDefeat: 'data.kings.cratere-des-legends.dialogDefeat',
     reward: zonesData.find(z => z.id === 'cratere-des-legends')?.maxLevel || 1,
     shlagemons: [
       minidrapcon.id,
@@ -484,12 +424,9 @@ export const kings: Kings = {
   'mont-kouillasse': {
     id: 'king-mont-kouillasse',
     character: etronMuscle,
-    dialogBefore: 'Bonjour, en tant que Roi du Mont Kouillasse, j\'ai une liberté d\'expression TOTALE ! Je peux dire ce que je veux et sucer des petits moustachus Allemands sans aucune censure !',
-    dialogBeforeKey: 'data.kings.mont-kouillasse.dialogBefore',
-    dialogAfter: 'Vas te faire foutre, je t\'enverrai dans une fusée pour que t\'ailles sucer des couilles sur Mars !',
-    dialogAfterKey: 'data.kings.mont-kouillasse.dialogAfter',
-    dialogDefeat: 'T\'es aussi con que ta mère, tu ne mérites pas de traverser le Mont Kouillasse !',
-    dialogDefeatKey: 'data.kings.mont-kouillasse.dialogDefeat',
+    dialogBefore: 'data.kings.mont-kouillasse.dialogBefore',
+    dialogAfter: 'data.kings.mont-kouillasse.dialogAfter',
+    dialogDefeat: 'data.kings.mont-kouillasse.dialogDefeat',
     reward: zonesData.find(z => z.id === 'mont-kouillasse')?.maxLevel || 1,
     shlagemons: [
       lecocu.id,
@@ -503,12 +440,9 @@ export const kings: Kings = {
   'paturage-crado': {
     id: 'king-paturage-crado',
     character: elisabethBorgne,
-    dialogBefore: 'Je vais te faire bouffer ton petit cul !',
-    dialogBeforeKey: 'data.kings.paturage-crado.dialogBefore',
-    dialogAfter: 'Alors là bravo, tu as réussi à me battre. Je vais aller me faire un petit café pour me remettre de cette défaite.',
-    dialogAfterKey: 'data.kings.paturage-crado.dialogAfter',
-    dialogDefeat: 'Je vais imposer une loi pour interdire les losers comme toi de se balader dans les pâturages !',
-    dialogDefeatKey: 'data.kings.paturage-crado.dialogDefeat',
+    dialogBefore: 'data.kings.paturage-crado.dialogBefore',
+    dialogAfter: 'data.kings.paturage-crado.dialogAfter',
+    dialogDefeat: 'data.kings.paturage-crado.dialogDefeat',
     reward: zonesData.find(z => z.id === 'paturage-crado')?.maxLevel || 1,
     shlagemons: [
       floripute.id,

--- a/src/data/shlagemons.ts
+++ b/src/data/shlagemons.ts
@@ -10,7 +10,7 @@ export const allShlagemons: BaseShlagemon[] = Object.entries(modules)
       .replace('./shlagemons/', '')
       .replace(/\.ts$/, '')
     const key = rel.replace(/\//g, '.')
-    base.descriptionKey = `data.shlagemons.${key}.description`
+    base.description = `data.shlagemons.${key}.description`
     return base
   })
 

--- a/src/data/shlagemons/01-05/fantomanus.ts
+++ b/src/data/shlagemons/01-05/fantomanus.ts
@@ -5,12 +5,7 @@ import sperectum from '../evolutions/sperectum'
 export const fantomanus: BaseShlagemon = {
   id: 'fantomanus',
   name: 'Fantomanus',
-  description: `Fantomanus est littéralement un esprit… de fesses. Son corps flotte dans l’air, entouré d’un brouillard violet bien douteux, avec des traces et des auréoles un peu partout. Là où les autres Shlagémons ont une bouche, lui, c’est un vrai trou de balle — au sens propre. Il communique en faisant des bruits bizarres et des pets spectraux, tout en laissant planer une odeur indescriptible.
-
-Il adore apparaître dans les toilettes publiques, les vestiaires de gymnase ou les canapés douteux, juste pour le plaisir de foutre la gêne. Sa spécialité : l’attaque *Gaz Spectro-Anal*, un souffle surnaturel par son orifice central, qui hante l’âme et les narines pour toujours.
-
-On raconte qu’il rêve d’atteindre la perfection du prout astral, mais il galère à viser droit, même dans l’au-delà.`,
-  descriptionKey: 'data.shlagemons.01-05.fantomanus.description',
+  description: 'data.shlagemons.01-05.fantomanus.description',
   types: [shlagemonTypes.spectre, shlagemonTypes.poison],
   evolution: {
     base: sperectum,

--- a/src/data/shlagemons/01-05/jeunebelette.ts
+++ b/src/data/shlagemons/01-05/jeunebelette.ts
@@ -5,12 +5,7 @@ import vieuxBlaireau from '../evolutions/vieuxblaireau'
 export const jeunebelette: BaseShlagemon = {
   id: 'jeunebelette',
   name: 'Jeunebelette',
-  description: `Jeunebelette passe ses journées à zoner en jogging dans les terrains vagues, à moitié enterré, les écouteurs plantés dans les oreilles sans musique. Son pelage jauni est rêche et collant, comme un blouson synthétique mal lavé. Il creuse, mais sans réel but, juste pour passer le temps.
-
-Il attaque rarement, sauf s’il sent que "ça parle mal". Sa capacité spéciale *Tacle Banal* inflige des dégâts moyens mais a une chance de provoquer l’état **Flemme Profonde**. En général, Jeunebelette traîne autour des autres Shlagémons pour "voir ce qu’il se passe", sans vraiment participer. Il est là, quoi. 
-
-On raconte qu'il pourrait évoluer s'il trouvait enfin une vraie motivation. Mais c'est pas pour tout de suite.`,
-  descriptionKey: 'data.shlagemons.01-05.jeunebelette.description',
+  description: 'data.shlagemons.01-05.jeunebelette.description',
   types: [shlagemonTypes.sol],
   evolution: {
     base: vieuxBlaireau,

--- a/src/data/shlagemons/01-05/rouxPasCool.ts
+++ b/src/data/shlagemons/01-05/rouxPasCool.ts
@@ -5,8 +5,7 @@ import rouxScoop from '../evolutions/roux-scoop'
 export const rouxPasCool: BaseShlagemon = {
   id: 'roux-pas-cool',
   name: 'Roux pas Cool',
-  description: `Roux pas Cool était anciennement cool. Roux pas Cool a passé trop de temps à gratter des accords mineurs au bord d’un volcan éteint. Désormais, Roux pas Cool erre avec une guitare trop grande pour ses ailes, des taches de rousseur qui pleurent, et une chemise à carreaux qui sent l’herbe humide et les regrets. Son plumage a pris une teinte rouille triste, et sa mèche rousse cache un regard empli de remords, comme s’il réalisait constamment qu’il aurait pu évoluer en rapace légendaire, mais a préféré sortir un EP en indépendant. Il fait toujours un peu froid autour de lui, même en plein été. Sa capacité signature, Refrain Gênant, inflige un malaise profond à toute l’arène, réduisant la précision des attaques ennemies tant qu’ils détournent le regard. Il est très doué pour faire fuir les Pokémon sauvages… et les rendez-vous galants.`,
-  descriptionKey: 'data.shlagemons.01-05.rouxPasCool.description',
+  description: 'data.shlagemons.01-05.rouxPasCool.description',
   types: [shlagemonTypes.vol],
   evolution: { base: rouxScoop, condition: { type: 'lvl', value: 18 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/01-05/sacdepates.ts
+++ b/src/data/shlagemons/01-05/sacdepates.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const sacdepates: BaseShlagemon = {
   id: 'sacdepates',
   name: 'Sac de Pâtes',
-  description: `Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser.`,
-  descriptionKey: 'data.shlagemons.01-05.sacdepates.description',
+  description: 'data.shlagemons.01-05.sacdepates.description',
   types: [shlagemonTypes.plante],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/05-10/aspigros.ts
+++ b/src/data/shlagemons/05-10/aspigros.ts
@@ -12,16 +12,7 @@ export const aspigros: BaseShlagemon = {
       value: 14,
     },
   },
-  description: `Aspigros est dodu, lent, et fier de ses bourrelets qu’il appelle affectueusement ses "paniers-repas". Son dard a disparu sous une couche de gras douteux, remplacé par une fourchette plantée là "par commodité".
-
-Il est constamment en train de mâchouiller quelque chose : une feuille, un emballage, un caillou, ou parfois un de ses propres segments. Lorsqu’il attaque, il roule vers l’ennemi en gémissant de plaisir, espérant qu’un snack se trouve en chemin.
-
-Son attaque signature, *Miam-Massacre*, inflige des dégâts proportionnels au nombre de snacks qu’il a ingérés dans les 5 dernières minutes. Il peut aussi utiliser *Éructo-Défensif*, une attaque sonore à base de rots sucrés qui repoussent les ennemis faibles d’estomac.
-
-Il ne parle pas, mais fait des bruits de mastication 100% du temps. Il adore les pique-niques, les buffets de mariage et les sacs plastiques qui font du bruit. En revanche, il fuit à la simple mention du mot "diète", "protéines" ou "cure détox".
-
-On le reconnaît à sa forme sphérique, ses yeux toujours mi-clos de satiété, et à sa devise gravée sur son ventre : "Si ça rentre, c’est que c’est bon."`,
-  descriptionKey: 'data.shlagemons.05-10.aspigros.description',
+  description: 'data.shlagemons.05-10.aspigros.description',
   types: [shlagemonTypes.insecte],
   speciality: 'evolution0',
 }

--- a/src/data/shlagemons/05-10/chenipaon.ts
+++ b/src/data/shlagemons/05-10/chenipaon.ts
@@ -12,14 +12,7 @@ export const chenipaon: BaseShlagemon = {
       value: 14,
     },
   },
-  description: `Chenipaon est une larve flamboyante, fruit improbable d’une chenille miteuse et d’un paon beaucoup trop narcissique. Il se déplace lentement, en traînant derrière lui une traîne de plumes multicolores qu’il a lui-même collées à la salive sur son dos mou. Ces plumes ne servent à rien, sauf à faire des "claquettes dramatiques" quand il se retourne brusquement.
-
-Sa parade nuptiale est un désastre chorégraphique où il tourne sur lui-même en hurlant "GRAAAAAAAH-PAOON", ce qui a pour effet de faire fuir 90% des êtres vivants à proximité, y compris les pierres. Les rares adversaires qui restent sont hypnotisés par la laideur fascinante de sa danse, ce qui donne à Chenipaon un court avantage stratégique.
-
-Son cri officiel est enregistré dans les bases de données comme *"KRRRR-païïïïïïïïïïïïïïïïïn"*, mais chaque spécimen semble inventer le sien sur le moment, généralement accompagné d’un effet sonore de flûte désaccordée et d’un éternuement humide.
-
-Il possède l’attaque spéciale *Roule Par Terre Coloré*, qui inflige des dégâts aléatoires et laisse des plumes toxiques sur le champ de bataille. Il peut également utiliser *Faux Charisme*, qui augmente brièvement son taux de critique en fonction du nombre de regards consternés qu’il reçoit.`,
-  descriptionKey: 'data.shlagemons.05-10.chenipaon.description',
+  description: 'data.shlagemons.05-10.chenipaon.description',
   types: [shlagemonTypes.insecte],
   speciality: 'evolution0',
 }

--- a/src/data/shlagemons/05-10/metamorve.ts
+++ b/src/data/shlagemons/05-10/metamorve.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const metamorve: BaseShlagemon = {
   id: 'metamorve',
   name: 'Metamorve',
-  description: `Une masse de boue nauséabonde qui se traîne lentement. Là où il passe, plus rien ne pousse à cause de sa toxicité. Il est fait d'une boue toxique. Il pollue tout ce qu’il touche, même le sol devient stérile. Il pue tellement que des gens s’évanouissent rien qu’en le croisant. Son corps est un concentré de toxines.`,
-  descriptionKey: 'data.shlagemons.05-10.metamorve.description',
+  description: 'data.shlagemons.05-10.metamorve.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/05-10/ptitocard.ts
+++ b/src/data/shlagemons/05-10/ptitocard.ts
@@ -5,8 +5,7 @@ import grossetarte from '../evolutions/grossetarte'
 export const ptitocard: BaseShlagemon = {
   id: 'ptitocard',
   name: 'Ptitocard',
-  description: `Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion... mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr.`,
-  descriptionKey: 'data.shlagemons.05-10.ptitocard.description',
+  description: 'data.shlagemons.05-10.ptitocard.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: grossetarte,

--- a/src/data/shlagemons/10-15/abraquemar.ts
+++ b/src/data/shlagemons/10-15/abraquemar.ts
@@ -12,8 +12,7 @@ export const abraquemar: BaseShlagemon = {
       value: 46,
     },
   },
-  description: `Abraquemar est adepte de la sieste transcendantale et de la fuite passive-agressive. À la moindre interaction sociale, il disparaît dans un nuage de poussière en marmonnant "j’te sens pas, j’me tire". Son taux de fuite est de 100%, sauf s’il entend une discussion sur les chakras ou les promos sur les tapis ethniques. On le trouve souvent assis en tailleur, les yeux mi-ouverts, entre deux posters de l’Univers collés avec du chewing-gum. Il porte toujours une capuche trop grande et une écharpe mal nouée, et prétend être "entre deux plans d’alignement stellaire". Sa capacité spéciale, *Téléportation du Malaise*, permet d’échanger de place avec une poubelle proche. Il possède aussi l’attaque *Sérénité Forcée*, qui fait baisser l’attaque ennemie par culpabilité énergétique. Abraquemar évolue uniquement quand il arrête de dire “j’ai pas envie de fight, moi je suis plus dans la vibe.”`,
-  descriptionKey: 'data.shlagemons.10-15.abraquemar.description',
+  description: 'data.shlagemons.10-15.abraquemar.description',
   types: [shlagemonTypes.psy],
   speciality: 'evolution0',
 }

--- a/src/data/shlagemons/10-15/amoche.ts
+++ b/src/data/shlagemons/10-15/amoche.ts
@@ -5,8 +5,7 @@ import barbok from '../evolutions/barbok'
 export const amoche: BaseShlagemon = {
   id: 'amoche',
   name: 'Amoche',
-  description: `Amoche est une tentative ratée de serpent. Son corps est irrégulier, cabossé, et son museau semble avoir été dessiné au marqueur par un enfant triste. Sa peau terne évoque le plastique fondu, et il laisse derrière lui une traînée légèrement gluante dont l’origine reste floue. Amoche n’a pas conscience de sa propre mocheté, mais les autres Shlagémons la ressentent physiquement, ce qui lui confère une présence toxique passive. Son attaque *Regard Déformant* a une chance d’infliger l’état Malaise. Il ne rampe pas, il traîne. Il n’effraie pas, il gêne.`,
-  descriptionKey: 'data.shlagemons.10-15.amoche.description',
+  description: 'data.shlagemons.10-15.amoche.description',
   types: [shlagemonTypes.poison],
   evolution: { base: barbok, condition: { type: 'lvl', value: 42 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/10-15/emboli.ts
+++ b/src/data/shlagemons/10-15/emboli.ts
@@ -8,8 +8,7 @@ import tuberculi from '../evolutions/tuberculi'
 export const emboli: BaseShlagemon = {
   id: 'emboli',
   name: 'Emboli',
-  description: `Emboli est survenue après un long séjour dans une cave mal ventilée. Son pelage sent le tabac froid et la lassitude, et il émet en permanence de petites volutes grisâtres, sans raison apparente. Il ne se bat presque jamais. Il souffle. Lourdement. S’il attaque, c’est généralement par accident, ou parce qu’on lui a demandé trop fort. Son attaque signature, Soupir Toxique, inflige des dégâts progressifs à l’adversaire et peut provoquer l’état Démotivation. En combat, il préfère s’asseoir et regarder les autres se battre. Il est surtout là "pour l’ambiance".`,
-  descriptionKey: 'data.shlagemons.10-15.emboli.description',
+  description: 'data.shlagemons.10-15.emboli.description',
   types: [shlagemonTypes.poison],
   evolutions: [
     { base: pyrolise, condition: { type: 'item', value: lighter } },

--- a/src/data/shlagemons/10-15/nosferailleur.ts
+++ b/src/data/shlagemons/10-15/nosferailleur.ts
@@ -5,14 +5,7 @@ import nosferasta from '../evolutions/nosferasta'
 export const nosferailleur: BaseShlagemon = {
   id: 'nosferailleur',
   name: 'Nosferailleur',
-  description: `Nosferailleur rôde entre les carcasses de machines à laver et les palettes calcinées, planant au-dessus des déchetteries comme un vautour sous méthamphétamines. C’est un hybride improbable entre une chauve-souris épileptique et un vieux grille-pain soviétique.
-
-Sa peau est constellée de morceaux de ferraille rouillée qu’il a “empruntés” sur des scooters abandonnés, et ses ailes grincent à chaque battement, produisant un son si strident qu’il peut arracher les plombages. Il carbure à la fumée de cuivre brûlé et dévore les câbles électriques comme des spaghettis.
-
-Son attaque *Vent de Décharge* envoie une bourrasque tiède chargée de particules métalliques, provoquant paralysie, migraines, et des flashbacks de centre de tri. On le soupçonne aussi d’avoir siphonné plusieurs transformateurs EDF.
-
-Il niche dans les toitures en fibrociment et collectionne les boulons comme des trésors. Certains dresseurs affirment qu’il peut apparaître dans un vieux frigo si on le laisse trop longtemps branché dans un squat.`,
-  descriptionKey: 'data.shlagemons.10-15.nosferailleur.description',
+  description: 'data.shlagemons.10-15.nosferailleur.description',
 
   types: [shlagemonTypes.poison, shlagemonTypes.vol],
   evolution: {

--- a/src/data/shlagemons/15-20/goubite.ts
+++ b/src/data/shlagemons/15-20/goubite.ts
@@ -5,8 +5,7 @@ import feunouille from '../evolutions/feunouille'
 export const goubite: BaseShlagemon = {
   id: 'goubite',
   name: 'Goubite',
-  description: `Goubite est difficile à regarder... et encore plus difficile à oublier. Doté d’un corps long et rosâtre, légèrement bombé sur le haut, il est souvent victime de malentendus anatomiques dans les écoles de dresseurs. Pourtant, lui, il s’assume. Fier, droit, et toujours un peu moite. Sa tête est cerclée d’une barbe flasque, dégoulinante de sueur tiède, qu’il secoue parfois pour marquer son territoire. Il sourit en permanence, d’un air satisfait qui met tout le monde mal à l’aise, même les aveugles. Ses pieds sont fripés, velus, et sentent la crevette oubliée dans une chaussette humide. Il se déplace lentement en produisant un petit bruit mou et répétitif, comparable à un bisou dont on ne veut pas. Sa capacité signature, *Giclée Visqueuse*, inflige des dégâts modérés mais impose un malus mental permanent à ceux qui en sont témoins. Certains affirment qu’il peut aussi lancer *Barbe Emotive*, une attaque qui colle et qui sent la salle de muscu humide. À ne pas confondre avec un objet sexuel. Sauf si vraiment on est pressé de consulter.`,
-  descriptionKey: 'data.shlagemons.15-20.goubite.description',
+  description: 'data.shlagemons.15-20.goubite.description',
   types: [shlagemonTypes.feu],
   evolution: {
     base: feunouille,

--- a/src/data/shlagemons/15-20/nameouesh.ts
+++ b/src/data/shlagemons/15-20/nameouesh.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const nanmeouesh: BaseShlagemon = {
   id: 'nanmeouesh',
   name: 'Nanméouesh',
-  description: `Nanmeouesh passe ses journées à zoner devant la pharmacie en donnant des diagnostics à voix haute, sans qu’on lui demande. Il prétend avoir un diplôme "d’université de la street" et soigne surtout avec du sirop de tonton. Il communique uniquement en "wesh", "t'as capté" et "t’inquiète t’as rien". Malgré son allure nonchalante et ses lunettes trop stylées pour le reste de son corps, il ressent les bobos émotionnels mieux que n’importe quel Psy-type. Son attaque signature, Check-up Relou, oblige tous les ennemis à écouter une consultation de 3 minutes avec bilan complet, ce qui peut causer Sommeil ou Confusion.`,
-  descriptionKey: 'data.shlagemons.15-20.nameouesh.description',
+  description: 'data.shlagemons.15-20.nameouesh.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/15-20/pikachiant.ts
+++ b/src/data/shlagemons/15-20/pikachiant.ts
@@ -6,9 +6,7 @@ import raichiotte from '../evolutions/raichiotte'
 export const pikachiant: BaseShlagemon = {
   id: 'pikachiant',
   name: 'Pikachiant',
-  description: `Pikachiant est capable de te saouler avant même de lancer une attaque. Sa queue ressemble à une antenne de TNT tordue, et il émet des bips stridents dès qu’il est contrarié. Il se décharge en permanence (surtout en présence d’appareils électroniques de valeur), et son attaque signature, *Charge Sociale*, provoque une gêne électrique dans tout un rayon de 3 mètres.
-Il vit généralement dans des squats connectés où il recharge ses batteries avec des câbles USB volés dans les trains. Il pense que TikTok est une source d’énergie et parle en onomatopées gênantes. À ne pas confondre avec Pikachu, même si lui aussi finit souvent dans une Poképrison pour tapage nocturne.`,
-  descriptionKey: 'data.shlagemons.15-20.pikachiant.description',
+  description: 'data.shlagemons.15-20.pikachiant.description',
   types: [shlagemonTypes.electrique],
   evolution: {
     base: raichiotte,

--- a/src/data/shlagemons/15-20/qulbudrogue.ts
+++ b/src/data/shlagemons/15-20/qulbudrogue.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const qulbudrogue: BaseShlagemon = {
   id: 'qulbudrogue',
   name: 'Qulbudrogué',
-  description: `Qulbudrogué est connu pour son attitude détendue et sa démarche nonchalante. Il donne l’impression d’être dans un état de réflexion constante… ou complètement à l’ouest. Il se balade en sifflotant des sons qu’il est probablement le seul à comprendre. On raconte qu’il voit la vie en "slow motion" et qu’il communique avec les autres Pokémon par télépathie — mais uniquement quand il en a envie, c’est-à-dire rarement.`,
-  descriptionKey: 'data.shlagemons.15-20.qulbudrogue.description',
+  description: 'data.shlagemons.15-20.qulbudrogue.description',
   types: [shlagemonTypes.psy],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/20-25/cacanus.ts
+++ b/src/data/shlagemons/20-25/cacanus.ts
@@ -5,16 +5,7 @@ import ricardnin from '../evolutions/ricardnin'
 export const cacanus: BaseShlagemon = {
   id: 'cacanus',
   name: 'Cacanus',
-  description: `Cacanus est un petit chien flamboyant dont l’obsession tourne autour d’un seul et unique point cardinal : l’anus.
-
-Né dans une ruelle à côté d’un centre de compostage, il a grandi en développant une passion étrange pour les odeurs fortes, les frottements suspects, et tout ce qui sort par derrière. Sa truffe est si fine qu’il peut deviner ce qu’un ennemi a mangé il y a trois jours, rien qu’en flairant une chaise vide.
-
-Il attaque rarement de face : son style de combat est centré sur la diversion fécale. Son attaque *Jet de Glandes Anales* inflige des dégâts sur la durée et baisse drastiquement la dignité de l’adversaire. Il peut aussi creuser un petit terrier appelé *Tunnel du Cul*, dans lequel il se cache pour préparer des coups bas (littéralement).
-
-On dit que lorsqu’il est content, il ne remue pas la queue : il te l’offre comme un cadeau, bien sale, bien chaud. Il est l’incarnation canine de l’humour douteux et des plaisirs honteux.
-
-Son flair est légendaire, mais son hygiène mentale, beaucoup moins.`,
-  descriptionKey: 'data.shlagemons.20-25.cacanus.description',
+  description: 'data.shlagemons.20-25.cacanus.description',
   types: [shlagemonTypes.feu, shlagemonTypes.poison],
   evolution: {
     base: ricardnin,

--- a/src/data/shlagemons/20-25/mystouffe.ts
+++ b/src/data/shlagemons/20-25/mystouffe.ts
@@ -5,16 +5,7 @@ import orchibre from '../evolutions/orchibre'
 export const mystouffe: BaseShlagemon = {
   id: 'mystouffe',
   name: 'Mystouffe',
-  description: `Mystouffe est un Shlagémon recouvert d'une touffe si vaste, si dense, si touffue, qu’on ne sait plus vraiment où il commence ni où il finit. Sa pilosité semble dotée d’une vie propre, frémissant au moindre courant d’air, et émettant parfois des sons de sac plastique.
-
-Il vit tapi dans les coins d’appartements insalubres, entre les coussins éventrés et les tas de linge humide. Des rumeurs disent qu’il abrite dans sa touffe des créatures plus petites… voire d'autres Mystouffes.
-
-Il déteste l’eau, les peignes, et les remarques sur son hygiène. Il attaque en agitant frénétiquement sa toison, libérant des spores poisseux et des poils électrostatiques.
-
-Son attaque *Pollen de Touffe* est connue pour déclencher des crises d’éternuements en chaîne chez les dresseurs non préparés. On dit qu’un Mystouffe particulièrement touffu aurait un jour étouffé un aspirateur industriel.
-
-Sa touffe le protège des coups directs, mais le rend lent et imprévisible. Son regard reste un mystère : personne ne l’a jamais vu sous les poils.`,
-  descriptionKey: 'data.shlagemons.20-25.mystouffe.description',
+  description: 'data.shlagemons.20-25.mystouffe.description',
 
   types: [shlagemonTypes.plante, shlagemonTypes.poison],
   evolution: {

--- a/src/data/shlagemons/20-25/plegique.ts
+++ b/src/data/shlagemons/20-25/plegique.ts
@@ -5,16 +5,7 @@ import parasecte from '../evolutions/parasecte'
 export const plegique: BaseShlagemon = {
   id: 'plegique',
   name: 'Plégique',
-  description: `Plégique est un ancien Paras qui a mal tourné lors d’une chute de compost. Depuis, il est paraplégique — ses deux pattes arrière ne répondent plus, figées dans une position étrange qu’il appelle "le yoga du sol". Mais loin de se laisser abattre, il rampe avec la dignité d’un ver de calcaire, traînant derrière lui une traînée de spores et de miettes de pain détrempées.
-
-Ses champignons, devenus trop lourds, l’obligent à se déplacer en roulant sur le côté ou en se laissant glisser sur des cartons imbibés. Il a bricolé une sorte d’exosquelette en canettes vides et morceaux de Tupperware, mais il oublie souvent comment ça s’attache.
-
-Plégique communique avec des cliquetis de mandibules et des phrases absconses du genre "le sol m’a choisi". Il est convaincu que sa condition est un avantage évolutif, car "plus bas que terre, y’a que la vérité".
-
-Son attaque *Spore Rampante* endort l’ennemi en libérant un sifflement humide au ras du sol, tandis que *Myco-Suceur*, sa capacité signature, draine lentement la vie des ennemis... et un peu la tienne aussi, émotionnellement.
-
-Il vit dans des zones Wi-Fi oubliées, collé contre des murs suintants. On dit qu’il peut survivre plusieurs jours sans bouger, simplement en absorbant l’humidité ambiante et des pensées négatives. Un vrai survivant… à sa manière.`,
-  descriptionKey: 'data.shlagemons.20-25.plegique.description',
+  description: 'data.shlagemons.20-25.plegique.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
   evolution: {
     base: parasecte,

--- a/src/data/shlagemons/20-25/ratonton.ts
+++ b/src/data/shlagemons/20-25/ratonton.ts
@@ -5,14 +5,7 @@ import ratartine from '../evolutions/ratartine'
 export const ratonton: BaseShlagemon = {
   id: 'ratonton',
   name: 'Ratonton',
-  description: `Ratonton est un vieux tonton en forme de rat mal rasé, expert en mauvaise foi et en tir au fer. Il ne court pas, il trottine en râlant, le bide en avant, sa moustache grise tremblotant au rythme de ses ricanements. Il vit dans des campings à l’année et pense que la pétanque est un art martial ancestral.
-
-Toujours armé d’une boule cabossée et d’un verre de pastis tiède, il attaque avec *Lancer de Boule Aléatoire*, qui a 50% de chances de rater la cible mais 100% de chances de démolir une glaciaire innocente. Son haleine est classée *toxique* dans certains pays, et sa capacité passive, *Verre Dans Le Nez*, réduit sa précision mais augmente son attaque à chaque toast.
-
-Ratonton parle fort, dit toujours "t’as vu c’est technique hein" après un échec, et se bat uniquement s’il a perdu à la belote. Il peut également utiliser *Tontonade*, une attaque confuse qui consiste à expliquer des règles inventées de pétanque tout en te bousculant verbalement.
-
-Il adore les coins d’ombre, les parasols Lidl, et les anecdotes gênantes. Si on lui parle de retraite ou de régime, il se met à ronfler de colère. Pourtant, malgré tout, il est fidèle. Et il sent le Ricard à 8h du matin.`,
-  descriptionKey: 'data.shlagemons.20-25.ratonton.description',
+  description: 'data.shlagemons.20-25.ratonton.description',
   types: [shlagemonTypes.normal],
   evolution: { base: ratartine, condition: { type: 'lvl', value: 45 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/25-30/grosmitoss.ts
+++ b/src/data/shlagemons/25-30/grosmitoss.ts
@@ -5,12 +5,7 @@ import aerobite from '../evolutions/aerobite'
 export const grosmitoss: BaseShlagemon = {
   id: 'grosmitoss',
   name: 'GrosMitoss',
-  description: `GrosMitoss est un concentré de poils, de mauvaise foi et de fabulations. Son corps sphérique et pelucheux dissimule un cerveau saturé de bobards : il prétend avoir battu un Nidodragqueen avec une feuille de salade, connu Mewteub à l'école primaire, et participé à la création de Shlagémon — rien que ça.
-
-Il parle sans arrêt, même quand personne ne l’écoute, et chaque phrase commence par "C’est vrai, j’te jure !". Les autres Shlagémons le fuient, non pas pour ses attaques, mais pour sa capacité à déformer la réalité à chaque mot. 
-
-Sa compétence spéciale, *Mythobluff*, embrouille l’adversaire en lui faisant douter de tout — y compris de ses propres attaques. Il peut aussi utiliser *Souffle de Pipeau*, un vent nauséabond qui sent fort la mauvaise excuse et la clope froide.`,
-  descriptionKey: 'data.shlagemons.25-30.grosmitoss.description',
+  description: 'data.shlagemons.25-30.grosmitoss.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
   evolution: {
     base: aerobite,

--- a/src/data/shlagemons/25-30/piafsansbec.ts
+++ b/src/data/shlagemons/25-30/piafsansbec.ts
@@ -5,16 +5,7 @@ import { rapasdepisse } from '../evolutions/rapasdepisse'
 export const piafsansbec: BaseShlagemon = {
   id: 'piafsansbec',
   name: 'Piafsansbec',
-  description: `Piafsansbec est un Shlagémon maudit, né avec un potentiel de piaf... mais sans l’accessoire principal : son bec. L’histoire raconte qu’il aurait tenté de l’échanger contre un bonbon dans une brocante, ou qu’il l’a simplement perdu en essayant d’ouvrir une canette de soda trop gazeuse.
-
-Depuis, il vit dans une forme de déni nasal : ses trous de nez compensent tant bien que mal, mais chaque tentative de chant se solde par un *FLUUUUIIII* humide et une grande solitude. Il communique avec des coups d’aile frénétiques, des yeux tristes, et des dessins au sol avec ses pattes crasseuses.
-
-Il ne peut ni manger proprement, ni picorer, ni faire peur aux autres oiseaux — il s’est même fait piquer sa graine par un Papi Suçon une fois. Son attaque signature, *Claquement de Gorge*, consiste à faire vibrer violemment sa trachée pour créer une onde sonore perturbante. Il possède aussi *Regard Gênant*, qui inflige un malus de moral à l’ennemi.
-
-Sa capacité passive, *Silence Pesant*, fait baisser l’initiative des adversaires en les mettant mal à l’aise.
-
-Piafsansbec est souvent vu au bord des routes, essayant de siffler le vent ou de grignoter des miettes qu’il finit par pousser du front, la dignité en option. Mais dans son regard brille une chose rare… non, en fait, non. Rien ne brille. C’est juste humide.`,
-  descriptionKey: 'data.shlagemons.25-30.piafsansbec.description',
+  description: 'data.shlagemons.25-30.piafsansbec.description',
   types: [shlagemonTypes.vol],
   evolution: { base: rapasdepisse, condition: { type: 'lvl', value: 50 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/25-30/taupicouze.ts
+++ b/src/data/shlagemons/25-30/taupicouze.ts
@@ -5,12 +5,7 @@ import triopikouze from '../evolutions/triopikouze'
 export const taupicouze: BaseShlagemon = {
   id: 'taupicouze',
   name: 'Taupicouze',
-  description: `Taupicouze s’est improvisé infirmier de quartier après un stage de 3 semaines non validé dans un centre de désintox. Armé de seringues douteuses et d’un stéthoscope qui sent la cave, il surgit sans prévenir pour "faire une petite piqûre", souvent sans demander le consentement.
-
-Son problème ? Il ne trouve *jamais* la veine. Il plante, il retire, il re-plante… et il jubile. Car derrière son sourire crispant, se cache une âme légèrement sadique. Il adore les cris d’agonie, qu’il interprète comme des encouragements.
-
-Son attaque signature, *Tricouze Saignante*, inflige des dégâts progressifs et désoriente l’ennemi avec une sensation de malaise médical. Il peut aussi utiliser *Piqure Surprise*, qui a 30% de chances de faire perdre connaissance à un Shlagémon... ou au dresseur.`,
-  descriptionKey: 'data.shlagemons.25-30.taupicouze.description',
+  description: 'data.shlagemons.25-30.taupicouze.description',
   types: [shlagemonTypes.sol],
   evolution: {
     base: triopikouze,

--- a/src/data/shlagemons/25-30/waouff.ts
+++ b/src/data/shlagemons/25-30/waouff.ts
@@ -5,12 +5,7 @@ import perchiste from '../evolutions/perchiste'
 export const waouff: BaseShlagemon = {
   id: 'waouff',
   name: 'Waouff',
-  description: `Waouff est le fruit d’une expérience génétique ratée entre un chat castré et un chien errant accro au pain mouillé. Ce Shlagémon aboie sur tout ce qui bouge — ou pas — et court après sa propre ombre dès qu’elle change d’orientation.
-
-Il a un regard vide mais sincère, une langue toujours pendante, et porte autour du cou un vieux collier GPS cassé qu’il lèche compulsivement. Il tente souvent de mordre des roues de vélo, même en combat, ce qui le rend imprévisible mais rarement utile.
-
-Son attaque signature, *Croquette Mental*, inflige des dégâts aléatoires en fonction de la météo, de la phase lunaire et de la marque de la balle qu'on utilise. Il peut aussi utiliser *Aboyeur Passif-Agressif*, qui inflige la confusion à tout le monde... y compris à lui-même.`,
-  descriptionKey: 'data.shlagemons.25-30.waouff.description',
+  description: 'data.shlagemons.25-30.waouff.description',
   types: [shlagemonTypes.normal],
   evolution: {
     base: perchiste,

--- a/src/data/shlagemons/30-35/canarchicon.ts
+++ b/src/data/shlagemons/30-35/canarchicon.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const canarchicon: BaseShlagemon = {
   id: 'canarchicon',
   name: 'Canarchicon',
-  description: `Canarchicon est un cousin dégénéré du célèbre canard qu'on ne nommera pas pour des raisons juridiques. Toujours armé de son poireau fatigué (qu’il appelle tendrement “Jean-Chibre”), il chancelle d’un pas bancal, probablement à cause de ses soirées passées à picoler du bouillon cube fermenté. Son œil au beurre noir laisse deviner un mode de vie instable, fait de bastons derrière des bennes à frites et de paris perdus contre des Roucool. Il ne vole pas, il flotte à moitié — sans réelle direction — au gré des vents et des vapeurs d’alcool de cuisson. Sa capacité signature, *Coup de Poireau Tournoyant*, inflige peu de dégâts mais une honte durable. Il peut aussi utiliser *Flatulence de Gras*, une attaque à effet de zone olfactif. Canarchichon n’a jamais gagné un seul combat, mais il persiste... parce qu’il a oublié qu’il pouvait abandonner.`,
-  descriptionKey: 'data.shlagemons.30-35.canarchicon.description',
+  description: 'data.shlagemons.30-35.canarchicon.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/30-35/melofoutre.ts
+++ b/src/data/shlagemons/30-35/melofoutre.ts
@@ -5,12 +5,7 @@ import meladolphe from '../evolutions/meladolphe'
 export const melofoutre: BaseShlagemon = {
   id: 'melofoutre',
   name: 'Mélofoutre',
-  description: `Mélofoutre est un petit être visqueux à l’apparence faussement candide. Né dans une éprouvette d’amour non-consenti entre une étoile filante et une chaussette oubliée sous un lit d'ado, il brille d’un éclat douteux, oscillant entre le nacré et le gluant.
-
-Sa voix flûtée fait vibrer l’air comme une vieille VHS de film interdit, et sa capacité signature, *Berceuse Mouillée*, endort l’ennemi sous un flot de soupirs gênants. Il peut aussi lancer *Giclée Cosmique*, une attaque magique à la trajectoire imprévisible, qui laisse des taches indélébiles sur l’estime de soi.
-
-Mélofoutre ne cherche pas le combat, mais s’y retrouve souvent par accident… ou par pulsion. Toujours collant, jamais touchant, il est l’anti-héros des berceuses.`,
-  descriptionKey: 'data.shlagemons.30-35.melofoutre.description',
+  description: 'data.shlagemons.30-35.melofoutre.description',
 
   types: [shlagemonTypes.fee, shlagemonTypes.normal],
   evolution: {

--- a/src/data/shlagemons/30-35/nidononbinaire-f.ts
+++ b/src/data/shlagemons/30-35/nidononbinaire-f.ts
@@ -5,10 +5,7 @@ import nidoschneck from '../evolutions/nidoschneck'
 export const nidononbinaireF: BaseShlagemon = {
   id: 'nidononbinaire-f',
   name: 'Nidononbinaire♀',
-  description: `Nidononbinaire♀ a des cornes molles, un regard fixe, et une passion pour les plantes en plastique. Iel n’est pas vraiment là pour se battre, mais iel viendra quand même, avec ses fiches, son tote bag et une vibe étrange.
-
-Iel utilise souvent *Postillonnage Toxique*, une attaque à faible portée mais dont les effets durent étonnamment longtemps. Iel s’entend très bien avec les autres Shlagémons, surtout les moins bavards. En zone sauvage, iel se poste près des bancs et observe… longtemps. Peut-être trop longtemps.`,
-  descriptionKey: 'data.shlagemons.30-35.nidononbinaire-f.description',
+  description: 'data.shlagemons.30-35.nidononbinaire-f.description',
   types: [shlagemonTypes.poison],
   evolution: {
     base: nidoschneck,

--- a/src/data/shlagemons/30-35/nidononbinaire-m.ts
+++ b/src/data/shlagemons/30-35/nidononbinaire-m.ts
@@ -5,10 +5,7 @@ import nidoteub from '../evolutions/nidoteub'
 export const nidononbinaireM: BaseShlagemon = {
   id: 'nidononbinaire-m',
   name: 'Nidononbinaire♂',
-  description: `Nidononbinaire♂ s’est longtemps cherché. Iel porte des pics mais n’attaque jamais en premier. Iel adore les débats, surtout quand personne n’en veut, et iel commence souvent ses phrases par "techniquement". Iel se déplace avec une démarche hésitante mais bruyante, comme quelqu’un qui n’a pas de destination, mais qui veut quand même qu’on le remarque.
-
-Sa capacité *Point-Virgule* inflige peu de dégâts mais perturbe l’ordre d’attaque adverse en le rendant confus grammaticalement. Iel est souvent vu en train de refaire son look dans les flaques d’eau, persuadé que "l’esthétique, c’est déjà une stratégie".`,
-  descriptionKey: 'data.shlagemons.30-35.nidononbinaire-m.description',
+  description: 'data.shlagemons.30-35.nidononbinaire-m.description',
   types: [shlagemonTypes.poison],
   evolution: {
     base: nidoteub,

--- a/src/data/shlagemons/35-40/ferosang.ts
+++ b/src/data/shlagemons/35-40/ferosang.ts
@@ -5,14 +5,7 @@ import coloscopie from '../evolutions/coloscopie'
 export const ferosang: BaseShlagemon = {
   id: 'ferosang',
   name: 'Férosang',
-  description: `Férosang est une créature hargneuse, incontrôlable, et surtout passionnée par sa propre hémorragie. Il n’aime pas saigner : il *vit* pour ça. Chaque plaie est pour lui un trophée, chaque croûte une médaille. Il se cogne exprès les arcades contre des barres de skate, se jette volontairement en roulant sur du gravier, et fait exprès de rater ses tricks pour s’en coller une.
-
-Il a déjà tenté de donner son sang, mais les médecins lui ont dit qu’il n’en avait plus assez. "Trop de pertes, mon reuf", lui a lancé l’infirmière en fixant son coton-tige déjà rouge avant la piqûre. Depuis, il y retourne juste pour se faire piquer.
-
-Férosang est recouvert de pansements douteux, de croûtes arrachées trop tôt et de tatouages faits avec du stylo bic. Ses poings sont constamment en sang, soit parce qu’il frappe, soit parce qu’il frappe *mal*. On le voit souvent rire après s’être pris une droite dans le nez par un lampadaire.
-
-Son attaque signature, *Jet Hémato*, projette un arc de sang corrosif et contaminé, qui inflige panique et malaise. Il possède aussi *Patate Réflexe*, une attaque incontrôlable qui s’active à la moindre tape sur l’épaule.`,
-  descriptionKey: 'data.shlagemons.35-40.ferosang.description',
+  description: 'data.shlagemons.35-40.ferosang.description',
   types: [shlagemonTypes.combat],
   evolution: {
     base: coloscopie,

--- a/src/data/shlagemons/35-40/macho.ts
+++ b/src/data/shlagemons/35-40/macho.ts
@@ -6,14 +6,7 @@ import masschopeur from '../evolutions/masschopeur'
 export const macho: BaseShlagemon = {
   id: 'macho',
   name: 'Macho',
-  description: `Macho a absorbé trop de protéines... et de podcasts douteux. Musclé comme un couvercle de poubelle et persuadé d’être irrésistible, il passe son temps à faire des pompes, des clins d’œil et des blagues de vestiaire à toute créature possédant deux chromosomes X.
-
-Il parle fort, il sent fort, il pense fort — mais rarement bien. Sa technique *Main au Cul* est redoutée non pas pour ses dégâts, mais pour l’inconfort social qu’elle génère. Il dispose également de l’attaque *Blague de Beauf*, qui inflige un malus d’intelligence à toute l’arène pendant trois tours.
-
-Quand il n’est pas en train de se prendre en selfie devant un miroir cassé, il traîne en groupe avec d'autres Shlagémons virilistes, où ils débattent intensément de "la vraie nature des femelles". Aucun débat n’a encore abouti.
-
-Il évolue parfois... en pire.`,
-  descriptionKey: 'data.shlagemons.35-40.macho.description',
+  description: 'data.shlagemons.35-40.macho.description',
   types: [shlagemonTypes.combat],
   evolution: {
     base: masschopeur,

--- a/src/data/shlagemons/35-40/psykonaute.ts
+++ b/src/data/shlagemons/35-40/psykonaute.ts
@@ -5,12 +5,7 @@ import accrocrack from '../evolutions/accrocrack'
 export const psykonaute: BaseShlagemon = {
   id: 'psykonaute',
   name: 'Psykonaute',
-  description: `Psykonaute est l’évolution déviante de PsychoQuack, après qu’il ait découvert les vertus du shit bon marché et des herbes douteuses trouvées sous un banc de Lavanville. Depuis, il passe ses journées avachi sur un vieux canapé, l’œil vide et le bec entrouvert, fixant un écran qui ne capte plus aucune chaîne.
-
-Il arbore un bob délavé floqué "420", des cernes interdimensionnelles et un briquet qu’il appelle "son starter". On dit que ses pouvoirs psy sont toujours là, mais qu’il les utilise uniquement pour faire léviter ses cônes quand il a la flemme de les attraper.
-
-Son attaque signature, *Chichon Cosmique*, enveloppe l’arène d’un nuage dense et sucré, réduisant drastiquement la vitesse de tous les adversaires. Il peut aussi lancer *Télécanapé*, qui l’empêche de bouger pendant 5 tours mais lui rend toute sa vie mentale (ou presque).`,
-  descriptionKey: 'data.shlagemons.35-40.psykonaute.description',
+  description: 'data.shlagemons.35-40.psykonaute.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: accrocrack,

--- a/src/data/shlagemons/35-40/rondonichon.ts
+++ b/src/data/shlagemons/35-40/rondonichon.ts
@@ -5,14 +5,7 @@ import grochichon from '../evolutions/grochichon'
 export const rondonichon: BaseShlagemon = {
   id: 'rondonichon',
   name: 'Rondonichon',
-  description: `Rondonichon est une boule de poils disgracieuse et auto-satisfaite, coincée quelque part entre un hamster de cantine et un sex-toy défectueux. Il rebondit sans arrêt sur ses deux gros tétons, qu’il utilise comme ressorts, et laisse derrière lui une traînée de bave et d’inconfort.
-
-Né d’un croisement douteux avec une peluche retrouvée dans un vide-ordures, il chante des berceuses de PMU et rote sur l’intro. Son attaque *Ballon-Mamelon* fait jaillir un lait tiède dont l’odeur provoque des confusions massives, même chez les Shlagémons rouillés.
-
-Il adore s’incruster dans les sacs des dresseurs pour “y faire sa sieste”, mais finit toujours par s’y reproduire à l’insu de tous. On dit qu’un seul Rondonichon peut contaminer une Shlagéball pour toujours.
-
-Ne pas le caresser. Jamais.`,
-  descriptionKey: 'data.shlagemons.35-40.rondonichon.description',
+  description: 'data.shlagemons.35-40.rondonichon.description',
 
   types: [shlagemonTypes.normal],
   evolution: {

--- a/src/data/shlagemons/40-45/chetibranle.ts
+++ b/src/data/shlagemons/40-45/chetibranle.ts
@@ -5,12 +5,7 @@ import boustiflemme from '../evolutions/boustiflemme'
 export const chetibranle: BaseShlagemon = {
   id: 'chetibranle',
   name: 'Chétibranle',
-  description: `Chétibranle est un Shlagémon réputé pour sa capacité à s’occuper de lui-même avec une assiduité déconcertante. Amateur de plaisirs discrets, il aime s’isoler dans des coins humides pour se consacrer à l’art d’absorber tout ce qui passe à portée de sa tige. Certains chercheurs affirment qu’il est capable d’aspirer la moindre goutte d’énergie ambiante, ne laissant rien lui échapper, même dans les moments les plus solitaires.
-
-Sa technique favorite, *Pompage Introspectif*, consiste à canaliser toutes ses forces vers l’intérieur pour un plaisir personnel rarement égalé dans la faune des shlagémons. D’aucuns racontent qu’après ses longues séances d’absorption, il semble toujours un peu vidé, mais paradoxalement plus rayonnant que jamais.
-
-On ne sait jamais vraiment ce qu’il absorbe, ni ce qu’il fait pousser, mais il laisse toujours derrière lui une étrange atmosphère… moite et contemplative.`,
-  descriptionKey: 'data.shlagemons.40-45.chetibranle.description',
+  description: 'data.shlagemons.40-45.chetibranle.description',
   types: [shlagemonTypes.plante, shlagemonTypes.poison],
   evolution: {
     base: boustiflemme,

--- a/src/data/shlagemons/40-45/raboloss.ts
+++ b/src/data/shlagemons/40-45/raboloss.ts
@@ -5,14 +5,7 @@ import flaclodoss from '../evolutions/flaclodoss'
 export const raboloss: BaseShlagemon = {
   id: 'raboloss',
   name: 'Raboloss',
-  description: `Raboloss erre lentement dans la cour de récré, traînant ses baskets trouées et son jogging trop grand qu'il a récupéré dans un carton discount. Sa fourrure autrefois rose est devenue terne, mouchetée de taches douteuses et de pellicules. Toujours l'air un peu perdu, il garde les yeux rivés au sol, espérant qu'on ne le remarque pas... mais évidemment, il attire tous les regards, surtout ceux des autres shlagémons qui le prennent pour cible.
-
-Avec son expression de poisson-panique et son vieux sac à dos déchiré, il traîne une réputation de boloss ultime. Personne ne connaît la véritable couleur de son pull (il l’a hérité de 3 générations de schlags), et sa coiffure rappelle les matins pluvieux où l’on préfère rester sous la couette.
-
-Son attaque signature, *Gros Lancer de Cartable*, consiste à balancer son sac (qui sent la cantine froide et la misère) sur ses adversaires, infligeant confusion et gêne sociale.
-
-On raconte qu’il rêve, dans ses rares moments d’éveil, de devenir populaire... ou au moins d’avoir un goûter entier pour lui tout seul.`,
-  descriptionKey: 'data.shlagemons.40-45.raboloss.description',
+  description: 'data.shlagemons.40-45.raboloss.description',
   types: [shlagemonTypes.eau, shlagemonTypes.psy],
   evolution: {
     base: flaclodoss,

--- a/src/data/shlagemons/40-45/racaillou.ts
+++ b/src/data/shlagemons/40-45/racaillou.ts
@@ -5,14 +5,7 @@ import gravaglaire from '../evolutions/gravaglaire'
 export const racaillou: BaseShlagemon = {
   id: 'racaillou',
   name: 'Racaillou',
-  description: `Racaillou traîne toute la journée affalé contre un muret tagué, les bras ballants, le regard vitreux sous sa casquette trop grande. Son corps, vaguement rocailleux, est constellé de mégots incrustés et de petits sachets douteux. Sa peau grise est couverte de graffitis, et on dirait qu'il a essayé de cacher ses cernes avec des stickers Panini.
-
-Sa gueule affiche en permanence un sourire narquois, trois dents en or, et un air de te tester pour rien. Il propose aux autres Shlagémons de la “bonne verte” en marmonnant, tout en gardant une main dans sa banane Lacoste déchirée.
-
-**Attaque signature :** *Émanation douteuse* — Racaillou relâche un nuage de fumée nauséabonde qui fait planer tout le monde dans un rayon de 2 mètres, embrouillant les esprits et ralentissant les adversaires.
-
-On raconte qu'il ne se déplace jamais sans sa bande de Gravashlag, toujours prêts à lui fournir un briquet ou à jeter un caillou sur un dresseur trop curieux.`,
-  descriptionKey: 'data.shlagemons.40-45.racaillou.description',
+  description: 'data.shlagemons.40-45.racaillou.description',
   types: [shlagemonTypes.roche, shlagemonTypes.sol],
   evolution: {
     base: gravaglaire,

--- a/src/data/shlagemons/40-45/tatacool.ts
+++ b/src/data/shlagemons/40-45/tatacool.ts
@@ -5,14 +5,7 @@ import tatacruelle from '../evolutions/tatacruelle'
 export const tatacool: BaseShlagemon = {
   id: 'tatacool',
   name: 'Tatacool',
-  description: `Tatacool traîne dans les flaques d’eau croupie derrière les zones industrielles, en rêvant de sa jeunesse où il barbotait dans la piscine municipale. Son corps gélatineux a viré au gris-bleu délavé, constellé de taches de rouille et d’algues collées. Ses deux "joyaux" emblématiques sont désormais des boules de naphtaline fendues, ternies, dont sortent parfois des bulles douteuses.  
-
-Ses tentacules sont tout mous, comme s’il avait passé trois semaines à tremper dans l’eau de vaisselle. Il a des cernes violets sous ses petits yeux hagards, et son regard alterne entre le vide total et une suspicion inexplicable. Il se tient à moitié vautré, comme s’il venait de glisser sur une moule.  
-
-Son attaque signature, *Jet de Morve Aquatique*, asperge l’adversaire d’un mélange visqueux d’eau sale et de morve verte, qui colle pendant des heures. Certains disent qu’il peut aussi faire “Bulle à Pisse” dans les grandes occasions, mais personne ne veut vérifier.  
-
-On raconte que Tatacool collectionne les bouchons de bière et les vieux tickets de bus échoués dans son eau, persuadé que ça porte chance.`,
-  descriptionKey: 'data.shlagemons.40-45.tatacool.description',
+  description: 'data.shlagemons.40-45.tatacool.description',
   types: [shlagemonTypes.eau, shlagemonTypes.poison],
   evolution: {
     base: tatacruelle,

--- a/src/data/shlagemons/45-50/dosolo.ts
+++ b/src/data/shlagemons/45-50/dosolo.ts
@@ -5,11 +5,7 @@ import dopluspersonne from '../evolutions/dopluspersonne'
 export const dosolo: BaseShlagemon = {
   id: 'dosolo',
   name: 'Dosolo',
-  description: `Dosolo, l’autruche la plus triste de la région, erre dans les terrains vagues, tête basse et plumes en bataille. Il n’a littéralement aucun ami, même les pigeons l’ignorent. Son plumage, censé être doux et aéré, est tout terne, piqué de miettes de pain et de chewing-gums séchés.  
-Il se gratte la tête d’un air perdu, l’air de se demander ce qu’il fout là. Son unique crête est aplatie, comme son moral, et il laisse derrière lui des traces de larmes poussiéreuses dans la boue.  
-Son attaque signature, *Coup d’Blues*, plonge l’adversaire dans un désespoir existentiel qui lui fait perdre un tour.  
-On raconte qu’il tente souvent de parler à son ombre, mais même elle a fini par se barrer.`,
-  descriptionKey: 'data.shlagemons.45-50.dosolo.description',
+  description: 'data.shlagemons.45-50.dosolo.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
 
   evolution: {

--- a/src/data/shlagemons/45-50/magnubellule.ts
+++ b/src/data/shlagemons/45-50/magnubellule.ts
@@ -5,14 +5,7 @@ import magnementon from '../evolutions/magnementon'
 export const magnubellule: BaseShlagemon = {
   id: 'magnubellule',
   name: 'Magnubellule',
-  description: `Créature née d’une collision entre un vieux canette aimantée et une libellule qui a trop traîné près des flaques de bière tiède, Magnubellule flotte au-dessus des caniveaux et des parkings d’hypermarchés.  
-Son corps métallique est cabossé, orné d’antennes tordues et d’ailes translucides qui vibrent avec le bruit d’une mobylette qui cale.  
-Sa couleur : un gris terne tacheté de jaune pisse, comme une canette de 8.6 oubliée au soleil.  
-Magnubellule plane avec un regard hagard, souvent perché, prêt à déblatérer des chiffres mystérieux.  
-Son attaque signature, *Brise-Canette*, projette un jet mousseux et tiède, laissant ses adversaires confus — entre 8 souvenirs égarés et 6 excuses bancales.
-
-On raconte que chaque fois que Magnubellule passe en rase-motte, il laisse derrière lui une énigme de la loose et une odeur de festival terminé depuis trois semaines.`,
-  descriptionKey: 'data.shlagemons.45-50.magnubellule.description',
+  description: 'data.shlagemons.45-50.magnubellule.description',
   types: [shlagemonTypes.electrique, shlagemonTypes.insecte],
 
   evolution: {

--- a/src/data/shlagemons/45-50/otamere.ts
+++ b/src/data/shlagemons/45-50/otamere.ts
@@ -5,12 +5,7 @@ import lamantinedu38 from '../evolutions/lamantinedu38'
 export const otamere: BaseShlagemon = {
   id: 'otamere',
   name: 'Otamère',
-  description: `Otamère est la honte de la banquise. Dégoulinant de flotte, il passe ses journées vautré sur des glaçons fondus, la langue pendante, le regard perdu dans le vide. Son pelage, autrefois blanc, est devenu gris-jaune à force de se rouler dans la crasse et de sniffer les flaques douteuses du port.
-
-Son attaque signature, *Jet de Morve Polaire*, consiste à éternuer un glaçon baveux sur ses adversaires, ce qui leur colle un rhume pour trois semaines. On raconte qu’Otamère est interdit de piscine municipale depuis un incident impliquant une bouée percée et un lot de frites en mousse moisis.
-
-Personne n’a jamais vu Otamère sobre. Il aurait soi-disant un tatouage “MAMAN” sous une nageoire, mais personne n’ose vérifier.`,
-  descriptionKey: 'data.shlagemons.45-50.otamere.description',
+  description: 'data.shlagemons.45-50.otamere.description',
   types: [shlagemonTypes.eau],
 
   evolution: {

--- a/src/data/shlagemons/45-50/pouleyta.ts
+++ b/src/data/shlagemons/45-50/pouleyta.ts
@@ -5,12 +5,7 @@ import galopard from '../evolutions/galopard'
 export const pouleyta: BaseShlagemon = {
   id: 'pouleyta',
   name: 'Pouleyta',
-  description: `Pouleyta ressemble à un poney, mais c’est surtout un poulet sur pattes dont les plumes ont pris feu il y a bien trop longtemps. Son crin est constitué de plumes calcinées, mêlées de mégots et de miettes de chips. Il boite légèrement, sent le graillon, et laisse derrière lui une odeur persistante de barbecue foiré.
-
-Son attaque signature, *Flamme Panée*, consiste à se rouler dans la chapelure avant de charger ses adversaires, laissant des traces de graisse sur le terrain. On raconte que Pouleyta attire les chiens errants et les supporters bourrés lors des fêtes de village.
-
-Malgré son allure, il rêve secrètement d'être la mascotte d’un fast-food discount.`,
-  descriptionKey: 'data.shlagemons.45-50.pouleyta.description',
+  description: 'data.shlagemons.45-50.pouleyta.description',
   types: [shlagemonTypes.feu],
   evolution: {
     base: galopard,

--- a/src/data/shlagemons/50-55/cookieyas.ts
+++ b/src/data/shlagemons/50-55/cookieyas.ts
@@ -5,14 +5,7 @@ import crustabridou from '../evolutions/crustabridou'
 export const cookieyas: BaseShlagemon = {
   id: 'cookieyas',
   name: 'Cookieyas',
-  description: `Cookieyas ressemble à un Kokiyas qui aurait fusionné avec un vieux cookie tombé derrière le micro-ondes. Son coquillage est à moitié remplacé par une pâte brisée, toute molle et couverte de miettes douteuses. Il a des éclats de chocolat en guise de dents et des pépites incrustées jusque dans ses yeux globuleux, toujours à moitié fermés par la fatigue.
-
-Sa couleur varie entre le brun cramé et le beige sec, avec parfois des taches de lait caillé ou de confiture séchée sur la carapace. Son expression est un mélange de flemme totale et de suspicion envers quiconque s'approche trop près de "son coin de cuisine".
-
-Attitude générale : Cookieyas passe sa vie vautré dans les miettes, grognant quand on tente de le déloger, et se déplace en laissant une traînée collante derrière lui. Son attaque signature, *Jet de Lait Passé*, consiste à cracher un jet de lait périmé sur ses adversaires, infligeant des dégâts collants et une honte olfactive intense.
-
-On raconte que Cookieyas ne rêve que d’une chose : qu’on le laisse tranquille pour finir sa sieste au chaud derrière la cafetière. Mais gare à celui qui essaie de le grignoter : il mord, et c’est sec !`,
-  descriptionKey: 'data.shlagemons.50-55.cookieyas.description',
+  description: 'data.shlagemons.50-55.cookieyas.description',
   types: [shlagemonTypes.eau],
 
   evolution: {

--- a/src/data/shlagemons/50-55/marginal.ts
+++ b/src/data/shlagemons/50-55/marginal.ts
@@ -5,8 +5,7 @@ import leviaraison from '../evolutions/leviaraison'
 export const marginal: BaseShlagemon = {
   id: 'marginal',
   name: 'Marginal',
-  description: `Marginal passe son temps à jongler sur une corde raide tout en jouant du diabolo. Il fait la manche dans les ports en espérant qu'on lui lance autre chose que des tomates.`,
-  descriptionKey: 'data.shlagemons.50-55.marginal.description',
+  description: 'data.shlagemons.50-55.marginal.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: leviaraison,

--- a/src/data/shlagemons/50-55/tadsperm.ts
+++ b/src/data/shlagemons/50-55/tadsperm.ts
@@ -5,12 +5,7 @@ import grostadsperm from '../evolutions/grostadsperm'
 export const tadsperm: BaseShlagemon = {
   id: 'tadsperm',
   name: 'Tadsperm',
-  description: `Tadsperm est un tas visqueux au teint douteux, oscillant entre le gris laiteux et le beige maladif. Son corps dégouline de gouttes épaisses qui s’échappent en permanence, laissant derrière lui des traces suspectes et gluantes. Son sourire est béat, l’œil mi-clos, l’air totalement détaché du monde extérieur.
-
-Sa principale occupation : s’isoler dans des coins sombres pour savourer les plaisirs les plus solitaires de la vie. Son attaque signature, *Jet Spontané*, consiste à projeter une gerbe collante et opaque qui ralentit et colle l’adversaire sur place.
-
-On raconte qu’il passe plus de temps à “méditer” qu’à se battre. Certains dresseurs disent avoir glissé dessus dans les vestiaires…`,
-  descriptionKey: 'data.shlagemons.50-55.tadsperm.description',
+  description: 'data.shlagemons.50-55.tadsperm.description',
   types: [shlagemonTypes.poison],
   evolution: {
     base: grostadsperm,

--- a/src/data/shlagemons/55-60/amonichiasse.ts
+++ b/src/data/shlagemons/55-60/amonichiasse.ts
@@ -5,8 +5,7 @@ import amonitrace from '../evolutions/amonitrace'
 export const amonichiasse: BaseShlagemon = {
   id: 'amonichiasse',
   name: 'Amonichiasse',
-  description: `Amonichiasse est un mollusque fossilisé qui pue la diarrhée aquatique. Sa coquille gluante est couverte de taches brunâtres, comme si elle avait été utilisée comme seau de secours dans une gastro collective. Deux petits yeux globuleux dépassent mollement de son mucus, constamment embués par la vapeur tiède qu’il dégage. Il avance lentement, en laissant derrière lui une traînée suspecte et visqueuse. Certains dresseurs affirment qu’il émet des bruits de gargouillis intestinaux quand on le secoue trop fort.`,
-  descriptionKey: 'data.shlagemons.55-60.amonichiasse.description',
+  description: 'data.shlagemons.55-60.amonichiasse.description',
   types: [shlagemonTypes.roche, shlagemonTypes.eau],
   evolution: {
     base: amonitrace,

--- a/src/data/shlagemons/55-60/kraputo.ts
+++ b/src/data/shlagemons/55-60/kraputo.ts
@@ -5,8 +5,7 @@ import kaputrak from '../evolutions/kaputrak'
 export const kraputo: BaseShlagemon = {
   id: 'kraputo',
   name: 'Kraputo',
-  description: `Ce crabe éraflé se cache sous un casque cassé et offre ses pinces au plus offrant. Il raffole des fonds de verre et des pièces rouillées.`,
-  descriptionKey: 'data.shlagemons.55-60.kraputo.description',
+  description: 'data.shlagemons.55-60.kraputo.description',
   types: [shlagemonTypes.roche, shlagemonTypes.eau],
   evolution: {
     base: kaputrak,

--- a/src/data/shlagemons/55-60/pauvreetcon.ts
+++ b/src/data/shlagemons/55-60/pauvreetcon.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const pauvreetcon: BaseShlagemon = {
   id: 'pauvreetcon',
   name: 'Pauvreetcon',
-  description: `Pauvreetcon est un amas de polygones bancals issu d’un bug informatique. Il flotte maladroitement en cherchant sa connexion Wi-Fi et affiche de temps en temps un écran bleu en guise de cri.`,
-  descriptionKey: 'data.shlagemons.55-60.pauvreetcon.description',
+  description: 'data.shlagemons.55-60.pauvreetcon.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/55-60/ptitrat.ts
+++ b/src/data/shlagemons/55-60/ptitrat.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const ptitrat: BaseShlagemon = {
   id: 'ptitrat',
   name: 'Ptitrat',
-  description: `Ancien régne fossile au museau pointu, Ptitrat se prend pour un rongeur volant. Sa peau grisâtre s’effrite un peu plus à chaque battement d’aile.`,
-  descriptionKey: 'data.shlagemons.55-60.ptitrat.description',
+  description: 'data.shlagemons.55-60.ptitrat.description',
   types: [shlagemonTypes.roche, shlagemonTypes.vol],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/60-65/carreflex.ts
+++ b/src/data/shlagemons/60-65/carreflex.ts
@@ -1,13 +1,10 @@
 import type { BaseShlagemon } from '~/type'
 import { shlagemonTypes } from '../../shlagemons-type'
 
-export const CARREFLEX_DESCRIPTION = 'carreflex.description'
-
 export const carreflex: BaseShlagemon = {
   id: 'carreflex',
   name: 'Carréflex',
-  description: CARREFLEX_DESCRIPTION,
-  descriptionKey: 'data.shlagemons.60-65.carreflex.description',
+  description: 'data.shlagemons.60-65.carreflex.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/60-65/coksale.ts
+++ b/src/data/shlagemons/60-65/coksale.ts
@@ -5,8 +5,7 @@ import coksnif from '../evolutions/coksnif'
 export const coksale: BaseShlagemon = {
   id: 'coksale',
   name: 'Coksale',
-  description: `Une coccinelle de cité, toujours perchée sur un mégot. Deux yeux globuleux et des ailes qui puent le tabac froid.`,
-  descriptionKey: 'data.shlagemons.60-65.coksale.description',
+  description: 'data.shlagemons.60-65.coksale.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
   evolution: {
     base: coksnif,

--- a/src/data/shlagemons/60-65/houlard.ts
+++ b/src/data/shlagemons/60-65/houlard.ts
@@ -5,8 +5,7 @@ import noctedard from '../evolutions/noctedard'
 export const houlard: BaseShlagemon = {
   id: 'houlard',
   name: 'Houlard',
-  description: `Petit hibou shooté, avec un seul œil rouge qui tourne. Pose sur des poteaux EDF, lâche des fientes phosphorescentes.`,
-  descriptionKey: 'data.shlagemons.60-65.houlard.description',
+  description: 'data.shlagemons.60-65.houlard.description',
   types: [shlagemonTypes.vol, shlagemonTypes.psy],
   evolution: {
     base: noctedard,

--- a/src/data/shlagemons/60-65/kaiminable.ts
+++ b/src/data/shlagemons/60-65/kaiminable.ts
@@ -5,8 +5,7 @@ import croconaze from '../evolutions/croconaze'
 export const kaiminable: BaseShlagemon = {
   id: 'kaiminable',
   name: 'Kaiminable',
-  description: `Petit croco tout bouffi, baveux, qui mord ses propres doigts. A déjà une canette vide accrochée à la queue.`,
-  descriptionKey: 'data.shlagemons.60-65.kaiminable.description',
+  description: 'data.shlagemons.60-65.kaiminable.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: croconaze,

--- a/src/data/shlagemons/65-70/glandignon.ts
+++ b/src/data/shlagemons/65-70/glandignon.ts
@@ -5,8 +5,7 @@ import beuleef from '../evolutions/beuleef'
 export const glandignon: BaseShlagemon = {
   id: 'glandignon',
   name: 'Glandignon',
-  description: `Bébé plante molle et poisseuse. Le bulbe sur sa tête suinte. Odeur de chaussette trempée.`,
-  descriptionKey: 'data.shlagemons.65-70.glandignon.description',
+  description: 'data.shlagemons.65-70.glandignon.description',
   types: [shlagemonTypes.plante],
   evolution: {
     base: beuleef,

--- a/src/data/shlagemons/65-70/hericouille.ts
+++ b/src/data/shlagemons/65-70/hericouille.ts
@@ -5,8 +5,7 @@ import heriplouf from '../evolutions/heriplouf'
 export const hericouille: BaseShlagemon = {
   id: 'hericouille',
   name: 'Héricouille',
-  description: `Petit hérisson gris, les flammes ne s’allument plus. Il tousse en permanence, il a des brûlures aux fesses.`,
-  descriptionKey: 'data.shlagemons.65-70.hericouille.description',
+  description: 'data.shlagemons.65-70.hericouille.description',
   types: [shlagemonTypes.feu],
   evolution: {
     base: heriplouf,

--- a/src/data/shlagemons/65-70/minidrapcon.ts
+++ b/src/data/shlagemons/65-70/minidrapcon.ts
@@ -5,8 +5,7 @@ import drapcon from '../evolutions/drapcon'
 export const minidrapcon: BaseShlagemon = {
   id: 'minidrapcon',
   name: 'Minidrapcon',
-  description: `Petit serpent drapé et un peu demeuré, il se prend souvent les crochets dans ses propres replis.`,
-  descriptionKey: 'data.shlagemons.65-70.minidrapcon.description',
+  description: 'data.shlagemons.65-70.minidrapcon.description',
   types: [shlagemonTypes.dragon],
   evolution: {
     base: drapcon,

--- a/src/data/shlagemons/65-70/qwiflash.ts
+++ b/src/data/shlagemons/65-70/qwiflash.ts
@@ -5,8 +5,7 @@ import qwiflouch from '../evolutions/qwiflouch'
 export const qwiflash: BaseShlagemon = {
   id: 'qwiflash',
   name: 'Qwiflash',
-  description: `Poisson gonflé, mais tout mollasson, flotte à moitié crevé dans les caniveaux. Tire la langue, sans raison.`,
-  descriptionKey: 'data.shlagemons.65-70.qwiflash.description',
+  description: 'data.shlagemons.65-70.qwiflash.description',
   types: [shlagemonTypes.eau, shlagemonTypes.poison],
   evolution: {
     base: qwiflouch,

--- a/src/data/shlagemons/70-75/krabbyjaccob.ts
+++ b/src/data/shlagemons/70-75/krabbyjaccob.ts
@@ -5,8 +5,7 @@ import krabbolosse from '../evolutions/krabbolosse'
 export const krabbyjaccob: BaseShlagemon = {
   id: 'krabbyjaccob',
   name: 'Krabbyjaccob',
-  description: `Ce crustacé porte une petite kippa et danse sans arrêt comme dans le vieux film dont il est fan. Entre deux blagues douteuses, il pince tout ce qui traîne pour vérifier si c'est cashèr.`,
-  descriptionKey: 'data.shlagemons.70-75.krabbyjaccob.description',
+  description: 'data.shlagemons.70-75.krabbyjaccob.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: krabbolosse,

--- a/src/data/shlagemons/70-75/onixtamere.ts
+++ b/src/data/shlagemons/70-75/onixtamere.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const onixtamere: BaseShlagemon = {
   id: 'onixtamere',
   name: 'Onixtamere',
-  description: `Onixtamere est un gigantesque serpent de pierre qui se prend pour une reine tout en se déguisant en ta maman. Il parade au milieu des canyons en vantant ses conquêtes de papas comme d’autres collectionnent les cailloux. Son corps segmenté résonne à chaque mouvement, histoire d’annoncer son arrivée bien avant qu’il ouvre la bouche.`,
-  descriptionKey: 'data.shlagemons.70-75.onixtamere.description',
+  description: 'data.shlagemons.70-75.onixtamere.description',
   types: [shlagemonTypes.sol, shlagemonTypes.roche],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/70-75/soporifiak.ts
+++ b/src/data/shlagemons/70-75/soporifiak.ts
@@ -5,8 +5,7 @@ import hypsedentaire from '../evolutions/hypsedentaire'
 export const soporifiak: BaseShlagemon = {
   id: 'soporifiak',
   name: 'Soporifiak',
-  description: `Soporifiak roupille partout où il passe et son postérieur disproportionné lui sert d’oreiller improvisé. Il charme les passants en promettant des siestes miraculeuses avant de s’endormir lui-même en plein milieu de la conversation.`,
-  descriptionKey: 'data.shlagemons.70-75.soporifiak.description',
+  description: 'data.shlagemons.70-75.soporifiak.description',
   types: [shlagemonTypes.psy],
   evolution: {
     base: hypsedentaire,

--- a/src/data/shlagemons/70-75/voltamere.ts
+++ b/src/data/shlagemons/70-75/voltamere.ts
@@ -6,8 +6,7 @@ import electrobeauf from '../evolutions/electrobeauf'
 export const voltamere: BaseShlagemon = {
   id: 'voltamere',
   name: 'Voltamère',
-  description: `Voltamère ressemble à une vieille daronne déguisée en boule. Il vole tout ce qui brille pour l'empiler dans son sac à main imaginaire. Gare à la décharge statique quand il te fouille les poches !`,
-  descriptionKey: 'data.shlagemons.70-75.voltamere.description',
+  description: 'data.shlagemons.70-75.voltamere.description',
   types: [shlagemonTypes.electrique],
   evolution: {
     base: electrobeauf,

--- a/src/data/shlagemons/75-80/chignon.ts
+++ b/src/data/shlagemons/75-80/chignon.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const chignon: BaseShlagemon = {
   id: 'chignon',
   name: 'Chignon',
-  description: `Toujours tiré à quatre épingles, Chignon se bat avec des attaques de coiffure redoutables. Il lance ses épingles comme des shurikens et s'arrange pour que tout le monde admire sa queue-de-cheval.`,
-  descriptionKey: 'data.shlagemons.75-80.chignon.description',
+  description: 'data.shlagemons.75-80.chignon.description',
   types: [shlagemonTypes.combat],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/75-80/dentlait.ts
+++ b/src/data/shlagemons/75-80/dentlait.ts
@@ -2,13 +2,10 @@ import type { BaseShlagemon } from '~/type'
 import { shlagemonTypes } from '../../shlagemons-type'
 import hosoltueur from '../evolutions/hosoltueur'
 
-export const DENTLAIT_DESCRIPTION = 'dentlait.description'
-
 export const dentlait: BaseShlagemon = {
   id: 'dentlait',
   name: 'Dentlait',
-  description: DENTLAIT_DESCRIPTION,
-  descriptionKey: 'data.shlagemons.75-80.dentlait.description',
+  description: 'data.shlagemons.75-80.dentlait.description',
   types: [shlagemonTypes.sol],
   evolution: {
     base: hosoltueur,

--- a/src/data/shlagemons/75-80/huithuit.ts
+++ b/src/data/shlagemons/75-80/huithuit.ts
@@ -5,8 +5,7 @@ import noadcajou from '../evolutions/noadcajou'
 export const huithuit: BaseShlagemon = {
   id: 'huithuit',
   name: 'Huithuit',
-  description: `Formé de deux chiffres huit tout collés, Huithuit adore faire des blagues sur les œufs. Il se dandine maladroitement et déclenche parfois des visions psychédéliques chez ceux qui le regardent trop longtemps.`,
-  descriptionKey: 'data.shlagemons.75-80.huithuit.description',
+  description: 'data.shlagemons.75-80.huithuit.description',
   types: [shlagemonTypes.plante, shlagemonTypes.psy],
   evolution: {
     base: noadcajou,

--- a/src/data/shlagemons/75-80/kistlee.ts
+++ b/src/data/shlagemons/75-80/kistlee.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const kistlee: BaseShlagemon = {
   id: 'kistlee',
   name: 'Kistlee',
-  description: `Kistlee possède un énorme kyste qui sert autant d'arme que de chaise. Il frappe ses ennemis à coups de pied tout en se plaignant que ça tire un peu.`,
-  descriptionKey: 'data.shlagemons.75-80.kistlee.description',
+  description: 'data.shlagemons.75-80.kistlee.description',
   types: [shlagemonTypes.combat],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/80-85/languedepute.ts
+++ b/src/data/shlagemons/80-85/languedepute.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const languedepute: BaseShlagemon = {
   id: 'languedepute',
   name: 'Languedepute',
-  description: `Sa langue interminable traîne partout et sert principalement à médire. Il aime critiquer ses adversaires jusqu'à ce qu'ils abandonnent par lassitude.`,
-  descriptionKey: 'data.shlagemons.80-85.languedepute.description',
+  description: 'data.shlagemons.80-85.languedepute.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/80-85/lecocu.ts
+++ b/src/data/shlagemons/80-85/lecocu.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const lecocu: BaseShlagemon = {
   id: 'lecocu',
   name: 'Lecocu',
-  description: `Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.`,
-  descriptionKey: 'data.shlagemons.80-85.lecocu.description',
+  description: 'data.shlagemons.80-85.lecocu.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/80-85/rhinofaringite.ts
+++ b/src/data/shlagemons/80-85/rhinofaringite.ts
@@ -5,8 +5,7 @@ import rhinoplastie from '../evolutions/rhinoplastie'
 export const rhinofaringite: BaseShlagemon = {
   id: 'rhinofaringite',
   name: 'Rhinofaringite',
-  description: `Ce rhinocéros enrhumé éternue des rochers sur ses ennemis. Son nez coule en permanence, ce qui le rend aussi glissant qu'imprévisible.`,
-  descriptionKey: 'data.shlagemons.80-85.rhinofaringite.description',
+  description: 'data.shlagemons.80-85.rhinofaringite.description',
   types: [shlagemonTypes.sol, shlagemonTypes.roche],
   evolution: {
     base: rhinoplastie,

--- a/src/data/shlagemons/80-85/smongol.ts
+++ b/src/data/shlagemons/80-85/smongol.ts
@@ -5,8 +5,7 @@ import smongogol from '../evolutions/smongogol'
 export const smongol: BaseShlagemon = {
   id: 'smongol',
   name: 'Smongol',
-  description: `Smongol flotte dans une brume toxique et regarde le vide d'un air hébété. Il ne comprend pas grand-chose, mais il adore exploser quand on le secoue trop.`,
-  descriptionKey: 'data.shlagemons.80-85.smongol.description',
+  description: 'data.shlagemons.80-85.smongol.description',
   types: [shlagemonTypes.poison],
   evolution: {
     base: smongogol,

--- a/src/data/shlagemons/85-90/hypotrompe.ts
+++ b/src/data/shlagemons/85-90/hypotrompe.ts
@@ -5,8 +5,7 @@ import hyporuisseau from '../evolutions/hyporuisseau'
 export const hypotrompe: BaseShlagemon = {
   id: 'hypotrompe',
   name: 'Hypotrompe',
-  description: `Petit hippocampe distrait, Hypotrompe se trompe constamment de direction. Sa trompe démesurée lui sert à aspirer tout ce qui passe, y compris des objets qui n'auraient jamais dû finir dans un estomac.`,
-  descriptionKey: 'data.shlagemons.85-90.hypotrompe.description',
+  description: 'data.shlagemons.85-90.hypotrompe.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: hyporuisseau,

--- a/src/data/shlagemons/85-90/kandurex.ts
+++ b/src/data/shlagemons/85-90/kandurex.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const kandurex: BaseShlagemon = {
   id: 'kandurex',
   name: 'Kandurex',
-  description: `Toujours équipé de préservatifs fluo, Kandurex vante ses prouesses au lit à qui veut l'entendre. Il distribue des conseils douteux sur la reproduction entre deux uppercuts.`,
-  descriptionKey: 'data.shlagemons.85-90.kandurex.description',
+  description: 'data.shlagemons.85-90.kandurex.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/85-90/poissaucisse.ts
+++ b/src/data/shlagemons/85-90/poissaucisse.ts
@@ -5,8 +5,7 @@ import poissomerguez from '../evolutions/poissomerguez'
 export const poissaucisse: BaseShlagemon = {
   id: 'poissaucisse',
   name: 'Poissaucisse',
-  description: `Poissocisse se nourrit exclusivement de saucisses. Son odeur charcutière attire chiens et dresseurs affamés, ce qui le rend paradoxalement difficile à pêcher.`,
-  descriptionKey: 'data.shlagemons.85-90.poissaucisse.description',
+  description: 'data.shlagemons.85-90.poissaucisse.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: poissomerguez,

--- a/src/data/shlagemons/85-90/strabisme.ts
+++ b/src/data/shlagemons/85-90/strabisme.ts
@@ -6,8 +6,7 @@ import stabiscarosse from '../evolutions/stabiscarosse'
 export const strabisme: BaseShlagemon = {
   id: 'strabisme',
   name: 'Strabisme',
-  description: `Ses yeux partent chacun dans une direction différente, ce qui déstabilise ses adversaires. Il brille d'une lueur aquatique quand on lui parle de vacances au bord de la mer.`,
-  descriptionKey: 'data.shlagemons.85-90.strabisme.description',
+  description: 'data.shlagemons.85-90.strabisme.description',
   types: [shlagemonTypes.eau],
   evolution: {
     base: stabiscarosse,

--- a/src/data/shlagemons/90-95/elektektonik.ts
+++ b/src/data/shlagemons/90-95/elektektonik.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const elektektonik: BaseShlagemon = {
   id: 'elektektonik',
   name: 'Elektektonik',
-  description: `Toujours en train de danser la tecktonik, il électrise l'air autour de lui. Ses mouvements saccadés déclenchent de petites décharges qui font sauter les plombs partout où il passe.`,
-  descriptionKey: 'data.shlagemons.90-95.elektektonik.description',
+  description: 'data.shlagemons.90-95.elektektonik.description',
   types: [shlagemonTypes.electrique],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/90-95/insinerateur.ts
+++ b/src/data/shlagemons/90-95/insinerateur.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const insinerateur: BaseShlagemon = {
   id: 'insinerateur',
   name: 'Insinérateur',
-  description: `Armé de lames insectes, il a surtout envie de mettre le feu à tout ce qui bouge. Sa passion pour la combustion le rend particulièrement dangereux dans les forêts.`,
-  descriptionKey: 'data.shlagemons.90-95.insinerateur.description',
+  description: 'data.shlagemons.90-95.insinerateur.description',
   types: [shlagemonTypes.insecte],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/90-95/lipposucsion.ts
+++ b/src/data/shlagemons/90-95/lipposucsion.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const lipposucsion: BaseShlagemon = {
   id: 'lipposucsion',
   name: 'Lipposucsion',
-  description: `Après une liposuccion ratée, ce Shlagémon a la peau toute fripée et un tempérament glacial. Il embrasse ses ennemis pour les geler sur place avant de se plaindre de ses kilos en trop.`,
-  descriptionKey: 'data.shlagemons.90-95.lipposucsion.description',
+  description: 'data.shlagemons.90-95.lipposucsion.description',
   types: [shlagemonTypes.glace, shlagemonTypes.psy],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/90-95/m-ventriloque.ts
+++ b/src/data/shlagemons/90-95/m-ventriloque.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const mVentriloque: BaseShlagemon = {
   id: 'm-ventriloque',
   name: 'M. Ventriloque',
-  description: `C'est le sosie raté d'un célèbre humoriste et il passe son temps à discuter avec sa propre main. Ses tours de ventriloquie mettent mal à l'aise plus qu'ils ne font rire.`,
-  descriptionKey: 'data.shlagemons.90-95.m-ventriloque.description',
+  description: 'data.shlagemons.90-95.m-ventriloque.description',
   types: [shlagemonTypes.psy],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/95-99/lokhlash.ts
+++ b/src/data/shlagemons/95-99/lokhlash.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const lokhlash: BaseShlagemon = {
   id: 'lokhlash',
   name: 'Lokhlash',
-  description: `Lokhlash adore participer à des battles de rap improvisées sur son dos. Il navigue de scène en scène, lâchant des punchlines glaciales qui font frissonner l'auditoire.`,
-  descriptionKey: 'data.shlagemons.95-99.lokhlash.description',
+  description: 'data.shlagemons.95-99.lokhlash.description',
   types: [shlagemonTypes.eau, shlagemonTypes.glace],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/95-99/magmaretfred.ts
+++ b/src/data/shlagemons/95-99/magmaretfred.ts
@@ -1,13 +1,10 @@
 import type { BaseShlagemon } from '~/type'
 import { shlagemonTypes } from '../../shlagemons-type'
 
-export const MAGMARETFRED_DESCRIPTION = 'magmaretfred.description'
-
 export const magmaretfred: BaseShlagemon = {
   id: 'magmaretfred',
   name: 'Magmar&Fred',
-  description: MAGMARETFRED_DESCRIPTION,
-  descriptionKey: 'data.shlagemons.95-99.magmaretfred.description',
+  description: 'data.shlagemons.95-99.magmaretfred.description',
   types: [shlagemonTypes.feu],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/95-99/scarapute.ts
+++ b/src/data/shlagemons/95-99/scarapute.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const scarapute: BaseShlagemon = {
   id: 'scarapute',
   name: 'Scarapute',
-  description: `Cet insecte adore sucer le sang des voyageurs imprudents. On le voit souvent roder près des campings à la recherche d'un mollet juteux.`,
-  descriptionKey: 'data.shlagemons.95-99.scarapute.description',
+  description: 'data.shlagemons.95-99.scarapute.description',
   types: [shlagemonTypes.insecte],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/95-99/taurus.ts
+++ b/src/data/shlagemons/95-99/taurus.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const taurus: BaseShlagemon = {
   id: 'taurus',
   name: 'Taurus',
-  description: `Taurus est littéralement un taureau géométrique. Ses angles parfaits le rendent difficile à approcher sans se prendre une arrête dans les côtes.`,
-  descriptionKey: 'data.shlagemons.95-99.taurus.description',
+  description: 'data.shlagemons.95-99.taurus.description',
   types: [shlagemonTypes.normal],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/artichaud.ts
+++ b/src/data/shlagemons/artichaud.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../shlagemons-type'
 export const artichaud: BaseShlagemon = {
   id: 'artichaud',
   name: 'Artichaud',
-  description: `Artichaud est un Shlagémon légendaire qui symbolise le paradoxe ultime : avoir froid en transpirant. Né d’un choc thermique entre une glacière éventrée et une friteuse oubliée, il erre dans les friches industrielles, couvert de givre et de gouttes de sueur en même temps. Ses ailes en plumes de congélateur diffusent une brume glaciale, mais il porte toujours un Marcel trempé et un bonnet en laine boulochée. 
-
-On raconte qu’il est capable de déclencher des tempêtes de neige tiède, et qu’il fond dès qu’il s’énerve — avant de refiger dans la minute qui suit. Des témoins l’auraient aperçu en train de se réchauffer à côté d’un feu… qu’il a lui-même glacé. Il parle en soufflant de la buée chaude, et laisse derrière lui une traînée de taches humides et d’odeurs de soupe tiédie.
-
-Autrefois vénéré comme le “Gardien du Micro-ondes Sacré”, il aurait été banni du royaume des Shlagémons nobles pour avoir tenté de cuire des raviolis surgelés… sans enlever l’opercule métallique.
-
-Aujourd’hui, Artichaud veille sur les zones de non-droit climatiques, où il impose son règne moite et frigorifié, entre deux éternuements fumants et des engelures de l’aisselle.`,
-  descriptionKey: 'data.shlagemons.artichaud.description',
+  description: 'data.shlagemons.artichaud.description',
 
   types: [shlagemonTypes.glace, shlagemonTypes.vol],
   speciality: 'legendary',

--- a/src/data/shlagemons/bulgrosboule.ts
+++ b/src/data/shlagemons/bulgrosboule.ts
@@ -5,8 +5,7 @@ import { barbeBizarre } from './evolutions/barbe-bizarre'
 export const bulgrosboule: BaseShlagemon = {
   id: 'bulgrosboule',
   name: 'Bulgrosboule',
-  description: `Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller.`,
-  descriptionKey: 'data.shlagemons.bulgrosboule.description',
+  description: 'data.shlagemons.bulgrosboule.description',
   types: [shlagemonTypes.plante],
   evolution: { base: barbeBizarre, condition: { type: 'lvl', value: 16 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/carapouffe.ts
+++ b/src/data/shlagemons/carapouffe.ts
@@ -5,8 +5,7 @@ import { carabifle } from './evolutions/carabifle'
 export const carapouffe: BaseShlagemon = {
   id: 'carapouffe',
   name: 'Carapouffe',
-  description: `Carapouffe s'est enfoncée dans sa propre carapace moelleuse, elle ne se déplace qu’en roulant lentement, laissant derrière elle une traînée de paillettes et de gloss fondu. Son maquillage dégouline en permanence, formant une couche protectrice impénétrable — les scientifiques appellent ça le « fard d’armure ». Dotée d’un regard mi-séduisant, mi-comateux, elle hypnotise ses adversaires en leur lançant des œillades flasques, accompagnées d’un soupir de lassitude cosmique. Elle passe ses journées à se recoiffer sans bouger la tête, grâce à un système complexe de brosses dissimulées dans son chignon. Sa voix est rauque, son parfum est toxique, et sa principale attaque, "Écrasement Moussant", consiste à s’écrouler violemment sur son ennemi en faisant claquer ses faux ongles.`,
-  descriptionKey: 'data.shlagemons.carapouffe.description',
+  description: 'data.shlagemons.carapouffe.description',
   types: [shlagemonTypes.eau],
   evolution: { base: carabifle, condition: { type: 'lvl', value: 16 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/electhordu.ts
+++ b/src/data/shlagemons/electhordu.ts
@@ -4,16 +4,7 @@ import { shlagemonTypes } from '../shlagemons-type'
 export const electhordu: BaseShlagemon = {
   id: 'electhordu',
   name: 'Électhordu',
-  description: `Électhordu est un Shlagémon légendaire né d’un transformateur éclaté pendant une rave sauvage sous la pluie. Frappé par la foudre 347 fois (volontairement), il en est ressorti secoué comme jamais, avec le bec de travers, les plumes hérissées à vie, et un regard qui ne fixe jamais dans la même direction.
-
-Son cri, proche d’un vieux néon qui grésille, perturbe les ondes radio à des kilomètres à la ronde. Il vole en zigzag, souvent à l’envers, et s’électrocute lui-même pour rester éveillé. Son plumage est composé de câbles dénudés et de bouts d’antennes de télé volées. Certains disent qu’il porte toujours une multiprise autour du cou “pour recharger sa haine”.
-
-Électhordu n’a aucun sens de l’orientation, ni des limites sociales. Il débarque sans prévenir dans les zones industrielles désaffectées, où il frotte son plumage contre les pylônes pour “faire des étincelles d’amour”. Chaque battement d’aile provoque des surtensions, des pannes d’ascenseur, et des réveils en panique.
-
-Selon les shlagémonologues, Électhordu était jadis le gardien du “Courant Originel”, une énergie sacrée qui devait équilibrer le monde… mais il a confondu le disjoncteur sacré avec une friteuse et a tout cramé.
-
-Aujourd’hui, il erre, tordu du bec au voltage, parlant seul dans les fils électriques, et semant le chaos statique dans son sillage. Il est à la fois craint, moqué, et branché sur du 12 000 volts en permanence.`,
-  descriptionKey: 'data.shlagemons.electhordu.description',
+  description: 'data.shlagemons.electhordu.description',
 
   types: [shlagemonTypes.electrique, shlagemonTypes.vol],
   speciality: 'legendary',

--- a/src/data/shlagemons/evolutions/accrocrack.ts
+++ b/src/data/shlagemons/evolutions/accrocrack.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const accrocrack: BaseShlagemon = {
   id: 'accrocrack',
   name: 'Accrocrack',
-  description: `Accrocrack est ce qu’on appelle un “mauvais trip évolutif”. Il s’agit de l’évolution tragique de Psykonaute, après que celui-ci ait remplacé ses pétards artisanaux par des cailloux chimiques bien plus violents.
-
-Avec ses plumes en vrac, son regard halluciné et son bec fendu par les rires nerveux, Accrocrack passe son temps à errer dans des zones sombres du Shlagédex, frottant frénétiquement le sol à la recherche d’une pipe imaginaire. Son cri strident évoque à la fois le manque et la détresse existentielle.
-
-Il porte parfois un sac plastique en guise de cape et marmonne des théories cosmologiques incompréhensibles à des lampadaires. Son attaque signature, *Flashback Violent*, plonge tous les combattants dans une confusion intense pendant plusieurs tours. Il utilise aussi *Tirage d’Urgence*, qui lui permet de rejouer un tour au prix de la moitié de sa santé mentale.`,
-  descriptionKey: 'data.shlagemons.evolutions.accrocrack.description',
+  description: 'data.shlagemons.evolutions.accrocrack.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/aerobite.ts
+++ b/src/data/shlagemons/evolutions/aerobite.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const aerobite: BaseShlagemon = {
   id: 'aerobite',
   name: 'Aérobite',
-  description: `Aérobite est l’évolution honteusement assumée de GrosMitoss. Une créature ailée qui plane dans les airs... en toute impunité. Il a troqué son pelage pour une pilosité sélective : le torse rasé de près, mais le bas... comment dire… *aéré*. Et ça ne le dérange pas, bien au contraire — il revendique une "liberté corporelle totale".
-
-D’une impudeur sans faille, Aérobite adore surgir sans prévenir dans des lieux publics, déclenchant malaise et regards fuyants. Il clame haut et fort que “le corps, c’est naturel”, tout en déployant ses ailes à paillettes façon exhibition de foire.
-
-Son attaque signature *Claqueburnes* inflige des dégâts sonores et psychologiques, tandis que *Vent Glacial* laisse souvent les adversaires tétanisés — pas à cause du froid, mais du traumatisme visuel. On dit qu’aucun dresseur n’est jamais vraiment prêt à le voir voler au ralenti… jambes écartées.`,
-  descriptionKey: 'data.shlagemons.evolutions.aerobite.description',
+  description: 'data.shlagemons.evolutions.aerobite.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/alakalbar.ts
+++ b/src/data/shlagemons/evolutions/alakalbar.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const alakalbar: BaseShlagemon = {
   id: 'alakalbar',
   name: 'Alakalbar',
-  description: `Considéré comme un sage dans son quartier... du moins par lui-même. Il prétend maîtriser les arts mystiques du *Contrôle du Destin* mais confond souvent télékinésie et procrastination. On le reconnaît à ses deux grosses cuillères de cantine, tordues à force de remuer du thé aux herbes chelou dans des bouteilles de soda. Vêtu d’une djellaba délavée et d’un regard qui voit à travers toi (mais pas très loin), il marmonne des incantations approximatives pendant qu’il fait tourner sa sacoche à bandoulière en plastique doré. Il prétend méditer, mais il dort à 80%. Sa capacité spéciale, *Chakra Perimé*, déséquilibre l’ennemi avec une odeur de patchouli acide et une attaque psychique floue. Il peut aussi invoquer son attaque signature, *Projection Spirituelle*, qui consiste à lancer une cuillère sur son adversaire en hurlant “vision sacrée !” sans grand effet. On le croise souvent assis sur un banc, seul, en train de discuter avec ses propres Pokéball vides.`,
-  descriptionKey: 'data.shlagemons.evolutions.alakalbar.description',
+  description: 'data.shlagemons.evolutions.alakalbar.description',
   types: [shlagemonTypes.psy],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/alligastro.ts
+++ b/src/data/shlagemons/evolutions/alligastro.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const alligastro: BaseShlagemon = {
   id: 'alligastro',
   name: 'Alligastro',
-  description: `Géant torse nu avec une gueule de travers. Pue la bière et le vomi, et vomit la bière. Parle que en borborygmes.`,
-  descriptionKey: 'data.shlagemons.evolutions.alligastro.description',
+  description: 'data.shlagemons.evolutions.alligastro.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/amonitrace.ts
+++ b/src/data/shlagemons/evolutions/amonitrace.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const amonitrace: BaseShlagemon = {
   id: 'amonitrace',
   name: 'Amonitrace',
-  description: `Amonitrace est la forme décadente d’Amonichiasse. Sa coquille porte des traces suspectes et il tente de glisser loin des regards embarrassés.`,
-  descriptionKey: 'data.shlagemons.evolutions.amonitrace.description',
+  description: 'data.shlagemons.evolutions.amonitrace.description',
   types: [shlagemonTypes.roche, shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/barbe-bizarre.ts
+++ b/src/data/shlagemons/evolutions/barbe-bizarre.ts
@@ -5,10 +5,7 @@ import { floripute } from './floripute'
 export const barbeBizarre: BaseShlagemon = {
   id: 'barbe-bizarre',
   name: 'Barbebizarre',
-  description: `Barbe Bizarre est l’évolution grotesquement majestueuse de Bulgrosboule. Il a troqué ses bulles fessières pour une barbe mousseuse qui dégouline en permanence, composée d’un mélange inconnu entre dentifrice périmé et savon d'hôtel volé. Malgré son air hagard et sa démarche traînante, il se prend très au sérieux, persuadé d'être l'élu d’une prophétie écrite sur un emballage de kebab.
-
-Il parle en citations absurdes qu’il invente sur le moment (“si l’eau monte, c’est que t’es en bas”), et provoque ses adversaires à coups de bulles odorantes surgissant de son dos, appelées *Flatulence Mentale*. Son attaque signature, *Moussattaque*, étouffe ses ennemis sous une barbe si dense qu’on s’y perd physiquement et mentalement. On le trouve souvent en train de prêcher des paroles floues à des lampadaires.`,
-  descriptionKey: 'data.shlagemons.evolutions.barbe-bizarre.description',
+  description: 'data.shlagemons.evolutions.barbe-bizarre.description',
 
   types: [shlagemonTypes.plante],
   evolution: { base: floripute, condition: { type: 'lvl', value: 36 } },

--- a/src/data/shlagemons/evolutions/barbok.ts
+++ b/src/data/shlagemons/evolutions/barbok.ts
@@ -4,10 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const barbok: BaseShlagemon = {
   id: 'barbok',
   name: 'Barbok',
-  description: `Barbok est la forme évoluée d’Amoche, devenue plus imposante, plus poilue… et surtout plus fière de sa barbe que de ses capacités de combat. Sa pilosité faciale est incohérente et pousse jusqu’au bout de ses écailles. Il passe un temps démesuré à la peigner avec sa langue bifide, convaincu qu’elle lui donne +12 en charisme.
-
-Ancien joueur de Iop sur un vieux serveur oublié, il croit toujours qu’il a un rôle crucial dans le combat, même s’il passe plus de temps à commenter les tours qu’à les jouer. Ses attaques sont bruyantes et peu efficaces, comme *Coup d'Barbe*, qui inflige des dégâts très moyens mais provoque parfois un saignement de honte chez l’adversaire.`,
-  descriptionKey: 'data.shlagemons.evolutions.barbok.description',
+  description: 'data.shlagemons.evolutions.barbok.description',
   types: [shlagemonTypes.poison],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/beuleef.ts
+++ b/src/data/shlagemons/evolutions/beuleef.ts
@@ -5,8 +5,7 @@ import moisanium from './moisanium'
 export const beuleef: BaseShlagemon = {
   id: 'beuleef',
   name: 'Beuleef',
-  description: `Elle porte une écharpe en mousse moisie autour du cou. Se plaint tout le temps et attire les limaces.`,
-  descriptionKey: 'data.shlagemons.evolutions.beuleef.description',
+  description: 'data.shlagemons.evolutions.beuleef.description',
   types: [shlagemonTypes.plante],
   evolution: {
     base: moisanium,

--- a/src/data/shlagemons/evolutions/boustiflemme.ts
+++ b/src/data/shlagemons/evolutions/boustiflemme.ts
@@ -5,14 +5,7 @@ import empifouette from './empifouette'
 export const boustiflemme: BaseShlagemon = {
   id: 'boustiflemme',
   name: 'Boustiflemme',
-  description: `Boustiflemme est le Shlagémon ultime du laisser-aller. Doté d'une apathie légendaire, il passe le plus clair de ses journées à s'étaler de tout son long, cherchant l'endroit le plus mou et le moins dérangeant possible. On raconte qu'il a développé un sixième sens pour repérer la moindre parcelle d'ombre ou de confort, n'hésitant jamais à s'y abandonner pour des siestes interminables.
-
-Sa technique signature, *Soupir Universel*, consiste à expirer si fort qu'il peut assommer d'ennui tout adversaire ambitieux. Capable de repousser toute initiative, Boustiflemme préfère attendre que les occasions viennent littéralement à lui, quitte à rater tout le reste.
-
-Même la nourriture, il ne la chasse pas: il attend qu'elle lui tombe dessus. On dit que certains Boustiflemme restent plusieurs jours sans bouger, se contentant d'observer le monde d'un regard vide mais profondément satisfait. Sa présence dégage une aura soporifique capable de neutraliser même les plus dynamiques des Shlagémons.
-
-En résumé, Boustiflemme ne fait jamais rien... et il le fait très bien.`,
-  descriptionKey: 'data.shlagemons.evolutions.boustiflemme.description',
+  description: 'data.shlagemons.evolutions.boustiflemme.description',
   types: [shlagemonTypes.normal],
   evolution: {
     base: empifouette,

--- a/src/data/shlagemons/evolutions/carabifle.ts
+++ b/src/data/shlagemons/evolutions/carabifle.ts
@@ -5,14 +5,7 @@ import tordturc from './tord-turc'
 export const carabifle: BaseShlagemon = {
   id: 'carabifle',
   name: 'Carabifle',
-  description: `Carabifle est l’évolution logique — mais pas forcément souhaitable — de Carapouffe. Sa carapace moelleuse est devenue un trône de plastique rose fluo incrusté de miroirs cassés et de pinceaux de maquillage fossilisés. Elle ne roule plus, elle *glisse* avec une grâce douteuse, laissant une traînée collante parfum pamplemousse-suédois.
-
-Sa voix est désormais autotunée en permanence, et sa nouvelle attaque signature, *Cataclysme Glossy*, étale une couche de gloss tellement épaisse qu’elle bloque les mouvements ennemis pendant 3 tours. Son chignon est maintenant vivant, et attaque tout seul dès qu’on prononce le mot “naturel”.
-
-Carabifle possède aussi un éventail en acrylique qui lui permet de s’éventer avec violence tout en jugeant les autres. Sa moustache fine dessinée au crayon waterproof est redoutable et augmente son charisme de +12 contre les mâles en rut.
-
-On dit que si l’on regarde ses cils pailletés trop longtemps, on devient influenceur bien-être sans s’en rendre compte.`,
-  descriptionKey: 'data.shlagemons.evolutions.carabifle.description',
+  description: 'data.shlagemons.evolutions.carabifle.description',
   types: [shlagemonTypes.eau],
   evolution: { base: tordturc, condition: { type: 'lvl', value: 36 } },
   speciality: 'evolution1',

--- a/src/data/shlagemons/evolutions/chrysachier.ts
+++ b/src/data/shlagemons/evolutions/chrysachier.ts
@@ -12,14 +12,7 @@ export const chrysachier: BaseShlagemon = {
       value: 25,
     },
   },
-  description: `Chrysachier est coincée entre la majesté d’un paon et le désespoir d’une larve mal digérée. Censé être un papillon royal ou un oiseau sacré, il a raté son cocon à cause d’un excès de chips au vinaigre et d’un cycle de sommeil perturbé par ses propres flatulences.
-
-Son plumage, censé briller, est en réalité collé par des fluides douteux, des restes de compotes oubliées, et ce qui semble être… de la peinture à doigts. Il déploie ses ailes dans un grand *FLOP* sonore, suivi d’un nuage d’odeurs qui rappelle une cantine scolaire en été. Il fait caca. Partout. Tout le temps. Par réflexe. Par peur. Par joie aussi.
-
-Son cri ressemble à *"BLU-PFRT-GAAAAAAAAAAAAH"*, mélange d’effort intestinal et de désespoir artistique. Il possède l’attaque spéciale *Déjection Expansive*, qui inflige des dégâts de zone et réduit la dignité de tous les participants. Il dispose également de *Plumexplosion*, une attaque aléatoire qui projette des plumes rigides en spirale — parfois vers l’ennemi, parfois vers le ciel, parfois dans son propre œil.
-
-Chrysachier ne vole pas : il s’élève un peu, puis redescend avec le bruit d’un sac de linge sale. Il est cependant très respecté dans certains cercles underground pour sa capacité à ruiner l’ambiance instantanément.`,
-  descriptionKey: 'data.shlagemons.evolutions.chrysachier.description',
+  description: 'data.shlagemons.evolutions.chrysachier.description',
   types: [shlagemonTypes.insecte],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/coconnul.ts
+++ b/src/data/shlagemons/evolutions/coconnul.ts
@@ -12,18 +12,7 @@ export const coconnul: BaseShlagemon = {
       value: 25,
     },
   },
-  description: `Coconnul est une tentative d'évolution qui a mal tourné. Coincé dans une coquille trop petite pour son ego mais trop grande pour ses ambitions, il passe ses journées à soupirer et à dire "j’suis désolé" même quand personne ne lui parle.
-
-Son armure censée être rigide est molle comme du carton détrempé, et son attaque principale, *Jet de Doute*, inflige un léger inconfort moral à l’adversaire... et surtout à lui-même. Il rate 90% de ses attaques, 100% de ses esquives, et 120% de ses décisions.
-
-Il perd tous ses combats, même contre des adversaires inanimés. On l’a déjà vu perdre un duel contre une pierre. Il s’est ensuite excusé auprès de la pierre.
-
-Il ne croit en rien, pas même en ses propres stats. D’ailleurs, son cri ressemble à un "haaaan..." suivi d’un bruit de plastique qui se dégonfle.
-
-Sa capacité passive, *Auto-Sabotage*, lui fait perdre 1 point de vie à chaque fois qu’on l’encourage. On dit qu’il pourrait évoluer en quelque chose de puissant... mais qu’il "veut pas déranger".
-
-Il traîne dans les buissons, évite les regards et se planque dès qu’il entend le mot "match". Une icône de la lose, une légende de l’échec.`,
-  descriptionKey: 'data.shlagemons.evolutions.coconnul.description',
+  description: 'data.shlagemons.evolutions.coconnul.description',
   types: [shlagemonTypes.insecte],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/coksnif.ts
+++ b/src/data/shlagemons/evolutions/coksnif.ts
@@ -5,8 +5,7 @@ import coxymort from './coxymort'
 export const coksnif: BaseShlagemon = {
   id: 'coksnif',
   name: 'Coksnif',
-  description: `Elle a maintenant 4 bras, un sac banane, et les narines couvertes de poussière blanche. Plane constamment.`,
-  descriptionKey: 'data.shlagemons.evolutions.coksnif.description',
+  description: 'data.shlagemons.evolutions.coksnif.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
   evolution: {
     base: coxymort,

--- a/src/data/shlagemons/evolutions/coloscopie.ts
+++ b/src/data/shlagemons/evolutions/coloscopie.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const coloscopie: BaseShlagemon = {
   id: 'coloscopie',
   name: 'Coloscopie',
-  description: `Coloscopie est l’évolution catastrophique de Férosang, atteinte après un certain niveau d’inconscience et de pénétration conceptuelle. Depuis qu’il a découvert que son propre rectum pouvait être une aire de jeu, il s’est donné corps et orifices à l’exploration totale. Il s’est même auto-prescrit une caméra endoscopique, qu’il appelle "Mimi".
-
-Son obsession est simple : trifouiller. Que ce soit le sien ou celui des autres (volontaires ou non), Coloscopie ne vit que pour sonder, fouiller, retourner, aspirer, et parfois planter. Sa queue a muté en flexible médical, ses doigts en gants lubrifiés. On dit qu’il peut analyser une âme rien qu’en sentant une flatulence.
-
-Il n’a plus vraiment de force physique : tout est dans l’analyse, la perfusion mentale, la gêne. Son attaque *Tactile Rectal* inflige un effet de malaise profond qui désarme les ennemis. Il dispose aussi de *Grand Nettoyage*, une attaque en AOE qui provoque une panique collective et laisse un goût de savonnette mentale.`,
-  descriptionKey: 'data.shlagemons.evolutions.coloscopie.description',
+  description: 'data.shlagemons.evolutions.coloscopie.description',
   types: [shlagemonTypes.combat],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/coxymort.ts
+++ b/src/data/shlagemons/evolutions/coxymort.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const coxymort: BaseShlagemon = {
   id: 'coxymort',
   name: 'Coxymort',
-  description: `Immense insecte décrépi, recouvert de résidus douteux, avec des tatouages au blanco et un regard perdu. Il claque des ailes sans raison.`,
-  descriptionKey: 'data.shlagemons.evolutions.coxymort.description',
+  description: 'data.shlagemons.evolutions.coxymort.description',
   types: [shlagemonTypes.insecte, shlagemonTypes.poison],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/croconaze.ts
+++ b/src/data/shlagemons/evolutions/croconaze.ts
@@ -5,8 +5,7 @@ import alligastro from './alligastro'
 export const croconaze: BaseShlagemon = {
   id: 'croconaze',
   name: 'Croconaze',
-  description: `Il porte une veste en cuir moisi, fait le caïd dans les parkings, mais a des dents en plastique.`,
-  descriptionKey: 'data.shlagemons.evolutions.croconaze.description',
+  description: 'data.shlagemons.evolutions.croconaze.description',
   types: [shlagemonTypes.eau, shlagemonTypes.combat],
   evolution: {
     base: alligastro,

--- a/src/data/shlagemons/evolutions/crustabridou.ts
+++ b/src/data/shlagemons/evolutions/crustabridou.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const crustabridou: BaseShlagemon = {
   id: 'crustabridou',
   name: 'Crustabridou',
-  description: `Crustabridou, évolution de Cookieyas, ressemble à un Crustabri qui aurait passé trop de temps à traîner dans le fond du frigo familial. Sa carapace, autrefois fière et solide, est désormais couverte de traces de gras, de miettes et de filaments de saucisson sec oubliés. Le pourtour de sa coquille arbore une mystérieuse ficelle rouge et blanche, vestige d’un vieux sauciflard jamais terminé.
-
-Son intérieur n’est plus qu’un mélange douteux entre fromage qui coule, rondelles de saucisson et restes de biscuits moisis. Son regard est encore plus halluciné qu’avant, avec des cernes en forme de tranches de saucisson et une bouche pleine de miettes et de grains de poivre.
-
-Attitude : Crustabridou est persuadé qu’il est la star de tous les apéros, alors qu’en vrai, tout le monde l’évite à cause de son odeur de cave. Son attaque signature, *Jet de Graillon*, consiste à expulser une bouillie huileuse et collante qui fait fuir même les Pokémon les plus courageux.
-
-Anecdote : On raconte que Crustabridou rêve secrètement de devenir ambassadeur du saucisson, mais il confond toujours les plateaux de fromages avec les arènes Pokémon.`,
-  descriptionKey: 'data.shlagemons.evolutions.crustabridou.description',
+  description: 'data.shlagemons.evolutions.crustabridou.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/dartagnan.ts
+++ b/src/data/shlagemons/evolutions/dartagnan.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const dartagnan: BaseShlagemon = {
   id: 'dartagnan',
   name: 'D\'Art Tagnan',
-  description: `D\'Art Tagnan est un Mousquépique de type panache combatif. Toujours prêt à pérorer avant de piquer, il surgit d’un nuage de poussière dramatique en criant « En garde, manant ! », alors que personne ne l’a regardé. Avec ses dards en forme de rapières et ses antennes sculptées en bouclettes, il enchaîne les moulinets dans le vide juste pour le style. Sa moustache n’existe pas, mais il la twiste régulièrement du bout des griffes, persuadé que ça le rend irrésistible. Son chapeau à plume est greffé directement sur son crâne depuis sa naissance — selon la légende, il serait sorti de son cocon en criant « À l’attaque pour l’honneur et les gaufres ! » Il défie les Pokémon sauvages à des duels de poésie, vole au secours des baies tombées au sol, et fond en larmes si on lui abîme sa cape. Sa technique signature, Tournoyement Galant, consiste à piquer son adversaire après avoir tourné sur lui-même au moins huit fois, tout en citant du théâtre. Son flair pour le drame est tel que certains chercheurs pensent qu’il est en fait mi-insecte, mi-acteur raté.`,
-  descriptionKey: 'data.shlagemons.evolutions.dartagnan.description',
+  description: 'data.shlagemons.evolutions.dartagnan.description',
   types: [shlagemonTypes.poison],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/dopluspersonne.ts
+++ b/src/data/shlagemons/evolutions/dopluspersonne.ts
@@ -4,11 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const dopluspersonne: BaseShlagemon = {
   id: 'dopluspersonne',
   name: 'Dopluspersonne',
-  description: `Dopluspersonne, c’est l’évolution ultime de la solitude. Même lui-même en a eu marre de lui : il ne reste plus qu’un grand corps d’autruche désabusé, sans tête, qui erre en rond comme un fantôme du désert.  
-Des plumes arrachées pendent comme des mouchoirs sales sur un fil à linge, et on peut parfois entendre un soupir venir de nulle part.  
-Son attaque signature, *Vide Sidéral*, aspire toute volonté de combattre, laissant l’adversaire avec une envie soudaine de rentrer chez lui regarder la télé.  
-On dit que parfois, une petite brise fait tourner Dopluspersonne sur lui-même, mais personne ne sait si c’est la honte, l’ennui ou juste le vent.`,
-  descriptionKey: 'data.shlagemons.evolutions.dopluspersonne.description',
+  description: 'data.shlagemons.evolutions.dopluspersonne.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/draco-con.ts
+++ b/src/data/shlagemons/evolutions/draco-con.ts
@@ -4,16 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const dracoCon: BaseShlagemon = {
   id: 'draco-con',
   name: 'Draco Con',
-  description: `Draco-con est la dernière forme de l’ancienne lignée des Salamiches. En apparence, c’est un dragon colossal, avec des ailes de moto-tuning, des flammes arc-en-bouse et des muscles qui crient "anabolisés". Mais derrière cette façade volcanique se cache une stupidité abyssale.
-
-Il confond souvent ses propres attaques avec celles de l’adversaire, et peut littéralement s’auto-cramer en tentant un *Jet d’Feu Vers le Vent*. Son cri de guerre est un mélange d’aboiement rauque et de rot mal digéré, et il ne comprend pas pourquoi les autres fuient quand il parle stratégie.
-
-Draco-con adore faire des lives en pleine arène pour dire "yo la team" à ses 3 abonnés imaginaires. Il pense que ses écailles brillent parce qu’il est rare, alors qu’en réalité, c’est juste de la graisse de kebab incrustée.
-
-Il possède la capacité *Combo Kéké*, qui mélange toutes ses attaques en un seul mouvement incohérent, mais bruyant. Résultat : les ennemis sont plus confus que blessés, et parfois, ils tombent simplement d’ennui.
-
-On dit que même le Professeur Merdant a arrêté d’essayer de l’étudier : "trop con pour la science", selon ses notes.`,
-  descriptionKey: 'data.shlagemons.evolutions.draco-con.description',
+  description: 'data.shlagemons.evolutions.draco-con.description',
   types: [shlagemonTypes.feu, shlagemonTypes.vol],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/evolutions/drapcoloscopie.ts
+++ b/src/data/shlagemons/evolutions/drapcoloscopie.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const drapcoloscopie: BaseShlagemon = {
   id: 'drapcoloscopie',
   name: 'Drapcoloscopie',
-  description: `Forme finale du DrapCon, ce drap géant se prend pour un médecin de l’obscur et fouille tout ce qui passe à sa portée.`,
-  descriptionKey: 'data.shlagemons.evolutions.drapcoloscopie.description',
+  description: 'data.shlagemons.evolutions.drapcoloscopie.description',
   types: [shlagemonTypes.dragon, shlagemonTypes.vol],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/drapcon.ts
+++ b/src/data/shlagemons/evolutions/drapcon.ts
@@ -5,8 +5,7 @@ import drapcoloscopie from './drapcoloscopie'
 export const drapcon: BaseShlagemon = {
   id: 'drapcon',
   name: 'DrapCon',
-  description: `Cette étape intermédiaire se prend pour un grand drap majestueux mais reste aussi stupide que sa version minuscule.`,
-  descriptionKey: 'data.shlagemons.evolutions.drapcon.description',
+  description: 'data.shlagemons.evolutions.drapcon.description',
   types: [shlagemonTypes.dragon],
   evolution: {
     base: drapcoloscopie,

--- a/src/data/shlagemons/evolutions/ectroudbal.ts
+++ b/src/data/shlagemons/evolutions/ectroudbal.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const ectroudbal: BaseShlagemon = {
   id: 'ectroudbal',
   name: 'Ectroudbal',
-  description: `Émanation spectrale d’un esprit trop longtemps resté coincé dans les toilettes d’un bar PMU, Ectroudbal hante les lieux où l’on oublie de tirer la chasse. Sa forme rappelle vaguement un fantôme, mais avec la grâce d’un vieux torchon de WC imbibé de sueur et de mauvaises décisions.
-
-Son corps est couvert de taches suspectes et de traces d'usure en forme de... ben de trous de balle, justement. Certains disent que ce sont des impacts de sorts, d'autres penchent pour une malédiction scatologique. Il flotte en éructant des bruits de chasse d’eau, et laisse derrière lui un sillage de gaz verdâtres qui forment parfois des emojis caca.
-
-Son attaque signature, *Souffle de Troudbal*, relâche un jet gazeux issu de l’au-delà (et de l’en-d’ssous), infligeant de lourds dégâts olfactifs et mentaux. Elle peut provoquer la panique, l’étourdissement, ou un fou rire nerveux chez les plus fragiles.
-
-On raconte qu’Ectroudbal peut apparaître dans tes chiottes si tu dis “Papier triple épaisseur” trois fois devant ton miroir après un kebab trop épicé.`,
-  descriptionKey: 'data.shlagemons.evolutions.ectroudbal.description',
+  description: 'data.shlagemons.evolutions.ectroudbal.description',
   types: [shlagemonTypes.spectre, shlagemonTypes.poison],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/electrobeauf.ts
+++ b/src/data/shlagemons/evolutions/electrobeauf.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const electrobeauf: BaseShlagemon = {
   id: 'electrobeauf',
   name: 'Électrobeauf',
-  description: `DJ de soirée miteuse, Électrobeauf fait exploser les watts et les tympans à coups de beats ringards. Il se prend pour la star des discothèques de camping.`,
-  descriptionKey: 'data.shlagemons.evolutions.electrobeauf.description',
+  description: 'data.shlagemons.evolutions.electrobeauf.description',
   types: [shlagemonTypes.electrique],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/empifouette.ts
+++ b/src/data/shlagemons/evolutions/empifouette.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const empifouette: BaseShlagemon = {
   id: 'empifouette',
   name: 'Empifouette',
-  description: `Empifouette est un Shlagémon tristement célèbre pour son parfum… inoubliable. Mais ce n’est pas tout : il est aussi doté d’un fouet végétal particulièrement sournois. Sa présence ne passe jamais inaperçue : même les plus téméraires préfèrent garder leurs distances tant son odeur est capable de terrasser un troupeau de Tauros à plusieurs kilomètres.
-
-Sa technique signature, *Fouet Puant*, consiste à agiter frénétiquement son appendice végétal pour répandre autour de lui un nuage pestilentiel, tout en infligeant des coups bien placés à ceux qui oseraient s’approcher. Les rares Shlagémons à s’être laissés tromper par son attitude nonchalante parlent d’un véritable cauchemar olfactif et tactique.
-
-Empifouette s’en sert aussi comme d’un leurre : attirant l’ennemi avec un faux air pataud, il profite de la confusion (et du désespoir nasal) pour frapper par surprise. Sa réputation de Shlagémon le plus repoussant du coin est solidement ancrée, et on raconte que même les corbeaux n’osent pas s’en approcher après une attaque de ce spécimen.
-
-Si vous croisez un Empifouette, courez… ou retenez votre souffle, et espérez qu’il n’a pas décidé de sortir le grand jeu.`,
-  descriptionKey: 'data.shlagemons.evolutions.empifouette.description',
+  description: 'data.shlagemons.evolutions.empifouette.description',
   types: [shlagemonTypes.poison, shlagemonTypes.plante],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/feunouille.ts
+++ b/src/data/shlagemons/evolutions/feunouille.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const feunouille: BaseShlagemon = {
   id: 'feunouille',
   name: 'Feunouille',
-  description: `Feunouille est une erreur de casting dans l’évolution de Goupichiant. Persuadé d’être un Pokémon légendaire, il parade avec ses neuf queues en synthétique mal accrochées, achetées sur Vinted dans une vente privée de furries déchus.
-
-Son pelage est cramé par endroits à cause de ses propres attaques ratées, et il porte un piercing lumineux au museau qui clignote en rythme avec ses crises d’égo. Il utilise *Flamme AutoBronzante* pour se donner un teint de feu, mais finit souvent orange carotte.
-
-Feunouille attaque rarement, sauf si on critique son style ou qu’on dit que Ninetales est "mieux designé". Dans ce cas, il enchaîne *Queue-Slap TikTok* et *Souffle de Théorie Fumeuse*, une combinaison qui désoriente tous les Shlagémons normaux.
-
-Il est persuadé d’être l’élu d’une prophétie inventée par lui-même. Aucun autre Shlagémon ne valide.`,
-  descriptionKey: 'data.shlagemons.evolutions.feunouille.description',
+  description: 'data.shlagemons.evolutions.feunouille.description',
 
   types: [shlagemonTypes.feu],
   speciality: 'evolution1',

--- a/src/data/shlagemons/evolutions/flaclodoss.ts
+++ b/src/data/shlagemons/evolutions/flaclodoss.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const flaclodoss: BaseShlagemon = {
   id: 'flaclodoss',
   name: 'Flaclodoss',
-  description: `Flaclodoss erre le long des caniveaux, traînant sa carapace devenue sac de couchage miteux, constellé de tâches suspectes et de chewing-gums écrasés. Jadis promis à une belle évolution, il s’est fait recaler à toutes les arènes et a fini par élire domicile sous un abribus, là où les flaques de pluie deviennent son miroir de fortune.
-
-Sa fourrure a viré au gris sale, son regard flotte dans le vague comme s’il cherchait le bus qui ne viendra jamais. Sur son dos, on trouve une vieille boîte de conserve rouillée ou un pneu dégonflé, vestige de ses galères urbaines. Son jogging est devenu couverture, ses chaussettes dépareillées tiennent miraculeusement grâce à trois agrafes et un élastique récupéré sur un ticket de métro périmé.
-
-Son attaque signature, *Nuage de Misère*, dégage une aura de fatigue et de vieux sandwichs, plongeant ses adversaires dans un état de démotivation intense.
-
-On raconte que Flaclodoss possède le secret pour ouvrir toutes les poubelles à un seul doigt, et qu’il médite souvent sur la vie en fixant les pigeons. Sa philosophie ? “Tant qu’il y a un banc, y’a de l’espoir…”`,
-  descriptionKey: 'data.shlagemons.evolutions.flaclodoss.description',
+  description: 'data.shlagemons.evolutions.flaclodoss.description',
   types: [shlagemonTypes.eau, shlagemonTypes.psy],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/floripute.ts
+++ b/src/data/shlagemons/evolutions/floripute.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const floripute: BaseShlagemon = {
   id: 'floripute',
   name: 'Floripute',
-  description: `Floripute prétend être une plante rare capable de purifier les âmes — alors qu’elle pue littéralement la bougie au patchouli frelatée. Recouverte de feuilles grasses en forme de soutien-gorge floral, elle s'étale lascivement sous le soleil, attendant que des dresseurs "ouverts d’esprit" viennent lui parler d’astrologie et de pierres de chakra.
-  
-Elle tire ses pouvoirs d’un potager qu’elle cultive sur son dos, mélange douteux de mauvaises herbes, de tomates cerises et de substances interdites dans 4 régions de la Ligue. Son attaque signature, *Infusion Ancestrale*, consiste à t’arroser de tisane brûlante au CBD, ce qui inflige des dégâts mentaux et émotionnels.
-
-On raconte qu’elle peut invoquer des cercles de danse autour d’un feu sacré fait de palettes et de sacs Leclerc. Si elle grogne en récitant des mantras, cours. Elle s’apprête à t’offrir une purification... ou un sandwich au houmous moisi.`,
-  descriptionKey: 'data.shlagemons.evolutions.floripute.description',
+  description: 'data.shlagemons.evolutions.floripute.description',
   types: [shlagemonTypes.plante],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/galopard.ts
+++ b/src/data/shlagemons/evolutions/galopard.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const galopard: BaseShlagemon = {
   id: 'galopard',
   name: 'Galopard',
-  description: `Galopard était autrefois un fier destrier, mais aujourd’hui il traîne sa carcasse devant les PMU, recouvert d’un vieux tapis à la place de sa crinière flamboyante. Ses sabots sont couverts de chewing-gums et il porte souvent un gilet jaune taché, trouvé lors d’une manif. Sa flamme ne brûle plus vraiment, elle fume comme une clope mal éteinte.
-
-Son attaque signature, *Jet de Binouze*, consiste à asperger ses adversaires de bière tiède, ce qui réduit leur motivation à se battre. On dit qu’il passe ses journées à râler contre “les jeunes” et à raconter qu’à son époque, il courait bien plus vite.
-
-Il n’aime qu’une seule chose : quand la France gagne au tiercé.`,
-  descriptionKey: 'data.shlagemons.evolutions.galopard.description',
+  description: 'data.shlagemons.evolutions.galopard.description',
   types: [shlagemonTypes.feu],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/gravaglaire.ts
+++ b/src/data/shlagemons/evolutions/gravaglaire.ts
@@ -5,14 +5,7 @@ import grosseflemme from './grosseflemme'
 export const gravaglaire: BaseShlagemon = {
   id: 'gravaglaire',
   name: 'Gravaglaire',
-  description: `Gravaglaire est la version déglinguée et bien plus massive de Racaillou. On dirait une boule de roche mal roulée, couverte de croûtes, de taches jaunâtres et de restes de stickers arrachés. Son visage est encore plus fatigué, le teint gris-vert maladif, les yeux rouges et mi-clos, cernés à mort.
-
-À force de fumer du shit de mauvaise qualité, il passe ses journées à tousser et à cracher des glaires visqueuses sur ses ennemis. Parfois, une fine fumée s’échappe encore de ses narines ou de sa bouche. Il traîne des paquets de mouchoirs sales et s’essuie le museau d’un revers de bras rocailleux.
-
-**Attaque signature :** *Jet de Glaires* — Gravaglaire expulse une énorme glaire gluante et toxique qui colle à la cible, la ralentit et dégoûte tous les Shlagémons autour.
-
-On dit que plus personne ne veut s’asseoir à côté de lui, même dans les squats abandonnés. Mais, malgré sa crasse et ses glaires, il conserve toujours son éternelle casquette et une banane encore plus trouée.`,
-  descriptionKey: 'data.shlagemons.evolutions.gravaglaire.description',
+  description: 'data.shlagemons.evolutions.gravaglaire.description',
   types: [shlagemonTypes.roche, shlagemonTypes.sol],
   evolution: {
     base: grosseflemme,

--- a/src/data/shlagemons/evolutions/grochichon.ts
+++ b/src/data/shlagemons/evolutions/grochichon.ts
@@ -4,16 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const grochichon: BaseShlagemon = {
   id: 'grochichon',
   name: 'Grochichon',
-  description: `Grochichon est l’évolution fumeuse de Rondonichon, littéralement. Il passe ses journées vautré dans un hamac improvisé avec des slips oubliés, en marmonnant des phrases sans queue ni tête du genre “le cosmos, c’est dans la racine du chichon intérieur”.
-
-Son haleine dense et poivrée suffit à endormir les Pokémon psy à 20 mètres, tandis que sa peau rosâtre tire désormais vers le gris-beige-jaune-douteux. Une brume l’accompagne partout, mélange d’encens moisi, de kebab froid et d’interrogations métaphysiques.
-
-Grochichon ne marche plus : il flotte à dix centimètres du sol, uniquement quand il plane assez fort. Il attaque avec *Halène Putassique*, qui colle à l’âme, et *Bulle Mentale*, un projectile mou et chaud à base de pensées ralenties.
-
-On ne sait pas vraiment s’il combat, ou s’il est juste là pour poser une ambiance. Son cri ressemble à un “pfffft” suivi d’un éclat de rire essoufflé. Les experts en Shlagologie recommandent de ne jamais le déranger après 16h : “il redescend”.
-
-On ignore s’il a une évolution. Certains parlent d’un “Tontonchichon” tapi dans une cave…`,
-  descriptionKey: 'data.shlagemons.evolutions.grochichon.description',
+  description: 'data.shlagemons.evolutions.grochichon.description',
 
   types: [shlagemonTypes.normal, shlagemonTypes.poison],
   speciality: 'evolution1',

--- a/src/data/shlagemons/evolutions/grosseflemme.ts
+++ b/src/data/shlagemons/evolutions/grosseflemme.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const grosseflemme: BaseShlagemon = {
   id: 'grosseflemme',
   name: 'Grosseflemme',
-  description: `Grosseflemme est l’incarnation ultime de la dégradation shlagémonesque. Sa carapace rocheuse, autrefois robuste, est désormais couverte de taches d’humidité, de mousse et de vieux chewing-gums collés. Il est si lourd et vautré qu’il a fusionné avec le canapé abandonné sur lequel il traîne depuis des années. Ses bras et jambes semblent presque atrophiés, mais il parvient encore à tendre la main pour attraper un paquet de chips ou rallumer une clope.
-
-Son visage affiche un mélange de lassitude et d’aigreur, les yeux mi-clos, cernés à l’extrême. Des restes de pizza et des canettes vides jonchent le sol autour de lui. La seule chose qui le motive, c’est de râler sur les autres Shlagémons, tout en soupirant bruyamment.
-
-**Attaque signature :** *Souffle Fétide* — Grosseflemme baille en direction de l’adversaire, libérant un souffle d’haleine croupie capable d’endormir même les plus motivés.
-
-On raconte que personne n’a jamais vu Grosseflemme se lever de son canapé, sauf une fois, pour atteindre une télécommande tombée trop loin. Même là, il a préféré lancer une pantoufle plutôt que de faire l’effort de bouger.`,
-  descriptionKey: 'data.shlagemons.evolutions.grosseflemme.description',
+  description: 'data.shlagemons.evolutions.grosseflemme.description',
   types: [shlagemonTypes.roche, shlagemonTypes.sol],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/grossetarte.ts
+++ b/src/data/shlagemons/evolutions/grossetarte.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const grossetarte: BaseShlagemon = {
   id: 'grossetarte',
   name: 'Grossetarte',
-  description: `Grossetarte est l’évolution regrettable de Ptitocard, obtenue après une overdose de sucre industriel et de mauvaises idées. Autoproclamé "Maître Tartenier", il passe ses journées à cuisiner, lancer et... recuire des tartes. Le problème ? Ses créations sont infâmes. Collantes, croquantes, souvent vivantes, elles causent plus de dégâts buccaux que toutes les chutes de trottoirs réunies.
-
-Il ne se bat pas : il *sert*. À répétition. Son attaque *Service Trois Parts* invoque une volée de projectiles pâtissiers, chacun ayant une texture plus imprévisible que le précédent. Il dispose aussi de *Croûte Brutale*, une attaque physique qui explose en miettes de granite sucré, infligeant des blessures internes et une honte culinaire durable.
-
-Certains Shlagémons l’évitent non pas par peur, mais par goût. On raconte qu’un seul fragment de sa Tarte Ultime peut bloquer une mâchoire pendant 3 jours.`,
-  descriptionKey: 'data.shlagemons.evolutions.grossetarte.description',
+  description: 'data.shlagemons.evolutions.grossetarte.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/grostadsperm.ts
+++ b/src/data/shlagemons/evolutions/grostadsperm.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const grostadsperm: BaseShlagemon = {
   id: 'grostadsperm',
   name: 'Grostadsperm',
-  description: `Plus massif, plus flasque, Grostadsperm ressemble à une montagne de slime terne, parsemée de grumeaux douteux et de traînées visqueuses. Son odeur est… indescriptible, oscillant entre la sueur froide et la vieille lessive oubliée. Son visage affiche une fierté louche, le regard lointain, les bras mous toujours occupés à se tripoter sans gêne.
-
-Son attaque fétiche, *MasturBave*, recouvre le terrain d’une vague glissante et odorante, forçant l’ennemi à faire du surplace. On dit qu’il se nourrit exclusivement de restes de kleenex sales et adore zoner près des douches collectives.
-
-Anecdote : Il paraît qu’en période de reproduction, il faut désinfecter toute la zone après son passage…`,
-  descriptionKey: 'data.shlagemons.evolutions.grostadsperm.description',
+  description: 'data.shlagemons.evolutions.grostadsperm.description',
   types: [shlagemonTypes.poison],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/heriplouf.ts
+++ b/src/data/shlagemons/evolutions/heriplouf.ts
@@ -5,8 +5,7 @@ import heristrash from './heristrash'
 export const heriplouf: BaseShlagemon = {
   id: 'heriplouf',
   name: 'Hériplouf',
-  description: `A des seaux d’eau accrochés aux pattes pour "éteindre ses crises". En réalité, il pisse dans les flaques.`,
-  descriptionKey: 'data.shlagemons.evolutions.heriplouf.description',
+  description: 'data.shlagemons.evolutions.heriplouf.description',
   types: [shlagemonTypes.feu, shlagemonTypes.eau],
   evolution: {
     base: heristrash,

--- a/src/data/shlagemons/evolutions/heristrash.ts
+++ b/src/data/shlagemons/evolutions/heristrash.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const heristrash: BaseShlagemon = {
   id: 'heristrash',
   name: 'Héristrash',
-  description: `Ressemble à un raton-laveur carbonisé. Les flammes sont vertes et sentent l’œuf pourri.`,
-  descriptionKey: 'data.shlagemons.evolutions.heristrash.description',
+  description: 'data.shlagemons.evolutions.heristrash.description',
   types: [shlagemonTypes.feu, shlagemonTypes.poison],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/hosoltueur.ts
+++ b/src/data/shlagemons/evolutions/hosoltueur.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const hosoltueur: BaseShlagemon = {
   id: 'hosoltueur',
   name: 'Hosoltueur',
-  description: `Armé d'un os gigantesque, Hosoltueur règle ses comptes en une seule frappe. Il garde pourtant un air mélancolique en pensant à son enfance perdue.`,
-  descriptionKey: 'data.shlagemons.evolutions.hosoltueur.description',
+  description: 'data.shlagemons.evolutions.hosoltueur.description',
   types: [shlagemonTypes.sol],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/hyporuisseau.ts
+++ b/src/data/shlagemons/evolutions/hyporuisseau.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const hyporuisseau: BaseShlagemon = {
   id: 'hyporuisseau',
   name: 'Hyporuisseau',
-  description: `Hyporuisseau ne nage que dans les petits ruisseaux par peur des grandes eaux. Son courage grandit à mesure que le débit augmente, mais pas trop quand même.`,
-  descriptionKey: 'data.shlagemons.evolutions.hyporuisseau.description',
+  description: 'data.shlagemons.evolutions.hyporuisseau.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/hypsedentaire.ts
+++ b/src/data/shlagemons/evolutions/hypsedentaire.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const hypsedentaire: BaseShlagemon = {
   id: 'hypsedentaire',
   name: 'Hypsedentaire',
-  description: `Hypsedentaire a développé un pouvoir hypnotique tellement fort qu'il préfère rester affalé chez lui. Il endort ses ennemis à distance pour ne jamais avoir à se lever.`,
-  descriptionKey: 'data.shlagemons.evolutions.hypsedentaire.description',
+  description: 'data.shlagemons.evolutions.hypsedentaire.description',
   types: [shlagemonTypes.psy],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/kadavrebras.ts
+++ b/src/data/shlagemons/evolutions/kadavrebras.ts
@@ -5,14 +5,7 @@ import alakalbar from './alakalbar'
 export const kadavrebras: BaseShlagemon = {
   id: 'kadavrebras',
   name: 'Kadavrebras',
-  description: `Kadavrebras est un Shlagémon psychopathe issu de l’évolution maudite de Kadavrak. Ancien médium raté devenu croque-mort malgré lui, il s’est découvert une passion morbide : enlacer les cadavres. Dès qu’un corps sans vie croise son regard vitreux, il entre dans une transe macabre, le soulève avec une tendresse dérangeante et le trimballe partout comme une peluche fétiche.
-
-On ne sait pas exactement *pourquoi* il fait ça. Est-ce un rituel ? Un besoin affectif ? Une passion pour les postures rigides ? En tout cas, il ne les lâche plus. Certains dresseurs racontent qu’il a porté le même cadavre pendant **trois évolutions consécutives**.
-
-Son attaque *Embrasse Froide* paralyse d’effroi toute cible vivante, tandis que *Marche Funeste* inflige des dégâts psychiques au rythme de ses pas lugubres. Plus il avance, plus l’air se refroidit… et plus le silence devient pesant.
-
-On dit que Kadavrebras ne dort jamais. Il se contente de bercer ses cadavres en murmurant des berceuses oubliées, avec une voix tremblante et désaccordée. Ne croisez jamais son regard : il pourrait penser que vous êtes prêt… à être porté.`,
-  descriptionKey: 'data.shlagemons.evolutions.kadavrebras.description',
+  description: 'data.shlagemons.evolutions.kadavrebras.description',
   types: [shlagemonTypes.psy],
   evolution: {
     base: alakalbar,

--- a/src/data/shlagemons/evolutions/kaputrak.ts
+++ b/src/data/shlagemons/evolutions/kaputrak.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const kaputrak: BaseShlagemon = {
   id: 'kaputrak',
   name: 'Kaputrak',
-  description: `Issu de Kraputo, ce guerrier fossile manie des lames rouillées et vit dans la paranoïa permanente.`,
-  descriptionKey: 'data.shlagemons.evolutions.kaputrak.description',
+  description: 'data.shlagemons.evolutions.kaputrak.description',
   types: [shlagemonTypes.roche, shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/krabbolosse.ts
+++ b/src/data/shlagemons/evolutions/krabbolosse.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const krabbolosse: BaseShlagemon = {
   id: 'krabbolosse',
   name: 'Krabbolosse',
-  description: `Krabbolosse est un crabe massif mais un peu benêt. Il écrase tout sur son passage en bredouillant des prières en vieux dialecte.`,
-  descriptionKey: 'data.shlagemons.evolutions.krabbolosse.description',
+  description: 'data.shlagemons.evolutions.krabbolosse.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/lamantinedu38.ts
+++ b/src/data/shlagemons/evolutions/lamantinedu38.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const lamantinedu38: BaseShlagemon = {
   id: 'lamantinedu38',
   name: 'Lamantinedu38',
-  description: `Lamantinedu38 est la star déchue des patinoires discount. Son blouson en simili-fourrure est troué de partout, et il glisse lamentablement sur la banquise avec la grâce d’un caddie désaxé. Ses dents sont jaunes fluo, probablement à cause d’un régime exclusif de sirop à la grenadine bas de gamme.
-
-Son attaque signature, *Roule-Galoche Givrée*, consiste à te rouler une pelle glacée, laissant une trace de buée et d’odeur de Ricard sur le terrain. Il prétend avoir remporté le “Grand Prix de Plongeon du Lac d’Embrun”, mais les seuls témoins étaient des mouettes bourrées.
-
-On dit que même les autres shlagémons du 38 évitent de s’asseoir à côté de lui, de peur de repartir avec des morpions polaires.`,
-  descriptionKey: 'data.shlagemons.evolutions.lamantinedu38.description',
+  description: 'data.shlagemons.evolutions.lamantinedu38.description',
   types: [shlagemonTypes.eau, shlagemonTypes.glace],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/leviaraison.ts
+++ b/src/data/shlagemons/evolutions/leviaraison.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const leviaraison: BaseShlagemon = {
   id: 'leviaraison',
   name: 'Léviaraison',
-  description: `Toujours persuadé d'avoir raison, ce serpent de mer géant fulmine dès qu'on le contredit. Ses colères déclenchent des tempêtes monumentales.`,
-  descriptionKey: 'data.shlagemons.evolutions.leviaraison.description',
+  description: 'data.shlagemons.evolutions.leviaraison.description',
   types: [shlagemonTypes.eau, shlagemonTypes.vol],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/macintosh.ts
+++ b/src/data/shlagemons/evolutions/macintosh.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const macintosh: BaseShlagemon = {
   id: 'macintosh',
   name: 'Macintosh',
-  description: `Macintosh est la dernière évolution de la lignée Macho. Une évolution tragique, obtenue après avoir absorbé une *Ultra-Stéroïde* tout en lisant trois threads de Reddit sur "la féminité moderne".
-
-Ses muscles sont toujours là, mais personne n’y touche plus. Les meufs ? Parties. L’arrogance ? Transformée en *posts passifs-agressifs sur X*. Macintosh est désormais seul, vissé à son ordinateur portable, dans une chambre qui sent la **whey périmée et les rêves brisés**. Il s'est autoproclamé "coach en masculinité numérique", mais il passe surtout ses journées à commenter des shorts TikTok avec "bah elle va finir seule mdr".
-
-Il attaque avec *Clavier Rageur*, qui spam des insultes mal orthographiées, et *Copié/Collé de Citation*, un move inutile où il cite Alex Hitchens (son modèle) sans contexte. Il a également accès à *Alt+Tab Discret*, qui lui permet de cacher son onglet “Podcasts alpha” quand sa daronne rentre dans la pièce.
-
-On raconte qu’il a installé un fond d’écran de lui torse nu en noir et blanc avec marqué “GRIND” en majuscules. Aucun Shlagémon ne veut le combattre : pas par peur… par pitié.`,
-  descriptionKey: 'data.shlagemons.evolutions.macintosh.description',
+  description: 'data.shlagemons.evolutions.macintosh.description',
   types: [shlagemonTypes.combat],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/magnementon.ts
+++ b/src/data/shlagemons/evolutions/magnementon.ts
@@ -4,15 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const magnementon: BaseShlagemon = {
   id: 'magnementon',
   name: 'Magnementon',
-  description: `Magnementon, c’est la fusion de trois Magnubellules qui se sont pris la canette (et le trottoir) un peu trop fort. Leur carapace est cabossée et soudée autour d’un menton proéminent, d’une dureté légendaire — on raconte qu'il a déjà ouvert un distributeur de canettes d'un simple coup de boule.
-
-Leur corps évoque une libellule rouillée avec trois gros mentons métalliques qui s’entrechoquent bruyamment, chacun orné d’ecchymoses et de traces de mousse séchée. Leur couleur rappelle un festival de bières renversées : bleu profond, doré blafard, et reflets de canette usée.
-
-Magnementon flotte en meute dans les parkings, l’air mauvais, prêt à te juger du regard ou à te bousculer d’un coup de menton.  
-Son attaque signature, *Menton Omnipotent*, consiste à donner un coup de menton magistral, capable d’aplatir un panneau de signalisation… ou simplement de faire voler en éclats la dignité de l’adversaire.
-
-On raconte que croiser un Magnementon, c’est risquer de finir avec “8 mentons, 6 bosses” et une bonne excuse bidon pour rentrer au camping.`,
-  descriptionKey: 'data.shlagemons.evolutions.magnementon.description',
+  description: 'data.shlagemons.evolutions.magnementon.description',
   types: [shlagemonTypes.electrique, shlagemonTypes.insecte],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/masschopeur.ts
+++ b/src/data/shlagemons/evolutions/masschopeur.ts
@@ -6,16 +6,7 @@ import macintosh from './macintosh'
 export const masschopeur: BaseShlagemon = {
   id: 'masschopeur',
   name: 'Masschopeur',
-  description: `Masschopeur est l’évolution égotique et désastreuse de Macho. Plus musclé, plus bronzé, plus insupportable. Sa beauté indéniable est un piège : derrière ses abdos symétriques et son sourire UltraWhite™ se cache un Shlagémon **toxique à souhait**.
-
-Il ne combat pas pour la victoire : il combat pour l’ego. Chaque confrontation est un prétexte pour exhiber ses muscles huilés et réciter des punchlines dégoulinantes de narcissisme. Il commence toujours ses attaques par "*T’as vu ces pecs ?*" avant d’enchaîner avec *Flex Infernaux*, qui inflige des dégâts mentaux liés à l’humiliation.
-
-Sa capacité *Ghosting Flash* permet de fuir instantanément un combat sentimental après avoir fait croire à un "truc sérieux". Il est immunisé aux types cœur et sincérité.
-
-Malgré ses défauts évidents, il **choppe**. Tout le temps. C’est inexplicable. Peut-être le combo parfum discount + regard de prédateur affectif. Peut-être une malédiction. Ou une stat secrète appelée "charisme de l’enfer". Les scientifiques hésitent encore.
-
-On raconte qu’il s’auto-like sur Pokégram avec des faux comptes et laisse des commentaires à base de "🔥🔥🔥 t trop bg frèro".`,
-  descriptionKey: 'data.shlagemons.evolutions.masschopeur.description',
+  description: 'data.shlagemons.evolutions.masschopeur.description',
   types: [shlagemonTypes.combat],
   evolution: {
     base: macintosh,

--- a/src/data/shlagemons/evolutions/meladolphe.ts
+++ b/src/data/shlagemons/evolutions/meladolphe.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const meladolphe: BaseShlagemon = {
   id: 'meladolphe',
   name: 'Méladolphe',
-  description: `Méladolphe est l’évolution contestée de Mélofoutre, fruit d’une mutation auditive après trop de soirées karaoké entre beaufs autoritaires. Il a troqué sa douceur poisseuse contre un costume trop repassé, une raie bien tracée, et une passion suspecte pour les discours gênants.
-
-Il chante faux mais fort, avec des paroles douteuses qui font fuir les autres Shlagémons. Son attaque signature, *Chant Fascinazif*, oblige ses ennemis à se ranger en file indienne et à marcher au pas jusqu'à l'épuisement. Il peut aussi déclencher *Micro de Propagande*, un cri strident qui inflige des dégâts psychologiques même à travers les murs.
-
-Son aura autoritaire et son parfum de naphtaline lui valent d’être banni de plusieurs régions. Malgré tout, certains dresseurs le trouvent “charismatique”, mais ils ont souvent de drôles d’idées derrière la tête.`,
-  descriptionKey: 'data.shlagemons.evolutions.meladolphe.description',
+  description: 'data.shlagemons.evolutions.meladolphe.description',
 
   types: [shlagemonTypes.fee],
   speciality: 'evolution1',

--- a/src/data/shlagemons/evolutions/moisanium.ts
+++ b/src/data/shlagemons/evolutions/moisanium.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const moisanium: BaseShlagemon = {
   id: 'moisanium',
   name: 'Moisanium',
-  description: `Géante plante décrépite, tachetée de moisissure, avec des spores hallucinogènes. Elle rigole toute seule dans les champs.`,
-  descriptionKey: 'data.shlagemons.evolutions.moisanium.description',
+  description: 'data.shlagemons.evolutions.moisanium.description',
   types: [shlagemonTypes.plante, shlagemonTypes.poison],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/nidodragqueen.ts
+++ b/src/data/shlagemons/evolutions/nidodragqueen.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const nidodragqueen: BaseShlagemon = {
   id: 'nidodragqueen',
   name: 'Nidodragqueen',
-  description: `Nidodragqueen est l’icône absolue des arènes urbaines. Couronné·e par le destin et l’eyeliner, ce Shlagémon ne se bat pas pour dominer, mais pour éblouir. Avec sa voix grave qui roule les R et son déhanché de mammouth en talons de 15, Nidodragqueen enchaîne les uppercuts et les punchlines dans un même souffle.
-
-Son attaque signature *Talons de la Mort* inflige des dégâts massifs tout en réduisant le swag de l’adversaire de 3 niveaux. Iel peut aussi lancer *Contour Shocké*, qui désoriente tout adversaire par une entrée spectaculaire et un look irréfutable.
-
-On reconnaît Nidodragqueen à sa corne pailletée, son sceptre cosmique et son cri de guerre : “T'ES PAS PRÊT BÉBÉ 💅”. Iel ? On ne pose pas la question. Nidodragqueen EST. Et c’est bien assez.`,
-  descriptionKey: 'data.shlagemons.evolutions.nidodragqueen.description',
+  description: 'data.shlagemons.evolutions.nidodragqueen.description',
   types: [shlagemonTypes.poison],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/nidoqueer.ts
+++ b/src/data/shlagemons/evolutions/nidoqueer.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const nidoqueer: BaseShlagemon = {
   id: 'nidoqueer',
   name: 'Nidoqueer',
-  description: `Nidoqueer, c’est la Queen — dans tous les sens du terme. Iel a troqué l’armure classique contre une cuirasse pailletée et assume chaque couleur de son spectre avec dignité. Connu·e pour son cri de guerre "YES SHLAG!", iel ne cherche pas à dominer, mais à rayonner.
-
-Son attaque signature *Marche de la Fierté* lui permet de traverser n’importe quelle zone sans être interrompu·e, tout en boostant le moral de ses alliés. Iel manie aussi *Pluie de Paillettes*, une capacité de zone peu douloureuse mais extrêmement humiliante pour l’adversaire.
-
-Nidoqueer est un pilier des zones communautaires de Shlagémon, toujours là pour défendre les plus petit·e·s, corriger les propos déplacés avec élégance, et lâcher un *wink* bien placé. On reconnaît Nidoqueer à ses épines colorées, son regard fardé et sa démarche impeccable. Iel n'est pas là pour se battre... mais si iel le fait, ce sera avec **panache**.`,
-  descriptionKey: 'data.shlagemons.evolutions.nidoqueer.description',
+  description: 'data.shlagemons.evolutions.nidoqueer.description',
   types: [shlagemonTypes.poison],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/nidoschneck.ts
+++ b/src/data/shlagemons/evolutions/nidoschneck.ts
@@ -5,12 +5,7 @@ import nidoqueer from './nidoqueer'
 export const nidoschneck: BaseShlagemon = {
   id: 'nidoschneck',
   name: 'Nidoschneck',
-  description: `Nidoschneck est un·e Shlagémon·e à l’énergie débordante… mais toujours mal canalisée. Iel parle fort, rit en majuscules et ponctue toutes ses phrases par "tu vois c’que j’veux dire ou pas ?" Sa passion ? Les foufounes. La sienne, celles des autres, les concepts liés, les tatouages approximatifs sur le bas-ventre. Iel collectionne les selfies flous et les stories inutiles, toujours tourné·e à contre-jour.
-
-Son attaque signature *Frappe de Schnek* est moins puissante qu’iel en a l’air, mais elle fait toujours son petit effet dans les zones sauvages. En combat, iel aime provoquer ses adversaires avec *Cris Gênants*, ce qui inflige l’état **Malaise Profond** à tout le monde autour, alliés inclus.
-
-Iel s’entoure souvent de Nidononbinaire♀ ou d’autres Shlagémons influençables, qu’iel appelle ses “sœurs de la teucha”. On ne sait jamais si iel est sérieux·se ou si iel trolle. Probablement les deux.`,
-  descriptionKey: 'data.shlagemons.evolutions.nidoschneck.description',
+  description: 'data.shlagemons.evolutions.nidoschneck.description',
   types: [shlagemonTypes.poison],
 
   evolution: {

--- a/src/data/shlagemons/evolutions/nidoteub.ts
+++ b/src/data/shlagemons/evolutions/nidoteub.ts
@@ -5,12 +5,7 @@ import nidodragqueen from './nidodragqueen'
 export const nidoteub: BaseShlagemon = {
   id: 'nidoteub',
   name: 'Nidoteub',
-  description: `Nidoteub est l’évolution naturelle (et pourtant regrettée) de Nidononbinaire♂. Son corps a gonflé, ses pics sont plus rigides que ses arguments, et sa voix porte loin, même quand iel dit n’importe quoi. Iel passe son temps à scroller des profils de Shlagémon femelles et à crier “Tchooooleeee” dès qu’une silhouette passe dans un rayon de 50 mètres.
-
-Iel voue un culte étrange à une entité nommée “Chibrax”, dont iel porte un médaillon autour du cou en plastique doré. Personne ne sait qui c’est, ni ce que ça veut dire, mais Nidoteub y croit très fort. Iel utilise principalement l’attaque *DM Massif*, qui ne touche presque jamais, mais qui contient beaucoup trop d’émojis feu.
-
-Iel est bruyant·e, inefficace, et persuadé·e qu’iel est “trop stylé”. Ses dents sont toujours en PLS et son haleine est classée comme capacité toxique passive.`,
-  descriptionKey: 'data.shlagemons.evolutions.nidoteub.description',
+  description: 'data.shlagemons.evolutions.nidoteub.description',
   types: [shlagemonTypes.poison],
 
   evolution: {

--- a/src/data/shlagemons/evolutions/noadcajou.ts
+++ b/src/data/shlagemons/evolutions/noadcajou.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const noadcajou: BaseShlagemon = {
   id: 'noadcajou',
   name: 'Noadcajou',
-  description: `Cet arbre sur pattes produit des noix de cajou grillées à chaque attaque. Il préfère le climat tropical et se moque des régimes alimentaires de ses adversaires.`,
-  descriptionKey: 'data.shlagemons.evolutions.noadcajou.description',
+  description: 'data.shlagemons.evolutions.noadcajou.description',
   types: [shlagemonTypes.plante, shlagemonTypes.psy],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/noctedard.ts
+++ b/src/data/shlagemons/evolutions/noctedard.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const noctedard: BaseShlagemon = {
   id: 'noctedard',
   name: 'Noctédard',
-  description: `Grand hibou insomniaque, chauve par endroits, avec des seringues plantées dans les plumes et une clope toujours au bec. Parle seul.`,
-  descriptionKey: 'data.shlagemons.evolutions.noctedard.description',
+  description: 'data.shlagemons.evolutions.noctedard.description',
   types: [shlagemonTypes.vol, shlagemonTypes.psy],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/nosferasta.ts
+++ b/src/data/shlagemons/evolutions/nosferasta.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const nosferasta: BaseShlagemon = {
   id: 'nosferasta',
   name: 'Nosferasta',
-  description: `Nosferasta est l’éveil spirituel ultime de Nosferailleur. À mesure qu’il grandit, ses ailes se parent de dreadlocks tressées dans la laine d’un Ponchien mystique, et une douce aura verte l’entoure en permanence.
-
-Influencé par les écrits rastafaris et les vinyles usés de Koffeekeur et Bombé Marlée, il prêche une philosophie de vie fondée sur la non-violence, la connexion avec la nature, et une consommation très généreuse de plantes médicinales. Il parle en paraboles confuses, parfois entrecoupées de rires nerveux ou de citations approximatives de textes sacrés qu’il n’a jamais vraiment lus.
-
-Son attaque signature *Chant de Jah* étourdit tous les ennemis dans un large rayon, accompagnée d’un léger fondu reggae et d’un relent suspect. On dit que même les Pokémon de type acier se détendent à son contact.`,
-  descriptionKey: 'data.shlagemons.evolutions.nosferasta.description',
+  description: 'data.shlagemons.evolutions.nosferasta.description',
 
   types: [shlagemonTypes.poison, shlagemonTypes.vol],
   speciality: 'evolution1',

--- a/src/data/shlagemons/evolutions/orchibre.ts
+++ b/src/data/shlagemons/evolutions/orchibre.ts
@@ -5,14 +5,7 @@ import rafflamby from './rafflamby'
 export const orchibre: BaseShlagemon = {
   id: 'orchibre',
   name: 'Orchibre',
-  description: `Orchibre est l’évolution majestueuse — mais pas moins grotesque — du Chibre. Sa tige centrale, épaisse et charnue, s’élève fièrement d’une corolle d’orchidée aux couleurs criardes, éclatant comme un feu d’artifice dans une serre mal entretenue.
-
-On le trouve souvent dans des recoins humides, méditant au son des gouttes qui tombent sur du carrelage moisi. Lorsqu’il se sent menacé, il libère un nuage de pollen épais et entêtant, déclenchant toux, larmes et parfois même hallucinations florales.
-
-Son attaque signature, *Fleur du Mal Alpha*, projette une salve de pétales coupants chargés en testostérone volatile. Certains chercheurs pensent qu’Orchibre serait le chaînon manquant entre les plantes vertes et les darons en claquettes-chaussettes.
-
-Il n’évolue plus, car selon la légende : “Quand un chibre atteint la floraison, il n’a plus rien à prouver.”`,
-  descriptionKey: 'data.shlagemons.evolutions.orchibre.description',
+  description: 'data.shlagemons.evolutions.orchibre.description',
 
   types: [shlagemonTypes.plante, shlagemonTypes.poison],
   evolution: {

--- a/src/data/shlagemons/evolutions/papi-sucon.ts
+++ b/src/data/shlagemons/evolutions/papi-sucon.ts
@@ -4,16 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const papysucon: BaseShlagemon = {
   id: 'papysucon',
   name: 'Papi Suçon',
-  description: `Papy Suçon est la forme finale de cette lignée de la honte. Il a gardé ses ailes, mais elles sont désormais flétries, poussiéreuses, et sentent la vieille cave humide. Il ne vole plus, il "flotte en gémissant", traînant derrière lui une traînée de bave et de souvenirs gênants.
-
-Vieux, râleur et mou, il marmonne dans sa barbe inexistante des phrases comme "viens là que j’te montre l’amour vrai" ou "moi à mon époque, on suçait avec respect". Son attaque signature, *Suçon Spectral*, inflige des dégâts mentaux et physiques, car il laisse une marque violette là où il frappe, souvent à des endroits non consentis.
-
-Il ne distingue plus les ennemis des alliés. Dès qu’il voit quelque chose bouger, il se met en mode aspiration. Sa bouche se déforme en un entonnoir flasque pendant qu’il fait le bruit de l’amour perdu (*FLUURRRR-PCHHH*).
-
-Sa capacité passive, *Salive Persistante*, ralentit les adversaires qui l’ont approché de trop près, à cause de la texture collante laissée sur leur peau. On raconte qu’un dresseur a tenté de le prendre dans ses bras et s’est retrouvé avec une marque mauve sur le front pendant 4 jours.
-
-Papy Suçon est un type crasse par excellence, mais il est aussi classé *affection*, car il prétend toujours "faire ça avec tendresse".`,
-  descriptionKey: 'data.shlagemons.evolutions.papi-sucon.description',
+  description: 'data.shlagemons.evolutions.papi-sucon.description',
   types: [shlagemonTypes.insecte],
   speciality: 'evolution2',
 }

--- a/src/data/shlagemons/evolutions/parasecte.ts
+++ b/src/data/shlagemons/evolutions/parasecte.ts
@@ -4,16 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const parasecte: BaseShlagemon = {
   id: 'parasecte',
   name: 'Parasecte',
-  description: `Parasecte n’est plus vraiment un shlagémon. C’est un message. Une vision. Un ancien Plégique ayant fusionné corps et âme avec son champignon, jusqu’à devenir la bouche béante d’un mouvement spirituel douteux qu’il appelle simplement "le Cycle Humide".
-
-Il est vêtu de spores pendantes formant une sorte de toge naturelle, maculée de symboles dessinés à la moisissure. Il plane perpétuellement à 2 cm du sol — non pas par magie, mais parce qu’il est trop collant pour s’en détacher. Son regard fixe et vide traverse les êtres, comme s’il voyait déjà leur décomposition.
-
-Il ne combat pas. Il *évangélise*. Ses disciples, surnommés les "Ferments", répandent sa parole dans les canalisations et les parkings souterrains. Leur rituel d’initiation ? Dormir 48h dans un tupperware humide en écoutant des prêches marmonnés à travers un masque chirurgical usagé.
-
-Son attaque signature, *Révélation Sporale*, libère une explosion de spores qui oblige l’ennemi à méditer sur le sens de la moisissure. L’attaque *Bénédiction Fongique* soigne tous les alliés, mais remplace leur libre arbitre par une envie irrépressible de réciter des textes à voix basse dans des buanderies.
-
-Parasecte ne cherche pas la victoire. Il cherche *l’humidité universelle*. Et toi, es-tu prêt à entendre l’appel du Champi Total ?`,
-  descriptionKey: 'data.shlagemons.evolutions.parasecte.description',
+  description: 'data.shlagemons.evolutions.parasecte.description',
   types: [shlagemonTypes.poison, shlagemonTypes.spectre],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/perchiste.ts
+++ b/src/data/shlagemons/evolutions/perchiste.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const perchiste: BaseShlagemon = {
   id: 'perchiste',
   name: 'Perchiste',
-  description: `Perchiste a quitté le grand banditisme des ruelles de Kanto pour se reconvertir dans le cinéma d’auteur... mais pas le bon. Armé de sa perche micro rafistolée avec du chatterton et un vieux t-shirt de crew, il hante les plateaux de tournage miteux, toujours prêt à capter les souffles, les silences, et parfois... ses propres soupirs de dépression.
-
-Il prend très à cœur son rôle, quitte à interrompre une scène pour recadrer un angle de son ou insulter un stagiaire lumière. Ses coussinets amortissent les bruits de pas, mais sa touffe de poils sur l’oreille capte toutes les mauvaises vibes. 
-
-Son attaque signature, *Grésil du Désespoir*, inflige un bruit statique à l’ennemi pendant 3 tours, tandis que *Silence Plateau !* le fait disparaître temporairement du combat, le temps d’un long plan fixe inutile.`,
-  descriptionKey: 'data.shlagemons.evolutions.perchiste.description',
+  description: 'data.shlagemons.evolutions.perchiste.description',
   types: [shlagemonTypes.normal],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/poissomerguez.ts
+++ b/src/data/shlagemons/evolutions/poissomerguez.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const poissomerguez: BaseShlagemon = {
   id: 'poissomerguez',
   name: 'Poissomerguez',
-  description: `Poissomerguez dégage une forte odeur de barbecue. Il fait frire l'eau autour de lui et provoque des fringales incontrôlables chez ses adversaires.`,
-  descriptionKey: 'data.shlagemons.evolutions.poissomerguez.description',
+  description: 'data.shlagemons.evolutions.poissomerguez.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/pyrolise.ts
+++ b/src/data/shlagemons/evolutions/pyrolise.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const pyrolise: BaseShlagemon = {
   id: 'pyrolise',
   name: 'Pyrolise',
-  description: `Toujours entouré d’une fumée douteuse, Pyrolise adore brûler tout ce qu’il touche et sentir les vapeurs toxiques.`,
-  descriptionKey: 'data.shlagemons.evolutions.pyrolise.description',
+  description: 'data.shlagemons.evolutions.pyrolise.description',
   types: [shlagemonTypes.feu],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/qwiflouch.ts
+++ b/src/data/shlagemons/evolutions/qwiflouch.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const qwiflouch: BaseShlagemon = {
   id: 'qwiflouch',
   name: 'Qwiflouch',
-  description: `Enflé comme une boule à mites, recouvert de pics rouillés. Il lâche du gaz au moindre stress et fait fuir les autres Shlagémons.`,
-  descriptionKey: 'data.shlagemons.evolutions.qwiflouch.description',
+  description: 'data.shlagemons.evolutions.qwiflouch.description',
   types: [shlagemonTypes.eau, shlagemonTypes.poison],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/rafflamby.ts
+++ b/src/data/shlagemons/evolutions/rafflamby.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const rafflamby: BaseShlagemon = {
   id: 'rafflamby',
   name: 'Rafflamby',
-  description: `Rafflamby est une imposante fleur fongique au dôme tremblotant, dont la texture évoque irrésistiblement un Flamby oublié sur un radiateur. Sa corolle charnue vibre au moindre pas, et libère des effluves de caramel tourné mêlé à des relents de compost diplomatique.
-
-On le trouve souvent avachi au centre de clairières suintantes, là où la gravité semble plus molle qu'ailleurs. Certains dresseurs affirment qu’il bouge lentement, mais qu’il finit toujours par apparaître à la fin, d’un air penaud mais inévitable.
-
-Son attaque *Coulée Présidentielle* projette une flaque gluante et tiède, difficile à éviter et encore plus difficile à justifier. Lorsqu’il subit une défaite, il se contente de sourire doucement, comme s’il l’avait prévue depuis le début.
-
-Rafflamby n’évolue plus, mais reste malgré tout présent dans de nombreux débats. Certains experts affirment qu’il n’est ni aimé, ni détesté : il est simplement là, fidèle à lui-même, tremblotant mais constant.`,
-  descriptionKey: 'data.shlagemons.evolutions.rafflamby.description',
+  description: 'data.shlagemons.evolutions.rafflamby.description',
 
   types: [shlagemonTypes.plante, shlagemonTypes.poison],
   speciality: 'evolution2',

--- a/src/data/shlagemons/evolutions/raichiotte.ts
+++ b/src/data/shlagemons/evolutions/raichiotte.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const raichiotte: BaseShlagemon = {
   id: 'raichiotte',
   name: 'Raïchiotte',
-  description: `Raïchiotte est l’aboutissement tragique de l’évolution de Pikachiant. Il a absorbé tellement d’ondes négatives et de câbles de contrefaçon qu’il est devenu littéralement instable : chaque mouvement déclenche des étincelles involontaires et un léger bruit de chasse d’eau. Il porte en permanence une banane fluo où il range ses powerbanks, ses amendes impayées et quelques trottinettes volées.
-
-Sa queue est devenue un paratonnerre inversé qui attire les problèmes, et son rire grésille comme un haut-parleur saturé. Il attaque avec *Coup de Jus Verbal*, une insulte électrique qui te paralyse de gêne. On le reconnaît facilement grâce à son regard vide, son haleine d’écran brûlé, et sa capacité à pirater un interphone avec une paille.
-
-Même les bornes de recharge refusent de le connecter. Il est considéré comme un bug vivant du Pokédex, et certains dresseurs le fuient, non pas pour sa puissance… mais pour sa conversation.`,
-  descriptionKey: 'data.shlagemons.evolutions.raichiotte.description',
+  description: 'data.shlagemons.evolutions.raichiotte.description',
   types: [shlagemonTypes.electrique],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/rapasdepisse.ts
+++ b/src/data/shlagemons/evolutions/rapasdepisse.ts
@@ -4,16 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const rapasdepisse: BaseShlagemon = {
   id: 'rapasdepisse',
   name: 'Rapasdepisse',
-  description: `Rapasdepisse est l’évolution tragiquement humide de Piafsansbec. Il a enfin récupéré un peu de plumage, une carrure plus imposante, et même un cri (aigu, inutile, tremblant). Mais tout cela est ruiné par un détail... il fait pipi. Tout le temps. Par petites gouttes. Sans prévenir.
-
-Il n’a aucun contrôle. À chaque battement d’ailes : *plitch*. À chaque cri : *pshht*. À chaque victoire : *floc*. Il porte parfois une sorte de lange improvisé en mousse, mais ça déborde. Toujours. Son passage laisse derrière lui des flaques suspectes et des flaçons d’humiliation. Sa zone de spawn est officiellement déclarée "glissante".
-
-Son attaque signature, *Jet Honteux*, inflige un malus de défense à l’ennemi (et de respect à lui-même). Il possède aussi *Fuite Incontrôlée*, une attaque passive qui inflige des dégâts mineurs à chaque tour... au sol uniquement. Il peut aussi apprendre *Averse Doublée*, qui remplace les effets de météo par quelque chose de bien plus personnel.
-
-Rapasdepisse ne vole pas vraiment. Il fait des sauts nerveux et humides. Son cri ressemble à un "PRRRFFFFFT !" suivi d’un long silence gênant. Il évite les zones aérées et les dresseurs trop propres.
-
-On le garde par compassion, ou par erreur. Mais même s’il fait un peu pitié, certains affirment qu’il est doux, affectueux... et toujours tiède.`,
-  descriptionKey: 'data.shlagemons.evolutions.rapasdepisse.description',
+  description: 'data.shlagemons.evolutions.rapasdepisse.description',
   types: [shlagemonTypes.vol],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/raptorincel.ts
+++ b/src/data/shlagemons/evolutions/raptorincel.ts
@@ -5,14 +5,7 @@ import dracoCon from './draco-con'
 export const raptorincel: BaseShlagemon = {
   id: 'raptorincel',
   name: 'Raptor Incel',
-  description: `Raptor Incel est l’évolution naturellement toxique de Salamiches. Plus grand, plus anguleux, mais toujours aussi fragile intérieurement, il crache des flammes tièdes tout en débitant des discours passifs-agressifs sur "les vrais dresseurs" et "les femelles qui aiment que les Tortanks".
-
-Son hoodie à capuche intégrée est maintenant fusionné à sa peau, et sa flamme est alimentée uniquement par les débats Twitter auxquels personne ne participe. Il se déplace par bonds secs, comme s’il avait des choses à prouver à chaque pas, ce qui rend sa démarche aussi ridicule qu’hostile.
-
-Il possède une attaque spéciale : *Flamme Frustrée*, qui explose si l’adversaire est un Shlagémon féminin. Il peut aussi utiliser *Monologue Évolutif*, une capacité qui fait fuir les ennemis en leur expliquant pourquoi ils ont tort d'exister.
-
-On le trouve souvent dans des grottes sombres, en train de taper sur des claviers invisibles tout en s’entraînant à l’art du regard méprisant. Son rêve ? Devenir le Shlagémon alpha… et surtout que quelqu’un daigne lui répondre un jour.`,
-  descriptionKey: 'data.shlagemons.evolutions.raptorincel.description',
+  description: 'data.shlagemons.evolutions.raptorincel.description',
   types: [shlagemonTypes.feu],
   evolution: { base: dracoCon, condition: { type: 'lvl', value: 36 } },
   speciality: 'evolution1',

--- a/src/data/shlagemons/evolutions/ratartine.ts
+++ b/src/data/shlagemons/evolutions/ratartine.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const ratartine: BaseShlagemon = {
   id: 'ratartine',
   name: 'Ratartine',
-  description: `Ratartine est l’évolution tartinée de Ratonton. Après avoir trop siesté au soleil avec du pâté dans les poches, son corps a fusionné avec une immense tranche de pain de mie moisi. Sa fourrure est désormais dorée sur les bords, et son dos arbore en permanence une couche de rillettes, de confiture, ou parfois de sauce inconnue (selon la météo et son humeur digestive).
-
-Il se déplace lentement, en émettant des bruits de croûte qui frotte sur le carrelage. Il est obsédé par les tartines, au point de tenter de tartiner tout ce qui passe : murs, ennemis, alliés, sol, air. Son attaque signature, *Écrasé Beurré*, inflige des dégâts collants et ralentit la cible en lui projetant une couche grasse et tiède.
-
-Ratartine vit dans les placards, dort dans les grille-pains abandonnés, et rêve de se faire toaster par amour. Il pense que les ronds de gras sur la nappe sont des portails magiques. Sa capacité passive, *Pain Perdu*, lui permet de regagner des PV lorsqu’il est proche d’un pique-nique.
-
-On dit qu’il a tenté d’évoluer en "Croquemonsieur", mais qu’il a trop fondu avant la dernière étape.`,
-  descriptionKey: 'data.shlagemons.evolutions.ratartine.description',
+  description: 'data.shlagemons.evolutions.ratartine.description',
   types: [shlagemonTypes.normal],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/rhinoplastie.ts
+++ b/src/data/shlagemons/evolutions/rhinoplastie.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const rhinoplastie: BaseShlagemon = {
   id: 'rhinoplastie',
   name: 'Rhinoplastie',
-  description: `Après une chirurgie esthétique ratée, Rhinoplastie a la face entièrement remodelée. Il fait peur à tout le monde mais se trouve magnifique.`,
-  descriptionKey: 'data.shlagemons.evolutions.rhinoplastie.description',
+  description: 'data.shlagemons.evolutions.rhinoplastie.description',
   types: [shlagemonTypes.sol, shlagemonTypes.roche],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/ricardnin.ts
+++ b/src/data/shlagemons/evolutions/ricardnin.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const ricardnin: BaseShlagemon = {
   id: 'ricardnin',
   name: 'Ricardnin',
-  description: `Ricardnin n’apparaît que lors des barbecues familiaux prolongés. On le reconnaît à sa casquette délavée à l'odeur suspecte et à la fiole sacrée qu’il garde en pendentif, qu’il appelle sa réserve tactique. Il aboie dès qu’il entend les mots "pétanque", "saucisson" ou "c’est qui qui a pris ma chaise là ?". Son haleine inflige des dégâts sur la durée, surtout s’il a mangé de l’aïoli. Son attaque signature, Souffle Anisé, embrume le terrain dans un nuage jaunâtre qui réduit la précision de tous les Pokémon adverses. Il peut aussi lancer Provoquapéro, qui oblige les dresseurs à faire une pause et à sortir les chips.`,
-  descriptionKey: 'data.shlagemons.evolutions.ricardnin.description',
+  description: 'data.shlagemons.evolutions.ricardnin.description',
   types: [shlagemonTypes.feu, shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/roux-pignolage.ts
+++ b/src/data/shlagemons/evolutions/roux-pignolage.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const rouxPignolage: BaseShlagemon = {
   id: 'roux-pignolage',
   name: 'Roux Pignolage',
-  description: `Roux Pignolage est l’évolution finale et tragique de Roux pas Cool. Il a troqué sa guitare pour un clavier graisseux, et sa passion pour l’indé est devenue une fixette sur les archives "non censurées" des forums Shlagépédia. Il vit recroquevillé dans une carapace de mauvaise foi, de miettes de chips, et de regrets sociaux profonds.
-
-Ses plumes sont ternes, collées par des fluides suspects et du gel pour cheveux périmé. Il parle peu, mais quand il le fait, c’est pour balancer des monologues confus sur la liberté d’expression, les caméras planquées, et "ce que les gens veulent pas entendre". Il se pignole. Beaucoup. Trop. Il appelle ça du "recentrage énergétique". Les autres appellent ça un délit.
-
-Sa capacité signature, *Stimulation Solitaire*, le soigne légèrement à chaque tour... mais inflige un malus de moral à toute l’équipe alliée. Il utilise aussi *Main Moite*, une attaque de type contact qui a 30% de chance de faire fuir directement l’ennemi par gêne viscérale.
-
-On le croise rarement en public, sauf dans des commentaires de vidéos floues ou à 3h du matin dans des zones Wi-Fi libres. Il prétend être incompris, mais en vérité, tout le monde le comprend très bien… et c’est ça le problème.`,
-  descriptionKey: 'data.shlagemons.evolutions.roux-pignolage.description',
+  description: 'data.shlagemons.evolutions.roux-pignolage.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/evolutions/roux-scoop.ts
+++ b/src/data/shlagemons/evolutions/roux-scoop.ts
@@ -5,8 +5,7 @@ import { rouxPignolage } from './roux-pignolage'
 export const rouxScoop: BaseShlagemon = {
   id: 'roux-scoop',
   name: 'Roux Scoop',
-  description: `Roux Scoop a troqué sa guitare et ses illusions contre un vieil appareil photo rafistolé à base de chewing-gum et de sparadrap. Il virevolte dans les cieux en quête de scoops minables : disputes entre Pokémon, culottes envolées, ou encore la forme suspecte d’un nuage. Avec sa casquette trop grande estampillée "PRESSÉ", il se prend pour le roi du journalisme d’investigation, même s’il ne fait que spammer des clichés flous et des rumeurs non vérifiées sur les forums de PokéComplot. Il parle vite, renifle fort, et ponctue ses phrases de "j’ai mes sources". Son attaque signature, *Flash Infâme*, aveugle tous les adversaires, mais il oublie souvent de retirer le cache de l’objectif. Malgré ses ambitions, il reste désespérément à la recherche d’un vrai sujet... ou d’un peu de respect.`,
-  descriptionKey: 'data.shlagemons.evolutions.roux-scoop.description',
+  description: 'data.shlagemons.evolutions.roux-scoop.description',
   types: [shlagemonTypes.normal, shlagemonTypes.vol],
   evolution: { base: rouxPignolage, condition: { type: 'lvl', value: 36 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/evolutions/salmoneli.ts
+++ b/src/data/shlagemons/evolutions/salmoneli.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const salmoneli: BaseShlagemon = {
   id: 'salmoneli',
   name: 'Salmoneli',
-  description: `Ce poisson aux couleurs ternes traîne des germes partout où il passe et préfère l’eau croupie.`,
-  descriptionKey: 'data.shlagemons.evolutions.salmoneli.description',
+  description: 'data.shlagemons.evolutions.salmoneli.description',
   types: [shlagemonTypes.eau],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/smongogol.ts
+++ b/src/data/shlagemons/evolutions/smongogol.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const smongogol: BaseShlagemon = {
   id: 'smongogol',
   name: 'Smongogol',
-  description: `Toujours plus imbécile et plus toxique que Smongol, Smongogol libère un nuage épais qui empeste la débilité. On le confond souvent avec un vieux pneu en feu.`,
-  descriptionKey: 'data.shlagemons.evolutions.smongogol.description',
+  description: 'data.shlagemons.evolutions.smongogol.description',
   types: [shlagemonTypes.poison],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/sperectum.ts
+++ b/src/data/shlagemons/evolutions/sperectum.ts
@@ -5,8 +5,7 @@ import ectroudbal from './ectroudbal'
 export const sperectum: BaseShlagemon = {
   id: 'sperectum',
   name: 'Sperectum',
-  description: `Sperectum est la réincarnation d'un pet émis par un Shlagemon.`,
-  descriptionKey: 'data.shlagemons.evolutions.sperectum.description',
+  description: 'data.shlagemons.evolutions.sperectum.description',
   types: [shlagemonTypes.spectre],
   evolution: {
     base: ectroudbal,

--- a/src/data/shlagemons/evolutions/stabiscarosse.ts
+++ b/src/data/shlagemons/evolutions/stabiscarosse.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const stabiscarosse: BaseShlagemon = {
   id: 'stabiscarosse',
   name: 'Stabiscarosse',
-  description: `Parti s'installer à Biscarrosse pour profiter des vagues, ce Shlagémon se pavane désormais avec une planche de surf sous chaque bras.`,
-  descriptionKey: 'data.shlagemons.evolutions.stabiscarosse.description',
+  description: 'data.shlagemons.evolutions.stabiscarosse.description',
   types: [shlagemonTypes.eau, shlagemonTypes.psy],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/tatacruelle.ts
+++ b/src/data/shlagemons/evolutions/tatacruelle.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const tatacruelle: BaseShlagemon = {
   id: 'tatacruelle',
   name: 'Tatacruelle',
-  description: `Tatacruelle est la terreur des fonds de placard, la légende vivante que tous les jeunes Shlagémons redoutent. Son corps aquatique, usé et gonflé, ressemble à une vieille nappe plastique couverte de taches de gras indélébiles. Sur sa tête, ses vingt “bigoudis” se sont transformés en rouleaux de PQ rose, prêts à t’étouffer d’un regard mauvais.
-
-Son visage, tout plissé et tiré vers le bas, inspire l'effroi et le respect, avec des lèvres pincées et des yeux injectés de venin. Deux énormes tentacules couverts de bagues en toc et d’élastiques usagés s’agitent à chaque bruit suspect, prêts à claquer sur quiconque ose marcher sur SON carrelage.  
-
-Tatacruelle adore faire la morale en jetant du vinaigre partout, piquer les biscuits des autres et verrouiller les confitures dans une armoire à code secret. Son attaque signature, *Remontrance Aqueuse*, t’envoie une vague d’eau froide et d’insultes cinglantes, te laissant grelottant de honte et de remords.
-
-On raconte qu’elle hante les cuisines après 22h, prête à punir ceux qui osent ouvrir le frigo. Son rêve ? Être immortalisée en portrait sur chaque pot de cornichons du coin. Même les plus téméraires n’osent pas traîner près d’elle quand la nuit tombe.`,
-  descriptionKey: 'data.shlagemons.evolutions.tatacruelle.description',
+  description: 'data.shlagemons.evolutions.tatacruelle.description',
   types: [shlagemonTypes.eau, shlagemonTypes.poison],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/tord-turc.ts
+++ b/src/data/shlagemons/evolutions/tord-turc.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const tordturc: BaseShlagemon = {
   id: 'tord-turc',
   name: 'Tord Turc',
-  description: `Tord Turc est l’évolution ultime de la lignée Carapouffe. Il ne se déplace plus : il glisse latéralement, lentement, tout en tordant l’espace autour de lui. Sa simple présence froisse les meubles, plie les murs et recourbe les opinions.
-
-Armé de deux bras aux ongles vissés façon tire-bouchon, il peut littéralement tordre les attaques ennemies pour les renvoyer à l’expéditeur, accompagnées d’un soupir condescendant. Il parle peu, mais quand il le fait, c’est pour demander “c’est qui ce fragile ?” ou annoncer qu’il a “tordu l’univers pour trouver une teinte de gloss inédite”.
-
-Son dos est devenu un trône en spirale, incrusté de miroirs concaves qui renvoient à leurs adversaires une version déformée et déprimante d’eux-mêmes. Sa technique ultime, *Torsion Charismatique*, plie les statistiques ennemies jusqu’à ce qu’ils s’abandonnent au désespoir.
-
-On dit que même les légendaires évitent de le croiser : pas par peur de la défaite, mais par peur de se faire juger en silence.`,
-  descriptionKey: 'data.shlagemons.evolutions.tord-turc.description',
+  description: 'data.shlagemons.evolutions.tord-turc.description',
   types: [shlagemonTypes.eau],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/evolutions/triopikouze.ts
+++ b/src/data/shlagemons/evolutions/triopikouze.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const triopikouze: BaseShlagemon = {
   id: 'triopikouze',
   name: 'Triopikouze',
-  description: `Triopikouze est ce qu'on appelle dans le jargon un "incident ambulant". Radié de l’ordre des médecins pour raisons évidentes (et nombreuses), il a trouvé un nouveau terrain de jeu : les soirées crades et les rave-parties en sous-sol. Là où d'autres apportent de la bonne humeur, lui apporte... des piqûres surprises.
-
-Composé de trois têtes aux regards fuyants, il discute souvent avec lui-même pour se mettre d’accord sur *qui on va piquer ce soir*. Chacune de ses têtes possède une seringue différente, contenant un liquide aux effets mystérieux (hallucinations, évanouissements, envie de danser sur du Jul).
-
-Son attaque signature, *Injection Festive*, inflige un statut aléatoire à tous les ennemis présents. Il peut aussi déclencher *Soirée Non Consentante*, une capacité qui interrompt toutes les actions ennemies pendant un tour, le temps de créer un malaise palpable.`,
-  descriptionKey: 'data.shlagemons.evolutions.triopikouze.description',
+  description: 'data.shlagemons.evolutions.triopikouze.description',
   types: [shlagemonTypes.poison, shlagemonTypes.spectre],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/tuberculi.ts
+++ b/src/data/shlagemons/evolutions/tuberculi.ts
@@ -4,8 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const tuberculi: BaseShlagemon = {
   id: 'tuberculi',
   name: 'Tuberculi',
-  description: `Permanemment parcouru d’étincelles maladives, Tuberculi tousse des arcs électriques sur ses adversaires.`,
-  descriptionKey: 'data.shlagemons.evolutions.tuberculi.description',
+  description: 'data.shlagemons.evolutions.tuberculi.description',
   types: [shlagemonTypes.electrique],
   speciality: 'evolution1',
 }

--- a/src/data/shlagemons/evolutions/vieuxblaireau.ts
+++ b/src/data/shlagemons/evolutions/vieuxblaireau.ts
@@ -4,12 +4,7 @@ import { shlagemonTypes } from '../../shlagemons-type'
 export const vieuxBlaireau: BaseShlagemon = {
   id: 'vieux-blaireau',
   name: 'Vieux Blaireau',
-  description: `Vieux Blaireau est ce genre de Shlagémon qui traîne dans les mêmes coins depuis trente ans, sans que personne ne se souvienne vraiment quand il est arrivé. Son pelage est terne, ses articulations craquent quand il se baisse, et il parle souvent "d’avant", même quand personne n’a demandé.
-
-Il n’a pas vraiment de technique, mais beaucoup d'expérience : son attaque *Remontrance Fossile* a une chance d’étourdir l’adversaire avec un discours sur "la vraie vie". Il peut aussi utiliser *Jet de Pansement*, une capacité de soin modeste qu’il garde pour lui, évidemment.
-
-On dit qu’il a autrefois gagné un tournoi interzonier, mais la légende reste floue. Aujourd’hui, il râle, il grogne, et parfois, il dort en plein combat. Mais attention : sous la couche de rhumatismes, il reste dangereux… surtout pour les nerfs.`,
-  descriptionKey: 'data.shlagemons.evolutions.vieuxblaireau.description',
+  description: 'data.shlagemons.evolutions.vieuxblaireau.description',
   types: [shlagemonTypes.sol],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/mairiousse.ts
+++ b/src/data/shlagemons/mairiousse.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../shlagemons-type'
 export const mairiousse: BaseShlagemon = {
   id: 'mairiousse',
   name: 'Mairiousse',
-  description: `Mairiousse est un énorme chien blanc au poil jauni par l’usure, toujours affublé d’une écharpe tricolore crado, mal ajustée, qui pendouille de travers sur son flanc. Son torse est bombé comme s’il venait de serrer une cinquantième main municipale, mais ses pattes sont molles et déformées par trop de réunions debout. Il porte des lunettes de vue sales, à moitié embuées, calées sur un museau humide qui bave en permanence.
-
-Son regard est épuisé mais autoritaire, avec un sourcil levé de travers et l’autre tombant comme un panneau d'interdiction arraché. Il traîne derrière lui un petit nuage d’odeur de vieux bureau moisi, et des miettes de galette des rois restent coincées dans ses babines depuis janvier. L’un de ses crocs dépasse légèrement, usé comme un stylo Bic mâchonné en conseil communal.
-
-Il tient debout dans une posture ridicule mais solennelle, un peu penché, une patte sur un vieux micro cassé et l’autre tremblante sur un registre municipal couvert de poils. Parfois, il lève la patte par réflexe… sur une urne électorale.
-
-On dit que Mairiousse n’aboie pas : il fait des discours interminables qui endorment les Shlagémons ennemis d’ennui profond.`,
-  descriptionKey: 'data.shlagemons.mairiousse.description',
+  description: 'data.shlagemons.mairiousse.description',
 
   types: [shlagemonTypes.sol, shlagemonTypes.eau],
   speciality: 'legendary',

--- a/src/data/shlagemons/mewteub.ts
+++ b/src/data/shlagemons/mewteub.ts
@@ -4,9 +4,7 @@ import { shlagemonTypes } from '../shlagemons-type'
 export const mewteub: BaseShlagemon = {
   id: 'mewteub',
   name: 'Mewteub',
-  description: `Mewteub est un né d’un bug génétique entre une prise HDMI et une entité cosmique sous anxiolytiques. On murmure qu’il aurait été cloné à partir d’un vieux câble péritel tombé dans une bassine de Monster Energy. Il flotte constamment, mais sans élégance — plutôt comme une chaussette dans un jacuzzi. Son corps translucide laisse entrevoir un réseau veineux qui clignote au rythme d’un modem 56k. Il émet des sons télépathiques, tous plus gênants les uns que les autres : soupirs, "hmm" douteux et parfois des extraits de discussions MSN de 2003. Il communique principalement par vibration de teub psychique, ce qui perturbe fortement les autres Shlagémons — et les enfants non accompagnés. Sa capacité spéciale, *Onde Malaise*, fige l’adversaire dans une gêne abyssale pendant plusieurs tours. On dit que croiser son regard provoque des flashbacks de soirées gênantes en boîte de province.
-Mewteub est rare. Trop rare. Et franchement, c’est peut-être mieux ainsi.`,
-  descriptionKey: 'data.shlagemons.mewteub.description',
+  description: 'data.shlagemons.mewteub.description',
   types: [shlagemonTypes.psy],
   speciality: 'legendary',
 }

--- a/src/data/shlagemons/salamiches.ts
+++ b/src/data/shlagemons/salamiches.ts
@@ -5,8 +5,7 @@ import raptorincel from './evolutions/raptorincel'
 export const salamiches: BaseShlagemon = {
   id: 'salamiches',
   name: 'Salamiches',
-  description: `Salamiches brûle, mais pas de feu noble, non, plutôt de feu de briquet BIC vide qu’on rallume à la 27ᵉ tentative. Toujours torse nu, même en hiver, il arbore une crête en feu mal fixée et des lunettes de soleil qui fondent partiellement à chaque attaque. Il se nourrit exclusivement de chips au paprika, de whisky bon marché, et d’approbation sociale. On le trouve souvent en train de se filmer en selfie pendant qu’il crache des étincelles sur des poubelles. Sa capacité spéciale, *Feu d’ego*, augmente sa puissance chaque fois qu’il se fait huer. Il envoie des punchlines nulles entre deux jets de flamme molle, et rêve de devenir influenceur muscu alors qu’il n’a que deux abdos (et encore, en ombrage). C’est un être loyal, sauf si on lui propose un kebab gratuit ou une promotion chez Feu Vert.`,
-  descriptionKey: 'data.shlagemons.salamiches.description',
+  description: 'data.shlagemons.salamiches.description',
   types: [shlagemonTypes.feu],
   evolution: { base: raptorincel, condition: { type: 'lvl', value: 16 } },
   speciality: 'evolution0',

--- a/src/data/shlagemons/sulfusouris.ts
+++ b/src/data/shlagemons/sulfusouris.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../shlagemons-type'
 export const sulfusouris: BaseShlagemon = {
   id: 'sulfusouris',
   name: 'Sulfusouris',
-  description: `Sulfusouris est un Shlagémon légendaire né d’un court-circuit dans un four à micro-ondes abandonné. Selon la légende, une colonie de souris aurait tenté de construire un nid dans un grille-pain, et seule l’une d’entre elles aurait survécu… carbonisée, mais éveillée à une puissance ardente. Elle s’est relevée dans les flammes, plus déterminée que jamais à griller tout ce qui bouge — surtout les câbles électriques.
-
-Avec son pelage en poils roussis, ses ailes faites de tranches de pain de mie calcinées et sa queue qui crache des étincelles, Sulfusouris est la terreur des parkings souterrains et des compteurs Linky. Il émet un grincement aigu quand il vole, comme un cri de modem mourant. Son odeur évoque un mélange de plastique fondu et de fromage râpé oublié dans une voiture en plein été.
-
-Certains shlagémonologues affirment qu’il est capable de déclencher des incendies spontanés juste en éternuant, et qu’il s’abreuve exclusivement de Red Bull tiède pour alimenter ses flammes internes. D'autres disent qu’il aurait essayé de rejoindre le ciel comme un phénix… mais s’est arrêté à mi-hauteur pour fumer une clope sur un lampadaire.
-
-Vénéré par une secte de rats crasseux, Sulfusouris est considéré comme le “Dieu du Barbecue Éternel”. Il apparaît parfois lors des canicules extrêmes, planant en sueur au-dessus des toits, et beuglant des prophéties incompréhensibles en clignotant comme une veilleuse cassée.`,
-  descriptionKey: 'data.shlagemons.sulfusouris.description',
+  description: 'data.shlagemons.sulfusouris.description',
 
   types: [shlagemonTypes.feu, shlagemonTypes.vol],
   speciality: 'legendary',

--- a/src/data/shlagemons/wem.ts
+++ b/src/data/shlagemons/wem.ts
@@ -4,14 +4,7 @@ import { shlagemonTypes } from '../shlagemons-type'
 export const wem: BaseShlagemon = {
   id: 'wem',
   name: 'Wem',
-  description: `Wem est terne, pataud, et délibérément inutile. On raconte qu’il a été créé par erreur lors d’un téléchargement corrompu d’un clone sur une imprimante 3D alimentée par une bouilloire.
-
-Il ne vole pas, il ne flotte pas, il rampe doucement en couinant comme une chaussure mouillée. Chaque cellule de son corps transpire la médiocrité : ses attaques échouent à 60% du temps, ses pouvoirs sont incompatibles avec tous les systèmes connus, et même sa présence fait buguer les enceintes Bluetooth.
-
-Son attaque signature, *Raté Critique*, inflige 0 dégâts mais provoque un inconfort durable chez l’adversaire. Wem a le pouvoir unique d’annuler l’enthousiasme autour de lui, et certains dresseurs le transportent uniquement pour neutraliser les encouragements du public adverse.
-
-On ne le trouve pas : c’est lui qui reste, par erreur, au fond d’un sac. Son rêve ? Être ignoré parfaitement, comme un ticket de caisse mouillé.`,
-  descriptionKey: 'data.shlagemons.wem.description',
+  description: 'data.shlagemons.wem.description',
   types: [shlagemonTypes.psy],
   speciality: 'unique',
 }

--- a/src/data/shlagemons/zebrapoisbleu.ts
+++ b/src/data/shlagemons/zebrapoisbleu.ts
@@ -4,18 +4,7 @@ import { shlagemonTypes } from '../shlagemons-type'
 export const zebrapoisbleu: BaseShlagemon = {
   id: 'zebrapoisbleu',
   name: 'ZebraPoisBleu',
-  description: `ZebraPoisBleu est un Shlagémon ultra rare, aperçu seulement au lever de la rosée, lové contre un buisson de pois bleus luminescents. Il a l’apparence d’un petit zèbre dodu, tout doux et pastel, assis en position de méditation foireuse, le regard serein et l’odeur envoûtante.
-
-Son corps est bleu ciel délavé, constellé de grosses fleurs bleues enfoncées dans sa crinière et sa croupe, comme si quelqu’un avait essayé de le coiffer avec amour… mais les yeux fermés. Ces fleurs émettent des ondes zen, qui provoquent un état second chez les Shlagémons autour : soit ils s’endorment paisiblement, soit ils partent en crise de larmes incontrôlables.
-
-Il tient souvent une fleur magique entre les pattes avant, qu’il serre contre son torse en murmurant des phrases bizarres genre "calme ta violence intérieure, frère." Sa posture est totalement amorphe, il est posé comme une patate bouillie, mais avec la grâce d’un maître zen oublié depuis longtemps.
-
-Expression faciale : un sourire béat, yeux clos, genre "je plane à 3 cm du sol, et c’est très bien comme ça."
-Détail absurde : des petits pétales bleus lui sortent parfois des oreilles quand il éternue.
-Aura : un halo féerique vaporeux, avec des particules bleutées, un peu comme un encens cosmique.
-
-Ce Shlagémon n’attaque jamais directement. Il infuse le terrain d’une paix surnaturelle qui rend confus tous les Shlagémons agressifs. Sauf s’ils ont le type Métal Brutal, là ça les énerve encore plus.`,
-  descriptionKey: 'data.shlagemons.electhordu.description',
+  description: 'data.shlagemons.electhordu.description',
 
   types: [shlagemonTypes.psy, shlagemonTypes.vol],
   speciality: 'legendary',


### PR DESCRIPTION
## Summary
- use I18nKey across data
- drop plain text from items, wearables, kings and shlagemon data
- update Poulailler panel to read item names directly

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Property 'stop' does not exist on type)*
- `pnpm test` *(fails: Test Files 1 failed | 48 passed | 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688953d4cbe8832a934d01fbd5a115b2