### PR TITLE
Refactor settings modal tabs

### DIFF
--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -69,11 +69,6 @@ watch(tabs, (val) => {
     <h2 class="mb-2 text-center text-lg font-bold">
       {{ t('components.settings.SettingsModal.title') }}
     </h2>
-    <UiTabs v-model="activeTab" :tabs="tabs" is-small class="mb-4" />
-    <LayoutScrollablePanel class="max-h-60vh">
-      <template #content>
-        <component :is="tabs[activeTab].component" />
-      </template>
-    </LayoutScrollablePanel>
+    <UiTabs v-model="activeTab" :tabs="tabs" is-small class="mb-4 flex-1" />
   </UiModal>
 </template>

--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -151,7 +151,6 @@ const transitionName = computed(() => direction.value === 'left' ? 'slide-left' 
       tabindex="-1"
     >
       <Transition :name="transitionName" mode="out-in">
-        
         <component
           :is="props.tabs[active]?.component"
           :key="active"


### PR DESCRIPTION
## Summary
- remove unused LayoutScrollablePanel in SettingsModal
- rely on UiTabs for scrolling area
- minor whitespace fix in Tabs component

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: snapshot mismatch)*
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_688cbc95e3d4832a8d34d61bb95b4c96