### PR TITLE
refactor: validate locale with type guard

### DIFF
--- a/src/pages/root.vue
+++ b/src/pages/root.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
+import type { Locale } from '~/constants/locales'
 import { availableLocales, defaultLocale } from '~/constants/locales'
 import { useLocaleStore } from '~/stores/locale'
 
 const router = useRouter()
 const store = useLocaleStore()
 
+/**
+ * Check whether a given value is a supported locale.
+ */
+function isLocale(value: string | null): value is Locale {
+  return value !== null && availableLocales.includes(value as Locale)
+}
+
 onMounted(() => {
   const stored = store.locale || localStorage.getItem('locale')
   const nav = navigator.language.toLowerCase()
   const fallback = nav.startsWith('fr') ? 'fr' : defaultLocale
-  const target = availableLocales.includes(stored as any) ? stored as string : fallback
+  const target = isLocale(stored) ? stored : fallback
   router.replace({ path: `/${target}` })
 })
 


### PR DESCRIPTION
## Summary
- ensure stored locale matches supported locales via `isLocale` guard
- remove unnecessary `as any` casts in root page

## Testing
- `pnpm typecheck` *(fails: TS2339, TS2345, TS2339...)*

------
https://chatgpt.com/codex/tasks/task_e_688e9669182c832ab2a173ea4bae966e