### PR TITLE
Fix missing translations in Shortcuts tab

### DIFF
--- a/src/components/settings/ShortcutsTab.vue
+++ b/src/components/settings/ShortcutsTab.vue
@@ -6,7 +6,12 @@ import { allItems } from '~/data/items'
 const store = useShortcutsStore()
 const { t } = useI18n()
 
-const itemOptions = allItems.map(i => ({ label: i.name, value: i.id }))
+const itemOptions = computed(() =>
+  allItems.map(i => ({
+    label: t(i.name),
+    value: i.id,
+  })),
+)
 
 function updateKey(index: number, key: string) {
   const entry = { ...store.shortcuts[index], key }


### PR DESCRIPTION
## Summary
- ensure item names are translated in the shortcuts manager

## Testing
- `pnpm test --run` *(fails: `test/capture.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_688a32bd76b0832a8a38e05a9cd9ac41