### PR TITLE
Fix item name translation in modals

### DIFF
--- a/src/components/inventory/EvolutionItemModal.vue
+++ b/src/components/inventory/EvolutionItemModal.vue
@@ -7,7 +7,7 @@ const { t } = useI18n()
   <UiModal v-model="store.isVisible" footer-close>
     <div class="flex flex-col gap-2">
       <h3 class="text-center text-lg font-bold">
-        {{ t('components.inventory.EvolutionItemModal.title', { name: store.current?.name }) }}
+        {{ t('components.inventory.EvolutionItemModal.title', { name: t(store.current?.name || '') }) }}
       </h3>
       <div v-if="store.availableMons.length" class="flex flex-col gap-2">
         <div

--- a/src/components/inventory/ItemShortcutModal.vue
+++ b/src/components/inventory/ItemShortcutModal.vue
@@ -35,10 +35,10 @@ function assign(key: string) {
         <img
           v-else-if="modal.current?.image"
           :src="modal.current.image"
-          :alt="modal.current?.name"
+          :alt="t(modal.current?.name || '')"
           class="h-10 w-10 object-contain"
         >
-        <span class="text-center font-semibold">{{ modal.current?.name }}</span>
+        <span class="text-center font-semibold">{{ t(modal.current?.name || '') }}</span>
       </div>
       <div class="w-full flex flex-col items-center gap-2 border rounded p-2">
         <p class="text-center text-sm">

--- a/src/components/inventory/OdorElixirModal.vue
+++ b/src/components/inventory/OdorElixirModal.vue
@@ -13,7 +13,7 @@ function select(mon: DexShlagemon) {
   <UiModal v-model="store.isVisible" footer-close>
     <div class="flex flex-col gap-2">
       <h3 class="text-center text-lg font-bold">
-        {{ t('components.inventory.OdorElixirModal.title', { name: store.current?.name }) }}
+        {{ t('components.inventory.OdorElixirModal.title', { name: t(store.current?.name || '') }) }}
       </h3>
       <ShlagemonQuickSelect
         v-if="store.availableMons.length"

--- a/src/components/inventory/WearableItemModal.vue
+++ b/src/components/inventory/WearableItemModal.vue
@@ -14,7 +14,7 @@ function select(mon: DexShlagemon) {
   <UiModal v-model="store.isVisible" footer-close>
     <div class="flex flex-col gap-2">
       <h3 class="text-center text-lg font-bold">
-        {{ t('components.inventory.WearableItemModal.title', { name: store.current?.name }) }}
+        {{ t('components.inventory.WearableItemModal.title', { name: t(store.current?.name || '') }) }}
       </h3>
       <ShlagemonQuickSelect
         v-if="dex.shlagemons.length"


### PR DESCRIPTION
## Summary
- correctly translate item names in Inventory modals

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_688a31659a38832aacb9ac35029dc4e4