### PR TITLE
fix(interface): show classic village view by default

### DIFF
--- a/src/stores/interface.ts
+++ b/src/stores/interface.ts
@@ -5,8 +5,11 @@ import { defineStore } from 'pinia'
  * Controls optional UI behaviours.
  */
 export const useInterfaceStore = defineStore('interface', () => {
-  /** Whether villages are displayed on an interactive map instead of buttons. */
-  const showVillagesOnMap = ref(true)
+  /**
+   * Whether villages are displayed on an interactive map instead of buttons.
+   * Defaults to the classic button view.
+   */
+  const showVillagesOnMap = ref(false)
 
   function setShowVillagesOnMap(value: boolean) {
     showVillagesOnMap.value = value

--- a/test/interface-store.test.ts
+++ b/test/interface-store.test.ts
@@ -1,0 +1,18 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useInterfaceStore } from '../src/stores/interface'
+
+describe('interface store', () => {
+  it('defaults to classic villages view', () => {
+    setActivePinia(createPinia())
+    const store = useInterfaceStore()
+    expect(store.showVillagesOnMap).toBe(false)
+  })
+
+  it('updates map preference', () => {
+    setActivePinia(createPinia())
+    const store = useInterfaceStore()
+    store.setShowVillagesOnMap(true)
+    expect(store.showVillagesOnMap).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- revert village display to classic buttons by default instead of Leaflet map
- add unit tests for interface store map preference

## Testing
- `pnpm exec eslint src/stores/interface.ts test/interface-store.test.ts`
- `pnpm test:unit --run` *(fails: capture mechanics, header snapshot, sort evolutions/items/shiny, language switch, zone panel)*

------
https://chatgpt.com/codex/tasks/task_e_688e3931eb98832ab5f28198aa13c6e2