### PR TITLE
Split Arena welcome dialog intro

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -272,10 +272,15 @@ components:
         step1:
           text: >-
             Welcome to the arena. If you manage to conquer it, you'll be able to
-            catch Shlagémons up to level {levelCap}. To succeed, you'll need to
-            win 6 consecutive one-on-one battles, without potions or manual
-            attacks, and your potion bonuses will be disabled. Choose trained
-            Shlagémons effective against opposing types.
+            catch Shlagémons up to level {levelCap}.
+          responses:
+            next: Next
+        step2:
+          text: >-
+            To succeed, you'll need to win 6 consecutive one-on-one battles,
+            without potions or manual attacks, and your potion bonuses will be
+            disabled. Choose trained Shlagémons effective against opposing
+            types.
           responses:
             start: Let's go!
             quit: Leave
@@ -3152,6 +3157,13 @@ data:
           details: >-
             When worn, increases experience gained in battle by 33%. Can stack
             with XP potions.
+      preyAmulet:
+        preyAmulet:
+          name: Prey Amulet
+          description: Prevents the holder from finishing off enemies.
+          details: >-
+            When worn, the holder's attacks cannot reduce enemies below 1 HP and
+            deal no damage at that point. Ideal for capturing weakened foes.
     defensePotion:
       name: Defense Potion
       description: Temporarily increases defense.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -279,10 +279,15 @@ components:
         step1:
           text: >-
             Bienvenue dans l'arène. Si tu en vient à bout, tu pourras capturer
-            des Shlagémons jusqu'au niveau {levelCap}. Pour y parvenir, tu
-            devras enchaîner 6 combats en un contre un, sans potion ni attaque
-            manuelle, et tes bonus de potions sont annulés. Choisis des
-            Shlagémons entraînés et efficaces contre les types opposés.
+            des Shlagémons jusqu'au niveau {levelCap}.
+          responses:
+            next: Suite
+        step2:
+          text: >-
+            Pour y parvenir, tu devras enchaîner 6 combats en un contre un, sans
+            potion ni attaque manuelle, et tes bonus de potions sont annulés.
+            Choisis des Shlagémons entraînés et efficaces contre les types
+            opposés.
           responses:
             start: C'est parti !
             quit: Quitter
@@ -3530,6 +3535,14 @@ data:
           details: >-
             Portée par un Shlagémon, elle augmente l'expérience gagnée en combat
             de 33%. Effet cumulable avec les potions d'expérience.
