### PR TITLE
Implement locale prefix routing and update PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/LanguageSelector.vue
+++ b/src/components/LanguageSelector.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Locale } from 'vue-i18n'
-import { availableLocales, loadLanguageAsync } from '~/modules/i18n'
+import { availableLocales } from '~/constants/locales'
+import { loadLanguageAsync } from '~/modules/i18n'
 
 const { locale, t } = useI18n()
 const store = useLocaleStore()
@@ -12,7 +13,7 @@ const options = computed(() => availableLocales.map(l => ({
 
 async function change(val: string | number) {
   const lang = val as Locale
-  store.setLocale(lang as 'en' | 'fr')
+  store.setLocale(lang as Locale)
   await loadLanguageAsync(lang)
 }
 </script>

--- a/src/components/ui/LanguageToggle.vue
+++ b/src/components/ui/LanguageToggle.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { availableLocales } from '~/constants/locales'
+
 const { locale, t } = useI18n()
 const router = useRouter()
 const { switchLang } = useLangSwitch()
 
-const nextLocale = computed(() => (locale.value === 'fr' ? 'en' : 'fr'))
+const nextLocale = computed(() => {
+  const index = availableLocales.indexOf(locale.value as any)
+  const next = (index + 1) % availableLocales.length
+  return availableLocales[next]
+})
 
 async function toggle() {
   const path = await switchLang(nextLocale.value)

--- a/src/composables/useLangSwitch.ts
+++ b/src/composables/useLangSwitch.ts
@@ -1,3 +1,4 @@
+import type { Locale } from '~/constants/locales'
 import { loadLanguageAsync } from '~/modules/i18n'
 import { localizedRoutes } from '~/router/localizedRoutes'
 import { useLocaleStore } from '~/stores/locale'
@@ -18,7 +19,7 @@ export function useLangSwitch() {
    * @param targetLocale The desired locale (e.g. 'en' or 'fr').
    * @returns Resolved path for navigation or `null` if unknown route.
    */
-  async function switchLang(targetLocale: string): Promise<string | null> {
+  async function switchLang(targetLocale: Locale): Promise<string | null> {
     const currentLocale = String(route.meta.locale)
     const currentName = String(route.name)
     const baseName = currentName.replace(`${currentLocale}-`, '')
@@ -26,8 +27,8 @@ export function useLangSwitch() {
     const path = entry?.paths[targetLocale]
     if (!path)
       return null
-    store.setLocale(targetLocale as 'en' | 'fr')
-    await loadLanguageAsync(targetLocale as 'en' | 'fr')
+    store.setLocale(targetLocale)
+    await loadLanguageAsync(targetLocale)
     return router.resolve({ path, query: route.query }).fullPath
   }
 

--- a/src/composables/useSeoHead.ts
+++ b/src/composables/useSeoHead.ts
@@ -1,4 +1,4 @@
-import { availableLocales } from '~/modules/i18n'
+import { availableLocales } from '~/constants/locales'
 import { localizedRoutes } from '~/router/localizedRoutes'
 
 /**

--- a/src/constants/locales.ts
+++ b/src/constants/locales.ts
@@ -1,0 +1,3 @@
+export const availableLocales = ['fr', 'en'] as const
+export type Locale = typeof availableLocales[number]
+export const defaultLocale: Locale = 'en'

--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -3,6 +3,7 @@ import type { UserModule } from '~/types'
 import { useHead } from '@unhead/vue'
 import { getCurrentInstance } from 'vue'
 import { createI18n } from 'vue-i18n'
+import { defaultLocale } from '~/constants/locales'
 import { useLocaleStore } from '~/stores/locale'
 
 // Import i18n resources
@@ -11,8 +12,8 @@ import { useLocaleStore } from '~/stores/locale'
 // Don't need this? Try vitesse-lite: https://github.com/antfu/vitesse-lite
 export const i18n = createI18n({
   legacy: false,
-  locale: 'en',
-  fallbackLocale: 'en',
+  locale: defaultLocale,
+  fallbackLocale: defaultLocale,
   messages: {},
 })
 
@@ -21,7 +22,8 @@ const localesMap = Object.fromEntries(
     .map(([path, messages]) => [path.match(/([\w-]*)\.yml$/)?.[1], messages]),
 ) as Record<Locale, Record<string, string>>
 
-export const availableLocales = Object.keys(localesMap) as Locale[]
+// availableLocales constant is defined in ~/constants/locales and
+// should match the set of translation files present in `/locales`.
 
 const loadedLanguages: Locale[] = []
 
@@ -60,9 +62,9 @@ export const install: UserModule = ({ app, isClient }) => {
   const localeStore = useLocaleStore()
 
   if (isClient && !localStorage.getItem('locale')) {
-    const navigatorLang = navigator.language || 'en'
-    const lang = navigatorLang.toLowerCase().startsWith('fr') ? 'fr' : 'en'
-    localeStore.setLocale(lang)
+    const navigatorLang = navigator.language.toLowerCase()
+    const fallback = navigatorLang.startsWith('fr') ? 'fr' : defaultLocale
+    localeStore.setLocale(fallback as Locale)
   }
 
   loadLanguageAsync(localeStore.locale)

--- a/src/pages/root.vue
+++ b/src/pages/root.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { availableLocales, defaultLocale } from '~/constants/locales'
+import { useLocaleStore } from '~/stores/locale'
+
+const router = useRouter()
+const store = useLocaleStore()
+
+onMounted(() => {
+  const stored = store.locale || localStorage.getItem('locale')
+  const nav = navigator.language.toLowerCase()
+  const fallback = nav.startsWith('fr') ? 'fr' : defaultLocale
+  const target = availableLocales.includes(stored as any) ? stored as string : fallback
+  router.replace({ path: `/${target}` })
+})
+
+useHead({
+  link: [
+    { rel: 'canonical', href: 'https://shlagemon.aife.io/en' },
+    { rel: 'alternate', hreflang: 'en', href: 'https://shlagemon.aife.io/en' },
+    { rel: 'alternate', hreflang: 'fr', href: 'https://shlagemon.aife.io/fr' },
+  ],
+})
+</script>
+
+<template>
+  <div />
+</template>

--- a/src/pwa/manifest.ts
+++ b/src/pwa/manifest.ts
@@ -1,9 +1,10 @@
 import type { ManifestOptions } from 'vite-plugin-pwa'
+import type { Locale } from '~/constants/locales'
 
 /**
  * Build localized PWA manifest for the given locale.
  */
-export function getPwaManifest(locale: 'fr' | 'en'): ManifestOptions {
+export function getPwaManifest(locale: Locale): ManifestOptions {
   const base: ManifestOptions = {
     short_name: 'Shlagémon',
     theme_color: '#1865ab',
@@ -34,8 +35,8 @@ export function getPwaManifest(locale: 'fr' | 'en'): ManifestOptions {
       lang: 'fr',
       name: 'Shlagémon - Ça sent très fort',
       description: 'Attrape tous les Shlagémons pour éviter qu\'ils ne pourrissent la terre entière.',
-      start_url: '/',
-      scope: '/',
+      start_url: '/fr/',
+      scope: '/fr/',
     }
   }
 
@@ -44,7 +45,7 @@ export function getPwaManifest(locale: 'fr' | 'en'): ManifestOptions {
     lang: 'en',
     name: 'Shlagemon - It smells very strong',
     description: 'Catch all the Shlagemons before they rot the whole world.',
-    start_url: '/en',
+    start_url: '/en/',
     scope: '/en/',
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { setupLayouts } from 'virtual:generated-layouts'
 import { createRouter, createWebHistory } from 'vue-router'
-import { availableLocales } from '~/modules/i18n'
+import { availableLocales } from '~/constants/locales'
 import { localizedRoutes } from './localizedRoutes'
 
 /**
@@ -31,7 +31,14 @@ export function buildLocalizedRoutes(): RouteRecordRaw[] {
   return setupLayouts(records)
 }
 
-export const routes: RouteRecordRaw[] = buildLocalizedRoutes()
+export const routes: RouteRecordRaw[] = [
+  {
+    path: '/',
+    name: 'root',
+    component: () => import('~/pages/root.vue'),
+  },
+  ...buildLocalizedRoutes(),
+]
 
 /**
  * Application router instance.

--- a/src/router/localizedRoutes.ts
+++ b/src/router/localizedRoutes.ts
@@ -27,7 +27,7 @@ export const localizedRoutes: LocalizedRoute[] = [
     name: 'home',
     component: () => import('~/pages/index.vue'),
     paths: {
-      fr: '/',
+      fr: '/fr',
       en: '/en',
     },
     i18nKey: 'pages.index.title',
@@ -36,7 +36,7 @@ export const localizedRoutes: LocalizedRoute[] = [
     name: 'shlagedex',
     component: () => import('~/pages/shlagedex.vue'),
     paths: {
-      fr: '/shlagedex',
+      fr: '/fr/shlagedex',
       en: '/en/shlagedex',
     },
     i18nKey: 'pages.shlagedex.title',

--- a/src/stores/locale.ts
+++ b/src/stores/locale.ts
@@ -1,9 +1,11 @@
+import type { Locale } from '~/constants/locales'
 import { defineStore } from 'pinia'
+import { defaultLocale } from '~/constants/locales'
 
 export const useLocaleStore = defineStore('locale', () => {
-  const locale = ref<'en' | 'fr'>('en')
+  const locale = ref<Locale>(defaultLocale)
 
-  function setLocale(value: 'en' | 'fr') {
+  function setLocale(value: Locale) {
     locale.value = value
   }
 

--- a/test/pwa-manifest.test.ts
+++ b/test/pwa-manifest.test.ts
@@ -8,7 +8,7 @@ describe('getPwaManifest', () => {
     it(`returns manifest for ${locale}`, () => {
       const manifest = getPwaManifest(locale)
       expect(manifest.lang).toBe(locale)
-      expect(manifest.start_url).toBe(locale === 'fr' ? '/' : '/en')
+      expect(manifest.start_url).toBe(`/${locale}/`)
     })
   }
 })

--- a/test/useLangSwitch.test.ts
+++ b/test/useLangSwitch.test.ts
@@ -30,7 +30,7 @@ describe('useLangSwitch', () => {
     await router.isReady()
 
     const path = await wrapper.vm.switchLang('fr')
-    expect(path).toBe('/shlagedex')
+    expect(path).toBe('/fr/shlagedex')
     expect(useLocaleStore().locale).toBe('fr')
   })
 })


### PR DESCRIPTION
## Summary
- add centralized locale constants
- prefix all routes with locale
- add root page to redirect based on browser language
- update language toggle and selector
- adjust i18n module and locale store
- update PWA manifest paths
- fix unit tests for new paths
- set index HTML language to English

## Testing
- `pnpm test` *(fails: 6 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b833f111c832aa245d23d76c4553b