### PR TITLE
Reduce evolution speciality bonuses

### DIFF
--- a/changelog-fr.md
+++ b/changelog-fr.md
@@ -3,6 +3,12 @@
 Toutes les modifications importantes de ce projet seront documentées dans ce fichier.
 Le format s'inspire de [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
+## [0.3.9] - 2025-08-02
+
+### Modifié
+
+- Réduction des bonus de spécialité selon le stade d'évolution : 0 % pour les formes de base avec évolution, 5 % pour les évolutions, 10 % pour les évolutions de niveau 2 et 7 % pour les formes sans prédécesseur ni évolution.
+
 ## [0.3.5] - 2025-07-17
 
 ### Modifié

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.9] - 2025-08-02
+
+### Changed
+
+- Reduced evolution speciality bonuses: base forms with evolutions remain at 0%, first evolutions now receive a 5% boost, second evolutions 10%, and standalone forms without predecessors keep a 7% boost.
+
 ## [0.3.8] - 2025-07-18
 
 ### Added

--- a/src/constants/speciality.ts
+++ b/src/constants/speciality.ts
@@ -2,8 +2,8 @@ import type { Speciality } from '~/type'
 
 export const specialityBonus: Record<Speciality, number> = {
   legendary: 20,
-  unique: 10,
+  unique: 7,
   evolution0: 0,
-  evolution1: 10,
-  evolution2: 15,
+  evolution1: 5,
+  evolution2: 10,
 }

--- a/test/speciality-bonus.test.ts
+++ b/test/speciality-bonus.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { specialityBonus } from '../src/constants/speciality'
+
+describe('speciality bonus', () => {
+  it('applies reduced evolution bonuses', () => {
+    expect(specialityBonus.evolution0).toBe(0)
+    expect(specialityBonus.evolution1).toBe(5)
+    expect(specialityBonus.evolution2).toBe(10)
+  })
+
+  it('sets standalone bonuses', () => {
+    expect(specialityBonus.unique).toBe(7)
+    expect(specialityBonus.legendary).toBe(20)
+  })
+})


### PR DESCRIPTION
## Summary
- rebalance evolution speciality bonus percentages for a gentler progression
- cover speciality bonus values with a unit test
- document reduced bonuses in English and French changelogs

## Testing
- `pnpm exec eslint src/constants/speciality.ts test/speciality-bonus.test.ts changelog.md changelog-fr.md`
- `pnpm test:unit test/speciality-bonus.test.ts`
- `pnpm test:unit` *(fails: capture mechanics level 33, sort-evolution, sort-item, sort-shiny, useLangSwitch)*
- `pnpm typecheck` *(fails: 46 errors, e.g., map vue types, unattached properties, serializer signatures, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688dc48b0930832ab095df33aa907381