+      preyAmulet:
+        preyAmulet:
+          name: Amulette de la Proie
+          description: Empêche son porteur d'achever l'ennemi.
+          details: >-
+            Portée par un Shlagémon, ses attaques laissent toujours au moins 1
+            PV à l'adversaire et infligent ensuite 0 dégât. Parfait pour
+            capturer les adversaires affaiblis.
     defensePotion:
       name: Potion de Défense
       description: Augmente temporairement la défense.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -54,6 +54,7 @@ declare module 'vue' {
     DialogNewZoneDialog: typeof import('./components/dialog/NewZoneDialog.vue')['default']
     DialogOdorElixirDialog: typeof import('./components/dialog/OdorElixirDialog.vue')['default']
     DialogPotionInfoDialog: typeof import('./components/dialog/PotionInfoDialog.vue')['default']
+    DialogPreyAmuletDialog: typeof import('./components/dialog/PreyAmuletDialog.vue')['default']
     DialogRainbowPotionDialog: typeof import('./components/dialog/RainbowPotionDialog.vue')['default']
     DialogStarter: typeof import('./components/dialog/Starter.vue')['default']
     DialogWearableItemDialog: typeof import('./components/dialog/WearableItemDialog.vue')['default']

--- a/src/components/dialog/ArenaWelcomeDialog.i18n.yml
+++ b/src/components/dialog/ArenaWelcomeDialog.i18n.yml
@@ -1,8 +1,11 @@
 fr:
   steps:
     step1:
+      text: Bienvenue dans l'arène. Si tu en vient à bout, tu pourras capturer des Shlagémons jusqu'au niveau {levelCap}.
+      responses:
+        next: Suite
+    step2:
       text: >-
-        Bienvenue dans l'arène. Si tu en vient à bout, tu pourras capturer des Shlagémons jusqu'au niveau {levelCap}.
         Pour y parvenir, tu devras enchaîner 6 combats en un contre un, sans potion ni attaque manuelle, et tes bonus de potions sont annulés.
         Choisis des Shlagémons entraînés et efficaces contre les types opposés.
       responses:
@@ -11,8 +14,11 @@ fr:
 en:
   steps:
     step1:
+      text: Welcome to the arena. If you manage to conquer it, you'll be able to catch Shlagémons up to level {levelCap}.
+      responses:
+        next: Next
+    step2:
       text: >-
-        Welcome to the arena. If you manage to conquer it, you'll be able to catch Shlagémons up to level {levelCap}.
         To succeed, you'll need to win 6 consecutive one-on-one battles, without potions or manual attacks, and your potion bonuses will be disabled.
         Choose trained Shlagémons effective against opposing types.
       responses:

--- a/src/components/dialog/ArenaWelcomeDialog.vue
+++ b/src/components/dialog/ArenaWelcomeDialog.vue
@@ -6,37 +6,78 @@ const emit = defineEmits(['done'])
 const arena = useArenaStore()
 const panel = useMainPanelStore()
 const zone = useZoneStore()
+const dialog = useDialogStore()
 const preparationMusic = getArenaTrack('preparation') ?? '/audio/musics/arenas/preparation.ogg'
 const exitTrack = ref(preparationMusic)
 const { t } = useI18n()
+
+const showIntro = computed(() => !dialog.isDone('arenaWelcomeIntro'))
 
 function quit() {
   arena.reset()
   panel.showVillage()
   exitTrack.value = getZoneTrack(zone.current.id, zone.current.type) ?? preparationMusic
+  dialog.markDone('arenaWelcomeIntro')
   emit('done', 'arenaWelcome')
 }
 
-const dialogTree = computed<DialogNode[]>(() => [
-  {
-    id: 'start',
-    text: t('components.dialog.ArenaWelcomeDialog.steps.step1.text', {
-      levelCap: arena.arenaData?.badge.levelCap ?? '',
-    }),
-    responses: [
+const dialogTree = computed<DialogNode[]>(() => {
+  if (!showIntro.value) {
+    return [
       {
-        label: t('components.dialog.ArenaWelcomeDialog.steps.step1.responses.start'),
-        type: 'valid',
-        action: () => emit('done', 'arenaWelcome'),
+        id: 'start',
+        text: t('components.dialog.ArenaWelcomeDialog.steps.step1.text', {
+          levelCap: arena.arenaData?.badge.levelCap ?? '',
+        }),
+        responses: [
+          {
+            label: t('components.dialog.ArenaWelcomeDialog.steps.step2.responses.start'),
+            type: 'valid',
+            action: () => {
+              dialog.markDone('arenaWelcomeIntro')
+              emit('done', 'arenaWelcome')
+            },
+          },
+          {
+            label: t('components.dialog.ArenaWelcomeDialog.steps.step2.responses.quit'),
+            type: 'danger',
+            action: quit,
+          },
+        ],
       },
-      {
-        label: t('components.dialog.ArenaWelcomeDialog.steps.step1.responses.quit'),
-        type: 'danger',
-        action: quit,
-      },
-    ],
-  },
-])
+    ]
+  }
+  return [
+    {
+      id: 'start',
+      text: t('components.dialog.ArenaWelcomeDialog.steps.step1.text', {
+        levelCap: arena.arenaData?.badge.levelCap ?? '',
+      }),
+      responses: [
+        { label: t('components.dialog.ArenaWelcomeDialog.steps.step1.responses.next'), nextId: 'step2', type: 'primary' },
+      ],
+    },
+    {
+      id: 'step2',
+      text: t('components.dialog.ArenaWelcomeDialog.steps.step2.text'),
+      responses: [
+        {
+          label: t('components.dialog.ArenaWelcomeDialog.steps.step2.responses.start'),
+          type: 'valid',
+          action: () => {
+            dialog.markDone('arenaWelcomeIntro')
+            emit('done', 'arenaWelcome')
+          },
+        },
+        {
+          label: t('components.dialog.ArenaWelcomeDialog.steps.step2.responses.quit'),
+          type: 'danger',
+          action: quit,
+        },
+      ],
+    },
+  ]
+})
 </script>
 
 <template>

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -286,6 +286,7 @@ export const useDialogStore = defineStore('dialog', () => {
     done.value.arenaWelcome = false
     done.value.arenaVictory = false
     done.value.arenaDefeat = false
+    // keep arenaWelcomeIntro to avoid repeating the full introduction
   }
 
   function reset() {

--- a/test/arena-dialog-intro.test.ts
+++ b/test/arena-dialog-intro.test.ts
@@ -1,0 +1,20 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useDialogStore } from '../src/stores/dialog'
+
+/**
+ * Ensures arena intro flag persists across arena dialog resets.
+ */
+describe('arena welcome intro persistence', () => {
+  it('does not reset intro flag', () => {
+    setActivePinia(createPinia())
+    const dialog = useDialogStore()
+
+    dialog.markDone('arenaWelcomeIntro')
+    expect(dialog.isDone('arenaWelcomeIntro')).toBe(true)
+
+    dialog.resetArenaDialogs()
+    expect(dialog.isDone('arenaWelcomeIntro')).toBe(true)
+    expect(dialog.isDone('arenaWelcome')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- split arena welcome dialog into two steps
- remember when the second step was shown and skip it next time
- keep arena intro flag when resetting dialogs
- update translations
- update components type declarations
- add test for persistence of arena intro flag

## Testing
- `pnpm test:unit test/arena-dialog-intro.test.ts` *(fails: 0, passes: 1)*
- `pnpm lint` *(fails to pass: yaml/plain-scalar errors)*
- `pnpm typecheck` *(fails to pass: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b38f6a8b0832a9a708f34d3451f71