### PR TITLE
Add rainbow potion dialog

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -137,6 +137,8 @@ components:
         village to challenge the arena and earn this right.
     FightKingButton:
       challenge: Challenge {label}
+      male: the king
+      female: the queen
     Round:
       vs: VS
     Shlagemon:
@@ -636,6 +638,10 @@ components:
           text: Thanks! See you on the server. Enjoy the game!
           responses:
             finish: Close
+        discordNo:
+          text: You're really disgusting. Oh well... have fun anyway, dickhead.
+          responses:
+            finish: Close
     DuplicateRarityDialog:
       steps:
         step1:
@@ -658,12 +664,16 @@ components:
             back: Back
             next: Next
         step5:
-          text: If the captured one is very rare, yours inherits its rarity. Otherwise it gains only one rarity point and loses one level.
+          text: >-
+            If the captured one is very rare, yours inherits its rarity.
+            Otherwise it gains only one rarity point and loses one level.
           responses:
             back: Back
             next: Next
         step6:
-          text: A few link rarity to their level. {starter} can do it. Here, take this Super Shlageball!
+          text: >-
+            A few link rarity to their level. {starter} can do it. Here, take
+            this Super Shlageball!
           responses:
             back: Back
             valid: Thanks Professor!
@@ -671,6 +681,40 @@ components:
           text: You're really disgusting. Oh well... have fun anyway, dickhead.
           responses:
             finish: Close
+    RainbowPotionDialog:
+      steps:
+        step1:
+          text: >-
+            Congrats! Your Shlagemon reached level 25. Kings are becoming
+            tougher.
+          responses:
+            next: Continue
+        step2:
+          text: Each victory makes them stronger, so you'll need sharper strategies.
+          responses:
+            back: Back
+            next: Continue
+        step3:
+          text: >-
+            There's a very rare rainbow potion. Used at the end of battle, it
+            can deal massive damage or heal your companion.
+          responses:
+            back: Back
+            next: Continue
+        step4:
+          text: >-
+            This potion works only once and only in a king battle. Choose your
+            moment carefully.
+          responses:
+            back: Back
+            next: Continue
+        step5:
+          text: >-
+            I have only one, but I'm giving it to you. Use it wisely, it's
+            extremely valuable!
+          responses:
+            back: Back
+            valid: Thanks Professor!
   minigame:
     MasterMind:
       messages:
@@ -3209,6 +3253,10 @@ data:
       details: >-
         Use it on a beloved Shlagemon so its rarity matches its level from now
         on.
+    rainbowPotion:
+      name: Rainbow Potion
+      description: Use at the end of a king battle for massive damage or strong healing.
+      details: A unique rainbow-colored potion usable once per king fight.
   kings:
     plaine-kekette:
       dialogBefore: Hey, if you win I'll treat you to breakfast!

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -140,6 +140,8 @@ components:
         droit.
     FightKingButton:
       challenge: Défier {label}
+      male: le roi
+      female: la reine
     Round:
       vs: VS
     Shlagemon:
@@ -665,6 +667,12 @@ components:
           text: Merci ! À bientôt sur le serveur. Bon jeu !
           responses:
             finish: Fermer
+        discordNo:
+          text: >-
+            T'es vraiment dégueulasse. Mais bon... amuse-toi bien quand même,
+            tête de bite.
+          responses:
+            finish: Fermer
     DuplicateRarityDialog:
       steps:
         step1:
@@ -687,12 +695,16 @@ components:
             back: Retour
             next: Suite
         step5:
-          text: Si celui que tu attrapes est très rare, ton Shlagémon en héritera. Sinon il ne gagnera qu'un point de rareté et perdra un niveau.
+          text: >-
+            Si celui que tu attrapes est très rare, ton Shlagémon en héritera.
+            Sinon il ne gagnera qu'un point de rareté et perdra un niveau.
           responses:
             back: Retour
             next: Suite
         step6:
-          text: Certains lient leur rareté à leur niveau. {starter} en est capable. Prends donc cette Super Shlagéball !
+          text: >-
+            Certains lient leur rareté à leur niveau. {starter} en est capable.
+            Prends donc cette Super Shlagéball !
           responses:
             back: Retour
             valid: Merci Professeur !
@@ -702,6 +714,43 @@ components:
             tête de bite.
           responses:
             finish: Fermer
+    RainbowPotionDialog:
+      steps:
+        step1:
+          text: >-
+            Bravo ! Ton Shlagémon atteint le niveau 25. Les rois deviennent de
+            plus en plus coriaces.
+          responses:
+            next: Continuer
+        step2:
+          text: >-
+            Chaque victoire renforce leur couronne. Prépare-toi à des
+            affrontements plus stratégiques.
+          responses:
+            back: Retour
+            next: Continuer
+        step3:
+          text: >-
+            Il existe une potion très rare aux couleurs d'arc-en-ciel. Utilisée
+            à la fin d'un combat, elle peut asséner de lourds dégâts ou soigner
+            ton compagnon.
+          responses:
+            back: Retour
+            next: Continuer
+        step4:
+          text: >-
+            Cette potion ne peut être utilisée qu'une seule fois et uniquement
+            face à un roi. Choisis bien ton moment.
+          responses:
+            back: Retour
+            next: Continuer
+        step5:
+          text: >-
+            J'en ai une seule, mais je te la donne. Prends-en grand soin, elle
+            vaut extrêmement cher !
+          responses:
+            back: Retour
+            valid: Merci Professeur !
   minigame:
     MasterMind:
       messages:
