### PR TITLE
Refactor arena panel modal

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -213,8 +213,8 @@ components:
       main: Main
       confirmTitle: Release a Shlagemon?
       confirmText: Be careful, if you release it, it will shlage the whole land.
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       hp: HP
       attack: Attack
       defense: Defense
@@ -232,8 +232,8 @@ components:
         "{from}" wants to evolve into "{to}", will you allow it or stop the
         spread of shlaguitude?
       alreadyOwned: You already own this evolution
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
   LanguageSelector:
     label: Language
     en: English
@@ -749,13 +749,14 @@ components:
       SelectionModal:
         title: Choose a Shlagemon
   arena:
+    SelectionModal:
+      title: Choose a Shlagemon against {name}
     Panel:
       selectSix: You must select 6 Shlagemon to fight in the arena
       autoBattleInfo: The battle is automatic and proceeds without clicks.
       quit: Give up
       fight: Fight
       autoSelect: Automatic team selection
-      choose: Choose a Shlagemon against {name}
     EnemyStats:
       hp: HP
       attack: Attack
@@ -2866,8 +2867,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Fancy a game of Connect Four?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Fire Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2876,8 +2877,8 @@ data:
       restart: Restart
     ShlagMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2885,8 +2886,8 @@ data:
       restart: Restart
     Battleship:
       startText: How about a game of Battleship?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Victory! I give you a Water Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2894,8 +2895,8 @@ data:
       back: Back
     ShlagPairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2903,8 +2904,8 @@ data:
       back: Back
     ShlagTaquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2912,8 +2913,8 @@ data:
       back: Back
     TicTacToe:
       startText: Fancy a game of tic tac toe?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Grass Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2921,8 +2922,8 @@ data:
       back: Back
     MasterMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2930,8 +2931,8 @@ data:
       back: Back
     Pairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2939,8 +2940,8 @@ data:
       back: Back
     Taquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -220,8 +220,8 @@ components:
       main: Principal
       confirmTitle: Relâcher un Shlagémon ?
       confirmText: Attention, si vous le relâchez, il ira shlagiser tout le territoire.
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       hp: PV
       attack: Attaque
       defense: Défense
@@ -239,8 +239,8 @@ components:
         « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou
         l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
   LanguageSelector:
     label: Langue
     en: Anglais
@@ -785,13 +785,14 @@ components:
       SelectionModal:
         title: Choisis un Shlagémon
   arena:
+    SelectionModal:
+      title: Choisir un Shlagémon contre {name}
     Panel:
       selectSix: Vous devez sélectionner 6 Shlagémons pour combattre dans l'arène
       autoBattleInfo: Le combat est automatique et se déroule sans clics.
       quit: Abandonner
       fight: Combattre
       autoSelect: Sélection automatique de l'équipe
-      choose: Choisir un Shlagémon contre {name}
     EnemyStats:
       hp: PV
       attack: Attaque
