### PR TITLE
Add locked prop to ShlagemonList and QuickSelect

### DIFF
--- a/src/components/shlagemon/QuickSelect.vue
+++ b/src/components/shlagemon/QuickSelect.vue
@@ -3,9 +3,13 @@ import type { DexShlagemon } from '~/type/shlagemon'
 
 interface Props {
   selected?: string[]
+  locked?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), { selected: () => [] })
+const props = withDefaults(defineProps<Props>(), {
+  selected: () => [],
+  locked: false,
+})
 const emit = defineEmits<{ (e: 'select', mon: DexShlagemon): void }>()
 const dex = useShlagedexStore()
 
@@ -21,5 +25,6 @@ function choose(mon: DexShlagemon) {
     :show-checkbox="false"
     :highlight-ids="props.selected"
     :on-item-click="choose"
+    :locked="props.locked"
   />
 </template>

--- a/test/feature-lock.test.ts
+++ b/test/feature-lock.test.ts
@@ -43,6 +43,22 @@ describe('feature lock flags', () => {
     expect(checkbox.attributes('disabled')).not.toBeUndefined()
   })
 
+  it('keeps Shlagédex selection enabled when explicitly unlocked', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    dex.createShlagemon(carapouffe)
+    const featureLock = useFeatureLockStore()
+    featureLock.lockShlagedex()
+    const wrapper = mount(ShlagemonList, {
+      props: { mons: dex.shlagemons, showCheckbox: true, locked: false },
+      global: { plugins: [pinia] },
+    })
+    await wrapper.vm.$nextTick()
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.attributes('disabled')).toBeUndefined()
+  })
+
   it('disables inventory actions when locked', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)


### PR DESCRIPTION
## Summary
- allow ShlagemonList to accept a `locked` prop overriding store state
- expose same prop on ShlagemonQuickSelect and pass through
- adjust list internals and update feature-lock tests

## Testing
- `pnpm lint` *(fails: 167 problems)*
- `pnpm test` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b17fdf1d8832abcbb1edb1d878650