### PR TITLE
Fix Capture Potion dialog level

### DIFF
--- a/src/components/dialog/CapturePotionDialog.i18n.yml
+++ b/src/components/dialog/CapturePotionDialog.i18n.yml
@@ -1,7 +1,7 @@
 fr:
   steps:
     step1:
-      text: Incroyable, l'un de tes Shlagémons a atteint le niveau 50 !
+      text: Incroyable, l'un de tes Shlagémons a atteint le niveau 35 !
       responses:
         next: Continuer
     step2:
@@ -27,7 +27,7 @@ fr:
 en:
   steps:
     step1:
-      text: 'Incredible, one of your Shlagemons reached level 50!'
+      text: 'Incredible, one of your Shlagemons reached level 35!'
       responses:
         next: Continue
     step2:


### PR DESCRIPTION
## Summary
- adjust the Capture Potion dialog text to trigger at level 35 instead of level 50

## Testing
- `pnpm test` *(fails: Snapshot mismatches and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688d0f0d761c832abb065e7bf282c675