### PR TITLE
Fix shop item list overflow

### DIFF
--- a/src/components/panel/Shop.vue
+++ b/src/components/panel/Shop.vue
@@ -39,7 +39,10 @@ function closeShop() {
       class="flex-1"
       :class="selectedItem ? 'pointer-events-none opacity-50' : ''"
     />
-    <div v-else class="tiny-scrollbar flex flex-1 flex-col gap-2 overflow-auto">
+    <div
+      v-else
+      class="tiny-scrollbar flex flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto"
+    >
       <ShopItemCard
         v-for="item in filteredShopItems"
         :key="item.id"
@@ -48,7 +51,10 @@ function closeShop() {
         @click="selectItem(item)"
       />
     </div>
-    <div v-if="selectedItem" class="tiny-scrollbar flex-1 overflow-auto">
+    <div
+      v-if="selectedItem"
+      class="tiny-scrollbar flex-1 overflow-x-hidden overflow-y-auto"
+    >
       <ShopItemDetail v-model:qty="selectedQty" :item="selectedItem" />
     </div>
     <template #footer>

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -12,20 +12,20 @@ const { t } = useI18n()
       <div class="h-8 w-8 flex items-center justify-center">
         <div
           v-if="props.item.icon"
-          :class="[props.item.iconClass, props.item.icon, 'w-full h-full']"
+          class="h-full w-full" :class="[props.item.iconClass, props.item.icon]"
         />
         <img
           v-else-if="props.item.image"
           :src="props.item.image"
           :alt="t(props.item.name)"
-          class="w-full h-full object-contain"
+          class="h-full w-full object-contain"
         >
       </div>
     </template>
 
-    <div class="flex flex-col text-left min-w-0">
-      <span class="font-bold truncate">{{ t(props.item.name) }}</span>
-      <span class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ t(props.item.description) }}</span>
+    <div class="min-w-0 flex flex-col text-left">
+      <span class="truncate font-bold">{{ t(props.item.name) }}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400">{{ t(props.item.description) }}</span>
     </div>
 
     <template #right>

--- a/src/composables/useShopTabs.ts
+++ b/src/composables/useShopTabs.ts
@@ -76,7 +76,10 @@ export function useShopTabs(selectItem: (item: Item) => void) {
           const list = getList(cat.value)
           return () => h(
             'div',
-            { class: 'tiny-scrollbar grid xl:grid-cols-2 3xl:grid-cols-3 gap-2 overflow-auto p-1 auto-rows-min' },
+            {
+              class:
+                'tiny-scrollbar grid xl:grid-cols-2 3xl:grid-cols-3 gap-2 overflow-y-auto overflow-x-hidden p-1 auto-rows-min',
+            },
             list.value.map(item => h(
               ShopItemCard,
               {


### PR DESCRIPTION
## Summary
- avoid horizontal scrolling in the shop item list
- wrap item description text on multiple lines

## Testing
- `pnpm test --run` *(fails: Snapshot `component Header.vue > should render 1` mismatched and 4 other tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d18b34f5c832aafa45668b9806b87