### PR TITLE
Add manual attack stats

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -259,6 +259,7 @@ declare global {
   const useLocaleStore: typeof import('./stores/locale')['useLocaleStore']
   const useMagicKeys: typeof import('@vueuse/core')['useMagicKeys']
   const useMainPanelStore: typeof import('./stores/mainPanel')['useMainPanelStore']
+  const useManualAttackStatsStore: typeof import('./stores/manualAttackStats')['useManualAttackStatsStore']
   const useManualRefHistory: typeof import('@vueuse/core')['useManualRefHistory']
   const useMapModalStore: typeof import('./stores/mapModal')['useMapModalStore']
   const useMediaControls: typeof import('@vueuse/core')['useMediaControls']
@@ -448,6 +449,9 @@ declare global {
   // @ts-ignore
   export type { MainPanel } from './stores/mainPanel'
   import('./stores/mainPanel')
+  // @ts-ignore
+  export type { CombatClickStats } from './stores/manualAttackStats'
+  import('./stores/manualAttackStats')
   // @ts-ignore
   export type { MobileTab } from './stores/mobileTab'
   import('./stores/mobileTab')
@@ -709,6 +713,7 @@ declare module 'vue' {
     readonly useLocaleStore: UnwrapRef<typeof import('./stores/locale')['useLocaleStore']>
     readonly useMagicKeys: UnwrapRef<typeof import('@vueuse/core')['useMagicKeys']>
     readonly useMainPanelStore: UnwrapRef<typeof import('./stores/mainPanel')['useMainPanelStore']>
+    readonly useManualAttackStatsStore: UnwrapRef<typeof import('./stores/manualAttackStats')['useManualAttackStatsStore']>
     readonly useManualRefHistory: UnwrapRef<typeof import('@vueuse/core')['useManualRefHistory']>
     readonly useMediaControls: UnwrapRef<typeof import('@vueuse/core')['useMediaControls']>
     readonly useMediaQuery: UnwrapRef<typeof import('@vueuse/core')['useMediaQuery']>

--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -9,6 +9,7 @@ export function useBattleCore(options: BattleCoreOptions) {
   const battle = useBattleStore()
   const dex = useShlagedexStore()
   const audio = useAudioStore()
+  const manualAttack = useManualAttackStatsStore()
   const {
     playerEffect,
     enemyEffect,
@@ -43,6 +44,7 @@ export function useBattleCore(options: BattleCoreOptions) {
   function stopBattle() {
     battleActive.value = false
     stopInterval()
+    manualAttack.endCombat()
   }
 
   function startBattle(existing?: DexShlagemon | null) {
@@ -57,6 +59,7 @@ export function useBattleCore(options: BattleCoreOptions) {
     playerFainted.value = false
     enemyFainted.value = false
     battleActive.value = true
+    manualAttack.startCombat()
     startInterval()
   }
 

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -12,6 +12,7 @@ export const useBattleStore = defineStore('battle', () => {
   const dex = useShlagedexStore()
   const audio = useAudioStore()
   const disease = useDiseaseStore()
+  const manualAttack = useManualAttackStatsStore()
 
   let loop: ReturnType<typeof useIntervalFn> | undefined
 
@@ -53,6 +54,7 @@ export const useBattleStore = defineStore('battle', () => {
   }
 
   function clickAttack(attacker: DexShlagemon, defender: DexShlagemon) {
+    manualAttack.registerClick()
     return attack(attacker, defender, false, false, true)
   }
 

--- a/src/stores/manualAttackStats.ts
+++ b/src/stores/manualAttackStats.ts
@@ -1,0 +1,71 @@
+import { defineStore } from 'pinia'
+
+/**
+ * Tracks manual attack clicks for each battle and computes the average
+ * clicks per second.
+ */
+export interface CombatClickStats {
+  /** Total number of manual attacks performed in the battle. */
+  clicks: number
+  /** Duration of the battle in seconds. */
+  duration: number
+  /** Average clicks per second for the battle. */
+  cps: number
+}
+
+export const useManualAttackStatsStore = defineStore('manualAttackStats', () => {
+  const currentClicks = ref(0)
+  const startTime = ref<number | null>(null)
+  const history = ref<CombatClickStats[]>([])
+
+  /** Begin tracking a new battle. */
+  function startCombat() {
+    currentClicks.value = 0
+    startTime.value = Date.now()
+  }
+
+  /** Register a manual attack click. */
+  function registerClick() {
+    if (startTime.value !== null)
+      currentClicks.value += 1
+  }
+
+  /**
+   * Stop tracking the current battle and store the results.
+   * Does nothing if tracking was not started.
+   */
+  function endCombat() {
+    if (startTime.value === null)
+      return
+    const duration = (Date.now() - startTime.value) / 1000
+    const cps = duration > 0 ? currentClicks.value / duration : 0
+    history.value.push({ clicks: currentClicks.value, duration, cps })
+    currentClicks.value = 0
+    startTime.value = null
+  }
+
+  /** Reset all stored statistics. */
+  function reset() {
+    history.value = []
+    currentClicks.value = 0
+    startTime.value = null
+  }
+
+  /** Last recorded combat statistics or null if none. */
+  const last = computed(() => history.value.at(-1) ?? null)
+
+  return {
+    currentClicks,
+    startTime,
+    history,
+    last,
+    startCombat,
+    registerClick,
+    endCombat,
+    reset,
+  }
+}, {
+  persist: {
+    paths: ['history'],
+  },
+})

--- a/test/manual-attack-stats.test.ts
+++ b/test/manual-attack-stats.test.ts
@@ -1,0 +1,29 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { useManualAttackStatsStore } from '../src/stores/manualAttackStats'
+
+/**
+ * Validates manual attack statistics per combat.
+ */
+describe('manual attack stats store', () => {
+  it('records clicks and computes cps', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const store = useManualAttackStatsStore()
+    store.startCombat()
+    store.registerClick()
+    store.registerClick()
+    vi.advanceTimersByTime(1000)
+    store.registerClick()
+    store.registerClick()
+    vi.advanceTimersByTime(1000)
+    store.endCombat()
+
+    expect(store.history.length).toBe(1)
+    const stats = store.history[0]
+    expect(stats.clicks).toBe(4)
+    expect(stats.duration).toBeCloseTo(2, 1)
+    expect(stats.cps).toBeCloseTo(2, 1)
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- record manual attack clicks per battle
- compute average clicks per second
- integrate stats with battle core
- test manual attack tracking

## Testing
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_688a9914c08c832aa171adcf2e392993