### PR TITLE
Add Cuck Ring item and lore dialog

### DIFF
--- a/src/components/dialog/CuckRingDialog.i18n.yml
+++ b/src/components/dialog/CuckRingDialog.i18n.yml
@@ -1,0 +1,62 @@
+fr:
+  steps:
+    step1:
+      text: "Félicitations ! L'un de tes Shlagémons a atteint le niveau 60 !"
+      responses:
+        next: Continuer
+    step2:
+      text: "Je vais te parler d'un objet mystérieux : l'Anneau du Cocu."
+      responses:
+        back: Retour
+        next: Continuer
+    step3:
+      text: Cet anneau appartenait autrefois à {name}, un dresseur pas comme les autres.
+      responses:
+        back: Retour
+        next: Continuer
+    step4:
+      text: "On raconte qu'il rend chaque attaque imprévisible : soit le double de dégâts, soit un soin pour l'adversaire."
+      responses:
+        back: Retour
+        next: Continuer
+    step5:
+      text: Personne ne sait pourquoi {name} l'a perdu, mais il pourrait te servir.
+      responses:
+        back: Retour
+        next: Continuer
+    step6:
+      text: Le voici, à toi de tenter ta chance !
+      responses:
+        back: Retour
+        valid: Merci Professeur !
+en:
+  steps:
+    step1:
+      text: Congratulations! One of your Shlagemons reached level 60!
+      responses:
+        next: Continue
+    step2:
+      text: 'Let me tell you about a curious item: the Cuck Ring.'
+      responses:
+        back: Back
+        next: Continue
+    step3:
+      text: This ring once belonged to {name}, a rather unusual trainer.
+      responses:
+        back: Back
+        next: Continue
+    step4:
+      text: 'It makes each attack unpredictable: double damage or healing the foe instead.'
+      responses:
+        back: Back
+        next: Continue
+    step5:
+      text: No one knows why {name} lost it, but it might help you.
+      responses:
+        back: Back
+        next: Continue
+    step6:
+      text: Here it is, give it a try!
+      responses:
+        back: Back
+        valid: Thanks Professor!

