### PR TITLE
Fix keyboard shortcut modal translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -187,6 +187,8 @@ components:
       playtime: You have played for {minutes} minutes.
       generate: Generate
       loadFile: Load from file
+      exportDesc: Generate a code to back up your progress.
+      importDesc: Load a save by pasting a code or selecting a file.
     LanguageTab:
       label: Language
       description: The application is available in English and French.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -190,6 +190,10 @@ components:
       playtime: Tu as joué pendant {minutes} minutes.
       generate: Générer
       loadFile: Charger depuis un fichier
+      exportDesc: Générez un code pour sauvegarder votre progression.
+      importDesc: >-
+        Chargez une sauvegarde en collant un code ou en sélectionnant un
+        fichier.
     LanguageTab:
       label: Langue
       description: L'application est disponible en français et en anglais.


### PR DESCRIPTION
## Summary
- regenerate locales to include missing translations

## Testing
- `pnpm test:unit`
- `pnpm test:e2e` *(fails: missing Xvfb)*
- `pnpm test` *(fails: test run cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_688a0d98ad58832a9f3cb134b7100ead