### PR TITLE
Sort highlighted mons first

### DIFF
--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -84,6 +84,18 @@ const displayedMons = computed(() => {
   }
   if (!filter.sortAsc)
     mons.reverse()
+  // Place highlighted Shlagemons at the top while preserving sort order
+  if (props.highlightIds.length) {
+    const highlighted: DexShlagemon[] = []
+    const others: DexShlagemon[] = []
+    for (const m of mons) {
+      if (props.highlightIds.includes(m.id))
+        highlighted.push(m)
+      else
+        others.push(m)
+    }
+    mons = [...highlighted, ...others]
+  }
   return mons
 })
 


### PR DESCRIPTION
## Summary
- modify `ShlagemonList` so highlighted mons appear first

## Testing
- `npx eslint src/components/shlagemon/List.vue --fix`
- `pnpm test -- -r` *(fails: snapshots and expectations)*

------
https://chatgpt.com/codex/tasks/task_e_688d05aa4a98832a915cd71f6a0d7384