### PR TITLE
Clarify Shlagedex bonus explanation

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -47,11 +47,12 @@ components:
       locked: To unlock
     BonusDetails:
       intro1: >-
-        The Shlagedex bonus matches your **potential ShlagéDex**. It represents
-        the maximum bonus you could obtain by capturing all available Shlagémon.
+        The Shlagedex bonus increases the damage dealt by your Shlagémon.
+        Its upper limit equals your **potential Shlagedex**, meaning all
+        capturable Shlagémon.
       intro2: >-
-        It is based on the completion rate of this potential Shlagedex as well
-        as your team's average level.
+        The bonus depends on the completion rate of this potential Shlagedex and
+        on your team's average level.
       formula: Bonus = average level × 2 × (completion rate / 100)
       completion: 'Completion:'
       averageLevel: 'Average level:'

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -48,12 +48,12 @@ components:
       locked: À débloquer
     BonusDetails:
       intro1: >-
-        Le bonus du Shlagedex correspond à votre **ShlagéDex potentiel**. Il
-        représente le bonus maximal que vous pourriez obtenir en capturant tous
-        les Shlagémon accessibles.
+        Le bonus du Shlagédex augmente les dégâts infligés par vos Shlagémon.
+        Il est plafonné par votre **Shlagédex potentiel**, c'est-à-dire tous les
+        Shlagémon capturables.
       intro2: >-
-        Il se base sur le pourcentage de complétion de ce ShlagéDex potentiel
-        ainsi que sur le niveau moyen de votre équipe.
+        Sa valeur dépend du taux de complétion de ce Shlagédex potentiel et du
+        niveau moyen de votre équipe.
       formula: Bonus = niveau moyen × 2 × (taux de complétion / 100)
       completion: 'Complétion :'
       averageLevel: 'Niveau moyen :'


### PR DESCRIPTION
## Summary
- update French translation for Shlagedex bonus
- update English translation accordingly

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched and others)*

------
https://chatgpt.com/codex/tasks/task_e_688ab1c26a7c832a8224716de50b78f9