### PR TITLE
Fix ball icon hue-rotate in inventory

### DIFF
--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -97,6 +97,7 @@ watch(showInfo, (val) => {
           :src="props.item.image"
           :alt="t(props.item.name)"
           class="h-full w-full"
+          :style="ballFilter"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- apply hue-rotate filter on shlagéball images in inventory item cards

## Testing
- `pnpm test` *(fails: 6 failed, 98 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688b8bdebdb4832ab3ab77c72f86ebdb