### PR TITLE
fix(battle): show owned ball in wild encounters

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -40,6 +40,10 @@ const showOwnedBall = computed(() =>
   zone.current.type === 'sauvage' && panel.current === 'battle',
 )
 
+const enemyOwned = computed<boolean>(() =>
+  displayedEnemy.value ? dex.capturedBaseIds.has(displayedEnemy.value.base.id) : false,
+)
+
 const {
   playerHp,
   enemyHp,
@@ -232,6 +236,7 @@ function onClick(_e: MouseEvent) {
             :fainted="enemyFainted"
             :flash="flashEnemy"
             :show-ball="showOwnedBall"
+            :owned="enemyOwned"
             @faint-end="onEnemyFaintEnd"
           >
             <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />

--- a/test/owned-ball.test.ts
+++ b/test/owned-ball.test.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import BattleRound from '../src/components/battle/Round.vue'
+import BattleShlagemon from '../src/components/battle/Shlagemon.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useMainPanelStore } from '../src/stores/mainPanel'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { useZoneStore } from '../src/stores/zone'
+
+describe('battle round enemy owned indicator', () => {
+  it('passes owned prop when enemy is already captured', async () => {
+    vi.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const zone = useZoneStore()
+    const panel = useMainPanelStore()
+    zone.setZone('plaine-kekette')
+    panel.current = 'battle'
+    const captured = dex.createShlagemon(carapouffe)
+    dex.addShlagemon(captured)
+    const player = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(player)
+    const enemy = dex.createShlagemon(carapouffe)
+    const wrapper = mount(BattleRound, {
+      props: { player, enemy },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          BattleAttackCursor: true,
+          BattleToast: true,
+          ShlagemonXpBar: true,
+          EffectBadge: true,
+          DiseaseBadge: true,
+          InventoryWearableItemIcon: true,
+          ShlagemonImage: true,
+          UiTooltip: { template: '<div><slot /></div>' },
+          UiProgressBar: true,
+        },
+      },
+    })
+    await nextTick()
+    const shlagemons = wrapper.findAllComponents(BattleShlagemon)
+    const enemyComp = shlagemons.at(1)!
+    expect(enemyComp.props('owned')).toBe(true)
+    expect(enemyComp.props('showBall')).toBe(true)
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- ensure owned wild Schlagémon display capture ball indicator
- test enemy owned indicator in battles

## Testing
- `pnpm test test/owned-ball.test.ts --run`
- `pnpm test` *(fails: expected false to be true, snapshot mismatch, import ordering, and other unrelated test failures)*


------
https://chatgpt.com/codex/tasks/task_e_688ea30686a8832ab8dab23ec1e9cbc6