@@ -3206,8 +3207,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Une partie de Puissance 4 ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Feu.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3216,8 +3217,8 @@ data:
       restart: Recommencer
     ShlagMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3225,8 +3226,8 @@ data:
       restart: Recommencer
     Battleship:
       startText: Une partie de bataille navale ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Victoire ! Je te donne un œuf Eau.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3234,8 +3235,8 @@ data:
       back: Retour
     ShlagPairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3243,8 +3244,8 @@ data:
       back: Retour
     ShlagTaquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3252,8 +3253,8 @@ data:
       back: Retour
     TicTacToe:
       startText: Envie d'une partie de morpion ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un Œuf Herbe.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3261,8 +3262,8 @@ data:
       back: Retour
     MasterMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3270,8 +3271,8 @@ data:
       back: Retour
     Pairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3279,8 +3280,8 @@ data:
       back: Retour
     Taquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -14,7 +14,7 @@ declare module 'vue' {
     ArenaEnemyStats: typeof import('./components/arena/EnemyStats.vue')['default']
     ArenaEnemyStatsCompact: typeof import('./components/arena/EnemyStatsCompact.vue')['default']
     ArenaPanel: typeof import('./components/arena/Panel.vue')['default']
-    ArenaSelectionModale: typeof import('./components/arena/SelectionModale.vue')['default']
+    ArenaSelectionModal: typeof import('./components/arena/SelectionModal.vue')['default']
     AudioSettingsModal: typeof import('./components/audio/SettingsModal.vue')['default']
     BallSelectionModal: typeof import('./components/ball/SelectionModal.vue')['default']
     BattleAttackCursor: typeof import('./components/battle/AttackCursor.vue')['default']

--- a/src/components/arena/Panel.i18n.yml
+++ b/src/components/arena/Panel.i18n.yml
@@ -4,11 +4,9 @@ fr:
   quit: Abandonner
   fight: Combattre
   autoSelect: Sélection automatique de l'équipe
-  choose: 'Choisir un Shlagémon contre {name}'
 en:
   selectSix: You must select 6 Shlagemon to fight in the arena
   autoBattleInfo: The battle is automatic and proceeds without clicks.
   quit: Give up
   fight: Fight
   autoSelect: Automatic team selection
-  choose: 'Choose a Shlagemon against {name}'

--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -196,18 +196,12 @@ onUnmounted(() => {
             </UiTooltip>
           </div>
         </div>
-        <UiModal v-model="showDex" footer-close>
-          <div class="h-full flex flex-col">
-            <h3 v-if="activeSlot !== null" class="mb-2 text-center text-lg font-bold">
-              {{ t('components.arena.Panel.choose', { name: enemyTeam[activeSlot].name }) }}
-            </h3>
-            <!-- <ArenaEnemyStatsCompact v-if="enemyTeam[activeSlot]" :mon="enemyTeam[activeSlot]" /> -->
-            <ShlagemonQuickSelect
-              :selected="arena.selections.filter(Boolean) as string[]"
-              @select="onMonSelected"
-            />
-          </div>
-        </UiModal>
+        <ArenaSelectionModal
+          v-model="showDex"
+          :enemy-name="activeSlot !== null ? enemyTeam[activeSlot].name : ''"
+          :selected="arena.selections.filter(Boolean) as string[]"
+          @select="onMonSelected"
+        />
 
         <UiModal v-model="showEnemy" footer-close>
           <ArenaEnemyStats v-if="enemyDetail" :mon="enemyDetail" />

--- a/src/components/arena/SelectionModal.i18n.yml
+++ b/src/components/arena/SelectionModal.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  title: Choisir un Shlagémon contre {name}
+en:
+  title: Choose a Shlagemon against {name}

--- a/src/components/arena/SelectionModal.vue
+++ b/src/components/arena/SelectionModal.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+
+interface Props {
+  modelValue: boolean
+  enemyName: string
+  selected: string[]
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'select', mon: DexShlagemon): void
+}>()
+
+const { t } = useI18n()
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function onSelect(mon: DexShlagemon) {
+  emit('select', mon)
+  close()
+}
+</script>
+
+<template>
+  <UiModal :model-value="props.modelValue" footer-close @update:model-value="emit('update:modelValue', $event)">
+    <div class="h-full flex flex-col">
+      <h3 class="mb-2 text-center text-lg font-bold">
+        {{ t('components.arena.SelectionModal.title', { name: props.enemyName }) }}
+      </h3>
+      <ShlagemonQuickSelect :selected="props.selected" @select="onSelect" />
+    </div>
+  </UiModal>
+</template>


### PR DESCRIPTION
## Summary
- split Arena selection modal into its own component
- update i18n files for the new component

## Testing
- `npx eslint --fix locales/en.yml locales/fr.yml src/components/arena/Panel.vue src/components/arena/Panel.i18n.yml src/components/arena/SelectionModal.vue src/components/arena/SelectionModal.i18n.yml src/components.d.ts`
- `pnpm typecheck` *(fails: Property 'shortDesc' does not exist on type 'Item')*
- `pnpm test` *(fails: snapshot mismatch and failing unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b26ece914832aa2e12e051e6e0a3d