### PR TITLE
Fix map reopen zone reset

### DIFF
--- a/src/components/panel/Map.vue
+++ b/src/components/panel/Map.vue
@@ -8,6 +8,11 @@ const zone = useZoneStore()
 const { currentZoneId } = storeToRefs(zone)
 const mapRef = ref<InstanceType<typeof LeafletMap> | null>(null)
 
+function onSelect(id: ZoneId) {
+  if (id !== currentZoneId.value)
+    zone.setZone(id)
+}
+
 provide('selectZone', (id: ZoneId) => {
   mapRef.value?.selectZone(id)
 })
@@ -33,6 +38,6 @@ watch(currentZoneId, (id) => {
         class="mb-1 h-1"
       />
     </div>
-    <LeafletMap ref="mapRef" @select="zone.setZone" />
+    <LeafletMap ref="mapRef" @select="onSelect" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- prevent map panel from resetting zone when reopened

## Testing
- `pnpm lint` *(fails: perfectionist/sort-named-imports, etc.)*
- `pnpm test:unit --run` *(fails: capture mechanics > level 33 halves capture chance, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688ab16a9b58832a8e73a54f92db0ed5