### PR TITLE
Add Prey Amulet wearable and tutorial

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -213,8 +213,8 @@ components:
       main: Main
       confirmTitle: Release a Shlagemon?
       confirmText: Be careful, if you release it, it will shlage the whole land.
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       hp: HP
       attack: Attack
       defense: Defense
@@ -232,8 +232,8 @@ components:
         "{from}" wants to evolve into "{to}", will you allow it or stop the
         spread of shlaguitude?
       alreadyOwned: You already own this evolution
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
   LanguageSelector:
     label: Language
     en: English
@@ -300,6 +300,27 @@ components:
           responses:
             back: Back
             valid: Thanks!
+    PreyAmuletDialog:
+      steps:
+        step1:
+          text: Amazing, one of your Shlagemons reached level 75!
+          responses:
+            next: Continue
+        step2:
+          text: This amulet makes its wearer incapable of knocking out foes.
+          responses:
+            back: Back
+            next: Continue
+        step3:
+          text: Attacks stop at 1 HP, then deal no damage.
+          responses:
+            back: Back
+            next: Continue
+        step4:
+          text: It's perfect to help you catch weakened Shlagemons. Here, take it!
+          responses:
+            back: Back
+            valid: Thanks Professor!
     Box: {}
     CapturePotionDialog:
       steps:
@@ -2866,8 +2887,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Fancy a game of Connect Four?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Fire Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2876,8 +2897,8 @@ data:
       restart: Restart
     ShlagMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2885,8 +2906,8 @@ data:
       restart: Restart
     Battleship:
       startText: How about a game of Battleship?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Victory! I give you a Water Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2894,8 +2915,8 @@ data:
       back: Back
     ShlagPairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2903,8 +2924,8 @@ data:
       back: Back
     ShlagTaquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2912,8 +2933,8 @@ data:
       back: Back
     TicTacToe:
       startText: Fancy a game of tic tac toe?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Grass Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2921,8 +2942,8 @@ data:
       back: Back
     MasterMind:
       startText: Fancy a game of ShlagMind?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.
@@ -2930,8 +2951,8 @@ data:
       back: Back
     Pairs:
       startText: Fancy a game of pairs?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! Well played! I give you a Psy Egg.
       super: Awesome!
       loseText: Too bad!
@@ -2939,8 +2960,8 @@ data:
       back: Back
     Taquin:
       startText: Fancy a sliding puzzle game?
-      'yes': 'Yes'
-      'no': 'No'
+      yes: Yes
+      no: No
       winText: Bravo! I give you a Thunder Egg.
       super: Awesome!
       loseText: Lost! Try again whenever you like.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -220,8 +220,8 @@ components:
       main: Principal
       confirmTitle: Relâcher un Shlagémon ?
       confirmText: Attention, si vous le relâchez, il ira shlagiser tout le territoire.
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       hp: PV
       attack: Attaque
       defense: Défense
@@ -239,8 +239,8 @@ components:
         « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou
         l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
   LanguageSelector:
     label: Langue
     en: Anglais
@@ -311,6 +311,27 @@ components:
           responses:
             back: Retour
             valid: Merci !
+    PreyAmuletDialog:
+      steps:
+        step1:
+          text: Incroyable, l'un de tes Shlagémons a atteint le niveau 75 !
+          responses:
+            next: Continuer
+        step2:
+          text: Cette amulette empêche son porteur de mettre K.O. ses adversaires.
+          responses:
+            back: Retour
+            next: Continuer
+        step3:
+          text: Ses attaques s'arrêtent à 1 PV puis n'infligent plus aucun dégât.
+          responses:
+            back: Retour
+            next: Continuer
+        step4:
+          text: Idéal pour capturer un Shlagémon affaibli. La voici pour toi !
+          responses:
+            back: Retour
+            valid: Merci Professeur !
     Box: {}
     CapturePotionDialog:
       steps:
@@ -3206,8 +3227,8 @@ data:
   Minigame:
     ConnectFour:
       startText: Une partie de Puissance 4 ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Feu.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3216,8 +3237,8 @@ data:
       restart: Recommencer
     ShlagMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3225,8 +3246,8 @@ data:
       restart: Recommencer
     Battleship:
       startText: Une partie de bataille navale ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Victoire ! Je te donne un œuf Eau.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3234,8 +3255,8 @@ data:
       back: Retour
     ShlagPairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3243,8 +3264,8 @@ data:
       back: Retour
     ShlagTaquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3252,8 +3273,8 @@ data:
       back: Retour
     TicTacToe:
       startText: Envie d'une partie de morpion ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un Œuf Herbe.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3261,8 +3282,8 @@ data:
       back: Retour
     MasterMind:
       startText: Une partie de ShlagMind ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.
