### PR TITLE
Add Shlagemon info modal

### DIFF
--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ActiveEffect } from '~/type/effect'
 import type { DexShlagemon } from '~/type/shlagemon'
+import { useDexInfoModalStore } from '~/stores/dexInfoModal'
 import DiseaseBadge from './DiseaseBadge.vue'
 import EffectBadge from './EffectBadge.vue'
 
@@ -38,6 +39,7 @@ interface Props {
 
 const typeChart = useTypeChartModalStore()
 const dex = useShlagedexStore()
+const infoModal = useDexInfoModalStore()
 
 const now = ref(Date.now())
 const { pause: stopTimer } = useIntervalFn(() => {
@@ -68,6 +70,10 @@ function showTypeChart() {
     typeChart.open(type.id)
 }
 
+function openInfo() {
+  infoModal.open(props.mon)
+}
+
 const maxHp = computed(() => dex.maxHp(props.mon))
 </script>
 
@@ -75,6 +81,7 @@ const maxHp = computed(() => dex.maxHp(props.mon))
   <div
     class="relative h-full flex flex-1 flex-col items-center"
     :class="[{ 'saturate-10 contrast-200': props.disease }, { flash: props.flash }]"
+    @contextmenu.prevent="openInfo"
   >
     <slot />
     <div class="absolute left-0 top-2 z-150 flex flex-col gap-1">

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -137,6 +137,7 @@ const bottomLocked = computed(() => {
       <ShlagemonTypeChartModal />
       <ShlagemonWearableEquipModal />
       <ShlagemonDetailModal />
+      <ShlagemonDexInfoModal />
     </div>
   </div>
 </template>

--- a/src/components/shlagemon/DexInfo.i18n.yml
+++ b/src/components/shlagemon/DexInfo.i18n.yml
@@ -1,0 +1,12 @@
+fr:
+  hp: PV
+  attack: Attaque
+  defense: Défense
+  smell: Puanteur
+  title: Informations Shlagémon
+en:
+  hp: HP
+  attack: Attack
+  defense: Defense
+  smell: Smell
+  title: Shlagemon Info

--- a/src/components/shlagemon/DexInfo.vue
+++ b/src/components/shlagemon/DexInfo.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+
+const props = defineProps<{ mon: DexShlagemon }>()
+const { t } = useI18n()
+
+const stats = computed(() => [
+  { label: t('components.shlagemon.DexInfo.hp'), value: props.mon.hp },
+  { label: t('components.shlagemon.DexInfo.attack'), value: props.mon.attack },
+  { label: t('components.shlagemon.DexInfo.defense'), value: props.mon.defense },
+  { label: t('components.shlagemon.DexInfo.smell'), value: props.mon.smelling },
+])
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-2">
+    <h3 class="text-lg font-bold">
+      {{ props.mon.base.name }} - lvl {{ props.mon.lvl }}
+    </h3>
+    <div class="h-32 w-32">
+      <ShlagemonImage :id="props.mon.base.id" :alt="props.mon.base.name" class="object-contain" />
+    </div>
+    <div class="flex gap-1">
+      <ShlagemonType
+        v-for="typeItem in props.mon.base.types"
+        :key="typeItem.id"
+        :value="typeItem"
+        open-on-click
+      />
+    </div>
+    <ShlagemonStats :stats="stats" />
+  </div>
+</template>

--- a/src/components/shlagemon/DexInfoModal.vue
+++ b/src/components/shlagemon/DexInfoModal.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { useDexInfoModalStore } from '~/stores/dexInfoModal'
+
+const modal = useDexInfoModalStore()
+</script>
+
+<template>
+  <UiModal v-model="modal.isVisible" footer-close @close="modal.close()">
+    <ShlagemonDexInfo v-if="modal.mon" :mon="modal.mon" />
+  </UiModal>
+</template>

--- a/src/stores/dexInfoModal.ts
+++ b/src/stores/dexInfoModal.ts
@@ -1,0 +1,14 @@
+import type { DexShlagemon } from '~/type/shlagemon'
+import { defineStore } from 'pinia'
+
+export const useDexInfoModalStore = defineStore('dexInfoModal', () => {
+  const { isVisible, open: openModal, close } = createModalStore('game')
+  const mon = ref<DexShlagemon | null>(null)
+
+  function open(target: DexShlagemon) {
+    mon.value = target
+    openModal()
+  }
+
+  return { isVisible, mon, open, close }
+})


### PR DESCRIPTION
## Summary
- create DexInfo component and modal for quick battle info
- trigger info modal via context menu on battle shlagemons
- register DexInfoModal globally in GameGrid
- expose dexInfoModal store

## Testing
- `pnpm lint` *(fails: style/max-statements-per-line etc.)*
- `pnpm test` *(fails: snapshot mismatches and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b657c9f84832aaa748dbdc22fd20c