### PR TITLE
Add locale-aware canonical and alternate links

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,8 @@
 // they will be rendered correctly in the html results with vite-ssg
 import { useI18n } from 'vue-i18n'
 
+const seoHead = useSeoHead()
+
 const { t } = useI18n()
 useHead({
   title: t('App.title'),
@@ -38,7 +40,7 @@ useHead({
     },
     {
       property: 'og:url',
-      content: 'https://shlagemon.aife.io',
+      content: () => seoHead.canonicalUrl.value,
     },
     {
       property: 'og:image',
@@ -78,10 +80,6 @@ useHead({
       rel: 'icon',
       type: 'image/svg+xml',
       href: () => preferredDark.value ? '/favicon-dark.svg' : '/favicon.svg',
-    },
-    {
-      rel: 'canonical',
-      href: 'https://shlagemon.aife.io',
     },
     {
       rel: 'image_src',

--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -314,6 +314,7 @@ declare global {
   const useScriptTag: typeof import('@vueuse/core')['useScriptTag']
   const useScroll: typeof import('@vueuse/core')['useScroll']
   const useScrollLock: typeof import('@vueuse/core')['useScrollLock']
+  const useSeoHead: typeof import('./composables/useSeoHead')['default']
   const useSeoMeta: typeof import('@unhead/vue')['useSeoMeta']
   const useServerHead: typeof import('@unhead/vue')['useServerHead']
   const useServerHeadSafe: typeof import('@unhead/vue')['useServerHeadSafe']
@@ -769,6 +770,7 @@ declare module 'vue' {
     readonly useScriptTag: UnwrapRef<typeof import('@vueuse/core')['useScriptTag']>
     readonly useScroll: UnwrapRef<typeof import('@vueuse/core')['useScroll']>
     readonly useScrollLock: UnwrapRef<typeof import('@vueuse/core')['useScrollLock']>
+    readonly useSeoHead: UnwrapRef<typeof import('./composables/useSeoHead')['default']>
     readonly useSeoMeta: UnwrapRef<typeof import('@unhead/vue')['useSeoMeta']>
     readonly useServerHead: UnwrapRef<typeof import('@unhead/vue')['useServerHead']>
     readonly useServerHeadSafe: UnwrapRef<typeof import('@unhead/vue')['useServerHeadSafe']>

--- a/src/composables/useSeoHead.ts
+++ b/src/composables/useSeoHead.ts
@@ -1,0 +1,55 @@
+import { availableLocales } from '~/modules/i18n'
+import { localizedRoutes } from '~/router/localizedRoutes'
+
+/**
+ * Base URL for the deployed application used to build absolute links.
+ */
+const SITE_URL = 'https://shlagemon.aife.io'
+
+interface AlternateLink {
+  hreflang: string
+  href: string
+}
+
+/**
+ * Manage canonical and alternate link tags based on the current route and locale.
+ * Must be invoked from a component setup function.
+ */
+export function useSeoHead() {
+  const route = useRoute()
+
+  const canonicalUrl = computed(() => `${SITE_URL}${route.path}`)
+
+  const alternateLinks = computed<AlternateLink[]>(() => {
+    const locale = String(route.meta.locale)
+    const baseName = String(route.name).replace(`${locale}-`, '')
+    const entry = localizedRoutes.find(r => r.name === baseName)
+    if (!entry)
+      return []
+
+    return availableLocales
+      .map((loc) => {
+        const path = entry.paths[loc]
+        if (!path)
+          return null
+        return {
+          hreflang: loc,
+          href: `${SITE_URL}${path}`,
+        }
+      })
+      .filter(Boolean) as AlternateLink[]
+  })
+
+  useHead(() => ({
+    link: [
+      { rel: 'canonical', href: canonicalUrl.value },
+      ...alternateLinks.value.map(l => ({ rel: 'alternate', hreflang: l.hreflang, href: l.href })),
+    ],
+  }))
+
+  return {
+    canonicalUrl,
+  }
+}
+
+export default useSeoHead


### PR DESCRIPTION
## Summary
- compute canonical URL from the current route
- expose `useSeoHead` composable to manage `<link>` tags
- update `App.vue` to use `useSeoHead` and set `og:url`

## Testing
- `pnpm lint` *(fails: yaml/plain-scalar errors)*
- `pnpm typecheck` *(fails: TS errors in existing files)*
- `pnpm test:unit` *(fails: snapshot and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b71de7bf4832abe6730e080d300ec