### PR TITLE
Fix arena naming in music generator

### DIFF
--- a/public/music-data.json
+++ b/public/music-data.json
@@ -306,25 +306,25 @@
     "image": "/characters/vladimir-putain/vladimir-putain.png"
   },
   {
-    "nom": "arena20",
+    "nom": "Arène lvl 20",
     "type": "arena",
     "url": "/audio/musics/arenas/arena20.ogg",
     "image": null
   },
   {
-    "nom": "arena40",
+    "nom": "Arène lvl 40",
     "type": "arena",
     "url": "/audio/musics/arenas/arena40.ogg",
     "image": null
   },
   {
-    "nom": "arena60",
+    "nom": "Arène lvl 60",
     "type": "arena",
     "url": "/audio/musics/arenas/arena60.ogg",
     "image": null
   },
   {
-    "nom": "arena80",
+    "nom": "Arène lvl 80",
     "type": "arena",
     "url": "/audio/musics/arenas/arena80.ogg",
     "image": null

--- a/scripts/generate-music-json.cjs
+++ b/scripts/generate-music-json.cjs
@@ -99,8 +99,9 @@ function parseArenas() {
   let match = regex.exec(content)
   while (match) {
     const id = match[1]
+    const lvl = id.match(/\d+/)?.[0]
     arenas.push({
-      nom: id,
+      nom: lvl ? `Arène lvl ${lvl}` : id,
       type: 'arena',
       url: tracks[id] || null,
       image: findImage('arenas', id),


### PR DESCRIPTION
## Summary
- tweak `parseArenas` to produce `Arène lvl {lvl}` labels
- regenerate `music-data.json` with updated names

## Testing
- `CI=1 pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f52c87e0832aa2f0d913c000c95e