### PR TITLE
Adjust attack bonus scaling

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -52,7 +52,7 @@ components:
       intro2: >-
         It is based on the completion rate of this potential Shlagedex as well
         as your team's average level.
-      formula: Bonus = average level × 2 × (completion rate / 100)
+      formula: Bonus = average level × 2 × (completion rate / 100) / 10
       completion: 'Completion:'
       averageLevel: 'Average level:'
       currentBonus: 'Current bonus:'

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -54,7 +54,7 @@ components:
       intro2: >-
         Il se base sur le pourcentage de complétion de ce ShlagéDex potentiel
         ainsi que sur le niveau moyen de votre équipe.
-      formula: Bonus = niveau moyen × 2 × (taux de complétion / 100)
+      formula: Bonus = niveau moyen × 2 × (taux de complétion / 100) / 10
       completion: 'Complétion :'
       averageLevel: 'Niveau moyen :'
       currentBonus: 'Bonus actuel :'

--- a/src/components/panel/BonusDetails.i18n.yml
+++ b/src/components/panel/BonusDetails.i18n.yml
@@ -3,7 +3,7 @@ fr:
     Le bonus du Shlagedex correspond à votre **ShlagéDex potentiel**. Il représente le bonus maximal que vous pourriez obtenir en capturant tous les Shlagémon accessibles.
   intro2: >-
     Il se base sur le pourcentage de complétion de ce ShlagéDex potentiel ainsi que sur le niveau moyen de votre équipe.
-  formula: Bonus = niveau moyen × 2 × (taux de complétion / 100)
+  formula: Bonus = niveau moyen × 2 × (taux de complétion / 100) / 10
   completion: 'Complétion :'
   averageLevel: 'Niveau moyen :'
   currentBonus: 'Bonus actuel :'
@@ -12,7 +12,7 @@ en:
     The Shlagedex bonus matches your **potential ShlagéDex**. It represents the maximum bonus you could obtain by capturing all available Shlagémon.
   intro2: >-
     It is based on the completion rate of this potential Shlagedex as well as your team's average level.
-  formula: Bonus = average level × 2 × (completion rate / 100)
+  formula: Bonus = average level × 2 × (completion rate / 100) / 10
   completion: 'Completion:'
   averageLevel: 'Average level:'
   currentBonus: 'Current bonus:'

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -82,8 +82,9 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       ? shlagemons.value.reduce((s, m) => s + m.lvl, 0) / shlagemons.value.length
       : 0,
   )
+  // Reduced global bonus by a factor of 10 for better balancing
   const bonusPercent = computed(
-    () => averageLevel.value * 2 * (potentialCompletionPercent.value / 100),
+    () => averageLevel.value * 2 * (potentialCompletionPercent.value / 100) / 10,
   )
   const bonusMultiplier = computed(() => 1 + bonusPercent.value / 100)
 


### PR DESCRIPTION
## Summary
- scale down global attack bonus by factor of 10
- update BonusDetails explanation in French and English

## Testing
- `pnpm test` *(fails: snapshots mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688b3bf91e9c832aa1a9078e42f8edf2