### PR TITLE
Add playtime tracking

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -184,6 +184,7 @@ components:
       invalid: Invalid code
       loaded: Save loaded
       copied: Copied
+      playtime: You have played for {minutes} minutes.
       generate: Generate
       loadFile: Load from file
     LanguageTab:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -187,6 +187,7 @@ components:
       invalid: Code invalide
       loaded: Sauvegarde chargée
       copied: Copié
+      playtime: Tu as joué pendant {minutes} minutes.
       generate: Générer
       loadFile: Charger depuis un fichier
     LanguageTab:

--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -287,6 +287,7 @@ declare global {
   const usePerformanceObserver: typeof import('@vueuse/core')['usePerformanceObserver']
   const usePermission: typeof import('@vueuse/core')['usePermission']
   const usePlayerStore: typeof import('./stores/player')['usePlayerStore']
+  const usePlaytimeStore: typeof import('./stores/playtime')['usePlaytimeStore']
   const usePointer: typeof import('@vueuse/core')['usePointer']
   const usePointerLock: typeof import('@vueuse/core')['usePointerLock']
   const usePointerSwipe: typeof import('@vueuse/core')['usePointerSwipe']
@@ -734,6 +735,7 @@ declare module 'vue' {
     readonly usePerformanceObserver: UnwrapRef<typeof import('@vueuse/core')['usePerformanceObserver']>
     readonly usePermission: UnwrapRef<typeof import('@vueuse/core')['usePermission']>
     readonly usePlayerStore: UnwrapRef<typeof import('./stores/player')['usePlayerStore']>
+    readonly usePlaytimeStore: UnwrapRef<typeof import('./stores/playtime')['usePlaytimeStore']>
     readonly usePointer: UnwrapRef<typeof import('@vueuse/core')['usePointer']>
     readonly usePointerLock: UnwrapRef<typeof import('@vueuse/core')['usePointerLock']>
     readonly usePointerSwipe: UnwrapRef<typeof import('@vueuse/core')['usePointerSwipe']>

--- a/src/components/settings/SaveTab.i18n.yml
+++ b/src/components/settings/SaveTab.i18n.yml
@@ -9,6 +9,7 @@ fr:
   invalid: Code invalide
   loaded: Sauvegarde chargée
   copied: Copié
+  playtime: Tu as joué pendant {minutes} minutes.
   loadFile: Charger depuis un fichier
 en:
   exportLabel: Save code
@@ -21,4 +22,5 @@ en:
   invalid: Invalid code
   loaded: Save loaded
   copied: Copied
+  playtime: You have played for {minutes} minutes.
   loadFile: Load from file

--- a/src/components/settings/SaveTab.vue
+++ b/src/components/settings/SaveTab.vue
@@ -4,6 +4,7 @@ import { applySave, collectSave, exportSave, importSave } from '~/utils/save-cod
 
 const emit = defineEmits<{ (e: 'remove'): void }>()
 const { t } = useI18n()
+const playtime = usePlaytimeStore()
 const exportCode = ref('')
 const importCode = ref('')
 const showImport = ref(false)
@@ -65,6 +66,9 @@ function loadFromFile(event: Event) {
 
 <template>
   <div class="flex flex-col gap-6">
+    <p class="text-center">
+      {{ t('components.settings.SaveTab.playtime', { minutes: playtime.minutes }) }}
+    </p>
     <section class="flex flex-col items-center gap-2">
       <label v-if="exportCode" class="font-bold">
         {{ t('components.settings.SaveTab.exportLabel') }}

--- a/src/stores/playtime.ts
+++ b/src/stores/playtime.ts
@@ -1,0 +1,23 @@
+import { defineStore } from 'pinia'
+
+/**
+ * Tracks total play time in minutes.
+ *
+ * The counter automatically increments every minute while the app is running.
+ */
+export const usePlaytimeStore = defineStore('playtime', () => {
+  const minutes = ref(0)
+
+  // Increment playtime every 60 seconds
+  useIntervalFn(() => {
+    minutes.value += 1
+  }, 60_000)
+
+  function reset() {
+    minutes.value = 0
+  }
+
+  return { minutes, reset }
+}, {
+  persist: true,
+})

--- a/src/utils/save-code.ts
+++ b/src/utils/save-code.ts
@@ -30,6 +30,7 @@ export const PERSISTED_STORE_KEYS = [
   'miniGame',
   'mobileTab',
   'player',
+  'playtime',
   'potionInfo',
   'shlagedex',
   'shopFilter',

--- a/test/playtime-store.test.ts
+++ b/test/playtime-store.test.ts
@@ -1,0 +1,20 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { usePlaytimeStore } from '../src/stores/playtime'
+
+/**
+ * Ensures playtime increases once per minute.
+ */
+describe('playtime store', () => {
+  it('increments minutes every minute', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const store = usePlaytimeStore()
+    expect(store.minutes).toBe(0)
+    vi.advanceTimersByTime(60_000)
+    expect(store.minutes).toBe(1)
+    vi.advanceTimersByTime(120_000)
+    expect(store.minutes).toBe(3)
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- track playtime minutes in new `playtime` store
- persist playtime in saves
- show playtime in the save tab
- provide translations for playtime display
- test playtime store logic

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6889ecd44800832a9ffe2295db3ee6ed