### PR TITLE
Fix egg box reset on new game

### DIFF
--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -19,6 +19,8 @@ export const useSaveStore = defineStore('save', () => {
   const player = usePlayerStore()
   const itemUsage = useItemUsageStore()
   const equipment = useEquipmentStore()
+  const eggBox = useEggBoxStore()
+  const egg = useEggStore()
 
   function reset() {
     dex.reset()
@@ -39,6 +41,8 @@ export const useSaveStore = defineStore('save', () => {
     player.reset()
     itemUsage.reset()
     equipment.reset()
+    eggBox.reset()
+    egg.reset()
   }
 
   return { reset }


### PR DESCRIPTION
## Summary
- ensure egg-related stores reset when starting a new game

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6889f55ffe58832aa23d704ad20e70ec