### PR TITLE
Randomize MasterMind palette

### DIFF
--- a/src/components/minigame/MasterMind.vue
+++ b/src/components/minigame/MasterMind.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import type { BaseShlagemon } from '~/type'
 import { useTimeoutFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { allShlagemons } from '~/data/shlagemons'
 import { useAudioStore } from '~/stores/audio'
+import { sample } from '~/utils/random'
 
 const emit = defineEmits<{ (e: 'win'): void, (e: 'lose'): void }>()
 
@@ -13,7 +15,8 @@ const messages = computed(() => {
   return Array.isArray(list) ? list as string[] : []
 })
 
-const palette = allShlagemons.slice(0, 12)
+const PALETTE_SIZE = 12
+const palette = ref<BaseShlagemon[]>([])
 const comboLength = 6
 const maxAttempts = 5
 
@@ -43,8 +46,9 @@ function openPicker(i: number) {
 }
 
 function initGame() {
+  palette.value = sample(allShlagemons, PALETTE_SIZE)
   solution.value = Array.from({ length: comboLength }, () => {
-    return palette[Math.floor(Math.random() * palette.length)].id
+    return palette.value[Math.floor(Math.random() * palette.value.length)].id
   }) as (string | null)[]
   attempts.value = []
   feedback.value = []

--- a/src/components/minigame/Pairs.vue
+++ b/src/components/minigame/Pairs.vue
@@ -3,6 +3,7 @@ import { useElementSize, useTimeoutFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { allShlagemons } from '~/data/shlagemons'
 import { useAudioStore } from '~/stores/audio'
+import { shuffle } from '~/utils/random'
 
 const emit = defineEmits(['win'])
 const audio = useAudioStore()
@@ -23,15 +24,6 @@ const size = computed(() => Math.min(width.value, height.value))
 const board = ref<Cell[]>([])
 const attempts = ref(0)
 const selected = ref<Cell[]>([])
-
-function shuffle<T>(arr: T[]): T[] {
-  const a = arr.slice()
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[a[i], a[j]] = [a[j], a[i]]
-  }
-  return a
-}
 
 function reset() {
   const mons = shuffle(allShlagemons).slice(0, (GRID_SIZE * GRID_SIZE) / 2)

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,22 @@
+/**
+ * Utility functions for random operations.
+ */
+
+/**
+ * Return a shuffled copy of the provided array using the Fisher-Yates algorithm.
+ */
+export function shuffle<T>(array: T[]): T[] {
+  const result = array.slice()
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[result[i], result[j]] = [result[j], result[i]]
+  }
+  return result
+}
+
+/**
+ * Return `count` random elements from the provided array.
+ */
+export function sample<T>(array: T[], count: number): T[] {
+  return shuffle(array).slice(0, count)
+}


### PR DESCRIPTION
## Summary
- add random utils for shuffle and sample
- randomize MasterMind minigame palette
- reuse shuffle util in Pairs minigame

## Testing
- `pnpm lint` *(fails: style/max-statements-per-line in Header.vue and other unused var errors)*
- `pnpm typecheck` *(fails: numerous TS errors across repo)*
- `pnpm test:unit` *(fails: snapshot mismatch and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688be900a434832ab774e6bc6f1db50c