### PR TITLE
Fix translation key usage in egg modal

### DIFF
--- a/src/components/egg/MonsModal.vue
+++ b/src/components/egg/MonsModal.vue
@@ -11,7 +11,7 @@ function owned(id: string) {
 <template>
   <UiModal v-model="modal.isVisible" footer-close>
     <UiPanelWrapper
-      :title="t('components.egg.MonsModal.title', { name: modal.item?.name })"
+      :title="t('components.egg.MonsModal.title', { name: modal.item ? t(modal.item.name) : '' })"
       is-inline
     >
       <template #icon>


### PR DESCRIPTION
## Summary
- ensure egg name translation in MonsModal title

## Testing
- `pnpm test` *(fails: snapshots and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_688be6c45d6c832aa859911152f73b23