### PR TITLE
Add loader for save generation and import

### DIFF
--- a/src/components/settings/SaveTab.i18n.yml
+++ b/src/components/settings/SaveTab.i18n.yml
@@ -11,6 +11,8 @@ fr:
   copied: Copié
   playtime: Tu as joué pendant {minutes} minutes.
   loadFile: Charger depuis un fichier
+  exportDesc: Générez un code pour sauvegarder votre progression.
+  importDesc: Chargez une sauvegarde en collant un code ou en sélectionnant un fichier.
 en:
   exportLabel: Save code
   generate: Generate
@@ -24,3 +26,5 @@ en:
   copied: Copied
   playtime: You have played for {minutes} minutes.
   loadFile: Load from file
+  exportDesc: Generate a code to back up your progress.
+  importDesc: Load a save by pasting a code or selecting a file.


### PR DESCRIPTION
## Summary
- show descriptions for save export and import
- display `<UiLoader />` when generating or loading saves
- add i18n strings for export/import descriptions

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: ELIFECYCLE Command failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a0b0cb588832a9800af5ceeece62f