### PR TITLE
Enable locked achievements toggle

### DIFF
--- a/src/components/ui/ListItem.vue
+++ b/src/components/ui/ListItem.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 type Colors = 'success' | 'info' | 'warning' | 'danger' | 'neutral' | 'locked'
 
-
 const props = withDefaults(defineProps<{
   active?: boolean
   disabled?: boolean
@@ -74,7 +73,6 @@ const colorClassMap: Record<Colors, string[]> = {
     'dark:text-gray-600',
     'opacity-70',
     'saturate-0',
-    'pointer-events-none',
     'select-none',
   ],
 } as const
@@ -86,7 +84,8 @@ const classes = computed(() => {
     'hover:shadow-lg hover:scale-[1.01] active:scale-100',
   ]
 
-  if (props.disabled) classes.push('pointer-events-none opacity-50 saturate-0')
+  if (props.disabled)
+    classes.push('pointer-events-none opacity-50 saturate-0')
   if (props.highlight)
     classes.push('animate-highlight bg-sky-900/20 dark:bg-sky-900/20')
   if (props.active)


### PR DESCRIPTION
## Summary
- keep locked achievement items clickable by removing pointer-events-none from the locked color style

## Testing
- `npx vitest run` *(fails: Snapshot `component Header.vue > should render 1` mismatched and other assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688cfc6f7fb4832ab843b022af97464e