### PR TITLE
feat(settings): add interface preferences tab

### DIFF
--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -1,11 +1,75 @@
 <script setup lang="ts">
+import type { SavageZoneId, VillagePOI, VillageZone } from '~/type'
+import { storeToRefs } from 'pinia'
 import ZoneActions from '../village/ZoneActions.vue'
 
 const mobile = useMobileTabStore()
 
 const zone = useZoneStore()
 const panel = useMainPanelStore()
+const mini = useMiniGameStore()
+const progress = useZoneProgressStore()
+const trainerBattle = useTrainerBattleStore()
+const arena = useArenaStore()
+const dialog = useDialogStore()
+const player = usePlayerStore()
+const interfaceStore = useInterfaceStore()
 const { t } = useI18n()
+const { showVillagesOnMap } = storeToRefs(interfaceStore)
+
+const currentKing = computed(() =>
+  zone.current.hasKing ? zone.getKing(zone.current.id as SavageZoneId) : undefined,
+)
+const arenaCompleted = computed(() => progress.isArenaCompleted(zone.current.id))
+const currentArenaData = computed(() => {
+  const data = zone.current.arena?.arena
+  if (!data)
+    return undefined
+  return typeof data === 'function' ? data() : data
+})
+
+function onPoi(poi: VillagePOI) {
+  if (arena.inBattle)
+    return
+  switch (poi.type) {
+    case 'shop':
+      panel.showShop()
+      break
+    case 'minigame':
+      if (zone.current.miniGame)
+        mini.select(zone.current.miniGame)
+      panel.showMiniGame()
+      mobile.set('game')
+      break
+    case 'arena': {
+      const data = currentArenaData.value
+      if (!data)
+        return
+      if (arenaCompleted.value && !useDeveloperStore().debug)
+        return
+      const required = data.requiredBadgeId
+      if (required && !player.hasBadge(required))
+        return
+      arena.setArena(data)
+      dialog.resetArenaDialogs()
+      panel.showArena()
+      break
+    }
+    case 'poulailler':
+      panel.showPoulailler()
+      break
+    case 'king': {
+      const trainer = currentKing.value
+      if (!trainer)
+        return
+      trainerBattle.setQueue([trainer])
+      panel.showTrainerBattle()
+      break
+    }
+    default:
+      panel.showTrainerBattle()
+  }
+}
 
 function leaveVillage() {
   if (zone.current.attachedTo)
@@ -23,12 +87,18 @@ function leaveVillage() {
   >
     <div class="flex flex-col items-center gap-2">
       <UiImageByBackground
-        v-if="zone.current.image"
+        v-if="!showVillagesOnMap && zone.current.image"
         :src="zone.current.image"
         :alt="zone.current.name"
         class="aspect-video h-full max-h-60 w-full object-contain md:max-h-80"
       />
-      <ZoneActions />
+      <VillageMap
+        v-if="showVillagesOnMap"
+        :village="zone.current as VillageZone"
+        class="w-full flex-1"
+        @select="onPoi"
+      />
+      <ZoneActions v-else />
     </div>
   </LayoutTitledPanel>
 </template>

--- a/src/components/settings/InterfaceTab.i18n.yml
+++ b/src/components/settings/InterfaceTab.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  villagesOnMap: Afficher les villages sur la carte
+en:
+  villagesOnMap: Show villages on the map

--- a/src/components/settings/InterfaceTab.vue
+++ b/src/components/settings/InterfaceTab.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+
+const { t } = useI18n()
+const interfaceStore = useInterfaceStore()
+const { showVillagesOnMap } = storeToRefs(interfaceStore)
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <UiCheckBox
+      v-model="showVillagesOnMap"
+      :label="t('components.settings.InterfaceTab.villagesOnMap')"
+    />
+  </div>
+</template>

--- a/src/components/settings/SettingsModal.i18n.yml
+++ b/src/components/settings/SettingsModal.i18n.yml
@@ -4,6 +4,7 @@ fr:
     save: Sauvegarde
     language: Langue
     shortcuts: Raccourcis
+    interface: Interface
     support: Soutien
 en:
   title: Settings
@@ -11,4 +12,5 @@ en:
     save: Save
     language: Language
     shortcuts: Shortcuts
+    interface: Interface
     support: Support

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
+import InterfaceTab from './InterfaceTab.vue'
 import LanguageTab from './LanguageTab.vue'
 import SaveTab from './SaveTab.vue'
 import SettingsShortcutsTab from './ShortcutsTab.vue'
@@ -38,6 +39,7 @@ const tabs = computed(() => {
       }),
     },
     { label: { text: t('components.settings.SettingsModal.tabs.language'), icon: 'i-carbon-language' }, component: LanguageTab },
+    { label: { text: t('components.settings.SettingsModal.tabs.interface'), icon: 'i-carbon-display' }, component: InterfaceTab },
   ]
 
   if (!isMobile.value) {

--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia'
+
+/**
+ * User interface preferences.
+ * Controls optional UI behaviours.
+ */
+export const useInterfaceStore = defineStore('interface', () => {
+  /** Whether villages are displayed on an interactive map instead of buttons. */
+  const showVillagesOnMap = ref(true)
+
+  function setShowVillagesOnMap(value: boolean) {
+    showVillagesOnMap.value = value
+  }
+
+  return { showVillagesOnMap, setShowVillagesOnMap }
+}, {
+  persist: true,
+})


### PR DESCRIPTION
## Summary
- add interface preferences store to toggle village maps
- expose interface toggle in new settings tab
- switch village panel to map based on interface preference

## Testing
- `pnpm eslint src/components/panel/Village.vue src/components/settings/InterfaceTab.vue src/components/settings/SettingsModal.vue src/stores/interface.ts`
- `pnpm typecheck` (fails: Property 'category' does not exist on type 'Ball')
- `pnpm test:unit` (fails: 6 failed tests, 64 passed)


------
https://chatgpt.com/codex/tasks/task_e_688df2501668832a80c1748a1c054769