--- a/src/components/dialog/CuckRingDialog.vue
+++ b/src/components/dialog/CuckRingDialog.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import type { DialogNode } from '~/type/dialog'
+import { etronMuscle } from '~/data/characters/etron-muscle'
+import { profMerdant } from '~/data/characters/prof-merdant'
+import { cuckRing } from '~/data/items/wearables/cuckRing'
+
+const emit = defineEmits(['done'])
+const inventory = useInventoryStore()
+const { t } = useI18n()
+
+const dialogTree = computed<DialogNode[]>(() => [
+  {
+    id: 'start',
+    text: t('components.dialog.CuckRingDialog.steps.step1.text'),
+    responses: [
+      { label: t('components.dialog.CuckRingDialog.steps.step1.responses.next'), nextId: 'step2', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step2',
+    text: t('components.dialog.CuckRingDialog.steps.step2.text'),
+    responses: [
+      { label: t('components.dialog.CuckRingDialog.steps.step2.responses.back'), nextId: 'start', type: 'danger' },
+      { label: t('components.dialog.CuckRingDialog.steps.step2.responses.next'), nextId: 'step3', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step3',
+    text: t('components.dialog.CuckRingDialog.steps.step3.text', { name: etronMuscle.name }),
+    responses: [
+      { label: t('components.dialog.CuckRingDialog.steps.step3.responses.back'), nextId: 'step2', type: 'danger' },
+      { label: t('components.dialog.CuckRingDialog.steps.step3.responses.next'), nextId: 'step4', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step4',
+    text: t('components.dialog.CuckRingDialog.steps.step4.text'),
+    responses: [
+      { label: t('components.dialog.CuckRingDialog.steps.step4.responses.back'), nextId: 'step3', type: 'danger' },
+      { label: t('components.dialog.CuckRingDialog.steps.step4.responses.next'), nextId: 'step5', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step5',
+    text: t('components.dialog.CuckRingDialog.steps.step5.text', { name: etronMuscle.name }),
+    responses: [
+      { label: t('components.dialog.CuckRingDialog.steps.step5.responses.back'), nextId: 'step4', type: 'danger' },
+      { label: t('components.dialog.CuckRingDialog.steps.step5.responses.next'), nextId: 'step6', type: 'primary' },
+    ],
+  },
+  {
+    id: 'step6',
+    text: t('components.dialog.CuckRingDialog.steps.step6.text'),
+    responses: [
+      { label: t('components.dialog.CuckRingDialog.steps.step6.responses.back'), nextId: 'step5', type: 'danger' },
+      {
+        label: t('components.dialog.CuckRingDialog.steps.step6.responses.valid'),
+        type: 'valid',
+        action: () => {
+          inventory.add(cuckRing.id, 1)
+          emit('done', 'cuckRing')
+        },
+      },
+    ],
+  },
+])
+</script>
+
+<template>
+  <DialogBox
+    :character="profMerdant"
+    :dialog-tree="dialogTree"
+    orientation="col"
+  />
+</template>

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -5,6 +5,7 @@ import {
   attackAmulet,
   attackRing,
 } from './items/wearables/attackRing'
+import { cuckRing } from './items/wearables/cuckRing'
 import {
   advancedDefenseRing,
   defenseAmulet,
@@ -532,6 +533,7 @@ export const allItems = [
   xpRing,
   advancedXpRing,
   xpAmulet,
+  cuckRing,
   preyAmulet,
   attackRing,
   advancedAttackRing,

--- a/src/data/items/wearables/cuckRing.i18n.yml
+++ b/src/data/items/wearables/cuckRing.i18n.yml
@@ -1,0 +1,12 @@
+en:
+  name: Cuck Ring
+  description: Each attack either deals double damage or heals the foe.
+  details: |
+    When worn, every attack has a 50% chance to deal double damage.
+    Otherwise, it heals the opponent for the same amount.
+fr:
+  name: Anneau du Cocu
+  description: Chaque attaque inflige soit le double de dégâts, soit soigne l'adversaire.
+  details: |
+    Porté par un Shlagémon, chaque attaque a 50% de chances
+    d'infliger le double de dégâts et 50% de chances de soigner l'ennemi du même montant.

--- a/src/data/items/wearables/cuckRing.ts
+++ b/src/data/items/wearables/cuckRing.ts
@@ -1,0 +1,17 @@
+import type { Item } from '~/type/item'
+
+export const cuckRing: Item = {
+  id: 'cuck-ring',
+  name: 'data.items.wearables.cuckRing.name',
+  description: 'data.items.wearables.cuckRing.description',
+  details: 'data.items.wearables.cuckRing.details',
+  price: 150,
+  currency: 'shlagidiamond',
+  category: 'utilitaire',
+  icon: 'i-game-icons:ring',
+  iconClass: 'text-violet-500 dark:text-violet-400',
+  unique: true,
+  wearable: true,
+}
+
+export const cuckWearables = [cuckRing] as const

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -1,5 +1,6 @@
 import type { DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
+import { cuckRing } from '~/data/items/wearables/cuckRing'
 import { preyAmulet } from '~/data/items/wearables/preyAmulet'
 import { computeDamage } from '~/utils/combat'
 
@@ -56,6 +57,16 @@ export const useBattleStore = defineStore('battle', () => {
         finalDamage = 0
       else
         finalDamage = Math.min(finalDamage, defender.hpCurrent - 1)
+    }
+
+    if (attacker.heldItemId === cuckRing.id) {
+      if (Math.random() < 0.5) {
+        finalDamage *= 2
+      }
+      else {
+        defender.hpCurrent = Math.min(dex.maxHp(defender), defender.hpCurrent + finalDamage)
+        finalDamage = 0
+      }
     }
 
     defender.hpCurrent = Math.max(0, defender.hpCurrent - finalDamage)

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -6,6 +6,7 @@ import ArenaVictoryDialog from '~/components/dialog/ArenaVictoryDialog.vue'
 import ArenaWelcomeDialog from '~/components/dialog/ArenaWelcomeDialog.vue'
 import AttackPotionDialog from '~/components/dialog/AttackPotionDialog.vue'
 import CapturePotionDialog from '~/components/dialog/CapturePotionDialog.vue'
+import CuckRingDialog from '~/components/dialog/CuckRingDialog.vue'
 import DeveloperSupportDialog from '~/components/dialog/DeveloperSupportDialog.vue'
 import DuplicateRarityDialog from '~/components/dialog/DuplicateRarityDialog.vue'
 import EggBoxDialog from '~/components/dialog/EggBoxDialog.vue'
@@ -207,6 +208,11 @@ export const useDialogStore = defineStore('dialog', () => {
       id: 'odorElixir',
       component: markRaw(OdorElixirDialog),
       condition: () => dex.highestLevel >= 50,
+    },
+    {
+      id: 'cuckRing',
+      component: markRaw(CuckRingDialog),
+      condition: () => dex.highestLevel >= 60,
     },
     {
       id: 'preyAmulet',


### PR DESCRIPTION
## Summary
- introduce the new wearable item "Cuck Ring"
- implement dialog unlocking the ring at level 60
- handle special battle effect for the ring

## Testing
- `pnpm lint --fix`
- `pnpm typecheck` *(fails: property 'stop' does not exist, missing declarations)*
- `pnpm test:unit` *(fails: several unit tests fail and a snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688d0da32948832a86bdfcec47892734