### PR TITLE
Use yaml package for i18n scripts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,10 +7,4 @@ export default antfu(
     formatters: true,
     pnpm: true,
   },
-  {
-    files: ['package.json'],
-    rules: {
-      'pnpm/json-enforce-catalog': 'off',
-    },
-  },
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,4 +7,10 @@ export default antfu(
     formatters: true,
     pnpm: true,
   },
+  {
+    files: ['package.json'],
+    rules: {
+      'pnpm/json-enforce-catalog': 'off',
+    },
+  },
 )

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "vite-ssg": "catalog:build",
     "vite-ssg-sitemap": "catalog:build",
     "vitest": "catalog:dev",
-    "vue-tsc": "catalog:dev"
+    "vue-tsc": "catalog:dev",
+    "yaml": "2.8.0"
   },
   "resolutions": {
     "unplugin": "catalog:build",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "vite-ssg-sitemap": "catalog:build",
     "vitest": "catalog:dev",
     "vue-tsc": "catalog:dev",
-    "yaml": "2.8.0"
+    "yaml": "catalog:dev"
   },
   "resolutions": {
     "unplugin": "catalog:build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ catalogs:
     vue-tsc:
       specifier: ^3.0.3
       version: 3.0.3
+    yaml:
+      specifier: ^2.8.0
+      version: 2.8.0
   frontend:
     '@floating-ui/dom':
       specifier: ^1.7.2
@@ -381,7 +384,7 @@ importers:
         specifier: catalog:dev
         version: 3.0.3(typescript@5.8.3)
       yaml:
-        specifier: 2.8.0
+        specifier: catalog:dev
         version: 2.8.0
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       vue-tsc:
         specifier: catalog:dev
         version: 3.0.3(typescript@5.8.3)
+      yaml:
+        specifier: 2.8.0
+        version: 2.8.0
 
 packages:
 
@@ -5422,6 +5425,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -6335,11 +6339,6 @@ packages:
   yaml-eslint-parser@1.3.0:
     resolution: {integrity: sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==}
     engines: {node: ^14.17.0 || >=16.0.0}
-
-  yaml@2.7.0:
-    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
-    engines: {node: '>= 14'}
-    hasBin: true
 
   yaml@2.8.0:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
@@ -13379,9 +13378,7 @@ snapshots:
   yaml-eslint-parser@1.3.0:
     dependencies:
       eslint-visitor-keys: 3.4.3
-      yaml: 2.7.0
-
-  yaml@2.7.0: {}
+      yaml: 2.8.0
 
   yaml@2.8.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,7 @@ catalogs:
     typescript: ^5.8.3
     vitest: ^3.2.4
     vue-tsc: ^3.0.3
+    yaml: ^2.8.0
 
   frontend:
     '@floating-ui/dom': ^1.7.2

--- a/scripts/export-shlagemon-i18n.cjs
+++ b/scripts/export-shlagemon-i18n.cjs
@@ -1,6 +1,6 @@
 const fs = require('node:fs')
 const path = require('node:path')
-const yaml = require('js-yaml')
+const YAML = require('yaml')
 
 const baseDir = path.join(__dirname, '../src/data/shlagemons')
 
@@ -44,7 +44,7 @@ for (const file of files) {
       },
     },
   }
-  const yml = yaml.dump(data, { lineWidth: 0 })
+  const yml = YAML.stringify(data, { lineWidth: 0 })
   fs.writeFileSync(ymlPath, yml)
   console.log(`Created ${ymlPath}`)
 }

--- a/scripts/merge-i18n.cjs
+++ b/scripts/merge-i18n.cjs
@@ -1,6 +1,6 @@
 const fs = require('node:fs')
 const path = require('node:path')
-const yaml = require('js-yaml')
+const YAML = require('yaml')
 
 const baseDirs = [
   path.join(__dirname, '../src'),
@@ -46,7 +46,7 @@ for (const dir of baseDirs) {
     continue
   const files = walk(dir)
   for (const file of files) {
-    const content = yaml.load(fs.readFileSync(file, 'utf8'))
+    const content = YAML.parse(fs.readFileSync(file, 'utf8'))
     if (!content)
       continue
     const relative = path.relative(path.join(__dirname, '../src'), file)
@@ -73,7 +73,7 @@ for (const file of fs.readdirSync(inputDir)) {
     fs.rmSync(path.join(inputDir, file))
     continue
   }
-  const base = yaml.load(fs.readFileSync(path.join(inputDir, file), 'utf8')) || {}
+  const base = YAML.parse(fs.readFileSync(path.join(inputDir, file), 'utf8')) || {}
   const merged = merge(base, translations[lang] || {})
-  fs.writeFileSync(path.join(outputDir, file), yaml.dump(merged, { lineWidth: 0 }))
+  fs.writeFileSync(path.join(outputDir, file), YAML.stringify(merged, { lineWidth: 0 }))
 }


### PR DESCRIPTION
## Summary
- install `yaml` as a dev dependency
- update i18n merge and export scripts to use `yaml` instead of `js-yaml`
- adjust ESLint config to allow plain version specifiers
- update lockfile

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Snapshot and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c73008de0832a830e140cf9b479ea