### PR TITLE
Highlight new shlagemons in dex list

### DIFF
--- a/src/components/shlagemon/ListItem.vue
+++ b/src/components/shlagemon/ListItem.vue
@@ -12,6 +12,9 @@ const _props = defineProps({
 })
 const emit = defineEmits(['click', 'activate'])
 
+// Highlight newly captured Shlagémon until acknowledged
+const shouldHighlight = computed(() => Boolean(_props.mon.isNew))
+
 const itemClass = computed(() => [
   _props.isActive
     ? 'bg-sky-500/10 border-sky-500 ring-2 ring-sky-400'
@@ -28,6 +31,7 @@ const itemClass = computed(() => [
     class="gap-1"
     :class="itemClass"
     :active="isActive"
+    :highlight="shouldHighlight"
     :disabled="locked || disabled"
     as="button"
     role="option"


### PR DESCRIPTION
## Summary
- keep list items pulsing when the shlagemon is new

## Testing
- `pnpm test` *(fails: Snapshots 1 failed, Test Files 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cf99dd5dc832a9f2c09378135e071