### PR TITLE
Fix info modals closing panels

### DIFF
--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -151,7 +151,6 @@ const transitionName = computed(() => direction.value === 'left' ? 'slide-left' 
       tabindex="-1"
     >
       <Transition :name="transitionName" mode="out-in">
-        
         <component
           :is="props.tabs[active]?.component"
           :key="active"

--- a/src/stores/dexInfoModal.ts
+++ b/src/stores/dexInfoModal.ts
@@ -2,7 +2,9 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
 
 export const useDexInfoModalStore = defineStore('dexInfoModal', () => {
-  const { isVisible, open: openModal, close } = createModalStore('game')
+  // Keep the current mobile tab so opening the modal doesn't hide
+  // the secondary panel on small screens
+  const { isVisible, open: openModal, close } = createModalStore()
   const mon = ref<DexShlagemon | null>(null)
 
   function open(target: DexShlagemon) {

--- a/src/stores/typeChartModal.ts
+++ b/src/stores/typeChartModal.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
 
 export const useTypeChartModalStore = defineStore('typeChartModal', () => {
-  const { isVisible, open: openModal, close } = createModalStore('game')
+  // Avoid switching mobile tabs to keep panels visible when opening the modal
+  const { isVisible, open: openModal, close } = createModalStore()
   const highlight = ref<string | null>(null)
 
   function open(typeId: string) {


### PR DESCRIPTION
## Summary
- keep current mobile tab when opening shlagemon info modals
- avoid switching mobile tabs for type chart modal
- fix trailing whitespace in Tabs.vue

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc77f810832a83a00a1512072ab8