### PR TITLE
fix: constant manual click attack damage

### DIFF
--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -73,9 +73,28 @@ export const useBattleStore = defineStore('battle', () => {
     return { ...result, damage: finalDamage }
   }
 
-  function clickAttack(attacker: DexShlagemon, defender: DexShlagemon) {
+  /**
+   * Executes a manual player click attack.
+   *
+   * The attack always inflicts a fixed amount of 10 damage, ignoring
+   * resistances, weaknesses, potions, and held item effects. Damage is capped
+   * by the defender's remaining hit points.
+   *
+   * @param attacker - The player's attacking shlagemon.
+   * @param defender - The defending shlagemon.
+   * @returns The resulting damage information.
+   */
+  function clickAttack(attacker: DexShlagemon, defender: DexShlagemon): AttackResult {
     manualAttack.registerClick()
-    return attack(attacker, defender, false, false, true)
+
+    const damage = Math.min(10, defender.hpCurrent)
+    defender.hpCurrent -= damage
+
+    return {
+      damage,
+      effect: 'normal',
+      crit: 'normal',
+    }
   }
 
   function duel(player: DexShlagemon, enemy: DexShlagemon) {

--- a/test/click-attack.test.ts
+++ b/test/click-attack.test.ts
@@ -1,0 +1,34 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { preyAmulet } from '../src/data/items/wearables/preyAmulet'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useBattleStore } from '../src/stores/battle'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('click attack', () => {
+  it('deals fixed 10 damage ignoring items and bonuses', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const battle = useBattleStore()
+    const player = dex.createShlagemon(carapouffe)
+    const enemy = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(player)
+
+    // boost stats and equip an item that would normally modify damage
+    player.attack = 1000
+    player.defense = 1000
+    player.heldItemId = preyAmulet.id
+    enemy.defense = 1000
+
+    const initialHp = enemy.hpCurrent
+    const result = battle.clickAttack(player, enemy)
+    expect(result.damage).toBe(10)
+    expect(enemy.hpCurrent).toBe(initialHp - 10)
+
+    // prey amulet should not prevent the finishing blow
+    enemy.hpCurrent = 5
+    const result2 = battle.clickAttack(player, enemy)
+    expect(result2.damage).toBe(5)
+    expect(enemy.hpCurrent).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- make manual click attacks always deal 10 damage and ignore bonuses
- add tests ensuring click attack damage is fixed and not affected by items

## Testing
- `CI=1 pnpm test:unit` *(fails: component Header.vue snapshot mismatch, sort-evolution, sort-item, sort-shiny, useLangSwitch, capture)*

------
https://chatgpt.com/codex/tasks/task_e_688dd7bd11a0832a87747aa1bb6973f8