@@ -3270,8 +3291,8 @@ data:
       back: Retour
     Pairs:
       startText: Une partie du jeu des paires ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Bien joué ! Je te donne un œuf Psy.
       super: Super !
       loseText: Dommage !
@@ -3279,8 +3300,8 @@ data:
       back: Retour
     Taquin:
       startText: Une partie de taquin ?
-      'yes': Oui
-      'no': Non
+      yes: Oui
+      no: Non
       winText: Bravo ! Je te donne un œuf Foudre.
       super: Super !
       loseText: Perdu ! Recommence quand tu veux.

--- a/src/components/dialog/PreyAmuletDialog.i18n.yml
+++ b/src/components/dialog/PreyAmuletDialog.i18n.yml
@@ -1,0 +1,42 @@
+fr:
+  steps:
+    step1:
+      text: Incroyable, l'un de tes Shlagémons a atteint le niveau 75 !
+      responses:
+        next: Continuer
+    step2:
+      text: Cette amulette empêche son porteur de mettre K.O. ses adversaires.
+      responses:
+        back: Retour
+        next: Continuer
+    step3:
+      text: Ses attaques s'arrêtent à 1 PV puis n'infligent plus aucun dégât.
+      responses:
+        back: Retour
+        next: Continuer
+    step4:
+      text: Idéal pour capturer un Shlagémon affaibli. La voici pour toi !
+      responses:
+        back: Retour
+        valid: Merci Professeur !
+en:
+  steps:
+    step1:
+      text: Amazing, one of your Shlagemons reached level 75!
+      responses:
+        next: Continue
+    step2:
+      text: This amulet makes its wearer incapable of knocking out foes.
+      responses:
+        back: Back
+        next: Continue
+    step3:
+      text: Attacks stop at 1 HP, then deal no damage.
+      responses:
+        back: Back
+        next: Continue
+    step4:
+      text: It's perfect to help you catch weakened Shlagemons. Here, take it!
+      responses:
+        back: Back
+        valid: Thanks Professor!

