### PR TITLE
Fix king battle button order

### DIFF
--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -41,10 +41,15 @@ const beforeDialogTree = computed<DialogNode[]>(() => {
     {
       id: 'start',
       text: t(trainer.value.dialogBefore),
-      responses: [
-        { label: t('components.battle.Trainer.startBattle'), type: 'primary', action: startFight },
-        { label: t('components.battle.Trainer.quit'), type: 'danger', action: cancelFight },
-      ],
+      responses: isZoneKing.value
+        ? [
+            { label: t('components.battle.Trainer.quit'), type: 'danger', action: cancelFight },
+            { label: t('components.battle.Trainer.startBattle'), type: 'primary', action: startFight },
+          ]
+        : [
+            { label: t('components.battle.Trainer.startBattle'), type: 'primary', action: startFight },
+            { label: t('components.battle.Trainer.quit'), type: 'danger', action: cancelFight },
+          ],
     },
   ]
 })


### PR DESCRIPTION
## Summary
- reorder start/quit buttons when fighting kings so Abandonner appears first

## Testing
- `pnpm test:unit` *(fails: snapshot and component tests)*

------
https://chatgpt.com/codex/tasks/task_e_688ab2388cd0832a8f82bd568efa90a3