### PR TITLE
Add retry option to king battle dialog

### DIFF
--- a/src/components/battle/Trainer.i18n.yml
+++ b/src/components/battle/Trainer.i18n.yml
@@ -1,6 +1,7 @@
 fr:
   startBattle: Démarrer le combat
   quit: Abandonner
+  retry: Recommencer
   continue: Continuer
   defeat: Défaite...
   queen: reine
@@ -10,6 +11,7 @@ fr:
 en:
   startBattle: Start battle
   quit: Surrender
+  retry: Retry
   continue: Continue
   defeat: Defeat...
   queen: queen

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -71,10 +71,25 @@ const afterDialogTree = computed<DialogNode[]>(() => {
     ]
   }
   else {
+    const defeatText = trainer.value.dialogDefeat
+      ? t(trainer.value.dialogDefeat)
+      : t('components.battle.Trainer.defeat')
+    if (isZoneKing.value) {
+      return [
+        {
+          id: 'start',
+          text: defeatText,
+          responses: [
+            { label: t('components.battle.Trainer.retry'), type: 'valid', action: startFight },
+            { label: t('components.battle.Trainer.quit'), type: 'danger', action: cancelFight },
+          ],
+        },
+      ]
+    }
     return [
       {
         id: 'start',
-        text: trainer.value.dialogDefeat ? t(trainer.value.dialogDefeat) : t('components.battle.Trainer.defeat'),
+        text: defeatText,
         responses: [
           { label: t('components.battle.Trainer.continue'), type: 'valid', action: finish },
         ],

--- a/src/components/ui/Loader.vue
+++ b/src/components/ui/Loader.vue
@@ -19,8 +19,7 @@ const props = withDefaults(defineProps<{
 // =======================
 
 // -- Types props
-const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const
-type Size = typeof sizes[number]
+type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
 // -- Taille réelle en pixels par taille
 const sizeMap: Record<Size, string> = {


### PR DESCRIPTION
## Summary
- allow players to retry or quit directly after losing a king battle
- add missing translations for the retry action
- fix unused constant warning in `Loader.vue`

## Testing
- `pnpm lint --fix`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_688a7c7fae68832a95586567ed28c4a3