### PR TITLE
Sync locale with URL

### DIFF
--- a/src/modules/localeFromPath.ts
+++ b/src/modules/localeFromPath.ts
@@ -1,0 +1,26 @@
+import type { Locale } from '~/constants/locales'
+import type { UserModule } from '~/types'
+import { useLocaleStore } from '~/stores/locale'
+import { loadLanguageAsync } from './i18n'
+
+/**
+ * Synchronize the locale store with the locale found in the current route.
+ *
+ * The URL locale always takes precedence over any stored locale. Only the root
+ * path `/` relies on the stored or browser locale to redirect accordingly.
+ */
+export const install: UserModule = ({ router, isClient }) => {
+  if (!isClient)
+    return
+
+  const store = useLocaleStore()
+
+  router.beforeEach(async (to) => {
+    const target = to.meta.locale as Locale | undefined
+    if (target && target !== store.locale) {
+      store.setLocale(target)
+      await loadLanguageAsync(target)
+    }
+    return true
+  })
+}

--- a/test/router-locale.test.ts
+++ b/test/router-locale.test.ts
@@ -1,0 +1,28 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { createRouter, createWebHistory } from 'vue-router'
+import { install as localeFromPath } from '../src/modules/localeFromPath'
+import { buildLocalizedRoutes } from '../src/router'
+import { useLocaleStore } from '../src/stores/locale'
+
+function setup(path: string) {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      { path: '/', name: 'root', component: { template: '<div></div>' } },
+      ...buildLocalizedRoutes(),
+    ],
+  })
+  localeFromPath({ router, isClient: true } as any)
+  router.push(path)
+  return router.isReady().then(() => router)
+}
+
+describe('router locale', () => {
+  it('updates store locale from URL', async () => {
+    await setup('/fr/shlagedex')
+    expect(useLocaleStore().locale).toBe('fr')
+  })
+})


### PR DESCRIPTION
## Summary
- handle language switch when route locale differs from stored value
- test locale synchronization via new router guard

## Testing
- `pnpm lint` *(fails: perfectionist/sort-imports, format/prettier, etc.)*
- `pnpm typecheck` *(fails: TS2339, TS2739, etc.)*
- `pnpm test:unit` *(fails: 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688bd4ecae90832a8831ee930c0ceb29