### PR TITLE
Fix rarity 100 sfx

### DIFF
--- a/test/rarity-sfx.test.ts
+++ b/test/rarity-sfx.test.ts
@@ -1,0 +1,23 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useAudioStore } from '../src/stores/audio'
+import { useOdorElixirStore } from '../src/stores/odorElixir'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+/** Ensure the rarity-100 sound plays when a mon reaches rarity 100. */
+describe('rarity 100 sound effect', () => {
+  it('plays when applying odor elixir', () => {
+    setActivePinia(createPinia())
+    const audio = useAudioStore()
+    const dex = useShlagedexStore()
+    useOdorElixirStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.lvl = 100
+    mon.rarity = 99
+    const spy = vi.spyOn(audio, 'playSfx')
+    dex.applyOdorElixir(mon)
+    expect(mon.rarity).toBe(100)
+    expect(spy).toHaveBeenCalledWith('rarity-100')
+  })
+})


### PR DESCRIPTION
## Summary
- trigger rarity 100 sound through helper
- ensure odor elixir plays the sound
- add unit test for the rarity sound

## Testing
- `pnpm lint src/stores/shlagedex.ts`
- `pnpm test` *(fails: snapshot mismatch and sort tests)*

------
https://chatgpt.com/codex/tasks/task_e_688be810cd94832a8843398642ae0115