### PR TITLE
Fix arena selection modal enemy lookup

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -16,6 +16,9 @@ const enemyTeam = computed(() => arena.lineup)
 const enemyDexTeam = computed(() => arena.lineupDex)
 const showDex = ref(false)
 const activeSlot = ref<number | null>(null)
+const selectedEnemy = computed(() =>
+  activeSlot.value !== null ? enemyDexTeam.value[activeSlot.value] : undefined,
+)
 const showDuel = ref(false)
 const showEnemy = ref(false)
 const enemyDetail = ref<DexShlagemon | null>(null)
@@ -197,9 +200,9 @@ onUnmounted(() => {
           </div>
         </div>
         <ArenaSelectionModal
-          v-if="activeSlot"
+          v-if="selectedEnemy"
           v-model="showDex"
-          :enemy="enemyTeam[activeSlot]"
+          :enemy="selectedEnemy"
           :selected="arena.selections.filter(Boolean) as string[]"
           @select="onMonSelected"
         />


### PR DESCRIPTION
## Summary
- fix enemy Dex lookup for ArenaSelectionModal
- compute selectedEnemy when clicking an enemy slot

## Testing
- `pnpm test:unit` *(fails: shlagedex sort evolution, capture mechanics level 33, sort item, sort shiny, component Header snapshot)*
- `pnpm lint` *(fails: numerous style violations)*

------
https://chatgpt.com/codex/tasks/task_e_688b3253ea8c832aa4ac275ae839278c