### PR TITLE
Fix highlight for inaccessible zones

### DIFF
--- a/src/components/zone/ButtonVillage.vue
+++ b/src/components/zone/ButtonVillage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Zone } from '~/type/zone'
 import { useZoneCompletion } from '~/composables/useZoneCompletion'
+import { useZoneAccess } from '~/stores/zoneAccess'
 
 const props = defineProps<{ zone: Zone }>()
 const zoneStore = useZoneStore()
@@ -10,6 +11,8 @@ const dialog = useDialogStore()
 const featureLock = useFeatureLockStore()
 const visit = useZoneVisitStore()
 const { arenaCompleted } = useZoneCompletion(props.zone)
+const dex = useShlagedexStore()
+const { canAccess } = useZoneAccess(toRef(dex, 'highestLevel'))
 
 const zoneButtonsDisabled = computed(
   () =>
@@ -49,7 +52,11 @@ function classes() {
     :class="[
       classes(),
       buttonDisabled() ? 'opacity-50 cursor-not-allowed' : '',
-      props.zone.id !== zoneStore.current.id && !visit.visited[props.zone.id] ? 'animate-pulse-alt  animate-count-infinite' : '',
+      props.zone.id !== zoneStore.current.id
+        && !visit.visited[props.zone.id]
+        && canAccess(props.zone)
+        ? 'animate-pulse-alt  animate-count-infinite'
+        : '',
     ]"
     :disabled="buttonDisabled()"
     @click="selectZone"

--- a/src/components/zone/ButtonWild.vue
+++ b/src/components/zone/ButtonWild.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { SavageZone } from '~/type/zone'
 import { useZoneCompletion } from '~/composables/useZoneCompletion'
+import { useZoneAccess } from '~/stores/zoneAccess'
 
 const props = defineProps<{ zone: SavageZone }>()
 const zoneStore = useZoneStore()
@@ -11,6 +12,7 @@ const dialog = useDialogStore()
 const featureLock = useFeatureLockStore()
 const visit = useZoneVisitStore()
 const { t } = useI18n()
+const { canAccess } = useZoneAccess(toRef(dex, 'highestLevel'))
 
 const zoneButtonsDisabled = computed(
   () =>
@@ -66,7 +68,11 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
     :class="[
       classes(),
       buttonDisabled() ? 'opacity-50 cursor-not-allowed' : '',
-      props.zone.id !== zoneStore.current.id && !visit.visited[props.zone.id] ? highlightClasses : '',
+      props.zone.id !== zoneStore.current.id
+        && !visit.visited[props.zone.id]
+        && canAccess(props.zone)
+        ? highlightClasses
+        : '',
     ]"
     :disabled="buttonDisabled()"
     @click="selectZone"

--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -60,7 +60,7 @@ export function useMapMarkers(map: LeafletMap) {
 
     function buildHtml() {
       const size = 12
-      const highlight = visited.value ? '' : 'animate-pulse-alt'
+      const highlight = !visited.value && !locked ? 'animate-pulse-alt' : ''
       const icon = `<img src="${iconPath(zone)}" class="w-${size} h-${size} block ${highlight}" />`
       const ballClasses = allCaptured.value
         ? `h-3 w-3${perfectZone.value ? ' filter-[hue-rotate(60deg)_brightness(1.1)]' : ''}`


### PR DESCRIPTION
## Summary
- highlight unvisited zones only when accessible
- show map marker pulse only for accessible zones

## Testing
- `pnpm test:unit` *(fails: Snapshots 1 failed, Test Files 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d618d4ec0832ab6fce64e6622cd8c