### PR TITLE
fix: show owned ball in wild battles

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -35,10 +35,7 @@ const nextPlayer = ref<DexShlagemon | null>(null)
 const displayedEnemy = ref(props.enemy)
 const nextEnemy = ref<DexShlagemon | null>(null)
 
-const panel = useMainPanelStore()
-const showOwnedBall = computed(() =>
-  zone.current.type === 'sauvage' && panel.current === 'battle',
-)
+const showOwnedBall = computed(() => zone.current.type === 'sauvage')
 
 const enemyOwned = computed<boolean>(() =>
   displayedEnemy.value ? dex.capturedBaseIds.has(displayedEnemy.value.base.id) : false,

--- a/test/owned-ball.test.ts
+++ b/test/owned-ball.test.ts
@@ -18,7 +18,8 @@ describe('battle round enemy owned indicator', () => {
     const zone = useZoneStore()
     const panel = useMainPanelStore()
     zone.setZone('plaine-kekette')
-    panel.current = 'battle'
+    await nextTick()
+    panel.current = 'trainerBattle'
     const captured = dex.createShlagemon(carapouffe)
     dex.addShlagemon(captured)
     const player = dex.createShlagemon(carapouffe)


### PR DESCRIPTION
## Summary
- ensure owned ball icon always shows in wild encounters
- cover owned ball indicator behavior when panel state changes

## Testing
- `npx eslint src/components/battle/Round.vue test/owned-ball.test.ts`
- `pnpm lint src/components/battle/Round.vue test/owned-ball.test.ts` *(fails: Attribute "role" should go before "@click", etc.)*
- `pnpm typecheck` *(fails: Argument of type 'string' is not assignable to parameter of type 'Locale', etc.)*
- `pnpm test:unit test/owned-ball.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f1797de90832a9778753fa0422e96