### PR TITLE
Fix missing i18n key warnings in modals

### DIFF
--- a/src/components/inventory/EvolutionItemModal.vue
+++ b/src/components/inventory/EvolutionItemModal.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 const store = useEvolutionItemStore()
 const { t } = useI18n()
+
+const itemName = computed(() => store.current ? t(store.current.name) : '')
 </script>
 
 <template>
   <UiModal v-model="store.isVisible" footer-close>
     <div class="flex flex-col gap-2">
       <h3 class="text-center text-lg font-bold">
-        {{ t('components.inventory.EvolutionItemModal.title', { name: t(store.current?.name || '') }) }}
+        {{ store.current ? t('components.inventory.EvolutionItemModal.title', { name: itemName }) : '' }}
       </h3>
       <div v-if="store.availableMons.length" class="flex flex-col gap-2">
         <div

--- a/src/components/inventory/ItemShortcutModal.vue
+++ b/src/components/inventory/ItemShortcutModal.vue
@@ -7,6 +7,8 @@ const shortcuts = useShortcutsStore()
 const { t } = useI18n()
 const capture = ref<InstanceType<typeof UiKeyCapture> | null>(null)
 
+const itemName = computed(() => modal.current ? t(modal.current.name) : '')
+
 watch(() => modal.isVisible, (visible) => {
   if (!visible)
     capture.value?.stopCapture()
@@ -35,10 +37,10 @@ function assign(key: string) {
         <img
           v-else-if="modal.current?.image"
           :src="modal.current.image"
-          :alt="t(modal.current?.name || '')"
+          :alt="itemName"
           class="h-10 w-10 object-contain"
         >
-        <span class="text-center font-semibold">{{ t(modal.current?.name || '') }}</span>
+        <span class="text-center font-semibold">{{ itemName }}</span>
       </div>
       <div class="w-full flex flex-col items-center gap-2 border rounded p-2">
         <p class="text-center text-sm">

--- a/src/components/inventory/OdorElixirModal.vue
+++ b/src/components/inventory/OdorElixirModal.vue
@@ -4,6 +4,8 @@ import type { DexShlagemon } from '~/type/shlagemon'
 const store = useOdorElixirStore()
 const { t } = useI18n()
 
+const itemName = computed(() => store.current ? t(store.current.name) : '')
+
 function select(mon: DexShlagemon) {
   store.useOn(mon)
 }
@@ -13,7 +15,7 @@ function select(mon: DexShlagemon) {
   <UiModal v-model="store.isVisible" footer-close>
     <div class="flex flex-col gap-2">
       <h3 class="text-center text-lg font-bold">
-        {{ t('components.inventory.OdorElixirModal.title', { name: t(store.current?.name || '') }) }}
+        {{ store.current ? t('components.inventory.OdorElixirModal.title', { name: itemName }) : '' }}
       </h3>
       <ShlagemonQuickSelect
         v-if="store.availableMons.length"

--- a/src/components/inventory/WearableItemModal.vue
+++ b/src/components/inventory/WearableItemModal.vue
@@ -5,6 +5,8 @@ const store = useWearableItemStore()
 const dex = useShlagedexStore()
 const { t } = useI18n()
 
+const itemName = computed(() => store.current ? t(store.current.name) : '')
+
 function select(mon: DexShlagemon) {
   store.setHolder(mon.id)
 }
@@ -14,7 +16,7 @@ function select(mon: DexShlagemon) {
   <UiModal v-model="store.isVisible" footer-close>
     <div class="flex flex-col gap-2">
       <h3 class="text-center text-lg font-bold">
-        {{ t('components.inventory.WearableItemModal.title', { name: t(store.current?.name || '') }) }}
+        {{ store.current ? t('components.inventory.WearableItemModal.title', { name: itemName }) : '' }}
       </h3>
       <ShlagemonQuickSelect
         v-if="dex.shlagemons.length"


### PR DESCRIPTION
## Summary
- avoid translating empty item names when modals are closed

## Testing
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_688a9cc98584832abe3ee261af68776d