### PR TITLE
style: outline capture button

### DIFF
--- a/src/components/battle/Capture.vue
+++ b/src/components/battle/Capture.vue
@@ -99,6 +99,7 @@ defineExpose({ open })
     <UiButton
       class="absolute right-50% top-12 aspect-square h-12 w-12 flex flex-col translate-x-1/2 cursor-pointer items-center gap-2 text-xs"
       circle
+      variant="outline"
       :class="{ ' cursor-not-allowed saturate-0': captureButtonDisabled }"
       :disabled="captureButtonDisabled"
       md="top-16 h-16 w-16"


### PR DESCRIPTION
## Summary
- switch capture button to outlined style

## Testing
- `pnpm test` *(fails: expected null to be '/fr/shlagedex')*

------
https://chatgpt.com/codex/tasks/task_e_688d60bc535c832aa7cccaa39834ab0b