### PR TITLE
refactor(event): simplify event listeners storage

### DIFF
--- a/src/stores/event.ts
+++ b/src/stores/event.ts
@@ -9,26 +9,21 @@ export interface EventMap {
   'battle:end': void
 }
 
-export type EventCallback<T = unknown> = (payload: T) => void
+export type EventCallback<T = unknown> = (payload?: T) => void
 
 export const useEventStore = defineStore('event', () => {
-  const listeners = new Map<
-    keyof EventMap,
-    Set<EventCallback<EventMap[keyof EventMap]>>
-  >()
+  const listeners: { [K in keyof EventMap]?: Set<EventCallback<EventMap[K]>> } = {}
 
   function on<K extends keyof EventMap>(event: K, cb: EventCallback<EventMap[K]>) {
-    if (!listeners.has(event))
-      listeners.set(event, new Set())
-    listeners.get(event)!.add(cb as EventCallback<EventMap[keyof EventMap]>)
+    (listeners[event] ||= new Set()).add(cb)
   }
 
   function off<K extends keyof EventMap>(event: K, cb: EventCallback<EventMap[K]>) {
-    listeners.get(event)?.delete(cb as EventCallback<EventMap[keyof EventMap]>)
+    listeners[event]?.delete(cb)
   }
 
   function emit<K extends keyof EventMap>(event: K, payload?: EventMap[K]) {
-    listeners.get(event)?.forEach(cb => cb(payload as EventMap[K]))
+    listeners[event]?.forEach(cb => cb(payload))
   }
 
   return { on, off, emit }


### PR DESCRIPTION
## Summary
- replace Map with typed listener object for event bus
- remove event callback casts and streamline on/off/emit

## Testing
- `pnpm typecheck` *(fails: Property 'category' does not exist on type 'Ball', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688e905b7a1c832a9aebb742162fe7ab