### PR TITLE
Add footer to UiTabs and update shortcuts UI

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -118,6 +118,7 @@ declare module 'vue' {
     SettingsSaveTab: typeof import('./components/settings/SaveTab.vue')['default']
     SettingsSettingsModal: typeof import('./components/settings/SettingsModal.vue')['default']
     SettingsShortcutsTab: typeof import('./components/settings/ShortcutsTab.vue')['default']
+    SettingsShortcutsTabFooter: typeof import('./components/settings/ShortcutsTabFooter.vue')['default']
     SettingsSupportTab: typeof import('./components/settings/SupportTab.vue')['default']
     ShlagemonDetail: typeof import('./components/shlagemon/Detail.vue')['default']
     ShlagemonDetailModal: typeof import('./components/shlagemon/DetailModal.vue')['default']

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -3,6 +3,7 @@ import { storeToRefs } from 'pinia'
 import LanguageTab from './LanguageTab.vue'
 import SaveTab from './SaveTab.vue'
 import SettingsShortcutsTab from './ShortcutsTab.vue'
+import ShortcutsTabFooter from './ShortcutsTabFooter.vue'
 import SupportTab from './SupportTab.vue'
 
 const props = defineProps<{ modelValue: boolean }>()
@@ -43,6 +44,7 @@ const tabs = computed(() => {
     arr.splice(1, 0, {
       label: { text: t('components.settings.SettingsModal.tabs.shortcuts'), icon: 'i-carbon-keyboard' },
       component: SettingsShortcutsTab,
+      footer: ShortcutsTabFooter,
     })
   }
 
@@ -63,9 +65,9 @@ watch(tabs, (val) => {
 <template>
   <UiModal
     :model-value="props.modelValue"
+    class="h-full"
     @update:model-value="emit('update:modelValue', $event)"
     @close="close"
-    class="h-full"
   >
     <h2 class="mb-2 text-center text-lg font-bold">
       {{ t('components.settings.SettingsModal.title') }}

--- a/src/components/settings/ShortcutsTab.vue
+++ b/src/components/settings/ShortcutsTab.vue
@@ -26,21 +26,8 @@ function updateItem(index: number, itemId: ItemId) {
   store.update(index, entry)
 }
 
-function addShortcut() {
-  const firstItem = allItems[0]
-  const entry: ShortcutEntry = {
-    key: '',
-    action: { type: 'use-item', itemId: firstItem.id },
-  }
-  store.add(entry)
-}
-
 function removeShortcut(index: number) {
   store.remove(index)
-}
-
-function reset() {
-  store.reset()
 }
 </script>
 
@@ -60,14 +47,6 @@ function reset() {
       />
       <UiButton type="icon" class="h-7 w-7" @click="removeShortcut(idx)">
         <div i-carbon-close />
-      </UiButton>
-    </div>
-    <div class="mt-2 flex gap-2">
-      <UiButton class="flex-1" @click="addShortcut">
-        {{ t('components.settings.ShortcutsTab.add') }}
-      </UiButton>
-      <UiButton type="danger" class="flex-1" @click="reset">
-        {{ t('components.settings.ShortcutsTab.reset') }}
       </UiButton>
     </div>
   </div>

--- a/src/components/settings/ShortcutsTabFooter.vue
+++ b/src/components/settings/ShortcutsTabFooter.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { ItemId } from '~/data/items'
+import type { ShortcutEntry } from '~/stores/shortcuts'
+import { allItems } from '~/data/items'
+
+const store = useShortcutsStore()
+const { t } = useI18n()
+
+function addShortcut() {
+  const firstItem = allItems[0]
+  const entry: ShortcutEntry = {
+    key: '',
+    action: { type: 'use-item', itemId: firstItem.id as ItemId },
+  }
+  store.add(entry)
+}
+
+function reset() {
+  store.reset()
+}
+</script>
+
+<template>
+  <div class="flex gap-2">
+    <UiButton class="flex-1 gap-2" @click="addShortcut">
+      <div i-carbon:add />
+      {{ t('components.settings.ShortcutsTab.add') }}
+    </UiButton>
+    <UiButton type="danger" class="flex-1 gap-2" @click="reset">
+      <div i-carbon:reset />
+      {{ t('components.settings.ShortcutsTab.reset') }}
+    </UiButton>
+  </div>
+</template>

--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -6,6 +6,7 @@ interface Label { text: string, icon?: string }
 interface Tab {
   'label': Label
   'component': any
+  'footer'?: any
   'highlight'?: boolean
   /** Number of new items to display as a badge. */
   'badge'?: number
@@ -42,6 +43,8 @@ watch(active, (v) => {
 
 const container = ref<HTMLElement>()
 const direction = ref<'left' | 'right'>('left')
+
+const currentFooter = computed(() => props.tabs[active.value]?.footer)
 
 function select(i: number) {
   if (i === active.value || props.tabs[i]?.disabled)
@@ -158,6 +161,12 @@ const transitionName = computed(() => direction.value === 'left' ? 'slide-left' 
         />
       </Transition>
     </section>
+    <div
+      v-if="currentFooter"
+      class="shrink-0 border-t border-gray-200 bg-white p-2 dark:border-gray-800 dark:bg-gray-900"
+    >
+      <component :is="currentFooter" />
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- extend **UiTabs** with optional per-tab footers
- create `ShortcutsTabFooter` component for Add/Reset actions
- integrate the footer in **SettingsModal** for the shortcuts tab
- adjust **ShortcutsTab** layout

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: snapshot and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ccd63e2e8832aad67225ee165f0e7