### PR TITLE
Add save clearing utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Les fichiers prêts à être servis se trouvent dans le dossier `dist`.
 
 Depuis le jeu, rendez-vous au village **Sux-Mais-Bouls** et cliquez sur « Mini-jeu » pour lancer une partie de Tic Tac Toe.
 
+- Supprimer une sauvegarde vide le stockage local puis recharge automatiquement l'application.
+
 ### Générer le fichier d'évolutions
 
 Ce script parcourt les données de chaque Shlagémon pour générer un tableau ordonné par niveau. Le fichier `evolutions.csv` indique la tranche de niveau à laquelle on rencontre chaque monstre et, s'il existe, son niveau d'évolution.

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -15,8 +15,9 @@ function close() {
 }
 
 function removeSave() {
+  save.clearPersisted()
   save.reset()
-  close()
+  window.location.reload()
 }
 
 const { isMobile } = storeToRefs(useUIStore())

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { PERSISTED_STORE_KEYS } from '~/utils/save-code'
 
 export const useSaveStore = defineStore('save', () => {
   const dex = useShlagedexStore()
@@ -45,5 +46,13 @@ export const useSaveStore = defineStore('save', () => {
     egg.reset()
   }
 
-  return { reset }
+  /**
+   * Remove every persisted store value from localStorage.
+   */
+  function clearPersisted(): void {
+    for (const key of PERSISTED_STORE_KEYS)
+      window.localStorage.removeItem(key)
+  }
+
+  return { reset, clearPersisted }
 })

--- a/test/save-clear.test.ts
+++ b/test/save-clear.test.ts
@@ -1,0 +1,18 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useSaveStore } from '../src/stores/save'
+import { PERSISTED_STORE_KEYS } from '../src/utils/save-code'
+
+describe('useSaveStore.clearPersisted', () => {
+  it('removes all persisted keys from localStorage', () => {
+    setActivePinia(createPinia())
+    const save = useSaveStore()
+    for (const key of PERSISTED_STORE_KEYS)
+      window.localStorage.setItem(key, 'foo')
+
+    save.clearPersisted()
+
+    for (const key of PERSISTED_STORE_KEYS)
+      expect(window.localStorage.getItem(key)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add `clearPersisted()` helper in the save store
- wipe storage from settings modal then reload
- mention save removal behavior in README
- test that `clearPersisted()` removes all persisted keys

## Testing
- `pnpm lint` *(fails: 128 errors)*
- `pnpm test:unit` *(fails: 6 failed, 52 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688b8ba95a10832a865661ce6dbeb091