### PR TITLE
refactor: restructure village POIs and zones

### DIFF
--- a/src/components/developer/SettingsModal.vue
+++ b/src/components/developer/SettingsModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getArena } from '~/data/arenas'
+import { getArenaByZoneId } from '~/data/arenas'
 import { allShlagemons } from '~/data/shlagemons'
 import { applyCurrentStats, applyStats, xpForLevel } from '~/utils/dexFactory'
 
@@ -90,24 +90,16 @@ function resetLevel() {
 }
 
 function completeArena(id: string) {
-  const arena = getArena(id)
+  const arena = getArenaByZoneId(id)
   if (!arena)
     return
   player.earnBadge(arena.id)
-  progress.completeArena(id)
   zone.completeArena(id)
 }
 
 function resetArenas() {
   player.reset()
   progress.reset()
-  zone.zones.forEach((z) => {
-    if (z.type === 'village') {
-      const poi = z.pois.find(p => p.type === 'arena')
-      if (poi?.arena)
-        poi.arena.completed = false
-    }
-  })
 }
 </script>
 

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -8,7 +8,6 @@ const emit = defineEmits(['done'])
 const arena = useArenaStore()
 const player = usePlayerStore()
 const panel = useMainPanelStore()
-const progress = useZoneProgressStore()
 const zone = useZoneStore()
 const badgeBox = useBadgeBoxStore()
 const preparationMusic = getArenaTrack('preparation') ?? '/audio/musics/arenas/preparation.ogg'
