### PR TITLE
Implement panel badge clear actions

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -100,6 +100,19 @@ const bottomBadgeColor = computed<BadgeColor>(() => {
       return 'info'
   }
 })
+
+const bottomBadgeHandler = computed(() => {
+  switch (activeTab.value) {
+    case 'inventory':
+      return usage.markAllUsed
+    case 'zones':
+      return visit.markAllAccessibleVisited
+    case 'dex':
+      return shlagedex.markAllSeen
+    default:
+      return undefined
+  }
+})
 </script>
 
 <template>
@@ -116,6 +129,7 @@ const bottomBadgeColor = computed<BadgeColor>(() => {
           :is-locked="lockStore.isInventoryLocked"
           :badge="newItemCount"
           badge-color="info"
+          :badge-click="usage.markAllUsed"
         >
           <template #icon>
             <div class="i-carbon-inventory-management" />
@@ -148,6 +162,7 @@ const bottomBadgeColor = computed<BadgeColor>(() => {
           :is-locked="lockStore.areZonesLocked"
           :badge="newZoneCount"
           badge-color="danger"
+          :badge-click="visit.markAllAccessibleVisited"
         >
           <template #icon>
             <div class="i-carbon-map" />
@@ -164,6 +179,7 @@ const bottomBadgeColor = computed<BadgeColor>(() => {
           :is-locked="lockStore.isShlagedexLocked"
           :badge="newDexCount"
           badge-color="info"
+          :badge-click="shlagedex.markAllSeen"
         >
           <template #icon>
             <IconShlagedex class="h-4 w-4" />
@@ -179,6 +195,7 @@ const bottomBadgeColor = computed<BadgeColor>(() => {
           :is-locked="bottomLocked"
           :badge="bottomBadge"
           :badge-color="bottomBadgeColor"
+          :badge-click="bottomBadgeHandler"
         >
           <template #icon>
             <div v-if="activeTab === 'achievements'" class="i-carbon-trophy" />

--- a/src/components/ui/PanelWrapper.vue
+++ b/src/components/ui/PanelWrapper.vue
@@ -2,7 +2,7 @@
 import type { BadgeColor } from '~/type/badge'
 import { storeToRefs } from 'pinia'
 
-const props = defineProps<{ title?: string, isInline?: boolean, isScrollable?: boolean, isMobileHidable?: boolean, isLocked?: boolean, badge?: number, badgeColor?: BadgeColor }>()
+const props = defineProps<{ title?: string, isInline?: boolean, isScrollable?: boolean, isMobileHidable?: boolean, isLocked?: boolean, badge?: number, badgeColor?: BadgeColor, badgeClick?: () => void }>()
 const opened = ref(true)
 const { isMobile } = storeToRefs(useUIStore())
 
@@ -77,6 +77,14 @@ const titleClasses = computed(() => {
 
 const showBadge = computed(() => (props.badge ?? 0) > 0)
 
+function onTitleClick(e: MouseEvent) {
+  if (showBadge.value && props.badgeClick) {
+    e.stopPropagation()
+    props.badgeClick()
+  }
+  toggle()
+}
+
 function clickPrevented(e: MouseEvent) {
   if (props.isLocked) {
     e.preventDefault()
@@ -88,19 +96,19 @@ function clickPrevented(e: MouseEvent) {
 
 <template>
   <div class="panel-wrapper" v-bind="$attrs" :class="wrapperClasses">
-    <div v-if="props.title" class="flex items-center justify-between p-2" :class="titleClasses" @click="toggle">
+    <div v-if="props.title" class="flex items-center justify-between p-2" :class="titleClasses" @click="onTitleClick">
       <div class="flex items-center gap-1">
         <slot name="icon" />
-        <span class="font-bold relative pr-4">{{ props.title }}
-        <UiBadge
-          v-if="showBadge"
-          :color="props.badgeColor || 'info'"
-          size="xs"
-          class="-top-1 -right-1"
-          inner
-        >
-          {{ props.badge }}
-        </UiBadge></span>
+        <span class="relative pr-4 font-bold">{{ props.title }}
+          <UiBadge
+            v-if="showBadge"
+            :color="props.badgeColor || 'info'"
+            size="xs"
+            class="-right-1 -top-1"
+            inner
+          >
+            {{ props.badge }}
+          </UiBadge></span>
       </div>
       <div class="relative flex items-center">
         <div v-if="hidable" class="i-carbon-chevron-down transition-transform" :class="opened ? '' : 'rotate-90'" />

--- a/src/stores/itemUsage.ts
+++ b/src/stores/itemUsage.ts
@@ -17,11 +17,18 @@ export const useItemUsageStore = defineStore('itemUsage', () => {
     used.value[id] = true
   }
 
+  function markAllUsed() {
+    for (const [id, qty] of Object.entries(inventory.items)) {
+      if ((qty ?? 0) > 0)
+        used.value[id] = true
+    }
+  }
+
   function reset() {
     used.value = {}
   }
 
-  return { used, hasUnusedItem, unusedItemCount, markUsed, reset }
+  return { used, hasUnusedItem, unusedItemCount, markUsed, markAllUsed, reset }
 }, {
   persist: true,
 })

--- a/test/item-usage.test.ts
+++ b/test/item-usage.test.ts
@@ -1,0 +1,17 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { attackPotion, defensePotion } from '../src/data/items'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useItemUsageStore } from '../src/stores/itemUsage'
+
+describe('item usage store', () => {
+  it('marks all owned items as used', () => {
+    setActivePinia(createPinia())
+    const inventory = useInventoryStore()
+    const usage = useItemUsageStore()
+    inventory.add(attackPotion.id)
+    inventory.add(defensePotion.id, 2)
+    usage.markAllUsed()
+    expect(usage.unusedItemCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- enable clearing panel badges by providing a `badgeClick` prop to `UiPanelWrapper`
- mark all inventory items as used when clearing the inventory badge
- clear all visited zones or new Shlagémon when clearing badges in GameGrid
- expose `markAllUsed` in `itemUsage` store
- add unit test for `markAllUsed`

## Testing
- `pnpm test:unit` *(fails: Snapshot mismatch and several assertions)*

------
https://chatgpt.com/codex/tasks/task_e_688d084523fc832ab8a5abedf34fd6f6