### PR TITLE
Add Support tab with donation and Discord links

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -196,6 +196,13 @@ components:
       label: Language
       description: The application is available in English and French.
       loadFile: Load from file
+    SupportTab:
+      donateLabel: Donate
+      donateDesc: >-
+        If you enjoy Shlagémon and want to support its development, you can
+        contribute on Patreon.
+      discordLabel: Join Discord
+      discordDesc: To discuss the game and share your ideas, join the community on Discord.
   shlagemon:
     Detail:
       equipItemTitle: Equip an item
@@ -206,8 +213,8 @@ components:
       main: Main
       confirmTitle: Release a Shlagemon?
       confirmText: Be careful, if you release it, it will shlage the whole land.
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       hp: HP
       attack: Attack
       defense: Defense
@@ -225,8 +232,8 @@ components:
         "{from}" wants to evolve into "{to}", will you allow it or stop the
         spread of shlaguitude?
       alreadyOwned: You already own this evolution
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
   LanguageSelector:
     label: Language
     en: English
@@ -2858,8 +2865,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Fancy a game of Connect Four?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Fire Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2868,8 +2875,8 @@ data:
       restart: Restart
     ShlagMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2877,8 +2884,8 @@ data:
       restart: Restart
     Battleship:
       startText: How about a game of Battleship?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Victory! I give you a Water Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2886,8 +2893,8 @@ data:
       back: Back
     ShlagPairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2895,8 +2902,8 @@ data:
       back: Back
     ShlagTaquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2904,8 +2911,8 @@ data:
       back: Back
     TicTacToe:
       startText: Fancy a game of tic tac toe?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Grass Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2913,8 +2920,8 @@ data:
       back: Back
     MasterMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2922,8 +2929,8 @@ data:
       back: Back
     Pairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2931,8 +2938,8 @@ data:
       back: Back
     Taquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -201,6 +201,15 @@ components:
       label: Langue
       description: L'application est disponible en français et en anglais.
       loadFile: Charger depuis un fichier
+    SupportTab:
+      donateLabel: Faire un don
+      donateDesc: >-
+        Si tu apprécies Shlagémon et que tu souhaites soutenir son
+        développement, tu peux contribuer sur Patreon.
+      discordLabel: Rejoindre le Discord
+      discordDesc: >-
+        Pour discuter du jeu et partager tes idées, rejoins la communauté sur
+        Discord.
   shlagemon:
     Detail:
       equipItemTitle: Équiper un objet
@@ -211,8 +220,8 @@ components:
       main: Principal
       confirmTitle: Relâcher un Shlagémon ?
       confirmText: Attention, si vous le relâchez, il ira shlagiser tout le territoire.
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       hp: PV
       attack: Attaque
       defense: Défense
@@ -230,8 +239,8 @@ components:
         « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou
         l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
   LanguageSelector:
     label: Langue
     en: Anglais
@@ -3197,8 +3206,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Une partie de Puissance 4 ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Feu.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3207,8 +3216,8 @@ data:
       restart: Recommencer
     ShlagMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3216,8 +3225,8 @@ data:
       restart: Recommencer
     Battleship:
       startText: Une partie de bataille navale ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Victoire ! Je te donne un œuf Eau.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3225,8 +3234,8 @@ data:
       back: Retour
     ShlagPairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3234,8 +3243,8 @@ data:
       back: Retour
     ShlagTaquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3243,8 +3252,8 @@ data:
       back: Retour
     TicTacToe:
       startText: Envie d'une partie de morpion ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un Œuf Herbe.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3252,8 +3261,8 @@ data:
       back: Retour
     MasterMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3261,8 +3270,8 @@ data:
       back: Retour
     Pairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3270,8 +3279,8 @@ data:
       back: Retour
     Taquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -115,6 +115,7 @@ declare module 'vue' {
     SettingsSaveTab: typeof import('./components/settings/SaveTab.vue')['default']
     SettingsSettingsModal: typeof import('./components/settings/SettingsModal.vue')['default']
     SettingsShortcutsTab: typeof import('./components/settings/ShortcutsTab.vue')['default']
+    SettingsSupportTab: typeof import('./components/settings/SupportTab.vue')['default']
     ShlagemonDetail: typeof import('./components/shlagemon/Detail.vue')['default']
     ShlagemonDetailModal: typeof import('./components/shlagemon/DetailModal.vue')['default']
     ShlagemonEvolutionModal: typeof import('./components/shlagemon/EvolutionModal.vue')['default']

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -3,6 +3,7 @@ import { storeToRefs } from 'pinia'
 import LanguageTab from './LanguageTab.vue'
 import SaveTab from './SaveTab.vue'
 import SettingsShortcutsTab from './ShortcutsTab.vue'
+import SupportTab from './SupportTab.vue'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void }>()
@@ -41,6 +42,10 @@ const tabs = computed(() => {
     })
   }
 
+  arr.push({
+    label: { text: 'Soutien', icon: 'i-carbon-favorite' },
+    component: SupportTab,
+  })
   return arr
 })
 

--- a/src/components/settings/SupportTab.i18n.yml
+++ b/src/components/settings/SupportTab.i18n.yml
@@ -1,0 +1,16 @@
+fr:
+  donateLabel: Faire un don
+  donateDesc: >-
+    Si tu apprécies Shlagémon et que tu souhaites soutenir son développement,
+    tu peux contribuer sur Patreon.
+  discordLabel: Rejoindre le Discord
+  discordDesc: >-
+    Pour discuter du jeu et partager tes idées, rejoins la communauté sur Discord.
+en:
+  donateLabel: Donate
+  donateDesc: >-
+    If you enjoy Shlagémon and want to support its development,
+    you can contribute on Patreon.
+  discordLabel: Join Discord
+  discordDesc: >-
+    To discuss the game and share your ideas, join the community on Discord.

--- a/src/components/settings/SupportTab.vue
+++ b/src/components/settings/SupportTab.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+const { t } = useI18n()
+
+function openPatreon() {
+  window.open('https://www.patreon.com/c/Aife_', '_blank')
+}
+
+function openDiscord() {
+  window.open('https://discord.gg/TnKdgfxf', '_blank')
+}
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-6 text-center">
+    <section class="flex flex-col items-center gap-2">
+      <p class="text-sm">
+        {{ t('components.settings.SupportTab.donateDesc') }}
+      </p>
+      <UiButton class="flex items-center gap-1" @click="openPatreon">
+        <div class="i-carbon-favorite" />
+        {{ t('components.settings.SupportTab.donateLabel') }}
+      </UiButton>
+    </section>
+    <section class="flex flex-col items-center gap-2">
+      <p class="text-sm">
+        {{ t('components.settings.SupportTab.discordDesc') }}
+      </p>
+      <UiButton
+        class="flex items-center gap-1 bg-[#5865F2] text-white hover:bg-[#4854c0]"
+        @click="openDiscord"
+      >
+        <div class="i-mdi-discord" />
+        {{ t('components.settings.SupportTab.discordLabel') }}
+      </UiButton>
+    </section>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add `SupportTab` with Patreon and Discord buttons
- show new Support tab in settings modal
- update locales with support translations

## Testing
- `pnpm test` *(fails: capture mechanics > level 33 halves capture chance)*

------
https://chatgpt.com/codex/tasks/task_e_688a9e85c1c0832ab328197dc8876285