### PR TITLE
Fix king challenge label

### DIFF
--- a/src/components/battle/FightKingButton.i18n.yml
+++ b/src/components/battle/FightKingButton.i18n.yml
@@ -1,4 +1,8 @@
 fr:
   challenge: 'Défier {label}'
+  male: le roi
+  female: la reine
 en:
   challenge: 'Challenge {label}'
+  male: the king
+  female: the queen

--- a/src/components/battle/FightKingButton.vue
+++ b/src/components/battle/FightKingButton.vue
@@ -10,7 +10,9 @@ const { t } = useI18n()
 
 const currentKing = computed(() => zone.getKing(zone.current.id as SavageZoneId))
 const kingLabel = computed(() =>
-  currentKing.value?.character.gender === 'female' ? 'la reine' : 'le roi',
+  currentKing.value?.character.gender === 'female'
+    ? t('components.battle.FightKingButton.female')
+    : t('components.battle.FightKingButton.male'),
 )
 
 const visible = computed(() => (


### PR DESCRIPTION
## Summary
- internationalize king challenge button label with gender-aware translations

## Testing
- `pnpm test` *(fails: capture mechanics > level 33 halves capture chance)*

------
https://chatgpt.com/codex/tasks/task_e_688a4e0fbe84832a8faf98b0bb2e5d4e