### PR TITLE
Fix meta translation reactivity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,11 +6,11 @@ import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 useHead({
-  title: t('App.title'),
+  title: () => t('App.title'),
   meta: [
     {
       name: 'description',
-      content: t('App.description'),
+      content: () => t('App.description'),
     },
     {
       name: 'keywords',
@@ -18,7 +18,7 @@ useHead({
     },
     {
       name: 'author',
-      content: t('App.author'),
+      content: () => t('App.author'),
     },
     {
       name: 'theme-color',
@@ -26,11 +26,11 @@ useHead({
     },
     {
       property: 'og:title',
-      content: t('App.title'),
+      content: () => t('App.title'),
     },
     {
       property: 'og:description',
-      content: t('App.description'),
+      content: () => t('App.description'),
     },
     {
       property: 'og:type',
@@ -54,11 +54,11 @@ useHead({
     },
     {
       name: 'twitter:title',
-      content: t('App.title'),
+      content: () => t('App.title'),
     },
     {
       name: 'twitter:description',
-      content: t('App.description'),
+      content: () => t('App.description'),
     },
     {
       name: 'twitter:image',


### PR DESCRIPTION
## Summary
- make page metadata react to language changes using functions in `useHead`

## Testing
- `pnpm test:unit` *(fails: expected 8 to be 4)*

------
https://chatgpt.com/codex/tasks/task_e_688ab210e66c832a8b270c41f6cf49a3