@@ -3608,6 +3657,14 @@ data:
       name: Élixir d'Odeur
       description: Un élixir très rare à offrir à un Shlagémon qu'on adore.
       details: Utilisé sur un Shlagémon, sa rareté suivra désormais son niveau.
+    rainbowPotion:
+      name: Potion Arc-en-ciel
+      description: >-
+        A utiliser en fin de combat contre un roi pour d'énormes dégâts ou un
+        soin puissant.
+      details: >-
+        Potion unique aux couleurs d'arc-en-ciel. Elle ne peut être employée
+        qu'une fois lors d'un combat de roi.
   kings:
     plaine-kekette:
       dialogBefore: Coucou, si tu gagnes, je te paye le petit déjeuné !

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -52,6 +52,7 @@ declare module 'vue' {
     DialogNewZoneDialog: typeof import('./components/dialog/NewZoneDialog.vue')['default']
     DialogOdorElixirDialog: typeof import('./components/dialog/OdorElixirDialog.vue')['default']
     DialogPotionInfoDialog: typeof import('./components/dialog/PotionInfoDialog.vue')['default']
+    DialogRainbowPotionDialog: typeof import('./components/dialog/RainbowPotionDialog.vue')['default']
     DialogStarter: typeof import('./components/dialog/Starter.vue')['default']
     DialogWearableItemDialog: typeof import('./components/dialog/WearableItemDialog.vue')['default']
     EggBoxModal: typeof import('./components/egg/BoxModal.vue')['default']

--- a/src/components/dialog/RainbowPotionDialog.i18n.yml
+++ b/src/components/dialog/RainbowPotionDialog.i18n.yml
@@ -1,0 +1,55 @@
+fr:
+  steps:
+    step1:
+      text: Bravo ! Ton Shlagémon atteint le niveau 25. Les rois deviennent de plus en plus coriaces.
+      responses:
+        next: Continuer
+    step2:
+      text: Chaque victoire renforce leur couronne. Prépare-toi à des affrontements plus stratégiques.
+      responses:
+        back: Retour
+        next: Continuer
+    step3:
+      text: >-
+        Il existe une potion très rare aux couleurs d'arc-en-ciel. Utilisée à la fin d'un combat,
+        elle peut asséner de lourds dégâts ou soigner ton compagnon.
+      responses:
+        back: Retour
+        next: Continuer
+    step4:
+      text: Cette potion ne peut être utilisée qu'une seule fois et uniquement face à un roi. Choisis bien ton moment.
+      responses:
+        back: Retour
+        next: Continuer
+    step5:
+      text: J'en ai une seule, mais je te la donne. Prends-en grand soin, elle vaut extrêmement cher !
+      responses:
+        back: Retour
+        valid: Merci Professeur !
+en:
+  steps:
+    step1:
+      text: Congrats! Your Shlagemon reached level 25. Kings are becoming tougher.
+      responses:
+        next: Continue
+    step2:
+      text: Each victory makes them stronger, so you'll need sharper strategies.
+      responses:
+        back: Back
+        next: Continue
+    step3:
+      text: >-
+        There's a very rare rainbow potion. Used at the end of battle, it can deal massive damage or heal your companion.
+      responses:
+        back: Back
+        next: Continue
+    step4:
+      text: This potion works only once and only in a king battle. Choose your moment carefully.
+      responses:
+        back: Back
+        next: Continue
+    step5:
+      text: I have only one, but I'm giving it to you. Use it wisely, it's extremely valuable!
+      responses:
+        back: Back
+        valid: Thanks Professor!

--- a/src/components/dialog/RainbowPotionDialog.vue
+++ b/src/components/dialog/RainbowPotionDialog.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { rainbowPotion } from '~/data/items'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+const { t } = useI18n()
+
+const dialogTree = computed<DialogNode[]>(() => [
+  {
+    id: 'step1',
+    text: t('components.dialog.RainbowPotionDialog.steps.step1.text'),
+    responses: [
+      { label: t('components.dialog.RainbowPotionDialog.steps.step1.responses.next'), nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: t('components.dialog.RainbowPotionDialog.steps.step2.text'),
+    responses: [
+      { label: t('components.dialog.RainbowPotionDialog.steps.step2.responses.back'), nextId: 'step1', type: 'danger' },
+      { label: t('components.dialog.RainbowPotionDialog.steps.step2.responses.next'), nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: t('components.dialog.RainbowPotionDialog.steps.step3.text'),
+    responses: [
+      { label: t('components.dialog.RainbowPotionDialog.steps.step3.responses.back'), nextId: 'step2', type: 'danger' },
+      { label: t('components.dialog.RainbowPotionDialog.steps.step3.responses.next'), nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: t('components.dialog.RainbowPotionDialog.steps.step4.text'),
+    responses: [
+      { label: t('components.dialog.RainbowPotionDialog.steps.step4.responses.back'), nextId: 'step3', type: 'danger' },
+      { label: t('components.dialog.RainbowPotionDialog.steps.step4.responses.next'), nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: t('components.dialog.RainbowPotionDialog.steps.step5.text'),
+    responses: [
+      { label: t('components.dialog.RainbowPotionDialog.steps.step5.responses.back'), nextId: 'step4', type: 'danger' },
+      {
+        label: t('components.dialog.RainbowPotionDialog.steps.step5.responses.valid'),
+        type: 'valid',
+        action: () => {
+          inventory.add(rainbowPotion.id, 1)
+          emit('done', 'rainbowPotion')
+        },
+      },
+    ],
+  },
+])
+</script>
+
+<template>
+  <DialogBox :character="profMerdant" :dialog-tree="dialogTree" orientation="col" />
+</template>

--- a/src/components/ui/Loader.vue
+++ b/src/components/ui/Loader.vue
@@ -19,8 +19,8 @@ const props = withDefaults(defineProps<{
 // =======================
 
 // -- Types props
-const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
-type Size = typeof sizes[number]
+const _sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
+type Size = typeof _sizes[number]
 
 // -- Taille réelle en pixels par taille
 const sizeMap: Record<Size, string> = {

--- a/src/data/items.i18n.yml
+++ b/src/data/items.i18n.yml
@@ -130,6 +130,10 @@ en:
     name: Fabulous Potion
     description: Works only during king battles. Hold to unleash its effect.
     details: During king battles, hold the button to perform a special action.
+  rainbowPotion:
+    name: Rainbow Potion
+    description: Use at the end of a king battle for massive damage or strong healing.
+    details: A unique rainbow-colored potion usable once per king fight.
   odorElixir:
     name: Odor Elixir
     description: A rare scent to bond forever with a Shlagemon.
@@ -266,6 +270,10 @@ fr:
     name: Potion Fabuleuse
     description: S'utilise seulement contre les rois et se déclenche en maintenant le bouton.
     details: Pendant les combats face aux rois, maintenez le bouton pour effectuer une action fabuleuse.
+  rainbowPotion:
+    name: Potion Arc-en-ciel
+    description: A utiliser en fin de combat contre un roi pour d'énormes dégâts ou un soin puissant.
+    details: Potion unique aux couleurs d'arc-en-ciel. Elle ne peut être employée qu'une fois lors d'un combat de roi.
   odorElixir:
     name: Élixir d'Odeur
     description: Un élixir très rare à offrir à un Shlagémon qu'on adore.

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -482,6 +482,20 @@ export const fabulousPotion: Item = {
 
 }
 
+export const rainbowPotion: Item = {
+  id: 'rainbow-potion',
+  name: 'data.items.rainbowPotion.name',
+  description: 'data.items.rainbowPotion.description',
+  details: 'data.items.rainbowPotion.details',
+  type: 'heal',
+  power: 125,
+  price: 999999,
+  category: 'activable',
+  icon: 'i-game-icons:fizzing-flask',
+  iconClass: 'mask-rainbow',
+  unique: true,
+}
+
 export const allItems = [
   shlageball,
   superShlageball,
@@ -533,6 +547,7 @@ export const allItems = [
   specialPotion,
   mysteriousPotion,
   fabulousPotion,
+  rainbowPotion,
 ] as const satisfies Item[]
 
 export type ItemId = typeof allItems[number]['id']

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -18,6 +18,7 @@ import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import NewZoneDialog from '~/components/dialog/NewZoneDialog.vue'
 import OdorElixirDialog from '~/components/dialog/OdorElixirDialog.vue'
 import PotionInfoDialog from '~/components/dialog/PotionInfoDialog.vue'
+import RainbowPotionDialog from '~/components/dialog/RainbowPotionDialog.vue'
 import DialogStarter from '~/components/dialog/Starter.vue'
 import WearableItemDialog from '~/components/dialog/WearableItemDialog.vue'
 import {
@@ -110,6 +111,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'attackPotion',
       component: markRaw(AttackPotionDialog),
       condition: () => dex.highestLevel >= 10,
+    },
+    {
+      id: 'rainbowPotion',
+      component: markRaw(RainbowPotionDialog),
+      condition: () => dex.highestLevel >= 25,
     },
     {
       id: 'vitalityRing',


### PR DESCRIPTION
## Summary
- add RainbowPotionDialog component and translations
- introduce rainbow potion item
- trigger the dialog at level 25
- fix lint error in Loader.vue

## Testing
- `pnpm lint --fix`
- `pnpm typecheck` *(fails: "Map" type errors)*
- `pnpm test` *(fails: capture mechanics test)*

------
https://chatgpt.com/codex/tasks/task_e_688a5a2e3768832ab0bb636e45b4bb4c