### PR TITLE
Trigger dev dialog on entering second village

### DIFF
--- a/src/components/dialog/DeveloperSupportDialog.i18n.yml
+++ b/src/components/dialog/DeveloperSupportDialog.i18n.yml
@@ -2,7 +2,7 @@ fr:
   steps:
     start:
       text: >-
-        Salut, moi c'est Aife, le développeur de ce jeu. Tu joues depuis un bon moment d'affilée. Si tu apprécies Shlagémon, tu peux me soutenir.
+        Salut, moi c'est Aife, le développeur de ce jeu. Si tu apprécies Shlagémon, tu peux me soutenir.
       responses:
         donate: Faire un don
         refuse: Refuser
@@ -31,7 +31,7 @@ en:
   steps:
     start:
       text: >-
-        Hi, I'm Aife, the developer of this game. You've been playing for a while. If you enjoy Shlagémon, you can support development.
+        Hi, I'm Aife, the developer of this game. If you enjoy Shlagémon, you can support development.
       responses:
         donate: Donate
         refuse: Refuse

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -69,8 +69,9 @@ export const useDialogStore = defineStore('dialog', () => {
   const ui: ReturnType<typeof useUIStore> = useUIStore()
   const mobile = useMobileTabStore()
   const potionInfo = usePotionInfoStore()
-  const showDeveloperSupport = ref(false)
-  useTimeoutFn(() => (showDeveloperSupport.value = true), 20 * 60_000)
+  const showDeveloperSupport = computed(
+    () => Boolean(visit.visited['village-boule']),
+  )
 
   const done = ref<DialogDone>({})
   const dialogs: Array<DialogItem | DialogItem<WearableItemDialogProps>> = [

--- a/test/developer-dialog-trigger.test.ts
+++ b/test/developer-dialog-trigger.test.ts
@@ -1,0 +1,26 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useDialogStore } from '../src/stores/dialog'
+import { useZoneStore } from '../src/stores/zone'
+import { useZoneVisitStore } from '../src/stores/zoneVisit'
+
+/**
+ * Ensures the developer dialog triggers when entering the second village.
+ */
+describe('developer dialog trigger', () => {
+  it('activates after visiting village-boule', () => {
+    setActivePinia(createPinia())
+    const zone = useZoneStore()
+    const visit = useZoneVisitStore()
+    const dialog = useDialogStore()
+
+    const dev = dialog.dialogs.find(d => d.id === 'developerSupport')
+    expect(dev?.condition()).toBe(false)
+
+    zone.setZone('village-boule')
+    expect(dev?.condition()).toBe(true)
+
+    visit.reset()
+    zone.reset()
+  })
+})


### PR DESCRIPTION
## Summary
- trigger developer support dialog when the player first reaches the second village
- update text to remove reference to long playtime
- add unit test for dialog trigger

## Testing
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_6889ff4e6318832a92d74ff21150396e