### PR TITLE
fix: hydrate badge box from player save

### DIFF
--- a/src/modules/badgeBoxHydrator.ts
+++ b/src/modules/badgeBoxHydrator.ts
@@ -1,0 +1,12 @@
+import type { UserModule } from '~/types'
+
+/**
+ * Syncs the badge box with the player's earned badges when the application loads.
+ */
+export const install: UserModule = ({ isClient }) => {
+  if (!isClient)
+    return
+
+  const badgeBox = useBadgeBoxStore()
+  badgeBox.syncWithPlayerBadges()
+}

--- a/src/stores/badgeBox.ts
+++ b/src/stores/badgeBox.ts
@@ -1,5 +1,6 @@
 import type { ArenaBadge } from '~/type'
 import { defineStore } from 'pinia'
+import { getArena } from '~/data/arenas'
 
 export const useBadgeBoxStore = defineStore('badgeBox', () => {
   const unlocked = ref(false)
@@ -23,13 +24,31 @@ export const useBadgeBoxStore = defineStore('badgeBox', () => {
     unlocked.value = true
   }
 
+  /**
+   * Ensures that every badge earned by the player is present in the badge box.
+   *
+   * This is primarily used when loading a save: if the player already has badges
+   * recorded in their profile but those badges are missing from the badge box,
+   * they are added here.
+   */
+  function syncWithPlayerBadges(): void {
+    const player = usePlayerStore()
+    for (const [arenaId, hasBadge] of Object.entries(player.arenaBadges)) {
+      if (!hasBadge)
+        continue
+      const arena = getArena(arenaId)
+      if (arena)
+        addBadge(arena.badge)
+    }
+  }
+
   function reset() {
     unlocked.value = false
     badges.value = []
     isModalOpen.value = false
   }
 
-  return { unlocked, badges, isModalOpen, open, close, addBadge, unlock, reset }
+  return { unlocked, badges, isModalOpen, open, close, addBadge, unlock, syncWithPlayerBadges, reset }
 }, {
   persist: true,
 })

--- a/test/badge-box-sync.test.ts
+++ b/test/badge-box-sync.test.ts
@@ -1,0 +1,37 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { getArena } from '../src/data/arenas'
+import { useBadgeBoxStore } from '../src/stores/badgeBox'
+import { usePlayerStore } from '../src/stores/player'
+
+describe('badge box sync', () => {
+  it('adds missing player badges into the box', () => {
+    setActivePinia(createPinia())
+    const player = usePlayerStore()
+    const badgeBox = useBadgeBoxStore()
+    const arena = getArena('arena20')
+    expect(arena).toBeDefined()
+
+    player.earnBadge('arena20')
+    expect(badgeBox.badges).toHaveLength(0)
+
+    badgeBox.syncWithPlayerBadges()
+
+    expect(badgeBox.badges).toEqual([arena!.badge])
+  })
+
+  it('does not duplicate badges already in the box', () => {
+    setActivePinia(createPinia())
+    const player = usePlayerStore()
+    const badgeBox = useBadgeBoxStore()
+    const arena = getArena('arena20')
+    expect(arena).toBeDefined()
+
+    player.earnBadge('arena20')
+    badgeBox.addBadge(arena!.badge)
+
+    badgeBox.syncWithPlayerBadges()
+
+    expect(badgeBox.badges).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure badge box includes player-earned badges when loading a save
- hydrate badge box at startup to sync missing badges
- test that badge box sync adds missing badges and avoids duplicates

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: snapshot & sorting tests)*

------
https://chatgpt.com/codex/tasks/task_e_688dd857e8b4832aadd16c6293f33a55