### PR TITLE
Fix shortcut consumption for activable items

### DIFF
--- a/src/stores/shortcuts.ts
+++ b/src/stores/shortcuts.ts
@@ -78,6 +78,10 @@ export const useShortcutsStore = defineStore('shortcuts', () => {
           useBallStore().equip(item.id as BallId)
           usage.markUsed(item.id)
         }
+        else if (item.category === 'activable') {
+          useKingPotionStore().equip(item.id)
+          usage.markUsed(item.id)
+        }
         else if (item.type === 'evolution') {
           useEvolutionItemStore().open(item)
         }

--- a/test/shortcuts.test.ts
+++ b/test/shortcuts.test.ts
@@ -1,8 +1,9 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
-import { potion, superPotion } from '../src/data/items'
+import { potion, specialPotion, superPotion } from '../src/data/items'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useInventoryStore } from '../src/stores/inventory'
+import { useKingPotionStore } from '../src/stores/kingPotion'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useShortcutsStore } from '../src/stores/shortcuts'
 
@@ -26,5 +27,28 @@ describe('shortcuts', () => {
     shortcuts.handleKeydown(new KeyboardEvent('keydown', { key: 'a' }))
     expect(inventory.items[potion.id]).toBeUndefined()
     expect(inventory.items[superPotion.id]).toBeUndefined()
+  })
+
+  it('equips activable items without consuming them', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const inventory = useInventoryStore()
+    const shortcuts = useShortcutsStore()
+    const kingPotion = useKingPotionStore()
+
+    inventory.add(specialPotion.id)
+    kingPotion.equip(specialPotion.id)
+
+    const mon = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(mon)
+
+    shortcuts.shortcuts = [
+      { key: 'b', action: { type: 'use-item', itemId: specialPotion.id } },
+    ]
+
+    shortcuts.handleKeydown(new KeyboardEvent('keydown', { key: 'b' }))
+
+    expect(inventory.items[specialPotion.id]).toBe(1)
+    expect(kingPotion.current).toBe(specialPotion.id)
   })
 })


### PR DESCRIPTION
## Summary
- fix shortcut logic so activable items (like king potions) get equipped instead of consumed
- add unit test covering activable item shortcuts

## Testing
- `pnpm test` *(fails: component snapshots and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_688ce4563d64832a96c493a4d9f3b381