### PR TITLE
Add rarity intro dialog

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -203,8 +203,8 @@ components:
       main: Main
       confirmTitle: Release a Shlagemon?
       confirmText: Be careful, if you release it, it will shlage the whole land.
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       hp: HP
       attack: Attack
       defense: Defense
@@ -222,8 +222,8 @@ components:
         "{from}" wants to evolve into "{to}", will you allow it or stop the
         spread of shlaguitude?
       alreadyOwned: You already own this evolution
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
   LanguageSelector:
     label: Language
     en: English
@@ -636,6 +636,37 @@ components:
           text: Thanks! See you on the server. Enjoy the game!
           responses:
             finish: Close
+    DuplicateRarityDialog:
+      steps:
+        step1:
+          text: Look, you caught a Shlagemon you already owned.
+          responses:
+            next: Continue
+        step2:
+          text: Rarity determines a Shlagemon's true potential.
+          responses:
+            back: Back
+            next: Next
+        step3:
+          text: The further you go, the rarer the Shlagemon you'll meet.
+          responses:
+            back: Back
+            next: Next
+        step4:
+          text: Catching a duplicate trades levels for rarity.
+          responses:
+            back: Back
+            next: Next
+        step5:
+          text: If the captured one is very rare, yours inherits its rarity. Otherwise it gains only one rarity point and loses one level.
+          responses:
+            back: Back
+            next: Next
+        step6:
+          text: A few link rarity to their level. {starter} can do it. Here, take this Super Shlageball!
+          responses:
+            back: Back
+            valid: Thanks Professor!
         discordNo:
           text: You're really disgusting. Oh well... have fun anyway, dickhead.
           responses:
@@ -2776,8 +2807,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Fancy a game of Connect Four?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Fire Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2786,8 +2817,8 @@ data:
       restart: Restart
     ShlagMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2795,8 +2826,8 @@ data:
       restart: Restart
     Battleship:
       startText: How about a game of Battleship?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Victory! I give you a Water Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2804,8 +2835,8 @@ data:
       back: Back
     ShlagPairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2813,8 +2844,8 @@ data:
       back: Back
     ShlagTaquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2822,8 +2853,8 @@ data:
       back: Back
     TicTacToe:
       startText: Fancy a game of tic tac toe?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Grass Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2831,8 +2862,8 @@ data:
       back: Back
     MasterMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2840,8 +2871,8 @@ data:
       back: Back
     Pairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2849,8 +2880,8 @@ data:
       back: Back
     Taquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -208,8 +208,8 @@ components:
       main: Principal
       confirmTitle: Relâcher un Shlagémon ?
       confirmText: Attention, si vous le relâchez, il ira shlagiser tout le territoire.
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       hp: PV
       attack: Attaque
       defense: Défense
@@ -227,8 +227,8 @@ components:
         « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou
         l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
   LanguageSelector:
     label: Langue
     en: Anglais
@@ -665,6 +665,37 @@ components:
           text: Merci ! À bientôt sur le serveur. Bon jeu !
           responses:
             finish: Fermer
+    DuplicateRarityDialog:
+      steps:
+        step1:
+          text: Tiens, tu as capturé un Shlagémon que tu possèdes déjà.
+          responses:
+            next: Continuer
+        step2:
+          text: La rareté définit le véritable potentiel d'un Shlagémon.
+          responses:
+            back: Retour
+            next: Suite
+        step3:
+          text: Plus tu avanceras, plus tu rencontreras de Shlagémons rares.
+          responses:
+            back: Retour
+            next: Suite
+        step4:
+          text: Capturer un doublon échange des niveaux contre de la rareté.
+          responses:
+            back: Retour
+            next: Suite
+        step5:
+          text: Si celui que tu attrapes est très rare, ton Shlagémon en héritera. Sinon il ne gagnera qu'un point de rareté et perdra un niveau.
+          responses:
+            back: Retour
+            next: Suite
+        step6:
+          text: Certains lient leur rareté à leur niveau. {starter} en est capable. Prends donc cette Super Shlagéball !
+          responses:
+            back: Retour
+            valid: Merci Professeur !
         discordNo:
           text: >-
             T'es vraiment dégueulasse. Mais bon... amuse-toi bien quand même,
