### PR TITLE
Fix type chart modal in SlugEdx

### DIFF
--- a/src/pages/shlagedex.vue
+++ b/src/pages/shlagedex.vue
@@ -21,6 +21,8 @@ function open(mon: BaseShlagemon) {
     <UiModal v-model="showDetail" footer-close @close="showDetail = false">
       <DeckDetail :mon="selected" @open-mon="open" />
     </UiModal>
+    <!-- Provide the type chart modal for type badges -->
+    <ShlagemonTypeChartModal />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- show `ShlagemonTypeChartModal` on the SlugEdx page so clicking a type opens the chart

## Testing
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688ab2539088832a9a72f061ce5e0dde