@@ -20,7 +19,6 @@ function collectBadge() {
     return
   player.earnBadge(arena.arenaData.id)
   badgeBox.addBadge(arena.arenaData.badge)
-  progress.completeArena(zone.current.id)
   zone.completeArena(zone.current.id)
   toast.success(`Badge ${arena.arenaData.badge.name} obtenu !`)
   arena.reset()

--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -2,6 +2,7 @@
 import type VillageMap from '../village/Map.vue'
 import type { SavageZoneId, VillagePOI, VillageZone } from '~/type'
 import { storeToRefs } from 'pinia'
+import { getArenaByZoneId } from '~/data/arenas'
 import ZoneActions from '../village/ZoneActions.vue'
 
 const mobile = useMobileTabStore()
@@ -20,7 +21,7 @@ const { showVillagesOnMap } = storeToRefs(interfaceStore)
 
 const mapRef = ref<InstanceType<typeof VillageMap> | null>(null)
 const activePoiId = ref<string | null>(null)
-const pois = computed(() => (zone.current as VillageZone).pois)
+const pois = computed(() => Object.values((zone.current as VillageZone).pois))
 const currentIndex = computed(() => pois.value.findIndex(p => p.id === activePoiId.value))
 
 const prevDisabled = computed(() => currentIndex.value <= 0)
@@ -50,21 +51,15 @@ watch(() => zone.current.id, () => {
 })
 
 const kingPoi = computed(() =>
-  (zone.current as VillageZone).pois.find(p => p.type === 'king'),
+  (zone.current as VillageZone).pois.king,
 )
 const currentKing = computed(() =>
   kingPoi.value ? zone.getKing(zone.current.id as SavageZoneId) : undefined,
 )
-const arenaPoi = computed(() =>
-  (zone.current as VillageZone).pois.find(p => p.type === 'arena'),
-)
 const arenaCompleted = computed(() => progress.isArenaCompleted(zone.current.id))
-const currentArenaData = computed(() => {
-  const data = arenaPoi.value?.arena?.arena
-  if (!data)
-    return undefined
-  return typeof data === 'function' ? data() : data
-})
+const currentArenaData = computed(() =>
+  zone.current.type === 'village' ? getArenaByZoneId(zone.current.id) : undefined,
+)
 
 function onPoi(poi: VillagePOI) {
   if (arena.inBattle)

--- a/src/components/village/Map.vue
+++ b/src/components/village/Map.vue
@@ -22,17 +22,16 @@ import { usePoiMarkers } from '~/composables/leaflet/usePoiMarkers'
  *     min: { lat: -10, lng: -10 },
  *     max: { lat: 10, lng: 10 },
  *   },
- *   actions: [],
  *   minLevel: 1,
- *   pois: [
- *     {
+ *   pois: {
+ *     shop: {
  *       id: 'shop',
  *       type: 'shop',
  *       label: 'Shop du Village',
  *       position: { lat: 0, lng: 0 },
  *       items: [],
  *     },
- *   ],
+ *   },
  * }
  * ```
  */
@@ -79,7 +78,7 @@ onMounted(() => {
         [village.map.min.lat, village.map.min.lng],
         [village.map.max.lat, village.map.max.lng],
       ])
-      village.pois.forEach(poi => markers.add(poi, buildHtml(poi), p => emit('select', p)))
+      Object.values(village.pois).forEach(poi => markers.add(poi, buildHtml(poi), p => emit('select', p)))
       markers.highlight(props.activePoiId ?? undefined)
     },
     { immediate: true, deep: true },
@@ -90,7 +89,7 @@ onMounted(() => {
     (id) => {
       markers.highlight(id ?? undefined)
       if (id) {
-        const poi = props.village.pois.find(p => p.id === id)
+        const poi = props.village.pois[id]
         if (poi)
           map.value?.panTo([poi.position.lat, poi.position.lng])
       }
@@ -104,7 +103,7 @@ onMounted(() => {
 
 function getTarget() {
   if (props.activePoiId) {
-    const poi = props.village.pois.find(p => p.id === props.activePoiId)
+    const poi = props.village.pois[props.activePoiId]
     if (poi)
       return poi.position
   }

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { SavageZoneId } from '~/type'
+import { getArenaByZoneId } from '~/data/arenas'
 
 const zone = useZoneStore()
 const panel = useMainPanelStore()
@@ -14,35 +15,32 @@ const { t } = useI18n()
 
 const hasKing = computed(() =>
   zone.current.type === 'sauvage'
-  || (zone.current.type === 'village' && zone.current.pois.some(p => p.type === 'king')),
+  || (zone.current.type === 'village' && 'king' in zone.current.pois),
 )
 const arenaPoi = computed(() =>
   zone.current.type === 'village'
-    ? zone.current.pois.find(p => p.type === 'arena')
+    ? zone.current.pois.arena
     : undefined,
 )
 const hasArena = computed(() => !!arenaPoi.value)
 const shopPoi = computed(() =>
   zone.current.type === 'village'
-    ? zone.current.pois.find(p => p.type === 'shop')
+    ? zone.current.pois.shop
     : undefined,
 )
 const miniGamePoi = computed(() =>
   zone.current.type === 'village'
-    ? zone.current.pois.find(p => p.type === 'minigame')
+    ? zone.current.pois.minigame
     : undefined,
 )
 const hasPoulailler = computed(() =>
   zone.current.type === 'village'
-  && zone.current.pois.some(p => p.type === 'poulailler'),
+  && 'poulailler' in zone.current.pois,
 )
 const arenaCompleted = computed(() => progress.isArenaCompleted(zone.current.id))
-const currentArenaData = computed(() => {
-  const data = arenaPoi.value?.arena?.arena
-  if (!data)
-    return undefined
-  return typeof data === 'function' ? data() : data
-})
+const currentArenaData = computed(() =>
+  zone.current.type === 'village' ? getArenaByZoneId(zone.current.id) : undefined,
+)
 const canOpenArena = computed(() => {
   if (!currentArenaData.value)
     return false

--- a/src/components/zone/ButtonVillage.vue
+++ b/src/components/zone/ButtonVillage.vue
@@ -72,7 +72,7 @@ function classes() {
       <div
         v-else-if="
           props.zone.type === 'village'
-            && props.zone.pois.some(p => p.type === 'arena')
+            && 'arena' in props.zone.pois
         "
         class="i-mdi:sword-cross h-4 w-4 opacity-50 grayscale"
       />

--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -74,7 +74,7 @@ export function useMapMarkers(map: LeafletMap) {
       const crown = kingDefeated.value ? '<div class="i-game-icons:crown h-3 w-3"></div>' : ''
       const arena = arenaCompleted.value
         ? '<div class="i-mdi:sword-cross h-3 w-3"></div>'
-        : zone.type === 'village' && zone.pois.some(p => p.type === 'arena')
+        : zone.type === 'village' && 'arena' in zone.pois
           ? '<div class="i-mdi:sword-cross h-3 w-3 opacity-50 grayscale"></div>'
           : ''
       const icons = [ball, crown, arena].filter(Boolean).join('')

--- a/src/composables/useShopTabs.ts
+++ b/src/composables/useShopTabs.ts
@@ -14,8 +14,9 @@ export function useShopTabs(selectItem: (item: Item) => void) {
   const { t } = useI18n()
 
   const shopItems = computed(() => {
-    const poi = zone.current.pois?.find(p => p.type === 'shop')
-    return poi?.items || []
+    if (zone.current.type !== 'village')
+      return []
+    return zone.current.pois.shop?.items || []
   })
 
   const categoryOptions = [

--- a/src/composables/useZoneCompletion.ts
+++ b/src/composables/useZoneCompletion.ts
@@ -26,8 +26,8 @@ export function useZoneCompletion(zone: Zone) {
 
   const kingDefeated = computed(() => {
     const hasKing
-      = zone.type === 'sauvage'
-        || (zone.type === 'village' && zone.pois.some(p => p.type === 'king'))
+        = zone.type === 'sauvage'
+          || (zone.type === 'village' && 'king' in zone.pois)
     return hasKing && progress.isKingDefeated(zone.id)
   })
 

--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -83,7 +83,7 @@ export const arena40: Arena = createArena({
 
 export const arena60: Arena = createArena({
   id: 'arena60',
-  zoneId: 'village-paume',
+  zoneId: 'village-cassos-land',
   character: profMerdant,
   level: 61,
   badge: {
@@ -97,7 +97,7 @@ export const arena60: Arena = createArena({
 
 export const arena80: Arena = createArena({
   id: 'arena80',
-  zoneId: 'village-paume',
+  zoneId: 'village-clitoland',
   character: profMerdant,
   level: 81,
   badge: {
@@ -118,4 +118,17 @@ export const arenas: Arena[] = [
 
 export function getArena(id: string): Arena | undefined {
   return arenas.find(a => a.id === id)
+}
+
+/** Mapping of arena zones by their associated village identifier. */
+const arenaByZoneId: Record<string, Arena> = {
+  'village-boule': arena20,
+  'village-paume': arena40,
+  'village-cassos-land': arena60,
+  'village-clitoland': arena80,
+}
+
+/** Retrieve an arena configuration using a village zone identifier. */
+export function getArenaByZoneId(zoneId: string): Arena | undefined {
+  return arenaByZoneId[zoneId]
 }

--- a/src/data/zones/villages/village10.ts
+++ b/src/data/zones/villages/village10.ts
@@ -25,8 +25,8 @@ export const village10: Zone = {
   },
   attachedTo: savage05.id as SavageZoneId,
   minLevel: 10,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop du Village',
@@ -41,5 +41,5 @@ export const village10: Zone = {
         shlageball,
       ],
     },
-  ],
+  },
 }

--- a/src/data/zones/villages/village100.ts
+++ b/src/data/zones/villages/village100.ts
@@ -41,8 +41,8 @@ export const village100: Zone = {
   },
   attachedTo: savage95.id as SavageZoneId,
   minLevel: 100,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop du Village',
@@ -75,18 +75,18 @@ export const village100: Zone = {
         fabulousPotion,
       ],
     },
-    {
+    arena: {
       id: 'arena',
       type: 'arena',
       label: 'Arène du Village',
       position: { lat: -173.0700852564047, lng: 54.829043706440956 },
     },
-    {
+    minigame: {
       id: 'minigame',
       type: 'minigame',
       label: 'Mini-jeu',
       position: { lat: -103.04004672405347, lng: 73.65783750714516 },
       miniGame: 'shlagpairs',
     },
-  ],
+  },
 }

--- a/src/data/zones/villages/village20.ts
+++ b/src/data/zones/villages/village20.ts
@@ -11,7 +11,6 @@ import {
 } from '~/data/items'
 import { shlageball } from '~/data/items/shlageball'
 import { move } from '~/utils/position'
-import { arena20 } from '../../arenas'
 import { savage15 } from '../savages/15-ravin-fesse-molle'
 
 export const village20: Zone = {
@@ -27,8 +26,8 @@ export const village20: Zone = {
   },
   attachedTo: savage15.id as SavageZoneId,
   minLevel: 20,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop du Village',
@@ -44,22 +43,18 @@ export const village20: Zone = {
         specialPotion,
       ],
     },
-    {
+    arena: {
       id: 'arena',
       type: 'arena',
       label: 'Arène du Village',
       position: { lat: -95.74953852889057, lng: 154.42777039911124 },
-      arena: {
-        get arena() { return arena20 },
-        completed: false,
-      },
     },
-    {
+    minigame: {
       id: 'minigame',
       type: 'minigame',
       label: 'Mini-jeu',
       position: { lat: -113.82454584408723, lng: 69.16446745959803 },
       miniGame: 'tictactoe',
     },
-  ],
+  },
 }

--- a/src/data/zones/villages/village40.ts
+++ b/src/data/zones/villages/village40.ts
@@ -19,7 +19,6 @@ import {
 } from '~/data/items'
 import { shlageball, superShlageball } from '~/data/items/shlageball'
 import { move } from '~/utils/position'
-import { arena40 } from '../../arenas'
 import { savage35 } from '../savages/35-route-du-nawak'
 
 export const village40: Zone = {
@@ -35,8 +34,8 @@ export const village40: Zone = {
   },
   attachedTo: savage35.id as SavageZoneId,
   minLevel: 40,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop du Village',
@@ -61,22 +60,18 @@ export const village40: Zone = {
         mysteriousPotion,
       ],
     },
-    {
+    arena: {
       id: 'arena',
       type: 'arena',
       label: 'Arène du Village',
       position: { lat: -92.54040358702598, lng: 106.11098650533404 },
-      arena: {
-        get arena() { return arena40 },
-        completed: false,
-      },
     },
-    {
+    minigame: {
       id: 'minigame',
       type: 'minigame',
       label: 'Mini-jeu',
       position: { lat: -133.93798499659755, lng: 190.74887868514963 },
       miniGame: 'battleship',
     },
-  ],
+  },
 }

--- a/src/data/zones/villages/village50.ts
+++ b/src/data/zones/villages/village50.ts
@@ -36,8 +36,8 @@ export const village50: Zone = {
   },
   attachedTo: savage45.id as SavageZoneId,
   minLevel: 50,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop du Village',
@@ -64,24 +64,24 @@ export const village50: Zone = {
         defibrillator,
       ],
     },
-    {
+    arena: {
       id: 'arena',
       type: 'arena',
       label: 'Arène des Flageolets',
       position: { lat: -164.06202154659638, lng: 156.93085810742366 },
     },
-    {
+    minigame: {
       id: 'minigame',
       type: 'minigame',
       label: 'Mini-jeu',
       position: { lat: -34.5505474676239, lng: 173.4937918691157 },
       miniGame: 'taquin',
     },
-    {
+    poulailler: {
       id: 'poulailler',
       type: 'poulailler',
       label: 'Poulailler',
       position: { lat: -128.86990141619194, lng: 127.53694175172706 },
     },
-  ],
+  },
 }

--- a/src/data/zones/villages/village60.ts
+++ b/src/data/zones/villages/village60.ts
@@ -21,7 +21,6 @@ import {
 } from '~/data/items'
 import { shlageball, superShlageball } from '~/data/items/shlageball'
 import { move } from '~/utils/position'
-import { arena60 } from '../../arenas'
 import { savage55 } from '../savages/55-vallee-des-chieurs'
 
 export const village60: Zone = {
@@ -37,8 +36,8 @@ export const village60: Zone = {
   },
   attachedTo: savage55.id as SavageZoneId,
   minLevel: 60,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop du Village',
@@ -65,22 +64,18 @@ export const village60: Zone = {
         mysteriousPotion,
       ],
     },
-    {
+    arena: {
       id: 'arena',
       type: 'arena',
       label: 'Arène du Village',
       position: { lat: -189.51209405836568, lng: 169.24977339340174 },
-      arena: {
-        get arena() { return arena60 },
-        completed: false,
-      },
     },
-    {
+    minigame: {
       id: 'minigame',
       type: 'minigame',
       label: 'Mini-jeu',
       position: { lat: -96.4523891083971, lng: 134.07193303489305 },
       miniGame: 'connectfour',
     },
-  ],
+  },
 }

--- a/src/data/zones/villages/village80.ts
+++ b/src/data/zones/villages/village80.ts
@@ -1,6 +1,5 @@
 import type { SavageZoneId, Zone } from '~/type'
 import { VILLAGE_OFFSET } from '~/constants/zone'
-import { arena80 } from '~/data/arenas'
 import {
   attackPotion,
   capturePotion,
@@ -42,8 +41,8 @@ export const village80: Zone = {
   },
   attachedTo: savage75.id as SavageZoneId,
   minLevel: 80,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop du Village',
@@ -76,22 +75,18 @@ export const village80: Zone = {
         fabulousPotion,
       ],
     },
-    {
+    arena: {
       id: 'arena',
       type: 'arena',
       label: 'Arène du Village',
       position: { lat: -153.48079278373268, lng: 194.17516406616386 },
-      arena: {
-        get arena() { return arena80 },
-        completed: false,
-      },
     },
-    {
+    minigame: {
       id: 'minigame',
       type: 'minigame',
       label: 'Mini-jeu',
       position: { lat: -199.50125361005428, lng: 142.2667046594498 },
       miniGame: 'shlagmind',
     },
-  ],
+  },
 }

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -44,7 +44,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
 
   const accessibleShopLevel = computed(() =>
     accessibleZones.value
-      .filter(z => z.type === 'village' && z.pois.some(p => p.type === 'shop'))
+      .filter(z => z.type === 'village' && 'shop' in z.pois)
       .reduce((m, z) => Math.max(m, z.minLevel), 0),
   )
 

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -3,6 +3,7 @@ import type { SavageZoneId, Zone, ZoneId } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { kings as kingsData } from '~/data/kings'
 import { zonesData } from '~/data/zones'
+import { useZoneProgressStore } from './zoneProgress'
 
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
@@ -43,12 +44,8 @@ export const useZoneStore = defineStore('zone', () => {
   }
 
   function completeArena(id: string) {
-    const z = zones.value.find(z => z.id === id)
-    if (z?.type === 'village') {
-      const poi = z.pois.find(p => p.type === 'arena')
-      if (poi?.arena)
-        poi.arena.completed = true
-    }
+    const progress = useZoneProgressStore()
+    progress.completeArena(id)
   }
 
   const rewardMultiplier = computed(() => {

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -62,7 +62,8 @@ export interface VillageZone extends BaseZoneCommon {
   readonly type: 'village'
   readonly villageType: VillageType
   readonly map: ZoneMap
-  readonly pois: readonly VillagePOI[]
+  /** Points of interest indexed by their identifier. */
+  readonly pois: POIsById
   /** Attached savage zone identifier, when applicable. */
   readonly attachedTo?: SavageZoneId
 }


### PR DESCRIPTION
## Summary
- convert village zone POIs from arrays to keyed objects
- map arenas by village id and update zone logic
- adjust stores and components to new POI structure

## Testing
- `pnpm test:unit` *(fails: snapshot and assertion mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_688f17eadb2c832aae1309d5f0d4a47d