### PR TITLE
Fix router history for SSG build

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,6 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { setupLayouts } from 'virtual:generated-layouts'
-import { createRouter, createWebHistory } from 'vue-router'
+import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
 import { availableLocales } from '~/constants/locales'
 import { localizedRoutes } from './localizedRoutes'
 
@@ -45,7 +45,9 @@ export const routes: RouteRecordRaw[] = [
  * Application router instance.
  */
 export const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: import.meta.env.SSR
+    ? createMemoryHistory(import.meta.env.BASE_URL)
+    : createWebHistory(import.meta.env.BASE_URL),
   routes,
 })
 


### PR DESCRIPTION
## Summary
- use memory history when running under SSR/SSG to avoid window reference error

## Testing
- `npx eslint src/router/index.ts`
- `pnpm test:unit` *(fails: Snapshots 1 failed, Tests 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688bdbb6ae58832ab1aa0fd5833d118f