### PR TITLE
Update inventory and map badges

### DIFF
--- a/src/components/dialog/NewZoneDialog.vue
+++ b/src/components/dialog/NewZoneDialog.vue
@@ -5,7 +5,6 @@ import { xpPotion } from '~/data/items'
 
 const emit = defineEmits(['done'])
 const inventory = useInventoryStore()
-const visit = useZoneVisitStore()
 const mobile = useMobileTabStore()
 const { t } = useI18n()
 
@@ -43,7 +42,6 @@ const dialogTree = computed<DialogNode[]>(() => [
         type: 'valid',
         action: () => {
           inventory.add(xpPotion.id, 1)
-          visit.markAllAccessibleVisited()
           mobile.set('zones')
           emit('done', 'newZone')
         },

--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -15,7 +15,7 @@ const visit = useZoneVisitStore()
 
 // Etats calculés réactifs pour le highlight + désactivation
 const newZoneCount = computed(() => visit.newZoneCount)
-const highlightInventory = computed(() => usage.hasUnusedItem)
+const newItemCount = computed(() => usage.unusedItemCount)
 const newDexCount = computed(() => shlagedex.newCount)
 
 const menuDisabled = computed(() => dialog.isDialogVisible || panel.current === 'arena')
@@ -107,11 +107,13 @@ const focusRing = 'outline-none focus-visible:ring-2 focus-visible:ring-teal-400
     >
       <span class="relative flex items-center justify-center">
         <div class="i-carbon-inventory-management text-xl" aria-hidden="true" />
-        <span
-          v-if="highlightInventory"
-          class="absolute h-3 w-3 animate-pulse rounded-full bg-sky-500 ring-2 ring-white -right-1.5 -top-1.5 dark:bg-sky-400 dark:ring-gray-900"
-          aria-hidden="true"
-        />
+        <UiBadge
+          v-if="newItemCount > 0"
+          color="info"
+          size="xs"
+          class="-right-1.5 -top-1.5"
+          :inner="false"
+        >{{ newItemCount }}</UiBadge>
       </span>
     </button>
 

--- a/src/stores/itemUsage.ts
+++ b/src/stores/itemUsage.ts
@@ -8,6 +8,11 @@ export const useItemUsageStore = defineStore('itemUsage', () => {
     Object.entries(inventory.items).some(([id, qty]) => (qty ?? 0) > 0 && !used.value[id]),
   )
 
+  const unusedItemCount = computed(() =>
+    Object.entries(inventory.items)
+      .reduce((acc, [id, qty]) => acc + ((qty ?? 0) > 0 && !used.value[id] ? 1 : 0), 0),
+  )
+
   function markUsed(id: string) {
     used.value[id] = true
   }
@@ -16,7 +21,7 @@ export const useItemUsageStore = defineStore('itemUsage', () => {
     used.value = {}
   }
 
-  return { used, hasUnusedItem, markUsed, reset }
+  return { used, hasUnusedItem, unusedItemCount, markUsed, reset }
 }, {
   persist: true,
 })


### PR DESCRIPTION
## Summary
- show count of undiscovered inventory items in `MobileMenu`
- remove automatic marking of new zones as visited
- track unused inventory item count in `useItemUsageStore`

## Testing
- `pnpm test` *(fails: capture mechanics, component snapshots, sort tests)*

------
https://chatgpt.com/codex/tasks/task_e_688cf2c2aa48832aaf657a1c1450b7dd