### PR TITLE
Create reusable UiListItem component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -151,6 +151,7 @@ declare module 'vue' {
     UiKbd: typeof import('./components/ui/Kbd.vue')['default']
     UiKeyCapture: typeof import('./components/ui/KeyCapture.vue')['default']
     UiLanguageToggle: typeof import('./components/ui/LanguageToggle.vue')['default']
+    UiListItem: typeof import('./components/ui/ListItem.vue')['default']
     UiLoader: typeof import('./components/ui/Loader.vue')['default']
     UiModal: typeof import('./components/ui/Modal.vue')['default']
     UiNavigationButton: typeof import('./components/ui/NavigationButton.vue')['default']

--- a/src/components/achievement/Item.vue
+++ b/src/components/achievement/Item.vue
@@ -13,11 +13,15 @@ function toggle() {
 </script>
 
 <template>
-  <div
-    class="flex flex-col border rounded-lg p-2 text-sm shadow-sm transition-colors"
+  <UiListItem
+    as="div"
+    class="flex-col p-2 text-sm"
     :class="props.achievement.achieved
       ? 'border-cyan-600 bg-cyan-50 text-gray-900 dark:border-cyan-500 dark:bg-cyan-950/40 dark:text-gray-100'
       : 'border-gray-300 bg-white text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400'"
+    role="button"
+    tabindex="0"
+    @click="toggle"
   >
     <div class="flex cursor-pointer items-center justify-between" @click="toggle">
       <div class="flex items-center gap-2">
@@ -38,5 +42,5 @@ function toggle() {
         <UiProgressBar :value="progress.value" :max="progress.max" class="h-1" />
       </div>
     </div>
-  </div>
+  </UiListItem>
 </template>

--- a/src/components/egg/BoxModal.vue
+++ b/src/components/egg/BoxModal.vue
@@ -25,18 +25,23 @@ function openEgg(id: EggItemId) {
         {{ t('components.egg.BoxModal.title') }}
       </h3>
       <div v-if="eggList.length" class="flex flex-col gap-1">
-        <div
+        <UiListItem
           v-for="id in eggList"
           :key="id"
-          class="flex cursor-pointer items-center justify-between border-b p-1"
+          as="div"
+          class="cursor-pointer items-center justify-between border-b p-1"
           @click="openEgg(id as EggItemId)"
         >
-          <div class="flex items-center gap-1">
-            <div v-if="getItem(id).icon" class="h-6 w-6" :class="[getItem(id).icon, getItem(id).iconClass]" />
-            <span class="text-sm">{{ t(getItem(id).name) }}</span>
-          </div>
-          <span class="text-xs font-bold">x{{ box.eggs[id] }}</span>
-        </div>
+          <template #left>
+            <div class="flex items-center gap-1">
+              <div v-if="getItem(id).icon" class="h-6 w-6" :class="[getItem(id).icon, getItem(id).iconClass]" />
+              <span class="text-sm">{{ t(getItem(id).name) }}</span>
+            </div>
+          </template>
+          <template #right>
+            <span class="text-xs font-bold">x{{ box.eggs[id] }}</span>
+          </template>
+        </UiListItem>
       </div>
       <span v-else class="text-center text-sm">{{ t('components.egg.BoxModal.empty') }}</span>
     </div>

--- a/src/components/inventory/EvolutionItemModal.vue
+++ b/src/components/inventory/EvolutionItemModal.vue
@@ -12,19 +12,24 @@ const itemName = computed(() => store.current ? t(store.current.name) : '')
         {{ store.current ? t('components.inventory.EvolutionItemModal.title', { name: itemName }) : '' }}
       </h3>
       <div v-if="store.availableMons.length" class="flex flex-col gap-2">
-        <div
+        <UiListItem
           v-for="mon in store.availableMons"
           :key="mon.id"
-          class="flex items-center justify-between border rounded p-2"
+          as="div"
+          class="items-center justify-between border rounded p-2"
         >
-          <div class="flex items-center gap-2">
-            <ShlagemonImage :id="mon.base.id" :alt="mon.base.name" class="aspect-1" />
-            <span>{{ mon.base.name }} (lvl {{ mon.lvl }})</span>
-          </div>
-          <UiButton class="text-xs" @click="store.useOn(mon)">
-            {{ t('components.inventory.EvolutionItemModal.evolve') }}
-          </UiButton>
-        </div>
+          <template #left>
+            <div class="flex items-center gap-2">
+              <ShlagemonImage :id="mon.base.id" :alt="mon.base.name" class="aspect-1" />
+              <span>{{ mon.base.name }} (lvl {{ mon.lvl }})</span>
+            </div>
+          </template>
+          <template #right>
+            <UiButton class="text-xs" @click="store.useOn(mon)">
+              {{ t('components.inventory.EvolutionItemModal.evolve') }}
+            </UiButton>
+          </template>
+        </UiListItem>
       </div>
       <p v-else class="text-center text-sm">
         {{ t('components.inventory.EvolutionItemModal.noCompatible') }}

--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -72,14 +72,15 @@ watch(showInfo, (val) => {
 </script>
 
 <template>
-  <article
-    class="hover:bg-primary-50/50 focus-visible:ring-primary-400 relative min-h-16 w-full flex items-center gap-1 overflow-hidden border rounded-xl bg-white/95 p-1 shadow-sm outline-none transition-all duration-150 active:scale-98 dark:bg-gray-900/90 hover:shadow-lg focus-visible:ring-2"
+  <UiListItem
+    as="article"
+    class="hover:bg-primary-50/50 focus-visible:ring-primary-400 relative min-h-16 w-full items-center gap-1 overflow-hidden rounded-xl bg-white/95 p-1 active:scale-98 dark:bg-gray-900/90 hover:shadow-lg focus-visible:ring-2"
     :class="[
       isUnused ? 'animate-pulse-alt animate-count-infinite' : '',
       zoom ? 'open-zoom' : '',
     ]"
-    tabindex="0"
     role="button"
+    tabindex="0"
     @click="onCardClick"
   >
     <!-- 1. Icon/image  -->
@@ -173,7 +174,7 @@ watch(showInfo, (val) => {
         </UiButton>
       </div>
     </UiModal>
-  </article>
+  </UiListItem>
 </template>
 
 <style scoped>

--- a/src/components/settings/ShortcutsTab.vue
+++ b/src/components/settings/ShortcutsTab.vue
@@ -33,7 +33,12 @@ function removeShortcut(index: number) {
 
 <template>
   <div class="flex flex-col gap-2">
-    <div v-for="(sc, idx) in store.shortcuts" :key="idx" class="flex items-center gap-2">
+    <UiListItem
+      v-for="(sc, idx) in store.shortcuts"
+      :key="idx"
+      as="div"
+      class="items-center gap-2"
+    >
       <UiKeyCapture
         class="w-12"
         :model-value="sc.key"
@@ -48,6 +53,6 @@ function removeShortcut(index: number) {
       <UiButton type="icon" class="h-7 w-7" @click="removeShortcut(idx)">
         <div i-carbon-close />
       </UiButton>
-    </div>
+    </UiListItem>
   </div>
 </template>

--- a/src/components/shlagemon/ListItem.vue
+++ b/src/components/shlagemon/ListItem.vue
@@ -11,47 +11,48 @@ const _props = defineProps({
   showCheckbox: { type: Boolean, default: false },
 })
 const emit = defineEmits(['click', 'activate'])
+
+const itemClass = computed(() => [
+  _props.isActive
+    ? 'bg-sky-500/10 border-sky-500 ring-2 ring-sky-400'
+    : _props.isHighlighted
+      ? 'bg-sky-400/10 border-sky-400 ring-2 ring-sky-300'
+      : _props.mon.rarity === 100
+        ? 'border-yellow-500 bg-yellow-100/10 dark:bg-yellow-900/5'
+        : '',
+])
 </script>
 
 <template>
-  <div
-    class="group relative min-h-11 flex cursor-pointer select-none items-center gap-1 border rounded-lg px-1.5 py-0.5 shadow-sm outline-none transition-all duration-150 focus:ring-2 focus:ring-sky-400"
-    :class="[
-      isActive
-        ? 'bg-sky-500/10 border-sky-500 ring-2 ring-sky-400'
-        : isHighlighted
-          ? 'bg-sky-400/10 border-sky-400 ring-2 ring-sky-300'
-          : mon.rarity === 100
-            ? 'border-yellow-500 bg-yellow-100/10 dark:bg-yellow-900/5'
-            : 'border-gray-300 dark:border-gray-700 bg-white/80 dark:bg-gray-900/70',
-      locked || disabled
-        ? 'opacity-50 pointer-events-none saturate-0'
-        : 'hover:shadow-lg hover:scale-[1.01] active:scale-100',
-    ]"
+  <UiListItem
+    class="gap-1"
+    :class="itemClass"
+    :active="isActive"
+    :disabled="locked || disabled"
     role="option"
-    :aria-selected="isActive"
-    :aria-disabled="disabled || locked"
     tabindex="0"
     @click.stop="() => emit('click')"
     @contextmenu.stop.prevent="() => emit('activate')"
     @keydown.enter.space.prevent="() => emit('click')"
   >
     <!-- Image Shlagemon, carré, prend toute la hauteur -->
-    <div class="relative h-10 w-10 flex flex-shrink-0 items-center justify-center">
-      <ShlagemonImage
-        :id="mon.base.id"
-        :alt="mon.base.name"
-        :shiny="mon.isShiny"
-        class="h-full w-full rounded object-contain"
-      />
-      <span
-        v-if="mon.isShiny"
-        class="pointer-events-none absolute left-0 top-0 animate-pulse select-none text-xs text-yellow-400"
-        aria-label="Shiny"
-      >
-        <div class="i-carbon-star" />
-      </span>
-    </div>
+    <template #left>
+      <div class="relative h-10 w-10 flex flex-shrink-0 items-center justify-center">
+        <ShlagemonImage
+          :id="mon.base.id"
+          :alt="mon.base.name"
+          :shiny="mon.isShiny"
+          class="h-full w-full rounded object-contain"
+        />
+        <span
+          v-if="mon.isShiny"
+          class="pointer-events-none absolute left-0 top-0 animate-pulse select-none text-xs text-yellow-400"
+          aria-label="Shiny"
+        >
+          <div class="i-carbon-star" />
+        </span>
+      </div>
+    </template>
     <!-- Infos principales (toujours 2 lignes) -->
     <div class="min-w-0 flex flex-1 flex-col gap-1 leading-tight">
       <div class="flex items-center gap-0.5 truncate text-sm font-semibold">
@@ -75,25 +76,27 @@ const emit = defineEmits(['click', 'activate'])
       </div>
     </div>
     <!-- Colonne droite, compacte et alignée -->
-    <div class="h-full min-w-7 flex flex-col items-end justify-between gap-0.5">
-      <div class="flex-1">
-        <InventoryWearableItemIcon
-          v-if="item"
-          :item="item"
-          class="h-4 w-4"
+    <template #right>
+      <div class="h-full min-w-7 flex flex-col items-end justify-between gap-0.5">
+        <div class="flex-1">
+          <InventoryWearableItemIcon
+            v-if="item"
+            :item="item"
+            class="h-4 w-4"
+          />
+        </div>
+        <UiCheckBox
+          v-if="showCheckbox"
+          class="scale-85"
+          :model-value="isActive"
+          :disabled="locked || disabled"
+          @update:model-value="() => emit('activate')"
+          @click.stop
         />
+        <div class="flex-1 text-center text-[10px] text-gray-500 leading-none font-mono dark:text-gray-400">
+          lvl <span class="font-bold">{{ mon.lvl }}</span>
+        </div>
       </div>
-      <UiCheckBox
-        v-if="showCheckbox"
-        class="scale-85"
-        :model-value="isActive"
-        :disabled="locked || disabled"
-        @update:model-value="() => emit('activate')"
-        @click.stop
-      />
-      <div class="flex-1 text-center text-[10px] text-gray-500 leading-none font-mono dark:text-gray-400">
-        lvl <span class="font-bold">{{ mon.lvl }}</span>
-      </div>
-    </div>
-  </div>
+    </template>
+  </UiListItem>
 </template>

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -7,7 +7,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div class="flex items-center gap-2 border rounded bg-white p-1 dark:bg-gray-900">
+  <UiListItem as="div" class="items-center gap-2 bg-white p-1 dark:bg-gray-900">
     <div
       v-if="props.item.icon"
       class="h-8 w-8"
@@ -19,5 +19,5 @@ const { t } = useI18n()
       <span class="text-xs">{{ t(props.item.description) }}</span>
     </div>
     <UiCurrencyAmount :amount="props.item.price ?? 0" :currency="props.item.currency ?? 'shlagidolar'" />
-  </div>
+  </UiListItem>
 </template>

--- a/src/components/ui/ListItem.vue
+++ b/src/components/ui/ListItem.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+/**
+ * Generic list item component with optional left and right slots.
+ * @prop active - highlights the item as selected
+ * @prop disabled - disables interactions and visuals
+ * @prop tabindex - tab index for focus navigation
+ * @prop as - tag name for root element
+ * @prop role - optional ARIA role
+ * @prop ariaLabel - optional label for assistive technologies
+ */
+const props = withDefaults(defineProps<{
+  active?: boolean
+  disabled?: boolean
+  tabindex?: number
+  as?: string
+  role?: string
+  ariaLabel?: string
+}>(), {
+  active: false,
+  disabled: false,
+  tabindex: 0,
+  as: 'div',
+  role: undefined,
+  ariaLabel: undefined,
+})
+
+const tag = computed(() => props.as)
+
+const classes = computed(() => [
+  'group relative w-full flex items-center gap-2 min-h-11 px-2 py-1 border rounded-lg bg-white/80 dark:bg-gray-900/70 shadow-sm outline-none transition-all duration-150',
+  'focus-visible:ring-2 focus-visible:ring-sky-400',
+  props.disabled
+    ? 'pointer-events-none opacity-50 saturate-0'
+    : 'hover:shadow-lg hover:scale-[1.01] active:scale-100',
+  props.active
+    ? 'bg-sky-500/10 border-sky-500 ring-2 ring-sky-400'
+    : 'border-gray-300 dark:border-gray-700',
+])
+</script>
+
+<template>
+  <component
+    :is="tag"
+    :class="classes"
+    :role="props.role"
+    :aria-selected="props.role === 'option' ? props.active : undefined"
+    :aria-disabled="props.disabled || undefined"
+    :aria-label="props.ariaLabel"
+    :tabindex="props.disabled ? -1 : props.tabindex"
+  >
+    <span v-if="$slots.left" class="mr-1 flex items-center">
+      <slot name="left" />
+    </span>
+    <div class="min-w-0 flex-1">
+      <slot />
+    </div>
+    <span v-if="$slots.right" class="ml-1 flex items-center">
+      <slot name="right" />
+    </span>
+  </component>
+</template>

--- a/test/ui-list-item.test.ts
+++ b/test/ui-list-item.test.ts
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import UiListItem from '../src/components/ui/ListItem.vue'
+
+describe('uiListItem', () => {
+  it('renders slots and active state', () => {
+    const wrapper = mount(UiListItem, {
+      props: { active: true },
+      slots: {
+        default: '<span class="content">content</span>',
+        left: '<span class="left">L</span>',
+        right: '<span class="right">R</span>',
+      },
+    })
+    expect(wrapper.find('.content').exists()).toBe(true)
+    expect(wrapper.find('.left').exists()).toBe(true)
+    expect(wrapper.find('.right').exists()).toBe(true)
+    expect(wrapper.classes().some(c => c.includes('ring'))).toBe(true)
+  })
+
+  it('handles disabled state', () => {
+    const wrapper = mount(UiListItem, { props: { disabled: true } })
+    expect(wrapper.attributes('aria-disabled')).toBe('true')
+    expect(wrapper.attributes('tabindex')).toBe('-1')
+  })
+})


### PR DESCRIPTION
## Summary
- implement new `UiListItem` for consistent list styling
- refactor `ShlagemonListItem` and other list-based components
- add unit tests for `UiListItem`

## Testing
- `pnpm test:unit --run test/ui-list-item.test.ts --silent`
- `pnpm test:unit --run --silent` *(fails: Snapshot mismatches and other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ccf88fd40832a98f604ece71626f7