### PR TITLE
Close mobile zone panel and enlarge village markers

### DIFF
--- a/src/components/panel/Map.vue
+++ b/src/components/panel/Map.vue
@@ -5,7 +5,9 @@ import { storeToRefs } from 'pinia'
 import { onMounted, watch } from 'vue'
 
 const zone = useZoneStore()
+const mobileTab = useMobileTabStore()
 const { currentZoneId } = storeToRefs(zone)
+const { isMobile } = storeToRefs(useUIStore())
 const mapRef = ref<InstanceType<typeof LeafletMap> | null>(null)
 
 function onSelect(id: ZoneId) {
@@ -21,8 +23,10 @@ onMounted(() => {
   mapRef.value?.selectZone(currentZoneId.value)
 })
 
-watch(currentZoneId, (id) => {
+watch(currentZoneId, (id, oldId) => {
   mapRef.value?.selectZone(id)
+  if (isMobile.value && id !== oldId)
+    mobileTab.set('game')
 })
 </script>
 

--- a/src/components/village/Map.vue
+++ b/src/components/village/Map.vue
@@ -66,7 +66,7 @@ onMounted(() => {
       render(vnode[0], container)
       return container.innerHTML
     }
-    return `<img src="/icons/village/${poi.id}.webp" alt="${poi.label}" class="h-8 w-8" />`
+    return `<img src="/icons/village/${poi.id}.webp" alt="${poi.label}" class="h-16 w-16" />`
   }
 
   watch(

--- a/src/composables/leaflet/usePoiMarkers.ts
+++ b/src/composables/leaflet/usePoiMarkers.ts
@@ -19,8 +19,8 @@ export function usePoiMarkers(map: LeafletMap) {
       map,
       position: [poi.position.lat, poi.position.lng],
       html,
-      size: 48,
-      anchorY: 48,
+      size: 96,
+      anchorY: 96,
       interactive: true,
       title: poi.label,
     })

--- a/test/panel-map-mobile-close.test.ts
+++ b/test/panel-map-mobile-close.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable import/first */
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { useMobileTabStore } from '../src/stores/mobileTab'
+import { useZoneStore } from '../src/stores/zone'
+
+vi.mock('../src/components/leaflet/map.vue', () => ({
+  default: defineComponent({
+    emits: ['select'],
+    setup(_, { expose }) {
+      function selectZone() {}
+      expose({ selectZone })
+      return () => h('div')
+    },
+  }),
+}))
+
+import PanelMap from '../src/components/panel/Map.vue'
+
+describe('panel map mobile behaviour', () => {
+  it('closes zones panel on mobile after selecting a village', async () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: true,
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as any
+
+    const wrapper = mount(PanelMap, {
+      global: {
+        stubs: {
+          ZonePrevButton: true,
+          ZoneNextButton: true,
+          UiProgressBar: true,
+        },
+      },
+    })
+
+    const zone = useZoneStore()
+    const mobileTab = useMobileTabStore()
+    mobileTab.set('zones')
+
+    zone.setZone(zone.zones[1].id)
+    await nextTick()
+
+    expect(mobileTab.current).toBe('game')
+
+    wrapper.unmount()
+    window.matchMedia = originalMatchMedia
+  })
+})


### PR DESCRIPTION
## Summary
- auto-close zones map panel on mobile when a village is entered
- double village map marker icon size for better touch targeting
- verify mobile panel closes via unit test

## Testing
- `pnpm exec eslint src/components/panel/Map.vue src/components/village/Map.vue src/composables/leaflet/usePoiMarkers.ts test/panel-map-mobile-close.test.ts`
- `pnpm test test/panel-map-mobile-close.test.ts --run`
- `pnpm test --run` *(fails: snapshot and other unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_688e2fa172ec832aaa0f96a289163bad