### PR TITLE
feat(village): add reusable village map

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -170,6 +170,7 @@ declare module 'vue' {
     UiTooltip: typeof import('./components/ui/Tooltip.vue')['default']
     UiTypingText: typeof import('./components/ui/TypingText.vue')['default']
     UpdateSnackbar: typeof import('./components/UpdateSnackbar.vue')['default']
+    VillageVillageMap: typeof import('./components/village/VillageMap.vue')['default']
     VillageZoneActions: typeof import('./components/village/ZoneActions.vue')['default']
     ZoneButtonVillage: typeof import('./components/zone/ButtonVillage.vue')['default']
     ZoneButtonWild: typeof import('./components/zone/ButtonWild.vue')['default']

--- a/src/components/village/VillageMap.spec.ts
+++ b/src/components/village/VillageMap.spec.ts
@@ -1,0 +1,48 @@
+import type { VillageZone } from '~/type'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import VillageMap from './VillageMap.vue'
+
+const baseVillage: VillageZone = {
+  id: 'test-village',
+  name: 'Test',
+  type: 'village',
+  villageType: 'basic',
+  position: { lat: 0, lng: 0 },
+  actions: [],
+  minLevel: 1,
+  pois: [
+    {
+      id: 'shop',
+      type: 'shop',
+      label: 'Shop',
+      position: { lat: 0, lng: 0 },
+      icon: 'i-carbon-shop',
+    },
+  ],
+}
+
+describe('village map', () => {
+  it('mounts and displays markers', () => {
+    const wrapper = mount(VillageMap, { props: { village: baseVillage } })
+    const markers = wrapper.element.querySelectorAll('.leaflet-marker-icon')
+    expect(markers.length).toBe(1)
+  })
+
+  it('emits select on marker click', async () => {
+    const wrapper = mount(VillageMap, { props: { village: baseVillage } })
+    const marker = wrapper.element.querySelector('.leaflet-marker-icon') as HTMLElement
+    marker.dispatchEvent(new Event('click'))
+    const events = wrapper.emitted('select')
+    expect(events).toBeTruthy()
+    expect(events![0][0].id).toBe('shop')
+  })
+
+  it('updates markers when village changes', async () => {
+    const wrapper = mount(VillageMap, { props: { village: baseVillage } })
+    const newVillage: VillageZone = { ...baseVillage, id: 'v2', pois: [] }
+    await wrapper.setProps({ village: newVillage })
+    const markers = wrapper.element.querySelectorAll('.leaflet-marker-icon')
+    expect(markers.length).toBe(0)
+  })
+})

--- a/src/components/village/VillageMap.vue
+++ b/src/components/village/VillageMap.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import type { VillagePOI, VillageZone } from '~/type'
+import { render } from 'vue'
+import { useLeafletMap } from '~/composables/leaflet/useLeafletMap'
+import { usePoiMarkers } from '~/composables/leaflet/usePoiMarkers'
+
+/**
+ * Interactive Leaflet map displaying points of interest for a village.
+ *
+ * @example
+ * <VillageMap :village="village" @select="onPoi" />
+ *
+ * ```ts
+ * const village: VillageZone = {
+ *   id: 'village-caca-boudin',
+ *   name: 'Village Caca-Boudin',
+ *   type: 'village',
+ *   villageType: 'basic',
+ *   position: { lat: 0, lng: 0 },
+ *   actions: [],
+ *   minLevel: 1,
+ *   pois: [
+ *     {
+ *       id: 'shop',
+ *       type: 'shop',
+ *       label: 'Shop du Village',
+ *       position: { lat: 0, lng: 0 },
+ *       icon: 'i-carbon-shop',
+ *     },
+ *   ],
+ * }
+ * ```
+ */
+const props = defineProps<{ readonly village: VillageZone }>()
+const emit = defineEmits<{
+  (e: 'select', poi: VillagePOI): void
+}>()
+
+const { mapRef, map, setTileLayer } = useLeafletMap({
+  center: [0, 0],
+  tileUrl: `/map/${props.village.id}/tiles/{z}/{x}/{y}.webp`,
+})
+const slots = useSlots()
+
+onMounted(() => {
+  const leaflet = map.value!
+  const markers = usePoiMarkers(leaflet)
+
+  function buildHtml(poi: VillagePOI): string {
+    if (slots.poi) {
+      const vnode = slots.poi({ poi })
+      const container = document.createElement('div')
+      render(vnode[0], container)
+      return container.innerHTML
+    }
+    if (poi.icon.startsWith('i-'))
+      return `<div class="${poi.icon} h-8 w-8"></div>`
+    return `<img src="${poi.icon}" alt="${poi.label}" class="h-8 w-8" />`
+  }
+
+  watch(
+    () => props.village,
+    (village) => {
+      markers.clear()
+      setTileLayer(`/map/${village.id}/tiles/{z}/{x}/{y}.webp`)
+      village.pois.forEach(poi => markers.add(poi, buildHtml(poi), p => emit('select', p)))
+    },
+    { immediate: true, deep: true },
+  )
+})
+</script>
+
+<template>
+  <div class="relative h-full w-full animate-fade-in animate-duration-300">
+    <div ref="mapRef" class="h-full w-full" aria-label="Village map" />
+  </div>
+</template>

--- a/src/composables/leaflet/useLeafletMap.ts
+++ b/src/composables/leaflet/useLeafletMap.ts
@@ -4,6 +4,7 @@ import { onMounted, onUnmounted, ref } from 'vue'
 
 export interface UseLeafletMapOptions {
   center?: LatLngExpression
+  tileUrl?: string
 }
 
 export function useLeafletMap(options: UseLeafletMapOptions = {}) {
@@ -49,14 +50,7 @@ export function useLeafletMap(options: UseLeafletMapOptions = {}) {
 
     mapRef.value!.style.background = '#508ed7'
 
-    tileLayer.value = new TileLayer('/map/main/tiles/{z}/{x}/{y}.webp', {
-      tileSize: 256,
-      minZoom: 0,
-      maxZoom: 4,
-      noWrap: true,
-    })
-
-    tileLayer.value.addTo(map.value!)
+    setTileLayer(options.tileUrl ?? '/map/main/tiles/{z}/{x}/{y}.webp')
 
     onUnmounted(() => {
       map.value?.remove()
@@ -64,5 +58,16 @@ export function useLeafletMap(options: UseLeafletMapOptions = {}) {
     })
   })
 
-  return { mapRef, map }
+  function setTileLayer(url: string) {
+    tileLayer.value?.remove()
+    tileLayer.value = new TileLayer(url, {
+      tileSize: 256,
+      minZoom: 0,
+      maxZoom: 4,
+      noWrap: true,
+    })
+    tileLayer.value.addTo(map.value!)
+  }
+
+  return { mapRef, map, setTileLayer }
 }

--- a/src/composables/leaflet/useLeafletMarker.ts
+++ b/src/composables/leaflet/useLeafletMarker.ts
@@ -10,6 +10,7 @@ export function useLeafletMarker(options: {
   anchorY?: number
   className?: string
   interactive?: boolean
+  title?: string
 }): Marker {
   const { map, position, iconUrl, html, className } = options
   const size = options.size || 48
@@ -32,6 +33,7 @@ export function useLeafletMarker(options: {
   const marker = new Marker(position, {
     interactive: options.interactive ?? true,
     icon,
+    title: options.title,
   })
 
   marker.addTo(map)

--- a/src/composables/leaflet/usePoiMarkers.ts
+++ b/src/composables/leaflet/usePoiMarkers.ts
@@ -1,0 +1,36 @@
+import type { Map as LeafletMap, Marker } from 'leaflet'
+import type { VillagePOI } from '~/type'
+import { onUnmounted } from 'vue'
+import { useLeafletMarker } from './useLeafletMarker'
+
+/**
+ * Manage a collection of Leaflet markers representing village points of interest.
+ */
+export function usePoiMarkers(map: LeafletMap) {
+  const markers: Marker[] = []
+
+  function clear() {
+    markers.forEach(m => m.remove())
+    markers.length = 0
+  }
+
+  function add(poi: VillagePOI, html: string, onSelect?: (poi: VillagePOI) => void) {
+    const marker = useLeafletMarker({
+      map,
+      position: [poi.position.lat, poi.position.lng],
+      html,
+      size: 48,
+      anchorY: 48,
+      interactive: true,
+      title: poi.label,
+    })
+    if (onSelect)
+      marker.on('click', () => onSelect(poi))
+    markers.push(marker)
+    return marker
+  }
+
+  onUnmounted(clear)
+
+  return { add, clear }
+}

--- a/src/data/zones/villages/village10.ts
+++ b/src/data/zones/villages/village10.ts
@@ -20,6 +20,7 @@ export const village10: Zone = {
   position: move.top(savage05.position, VILLAGE_OFFSET),
   attachedTo: savage05.id as SavageZoneId,
   minLevel: 10,
+  pois: [],
   actions: [],
   village: {
     shop: {

--- a/src/data/zones/villages/village100.ts
+++ b/src/data/zones/villages/village100.ts
@@ -39,6 +39,7 @@ export const village100: Zone = {
     { id: 'minigame', label: 'Mini-jeu' },
   ],
   minLevel: 100,
+  pois: [],
   village: {
     shop: {
       items: [

--- a/src/data/zones/villages/village20.ts
+++ b/src/data/zones/villages/village20.ts
@@ -25,6 +25,7 @@ export const village20: Zone = {
     { id: 'minigame', label: 'Mini-jeu' },
   ],
   minLevel: 20,
+  pois: [],
   arena: {
     get arena() { return arena20 },
     completed: false,

--- a/src/data/zones/villages/village40.ts
+++ b/src/data/zones/villages/village40.ts
@@ -31,6 +31,7 @@ export const village40: Zone = {
   attachedTo: savage35.id as SavageZoneId,
   actions: [],
   minLevel: 40,
+  pois: [],
   arena: {
     get arena() { return arena40 },
     completed: false,

--- a/src/data/zones/villages/village50.ts
+++ b/src/data/zones/villages/village50.ts
@@ -32,6 +32,29 @@ export const village50: Zone = {
   attachedTo: savage45.id as SavageZoneId,
   actions: [],
   minLevel: 50,
+  pois: [
+    {
+      id: 'shop',
+      type: 'shop',
+      label: 'Shop du Village',
+      position: { lat: 0, lng: 0 },
+      icon: 'i-carbon-shop',
+    },
+    {
+      id: 'arena',
+      type: 'arena',
+      label: 'Arène des Flageolets',
+      position: { lat: 10, lng: 5 },
+      icon: 'i-carbon-trophy',
+    },
+    {
+      id: 'minigame-xxx',
+      type: 'minigame',
+      label: 'Mini-jeu xxx',
+      position: { lat: -10, lng: -5 },
+      icon: 'i-carbon-game-console',
+    },
+  ],
   village: {
     shop: {
       items: [

--- a/src/data/zones/villages/village60.ts
+++ b/src/data/zones/villages/village60.ts
@@ -35,6 +35,7 @@ export const village60: Zone = {
     { id: 'minigame', label: 'Mini-jeu' },
   ],
   minLevel: 60,
+  pois: [],
   arena: {
     get arena() { return arena60 },
     completed: false,

--- a/src/data/zones/villages/village80.ts
+++ b/src/data/zones/villages/village80.ts
@@ -38,6 +38,7 @@ export const village80: Zone = {
   attachedTo: savage75.id as SavageZoneId,
   actions: [],
   minLevel: 80,
+  pois: [],
   arena: {
     get arena() { return arena80 },
     completed: false,

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -1,3 +1,4 @@
+import type { Component } from 'vue'
 import type { Arena } from './arena'
 import type { Item } from './item'
 import type { MiniGameId } from './minigame'
@@ -22,6 +23,20 @@ export interface ZoneArena {
 export interface Position {
   lat: number
   lng: number
+}
+
+export interface VillagePOI {
+  readonly id: string
+  readonly type: 'shop' | 'arena' | 'minigame' | string
+  readonly label: string
+  readonly position: Position
+  /**
+   * Icon representing the point of interest.
+   * May be an UnoCSS icon class or an image URL.
+   */
+  readonly icon: string | Component
+  /** Optional reference to domain data (shop, arena, etc.). */
+  readonly data?: unknown
 }
 
 interface BaseZone {
@@ -64,6 +79,8 @@ interface BaseNonSavageZone extends BaseZone {
 export interface VillageZone extends BaseNonSavageZone {
   type: 'village'
   villageType: VillageType
+  /** Points of interest displayed on the village map. */
+  readonly pois: readonly VillagePOI[]
 }
 
 interface NonVillageZone extends BaseNonSavageZone {


### PR DESCRIPTION
## Summary
- add strict VillagePOI types and extend VillageZone with POIs
- expose flexible tile layers and shared marker composable
- introduce reusable VillageMap component and sample data

## Testing
- `pnpm lint` *(fails: format/prettier in animations.css)*
- `pnpm typecheck` *(fails: missing types in unrelated modules)*
- `pnpm test:unit` *(fails: existing failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688de9d42194832a86bfa3d2134cc724