### PR TITLE
Add i18n for SettingsModal

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -203,6 +203,13 @@ components:
         a one-time or monthly contribution on Ko-fi.
       discordLabel: Join Discord
       discordDesc: To discuss the game and share your ideas, join the community on Discord.
+    SettingsModal:
+      title: Settings
+      tabs:
+        save: Save
+        language: Language
+        shortcuts: Shortcuts
+        support: Support
   shlagemon:
     Detail:
       equipItemTitle: Equip an item

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -211,6 +211,13 @@ components:
       discordDesc: >-
         Pour discuter du jeu et partager tes idées, rejoins la communauté sur
         Discord.
+    SettingsModal:
+      title: Paramètres
+      tabs:
+        save: Sauvegarde
+        language: Langue
+        shortcuts: Raccourcis
+        support: Soutien
   shlagemon:
     Detail:
       equipItemTitle: Équiper un objet

--- a/src/components/settings/SettingsModal.i18n.yml
+++ b/src/components/settings/SettingsModal.i18n.yml
@@ -1,0 +1,14 @@
+fr:
+  title: Paramètres
+  tabs:
+    save: Sauvegarde
+    language: Langue
+    shortcuts: Raccourcis
+    support: Soutien
+en:
+  title: Settings
+  tabs:
+    save: Save
+    language: Language
+    shortcuts: Shortcuts
+    support: Support

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -6,7 +6,10 @@ import SettingsShortcutsTab from './ShortcutsTab.vue'
 import SupportTab from './SupportTab.vue'
 
 const props = defineProps<{ modelValue: boolean }>()
+
 const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void }>()
+
+const { t } = useI18n()
 
 const save = useSaveStore()
 
@@ -25,7 +28,7 @@ const { isMobile } = storeToRefs(useUIStore())
 const tabs = computed(() => {
   const arr = [
     {
-      label: { text: 'Sauvegarde', icon: 'i-carbon-save' },
+      label: { text: t('components.settings.SettingsModal.tabs.save'), icon: 'i-carbon-save' },
       component: defineComponent({
         name: 'SettingsSaveTabWrapper',
         setup() {
@@ -33,18 +36,18 @@ const tabs = computed(() => {
         },
       }),
     },
-    { label: { text: 'Langue', icon: 'i-carbon-language' }, component: LanguageTab },
+    { label: { text: t('components.settings.SettingsModal.tabs.language'), icon: 'i-carbon-language' }, component: LanguageTab },
   ]
 
   if (!isMobile.value) {
     arr.splice(1, 0, {
-      label: { text: 'Raccourcis', icon: 'i-carbon-keyboard' },
+      label: { text: t('components.settings.SettingsModal.tabs.shortcuts'), icon: 'i-carbon-keyboard' },
       component: SettingsShortcutsTab,
     })
   }
 
   arr.push({
-    label: { text: 'Soutien', icon: 'i-carbon-favorite' },
+    label: { text: t('components.settings.SettingsModal.tabs.support'), icon: 'i-carbon-favorite' },
     component: SupportTab,
   })
   return arr
@@ -64,7 +67,7 @@ watch(tabs, (val) => {
     @close="close"
   >
     <h2 class="mb-2 text-center text-lg font-bold">
-      Paramètres
+      {{ t('components.settings.SettingsModal.title') }}
     </h2>
     <UiTabs v-model="activeTab" :tabs="tabs" is-small class="mb-4" />
     <LayoutScrollablePanel class="max-h-60vh">


### PR DESCRIPTION
## Summary
- translate SettingsModal.vue using vue-i18n
- add local translation file and merge into main locale files

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: various existing type errors)*
- `pnpm test` *(fails: snapshot and logic tests)*

------
https://chatgpt.com/codex/tasks/task_e_688c9a60814c832a9ede34b439b8ed5f