### PR TITLE
Add localized PWA manifest files

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -34,6 +34,12 @@ function setI18nLanguage(lang: Locale) {
       htmlAttrs: {
         lang,
       },
+      link: [
+        {
+          rel: 'manifest',
+          href: `/${lang}/manifest.webmanifest`,
+        },
+      ],
     })
   }
   return lang

--- a/src/pwa/manifest.ts
+++ b/src/pwa/manifest.ts
@@ -1,0 +1,50 @@
+import type { ManifestOptions } from 'vite-plugin-pwa'
+
+/**
+ * Build localized PWA manifest for the given locale.
+ */
+export function getPwaManifest(locale: 'fr' | 'en'): ManifestOptions {
+  const base: ManifestOptions = {
+    short_name: 'Shlagémon',
+    theme_color: '#1865ab',
+    background_color: '#1865ab',
+    icons: [
+      {
+        src: '/pwa-192x192.png',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: '/pwa-512x512.png',
+        sizes: '512x512',
+        type: 'image/png',
+      },
+      {
+        src: '/pwa-512x512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'any maskable',
+      },
+    ],
+  }
+
+  if (locale === 'fr') {
+    return {
+      ...base,
+      lang: 'fr',
+      name: 'Shlagémon - Ça sent très fort',
+      description: 'Attrape tous les Shlagémons pour éviter qu\'ils ne pourrissent la terre entière.',
+      start_url: '/',
+      scope: '/',
+    }
+  }
+
+  return {
+    ...base,
+    lang: 'en',
+    name: 'Shlagemon - It smells very strong',
+    description: 'Catch all the Shlagemons before they rot the whole world.',
+    start_url: '/en',
+    scope: '/en/',
+  }
+}

--- a/test/pwa-manifest.test.ts
+++ b/test/pwa-manifest.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { getPwaManifest } from '../src/pwa/manifest'
+
+const locales = ['fr', 'en'] as const
+
+describe('getPwaManifest', () => {
+  for (const locale of locales) {
+    it(`returns manifest for ${locale}`, () => {
+      const manifest = getPwaManifest(locale)
+      expect(manifest.lang).toBe(locale)
+      expect(manifest.start_url).toBe(locale === 'fr' ? '/' : '/en')
+    })
+  }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 import VueDevTools from 'vite-plugin-vue-devtools'
 import Layouts from 'vite-plugin-vue-layouts'
 import generateSitemap from 'vite-ssg-sitemap'
+import { getPwaManifest } from './src/pwa/manifest'
 import { localizedRoutes } from './src/router/localizedRoutes'
 import 'vitest/config'
 
@@ -96,34 +97,12 @@ export default defineConfig({
     }),
 
     // https://github.com/antfu/vite-plugin-pwa
-    VitePWA({
+    ...(['fr', 'en'] as const).map(locale => VitePWA({
       registerType: 'prompt',
       includeAssets: ['favicon.svg', 'safari-pinned-tab.svg'],
-      manifest: {
-        name: 'Shlagémon',
-        short_name: 'Shlagémon',
-        theme_color: '#1865ab',
-        background_color: '#1865ab',
-        icons: [
-          {
-            src: '/pwa-192x192.png',
-            sizes: '192x192',
-            type: 'image/png',
-          },
-          {
-            src: '/pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-          },
-          {
-            src: '/pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-        ],
-      },
-    }),
+      manifest: getPwaManifest(locale),
+      manifestFilename: `${locale}/manifest.webmanifest`,
+    })),
 
     // https://github.com/intlify/bundle-tools/tree/main/packages/unplugin-vue-i18n
     VueI18n({


### PR DESCRIPTION
## Summary
- generate one PWA manifest per locale
- select manifest via `useHead`
- expose `getPwaManifest()` helper
- test manifest generation logic

## Testing
- `pnpm exec vitest run test/pwa-manifest.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688b7af685bc832aa144251aa13b34f0