### PR TITLE
Fix HomeHeader link path

### DIFF
--- a/src/components/layout/HomeHeader.vue
+++ b/src/components/layout/HomeHeader.vue
@@ -12,7 +12,7 @@ const { t } = useI18n()
       <RouterLink to="/" class="hover:underline">
         {{ t('components.layout.HomeHeader.home') }}
       </RouterLink>
-      <RouterLink to="/schlagedex" class="hover:underline">
+      <RouterLink to="/shlagedex" class="hover:underline">
         {{ t('components.layout.HomeHeader.dex') }}
       </RouterLink>
     </nav>


### PR DESCRIPTION
## Summary
- fix link path for Shlagedex in `HomeHeader.vue`

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688b6599e940832a9c4c6be4881eccba