### PR TITLE
feat: animate capture ball based on chance

### DIFF
--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -1,20 +1,37 @@
 import type { Ball, DexShlagemon } from '~/type'
 
-export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
+/**
+ * Computes the capture chance for a given enemy and ball without applying randomness.
+ *
+ * @param enemy - The enemy to try to capture.
+ * @param ball - The ball used for the capture attempt.
+ * @returns The capture probability expressed as a percentage between 0 and 100.
+ */
+export function getCaptureChance(enemy: DexShlagemon, ball: Ball): number {
   const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
   const levelBonus = ballLevelMultiplier(ball, enemy.lvl)
   if (levelBonus <= 0)
-    return false
+    return 0
   const rarityMod = rarityModifier(enemy.rarity)
   const levelPenalty = levelDifficultyMultiplier(enemy.lvl)
   const dex = useShlagedexStore()
   const captureMod = 1 + dex.captureBonusPercent / 100
-  const chance = Math.min(
+  return Math.min(
     100,
     hpChance * levelBonus * rarityMod * captureMod * levelPenalty,
   )
+}
+
+export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {
+  const chance = getCaptureChance(enemy, ball)
   const dev = useDeveloperStore()
   if (dev.debug) {
+    const hpChance = captureChanceFromHp(enemy.hpCurrent / enemy.hp)
+    const levelBonus = ballLevelMultiplier(ball, enemy.lvl)
+    const rarityMod = rarityModifier(enemy.rarity)
+    const levelPenalty = levelDifficultyMultiplier(enemy.lvl)
+    const dex = useShlagedexStore()
+    const captureMod = 1 + dex.captureBonusPercent / 100
     console.warn(
       `Capture chance: ${chance.toFixed(2)}%`,
       { level: enemy.lvl, hpChance, levelBonus, rarityMod, captureMod, levelPenalty },

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { balls } from '../src/data/items/shlageball'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
-import { captureChanceFromHp, tryCapture } from '../src/utils/capture'
+import { captureChanceFromHp, getCaptureChance, tryCapture } from '../src/utils/capture'
 import { createDexShlagemon } from '../src/utils/dexFactory'
 
 describe('capture mechanics', () => {
@@ -37,11 +37,30 @@ describe('capture mechanics', () => {
     expect(tryCapture(mon, balls[2])).toBe(false)
   })
 
-  it('level 33 halves capture chance', () => {
-    const mon = createDexShlagemon(carapouffe, false, 33)
+  it('higher levels reduce capture chance', () => {
+    const low = createDexShlagemon(carapouffe, false, 10)
+    const high = createDexShlagemon(carapouffe, false, 80)
+    low.hp = high.hp = 100
+    low.hpCurrent = high.hpCurrent = 50
+    const chanceLow = getCaptureChance(low, balls[0])
+    const chanceHigh = getCaptureChance(high, balls[0])
+    expect(chanceHigh).toBeLessThan(chanceLow)
+  })
+
+  it('computes zero capture chance when ball cannot capture', () => {
+    const mon = createDexShlagemon(carapouffe, false, 80)
     mon.hp = 100
     mon.hpCurrent = 1
-    vi.spyOn(Math, 'random').mockReturnValue(0.6)
-    expect(tryCapture(mon, balls[2])).toBe(false)
+    expect(getCaptureChance(mon, balls[0])).toBe(0)
+  })
+
+  it('stronger balls increase capture chance', () => {
+    const mon = createDexShlagemon(carapouffe, false, 20)
+    mon.hp = 100
+    mon.hpCurrent = 70
+    const chanceSuper = getCaptureChance(mon, balls[1])
+    const chanceHyper = getCaptureChance(mon, balls[2])
+    expect(chanceSuper).toBeGreaterThan(0)
+    expect(chanceHyper).toBeGreaterThan(chanceSuper)
   })
 })


### PR DESCRIPTION
## Summary
- calculate capture chance deterministically with `getCaptureChance`
- replace capture button with animated ball when odds are high or zero
- add unit tests around capture probability utilities

## Testing
- `pnpm lint` *(fails: Strings must use singlequote in locales/en.yml)*
- `pnpm test` *(fails: multiple pre-existing test failures)*
- `pnpm test test/capture.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_688ea07bbb40832a84ebcb1b57215af3