### PR TITLE
Fix build error by removing obsolete route block

### DIFF
--- a/src/pages/shlagedex.vue
+++ b/src/pages/shlagedex.vue
@@ -17,7 +17,11 @@ function open(mon: BaseShlagemon) {
 
 <template>
   <div class="mx-auto max-w-160 w-full p-4">
-    <DeckList :mons="allShlagemons" :on-item-click="open" :selected-id="selected?.id" />
+    <DeckList
+      :mons="allShlagemons"
+      :on-item-click="open"
+      :selected-id="selected?.id"
+    />
     <UiModal v-model="showDetail" footer-close @close="showDetail = false">
       <DeckDetail :mon="selected" @open-mon="open" />
     </UiModal>
@@ -25,8 +29,3 @@ function open(mon: BaseShlagemon) {
     <ShlagemonTypeChartModal />
   </div>
 </template>
-
-<route lang="yaml">
-meta:
-  layout: home
-</route>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -23,6 +23,7 @@ export function buildLocalizedRoutes(): RouteRecordRaw[] {
         meta: {
           locale,
           i18nKey: route.i18nKey,
+          layout: route.layout,
         },
       })
     }

--- a/src/router/localizedRoutes.ts
+++ b/src/router/localizedRoutes.ts
@@ -17,6 +17,10 @@ export interface LocalizedRoute {
    * Optional i18n key used for the page title meta.
    */
   i18nKey?: string
+  /**
+   * Optional layout name to use for this route.
+   */
+  layout?: string
 }
 
 /**
@@ -31,6 +35,7 @@ export const localizedRoutes: LocalizedRoute[] = [
       en: '/en',
     },
     i18nKey: 'pages.index.title',
+    layout: 'home',
   },
   {
     name: 'shlagedex',
@@ -40,6 +45,7 @@ export const localizedRoutes: LocalizedRoute[] = [
       en: '/en/shlagedex',
     },
     i18nKey: 'pages.shlagedex.title',
+    layout: 'home',
   },
 ]
 export default localizedRoutes


### PR DESCRIPTION
## Summary
- remove unused `<route>` block from `shlagedex` page
- add optional `layout` info to localized routes
- pass layout metadata when building routes

## Testing
- `pnpm lint --fix` *(fails: max-statements-per-line etc.)*
- `pnpm typecheck` *(fails: numerous TS errors)*
- `pnpm test:unit` *(fails: snapshot mismatches)*
- `pnpm test` *(fails: same as unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b9655472c832ab3d75b2c730a7940