### PR TITLE
feat: badges for new zones and dex entries

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -14,8 +14,9 @@ const lockStore = useFeatureLockStore()
 const visit = useZoneVisitStore()
 
 // Etats calculés réactifs pour le highlight + désactivation
-const highlightMap = computed(() => visit.hasNewZone)
+const newZoneCount = computed(() => visit.newZoneCount)
 const highlightInventory = computed(() => usage.hasUnusedItem)
+const newDexCount = computed(() => shlagedex.newCount)
 
 const menuDisabled = computed(() => dialog.isDialogVisible || panel.current === 'arena')
 const zoneDisabled = menuDisabled
@@ -77,7 +78,16 @@ const focusRing = 'outline-none focus-visible:ring-2 focus-visible:ring-teal-400
       ]"
       @click="mobile.toggle('dex')"
     >
-      <IconShlagedex class="h-5 w-5" aria-hidden="true" />
+      <span class="relative flex items-center justify-center">
+        <IconShlagedex class="h-5 w-5" aria-hidden="true" />
+        <UiBadge
+          v-if="newDexCount > 0"
+          color="info"
+          size="xs"
+          class="-right-1.5 -top-1.5"
+          :inner="false"
+        >{{ newDexCount }}</UiBadge>
+      </span>
     </button>
 
     <!-- Inventory, avec badge animé si highlight -->
@@ -122,11 +132,13 @@ const focusRing = 'outline-none focus-visible:ring-2 focus-visible:ring-teal-400
     >
       <span class="relative flex items-center justify-center">
         <div class="i-carbon-map text-xl" aria-hidden="true" />
-        <span
-          v-if="highlightMap"
-          class="absolute h-3 w-3 animate-pulse rounded-full bg-pink-500 ring-2 ring-white -right-1.5 -top-1.5 dark:bg-pink-400 dark:ring-gray-900"
-          aria-hidden="true"
-        />
+        <UiBadge
+          v-if="newZoneCount > 0"
+          color="danger"
+          size="xs"
+          class="-right-1.5 -top-1.5"
+          :inner="false"
+        >{{ newZoneCount }}</UiBadge>
       </span>
     </button>
 

--- a/src/components/panel/Shlagedex.vue
+++ b/src/components/panel/Shlagedex.vue
@@ -11,6 +11,7 @@ const clickTimer = ref<Stoppable<[]> | null>(null)
 
 function open(mon: DexShlagemon | null) {
   if (mon) {
+    dex.markSeen(mon)
     detailMon.value = mon
     showDetail.value = true
   }

--- a/src/stores/dexDetailModal.ts
+++ b/src/stores/dexDetailModal.ts
@@ -7,6 +7,8 @@ export const useDexDetailModalStore = defineStore('dexDetailModal', () => {
 
   function open(target: DexShlagemon) {
     mon.value = target
+    const dex = useShlagedexStore()
+    dex.markSeen(target)
     openModal()
   }
 

--- a/src/stores/zoneVisit.ts
+++ b/src/stores/zoneVisit.ts
@@ -7,10 +7,10 @@ export const useZoneVisitStore = defineStore('zoneVisit', () => {
 
   const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
 
-  const hasNewZone = computed(
-    () => accessibleZones.value.length > 1
-      && accessibleZones.value.some(z => !visited.value[z.id]),
+  const newZoneCount = computed(() =>
+    accessibleZones.value.filter(z => !visited.value[z.id]).length,
   )
+  const hasNewZone = computed(() => newZoneCount.value > 0)
 
   function markVisited(id: string) {
     visited.value[id] = true
@@ -26,6 +26,7 @@ export const useZoneVisitStore = defineStore('zoneVisit', () => {
 
   return {
     visited,
+    newZoneCount,
     hasNewZone,
     markVisited,
     markAllAccessibleVisited,

--- a/src/type/shlagemon.ts
+++ b/src/type/shlagemon.ts
@@ -63,4 +63,10 @@ export interface DexShlagemon extends Stats {
    * Useful for the starter whose rarity scales with leveling.
    */
   rarityFollowsLevel?: boolean
+
+  /**
+   * Indicates that the player has not viewed or activated this Shlagémon yet.
+   * Used to display a "new" badge in the dex until acknowledged.
+   */
+  isNew?: boolean
 }

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -86,6 +86,7 @@ export function createDexShlagemon(
     allowEvolution: true,
     heldItemId: null,
     rarityFollowsLevel,
+    isNew: true,
   }
   applyStats(mon)
   applyCurrentStats(mon)


### PR DESCRIPTION
## Summary
- track unseen Shlagemons with `isNew` flag
- expose `newCount`, `markSeen` and `markAllSeen` in the shlagedex store
- track unvisited zones with `newZoneCount`
- show badges for new zones and new Shlagemons in mobile menu
- mark Shlagemons seen when viewing details

## Testing
- `pnpm test` *(fails: sort-item.test.ts, sort-evolution.test.ts, sort-shiny.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688ca26b0e60832a8a0c0d05477b03a9