### PR TITLE
Add inventory badge count per tab

### DIFF
--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -53,6 +53,15 @@ const availableCategories = computed(() =>
 const activeTab = ref(0)
 const categories = computed(() => availableCategories.value)
 
+const newItemCountByCategory = computed(() => {
+  const counts: Partial<Record<ItemCategory, number>> = {}
+  for (const { item } of inventory.list) {
+    if (!usage.used[item.id] && item.category)
+      counts[item.category] = (counts[item.category] || 0) + 1
+  }
+  return counts
+})
+
 const tabComponents = new Map<ItemCategory | 'all', Component>()
 function getTabComponent(category: ItemCategory | 'all') {
   if (tabComponents.has(category))
@@ -78,13 +87,15 @@ function getTabComponent(category: ItemCategory | 'all') {
 }
 
 const tabs = computed(() =>
-  categories.value.map(cat => ({
-    label: cat.label,
-    component: getTabComponent(cat.value),
-    highlight: inventory.list.some(entry =>
-      entry.item.category === cat.value && !usage.used[entry.item.id],
-    ),
-  })),
+  categories.value.map((cat) => {
+    const count = newItemCountByCategory.value[cat.value] || 0
+    return {
+      label: cat.label,
+      component: getTabComponent(cat.value),
+      highlight: count > 0,
+      badge: count,
+    }
+  }),
 )
 
 watch(() => filter.category, (val) => {

--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -7,6 +7,8 @@ interface Tab {
   'label': Label
   'component': any
   'highlight'?: boolean
+  /** Number of new items to display as a badge. */
+  'badge'?: number
   'disabled'?: boolean
   'aria-label'?: string
 }
@@ -132,6 +134,13 @@ const transitionName = computed(() => direction.value === 'left' ? 'slide-left' 
         >
           {{ tab.label.text }}
         </span>
+        <UiBadge
+          v-if="tab.badge && tab.badge > 0"
+          size="xs"
+          class="z-10"
+        >
+          {{ tab.badge }}
+        </UiBadge>
       </button>
     </nav>
 

--- a/test/inventory-badge.test.ts
+++ b/test/inventory-badge.test.ts
@@ -1,0 +1,23 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import InventoryPanel from '../src/components/panel/Inventory.vue'
+import { attackPotion, capturePotion, odorElixir } from '../src/data/items'
+import { useInventoryStore } from '../src/stores/inventory'
+
+describe('inventory tab badges', () => {
+  it('shows the number of undiscovered items per category', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const inventory = useInventoryStore()
+    inventory.add(odorElixir.id)
+    inventory.add(attackPotion.id)
+    inventory.add(capturePotion.id)
+
+    const wrapper = mount(InventoryPanel, { global: { plugins: [pinia] } })
+    await wrapper.vm.$nextTick()
+    const buttons = wrapper.findAll('nav button')
+    expect(buttons[0].text()).toContain('1')
+    expect(buttons[1].text()).toContain('2')
+  })
+})


### PR DESCRIPTION
## Summary
- show badge count on `UiTabs`
- add per-category new-item count in `Inventory` panel
- test badge count behaviour

## Testing
- `pnpm lint` *(fails: style errors in unrelated files)*
- `pnpm test` *(fails: snapshot mismatch and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b6a77f374832a8f2077939e2c61f3