### PR TITLE
Fix translation of ball names in selection modal

### DIFF
--- a/src/components/ball/SelectionModal.vue
+++ b/src/components/ball/SelectionModal.vue
@@ -34,11 +34,11 @@ function choose(id: BallId) {
       >
         <img
           :src="ball.image"
-          :alt="ball.name"
+          :alt="t(ball.name)"
           class="h-8 w-8"
           :style="{ filter: `hue-rotate(${ballHues[ball.id]})` }"
         >
-        {{ ball.name }} (x{{ ball.qty }})
+        {{ t(ball.name) }} (x{{ ball.qty }})
       </UiButton>
     </div>
   </UiModal>


### PR DESCRIPTION
## Summary
- translate ball selection names and alt text using the i18n `t()` helper

## Testing
- `pnpm exec eslint src/components/ball/SelectionModal.vue && echo "Lint passed"`
- `pnpm lint` *(fails: yaml/quotes errors in locales/en.yml)*
- `pnpm typecheck` *(fails: TypeScript errors in various files)*
- `pnpm test:unit` *(fails: multiple failing tests and snapshots)*

------
https://chatgpt.com/codex/tasks/task_e_688e98fb05e0832a9984eb5fde848c25