--- a/src/components/dialog/PreyAmuletDialog.vue
+++ b/src/components/dialog/PreyAmuletDialog.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { preyAmulet } from '~/data/items/wearables/preyAmulet'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+const { t } = useI18n()
+
+const dialogTree = computed<DialogNode[]>(() => [
+  {
+    id: 'start',
+    text: t('components.dialog.PreyAmuletDialog.steps.step1.text'),
+    responses: [
+      { label: t('components.dialog.PreyAmuletDialog.steps.step1.responses.next'), nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: t('components.dialog.PreyAmuletDialog.steps.step2.text'),
+    responses: [
+      { label: t('components.dialog.PreyAmuletDialog.steps.step2.responses.back'), nextId: 'start', type: 'danger' },
+      { label: t('components.dialog.PreyAmuletDialog.steps.step2.responses.next'), nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: t('components.dialog.PreyAmuletDialog.steps.step3.text'),
+    responses: [
+      { label: t('components.dialog.PreyAmuletDialog.steps.step3.responses.back'), nextId: 'step2', type: 'danger' },
+      { label: t('components.dialog.PreyAmuletDialog.steps.step3.responses.next'), nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: t('components.dialog.PreyAmuletDialog.steps.step4.text'),
+    responses: [
+      { label: t('components.dialog.PreyAmuletDialog.steps.step4.responses.back'), nextId: 'step3', type: 'danger' },
+      {
+        label: t('components.dialog.PreyAmuletDialog.steps.step4.responses.valid'),
+        type: 'valid',
+        action: () => {
+          inventory.add(preyAmulet.id, 1)
+          emit('done', 'preyAmulet')
+        },
+      },
+    ],
+  },
+])
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :dialog-tree="dialogTree"
+    orientation="col"
+  />
+</template>

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -10,6 +10,7 @@ import {
   defenseAmulet,
   defenseRing,
 } from './items/wearables/defenseRing'
+import { preyAmulet } from './items/wearables/preyAmulet'
 import {
   advancedVitalityRing,
   vitalityAmulet,
@@ -512,6 +513,7 @@ export const allItems = [
   xpRing,
   advancedXpRing,
   xpAmulet,
+  preyAmulet,
   attackRing,
   advancedAttackRing,
   attackAmulet,

--- a/src/data/items/wearables/preyAmulet.i18n.yml
+++ b/src/data/items/wearables/preyAmulet.i18n.yml
@@ -1,0 +1,10 @@
+en:
+  preyAmulet:
+    name: Prey Amulet
+    description: Prevents the holder from finishing off enemies.
+    details: When worn, the holder's attacks cannot reduce enemies below 1 HP and deal no damage at that point. Ideal for capturing weakened foes.
+fr:
+  preyAmulet:
+    name: Amulette de la Proie
+    description: Empêche son porteur d'achever l'ennemi.
+    details: Portée par un Shlagémon, ses attaques laissent toujours au moins 1 PV à l'adversaire et infligent ensuite 0 dégât. Parfait pour capturer les adversaires affaiblis.

--- a/src/data/items/wearables/preyAmulet.ts
+++ b/src/data/items/wearables/preyAmulet.ts
@@ -1,0 +1,17 @@
+import type { Item } from '~/type/item'
+
+export const preyAmulet: Item = {
+  id: 'prey-amulet',
+  name: 'data.items.wearables.preyAmulet.name',
+  description: 'data.items.wearables.preyAmulet.description',
+  details: 'data.items.wearables.preyAmulet.details',
+  price: 100,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:necklace',
+  iconClass: 'text-violet-600 dark:text-violet-500',
+  unique: true,
+  wearable: true,
+}
+
+export const preyWearables = [preyAmulet] as const

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -1,5 +1,6 @@
 import type { DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
+import { preyAmulet } from '~/data/items/wearables/preyAmulet'
 import { computeDamage } from '~/utils/combat'
 
 export interface AttackResult {
@@ -49,6 +50,14 @@ export const useBattleStore = defineStore('battle', () => {
     let finalDamage = reduced ? Math.round(roundedDamage / 5) : roundedDamage // reduced (case by clicking)
     if (disease.active && attacker.id === dex.activeShlagemon?.id)
       finalDamage = 10
+
+    if (attacker.heldItemId === preyAmulet.id) {
+      if (defender.hpCurrent <= 1)
+        finalDamage = 0
+      else
+        finalDamage = Math.min(finalDamage, defender.hpCurrent - 1)
+    }
+
     defender.hpCurrent = Math.max(0, defender.hpCurrent - finalDamage)
     return { ...result, damage: finalDamage }
   }

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -18,6 +18,7 @@ import Level5Dialog from '~/components/dialog/Level5Dialog.vue'
 import NewZoneDialog from '~/components/dialog/NewZoneDialog.vue'
 import OdorElixirDialog from '~/components/dialog/OdorElixirDialog.vue'
 import PotionInfoDialog from '~/components/dialog/PotionInfoDialog.vue'
+import PreyAmuletDialog from '~/components/dialog/PreyAmuletDialog.vue'
 import RainbowPotionDialog from '~/components/dialog/RainbowPotionDialog.vue'
 import DialogStarter from '~/components/dialog/Starter.vue'
 import WearableItemDialog from '~/components/dialog/WearableItemDialog.vue'
@@ -206,6 +207,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'odorElixir',
       component: markRaw(OdorElixirDialog),
       condition: () => dex.highestLevel >= 50,
+    },
+    {
+      id: 'preyAmulet',
+      component: markRaw(PreyAmuletDialog),
+      condition: () => dex.highestLevel >= 75,
     },
     {
       id: 'potionInfo',

--- a/test/prey-amulet.test.ts
+++ b/test/prey-amulet.test.ts
@@ -1,0 +1,23 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { preyAmulet } from '../src/data/items/wearables/preyAmulet'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useBattleStore } from '../src/stores/battle'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('prey amulet effect', () => {
+  it('never lets attacks reduce enemy below 1 hp', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const battle = useBattleStore()
+    const player = dex.createShlagemon(carapouffe)
+    const enemy = dex.createShlagemon(carapouffe)
+    player.attack = 1000
+    player.heldItemId = preyAmulet.id
+    enemy.hpCurrent = 50
+    battle.attack(player, enemy, true, false)
+    expect(enemy.hpCurrent).toBe(1)
+    battle.attack(player, enemy, true, false)
+    expect(enemy.hpCurrent).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- introduce new wearable item: Prey Amulet
- explain its usage via a four step dialog triggered at level 75
- prevent a Shlagémon holding the amulet from KO'ing foes
- add unit test covering the effect

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688b28b0f938832abf50df759a2c93fb