@@ -3111,8 +3142,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Une partie de Puissance 4 ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Feu.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3121,8 +3152,8 @@ data:
       restart: Recommencer
     ShlagMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3130,8 +3161,8 @@ data:
       restart: Recommencer
     Battleship:
       startText: Une partie de bataille navale ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Victoire ! Je te donne un œuf Eau.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3139,8 +3170,8 @@ data:
       back: Retour
     ShlagPairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3148,8 +3179,8 @@ data:
       back: Retour
     ShlagTaquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3157,8 +3188,8 @@ data:
       back: Retour
     TicTacToe:
       startText: Envie d'une partie de morpion ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un Œuf Herbe.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3166,8 +3197,8 @@ data:
       back: Retour
     MasterMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3175,8 +3206,8 @@ data:
       back: Retour
     Pairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3184,8 +3215,8 @@ data:
       back: Retour
     Taquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -41,6 +41,7 @@ declare module 'vue' {
     DialogBox: typeof import('./components/dialog/Box.vue')['default']
     DialogCapturePotionDialog: typeof import('./components/dialog/CapturePotionDialog.vue')['default']
     DialogDeveloperSupportDialog: typeof import('./components/dialog/DeveloperSupportDialog.vue')['default']
+    DialogDuplicateRarityDialog: typeof import('./components/dialog/DuplicateRarityDialog.vue')['default']
     DialogEggBoxDialog: typeof import('./components/dialog/EggBoxDialog.vue')['default']
     DialogFirstLossDialog: typeof import('./components/dialog/FirstLossDialog.vue')['default']
     DialogHalfDexDialog: typeof import('./components/dialog/HalfDexDialog.vue')['default']

--- a/src/components/dialog/DuplicateRarityDialog.i18n.yml
+++ b/src/components/dialog/DuplicateRarityDialog.i18n.yml
@@ -1,0 +1,62 @@
+fr:
+  steps:
+    step1:
+      text: Tiens, tu as capturé un Shlagémon que tu possèdes déjà.
+      responses:
+        next: Continuer
+    step2:
+      text: La rareté définit le véritable potentiel d'un Shlagémon.
+      responses:
+        back: Retour
+        next: Suite
+    step3:
+      text: Plus tu avanceras, plus tu rencontreras de Shlagémons rares.
+      responses:
+        back: Retour
+        next: Suite
+    step4:
+      text: Capturer un doublon échange des niveaux contre de la rareté.
+      responses:
+        back: Retour
+        next: Suite
+    step5:
+      text: Si celui que tu attrapes est très rare, ton Shlagémon en héritera. Sinon il ne gagnera qu'un point de rareté et perdra un niveau.
+      responses:
+        back: Retour
+        next: Suite
+    step6:
+      text: Certains lient leur rareté à leur niveau. {starter} en est capable. Prends donc cette Super Shlagéball !
+      responses:
+        back: Retour
+        valid: Merci Professeur !
+en:
+  steps:
+    step1:
+      text: Look, you caught a Shlagemon you already owned.
+      responses:
+        next: Continue
+    step2:
+      text: Rarity determines a Shlagemon's true potential.
+      responses:
+        back: Back
+        next: Next
+    step3:
+      text: The further you go, the rarer the Shlagemon you'll meet.
+      responses:
+        back: Back
+        next: Next
+    step4:
+      text: Catching a duplicate trades levels for rarity.
+      responses:
+        back: Back
+        next: Next
+    step5:
+      text: If the captured one is very rare, yours inherits its rarity. Otherwise it gains only one rarity point and loses one level.
+      responses:
+        back: Back
+        next: Next
+    step6:
+      text: A few link rarity to their level. {starter} can do it. Here, take this Super Shlageball!
+      responses:
+        back: Back
+        valid: Thanks Professor!

--- a/src/components/dialog/DuplicateRarityDialog.vue
+++ b/src/components/dialog/DuplicateRarityDialog.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { superShlageball } from '~/data/items/shlageball'
+
+const emit = defineEmits(['done'])
+const { t } = useI18n()
+const inventory = useInventoryStore()
+const dex = useShlagedexStore()
+const gameState = useGameStateStore()
+
+const starterName = computed(() => {
+  const id = gameState.starterId
+  if (!id)
+    return ''
+  const mon = dex.shlagemons.find(m => m.base.id === id)
+  return mon?.base.name ?? ''
+})
+
+const dialogTree = computed<DialogNode[]>(() => [
+  {
+    id: 'step1',
+    text: t('components.dialog.DuplicateRarityDialog.steps.step1.text'),
+    responses: [
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step1.responses.next'), nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: t('components.dialog.DuplicateRarityDialog.steps.step2.text'),
+    responses: [
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step2.responses.back'), nextId: 'step1', type: 'danger' },
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step2.responses.next'), nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: t('components.dialog.DuplicateRarityDialog.steps.step3.text'),
+    responses: [
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step3.responses.back'), nextId: 'step2', type: 'danger' },
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step3.responses.next'), nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: t('components.dialog.DuplicateRarityDialog.steps.step4.text'),
+    responses: [
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step4.responses.back'), nextId: 'step3', type: 'danger' },
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step4.responses.next'), nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: t('components.dialog.DuplicateRarityDialog.steps.step5.text'),
+    responses: [
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step5.responses.back'), nextId: 'step4', type: 'danger' },
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step5.responses.next'), nextId: 'step6', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step6',
+    text: t('components.dialog.DuplicateRarityDialog.steps.step6.text', { starter: starterName.value }),
+    responses: [
+      { label: t('components.dialog.DuplicateRarityDialog.steps.step6.responses.back'), nextId: 'step5', type: 'danger' },
+      {
+        label: t('components.dialog.DuplicateRarityDialog.steps.step6.responses.valid'),
+        type: 'valid',
+        action: () => {
+          inventory.add(superShlageball.id, 1)
+          emit('done', 'rarityIntro')
+        },
+      },
+    ],
+  },
+])
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :dialog-tree="dialogTree"
+  />
+</template>

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -7,6 +7,7 @@ import ArenaWelcomeDialog from '~/components/dialog/ArenaWelcomeDialog.vue'
 import AttackPotionDialog from '~/components/dialog/AttackPotionDialog.vue'
 import CapturePotionDialog from '~/components/dialog/CapturePotionDialog.vue'
 import DeveloperSupportDialog from '~/components/dialog/DeveloperSupportDialog.vue'
+import DuplicateRarityDialog from '~/components/dialog/DuplicateRarityDialog.vue'
 import EggBoxDialog from '~/components/dialog/EggBoxDialog.vue'
 import FirstLossDialog from '~/components/dialog/FirstLossDialog.vue'
 import HalfDexDialog from '~/components/dialog/HalfDexDialog.vue'
@@ -84,6 +85,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'inventoryIntro',
       component: markRaw(InventoryIntroDialog),
       condition: () => ui.isMobile.value && mobile.current === 'inventory',
+    },
+    {
+      id: 'rarityIntro',
+      component: markRaw(DuplicateRarityDialog),
+      condition: () => dex.shlagemons.some(m => m.captureCount > 1),
     },
     {
       id: 'richReward',


### PR DESCRIPTION
## Summary
- add `DuplicateRarityDialog` to teach rarity when capturing duplicates
- register new dialog in dialog store
- document translations in FR and EN
- reward players with a Super Shlagéball

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_688a59b609c4832ab49254fead93582a