### PR TITLE
Adjust XP gain when overleveled

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -492,8 +492,13 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const bonus = wearableBonus(mon.heldItemId, 'xp')
     if (bonus)
       amount = Math.round(amount * (1 + bonus / 100))
-    if (zoneMaxLevel && mon.lvl >= zoneMaxLevel)
-      amount = Math.round(amount / 2)
+    if (zoneMaxLevel) {
+      // Severely reduce XP when the Shlagémon outlevels the zone
+      if (mon.lvl >= zoneMaxLevel + 5)
+        amount = Math.round(amount / 10)
+      else if (mon.lvl >= zoneMaxLevel)
+        amount = Math.round(amount / 2)
+    }
     mon.xp += amount
     while (mon.lvl < maxLevel && mon.xp >= xpForLevel(mon.lvl)) {
       mon.xp -= xpForLevel(mon.lvl)

--- a/test/gainxp-zone-level.test.ts
+++ b/test/gainxp-zone-level.test.ts
@@ -1,0 +1,31 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { applyCurrentStats, applyStats, xpForLevel } from '../src/utils/dexFactory'
+
+describe('gainXp zone level penalties', () => {
+  it('halves xp when above zone max level', async () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.lvl = 10
+    applyStats(mon)
+    applyCurrentStats(mon)
+    const amount = xpForLevel(mon.lvl) - 1
+    await dex.gainXp(mon, amount, undefined, undefined, 10)
+    expect(mon.xp).toBe(Math.round(amount / 2))
+  })
+
+  it('divides xp by 10 when 5 levels above zone max', async () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.lvl = 15
+    applyStats(mon)
+    applyCurrentStats(mon)
+    const amount = xpForLevel(mon.lvl) - 1
+    await dex.gainXp(mon, amount, undefined, undefined, 10)
+    expect(mon.xp).toBe(Math.round(amount / 10))
+  })
+})


### PR DESCRIPTION
## Summary
- slow XP progression for Shlagémon exceeding zone level by halving or dividing gain
- test XP reduction rules for overleveled Shlagémon

## Testing
- `pnpm test:unit` *(fails: capture mechanics, snapshot, sorting, useLangSwitch)*

------
https://chatgpt.com/codex/tasks/task_e_688dc4de8858832a9e5eeb2dc3706d75