### PR TITLE
Add new achievement badge

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -22,6 +22,7 @@ const menuDisabled = computed(() => dialog.isDialogVisible || panel.current === 
 const zoneDisabled = menuDisabled
 const dexDisabled = computed(() => menuDisabled.value || shlagedex.shlagemons.length === 0)
 const achievementsDisabled = computed(() => menuDisabled.value || !achievements.hasAny)
+const hasNewAchievements = computed(() => achievements.hasNewUnlocked)
 const inventoryDisabled = computed(() =>
   menuDisabled.value || inventory.list.length === 0 || arena.inBattle || lockStore.isInventoryLocked,
 )
@@ -60,7 +61,16 @@ const focusRing = 'outline-none focus-visible:ring-2 focus-visible:ring-teal-400
       ]"
       @click="mobile.toggle('achievements')"
     >
-      <div class="i-carbon-trophy text-xl" aria-hidden="true" />
+      <span class="relative flex items-center justify-center">
+        <div class="i-carbon-trophy text-xl" aria-hidden="true" />
+        <UiBadge
+          v-if="hasNewAchievements"
+          color="info"
+          size="xs"
+          class="-right-1.5 -top-1.5"
+          :inner="false"
+        />
+      </span>
     </button>
 
     <!-- Dex -->

--- a/src/components/panel/Achievements.vue
+++ b/src/components/panel/Achievements.vue
@@ -25,6 +25,9 @@ const filteredList = computed(() => {
   return list.value.filter(a => a.title.toLowerCase().includes(q))
 })
 
+onMounted(() => store.markAllSeen())
+watch(() => store.unlockedList.length, store.markAllSeen)
+
 function toggleItem(id: string) {
   openedId.value = openedId.value === id ? null : id
 }

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -40,6 +40,11 @@ export const useAchievementsStore = defineStore('achievements', () => {
     {},
   )
 
+  const lastSeenCount = useLocalStorage(
+    'shlagemon_achievements_seen',
+    0,
+  )
+
   function reset() {
     counters.captures = 0
     counters.wins = 0
@@ -50,6 +55,7 @@ export const useAchievementsStore = defineStore('achievements', () => {
     counters.shiny = 0
     counters.minigameWins = 0
     unlocked.value = {}
+    lastSeenCount.value = 0
   }
 
   function unlock(id: string) {
@@ -283,6 +289,12 @@ export const useAchievementsStore = defineStore('achievements', () => {
   )
   const unlockedList = computed(() => list.value.filter(a => a.achieved))
   const hasAny = computed(() => unlockedList.value.length > 0)
+  const unlockedCount = computed(() => unlockedList.value.length)
+  const hasNewUnlocked = computed(() => unlockedCount.value > lastSeenCount.value)
+
+  function markAllSeen() {
+    lastSeenCount.value = unlockedCount.value
+  }
 
   function handleEvent(e: AchievementEvent) {
     switch (e.type) {
@@ -459,8 +471,10 @@ export const useAchievementsStore = defineStore('achievements', () => {
     list,
     unlockedList,
     hasAny,
+    hasNewUnlocked,
     handleEvent,
     reset,
+    markAllSeen,
     getProgress,
     counters,
   }


### PR DESCRIPTION
## Summary
- show a badge for new achievements in the mobile menu
- track newly unlocked achievements and mark them seen when the panel opens

## Testing
- `corepack pnpm lint-staged`
- `corepack pnpm test` *(fails: snapshot and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688cf8fd1f5c832a912f1a0fd3f0ec20