### PR TITLE
refactor: rely on keyed POIs

### DIFF
--- a/src/components/developer/SettingsModal.vue
+++ b/src/components/developer/SettingsModal.vue
@@ -15,7 +15,6 @@ const dev = useDeveloperStore()
 const game = useGameStore()
 const dex = useShlagedexStore()
 const player = usePlayerStore()
-const zone = useZoneStore()
 const progress = useZoneProgressStore()
 
 function addMoney() {
@@ -94,7 +93,7 @@ function completeArena(id: string) {
   if (!arena)
     return
   player.earnBadge(arena.id)
-  zone.completeArena(id)
+  progress.completeArena(id)
 }
 
 function resetArenas() {

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -9,6 +9,7 @@ const arena = useArenaStore()
 const player = usePlayerStore()
 const panel = useMainPanelStore()
 const zone = useZoneStore()
+const progress = useZoneProgressStore()
 const badgeBox = useBadgeBoxStore()
 const preparationMusic = getArenaTrack('preparation') ?? '/audio/musics/arenas/preparation.ogg'
 const exitTrack = ref(preparationMusic)
@@ -19,7 +20,7 @@ function collectBadge() {
     return
   player.earnBadge(arena.arenaData.id)
   badgeBox.addBadge(arena.arenaData.badge)
-  zone.completeArena(zone.current.id)
+  progress.completeArena(zone.current.id)
   toast.success(`Badge ${arena.arenaData.badge.name} obtenu !`)
   arena.reset()
   panel.showVillage()

--- a/src/components/village/VillageMap.spec.ts
+++ b/src/components/village/VillageMap.spec.ts
@@ -16,15 +16,15 @@ const baseVillage: VillageZone = {
   },
   actions: [],
   minLevel: 1,
-  pois: [
-    {
+  pois: {
+    shop: {
       id: 'shop',
       type: 'shop',
       label: 'Shop',
       position: { lat: 0, lng: 0 },
       items: [],
     },
-  ],
+  },
 }
 
 describe('village map', () => {
@@ -45,7 +45,7 @@ describe('village map', () => {
 
   it('updates markers when village changes', async () => {
     const wrapper = mount(VillageMap, { props: { village: baseVillage } })
-    const newVillage: VillageZone = { ...baseVillage, id: 'v2', pois: [] }
+    const newVillage: VillageZone = { ...baseVillage, id: 'v2', pois: {} }
     await wrapper.setProps({ village: newVillage })
     const markers = wrapper.element.querySelectorAll('.leaflet-marker-icon')
     expect(markers.length).toBe(0)

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -13,9 +13,14 @@ const dialog = useDialogStore()
 const player = usePlayerStore()
 const { t } = useI18n()
 
+const kingPoi = computed(() =>
+  zone.current.type === 'village'
+    ? zone.current.pois.king
+    : undefined,
+)
 const hasKing = computed(() =>
   zone.current.type === 'sauvage'
-  || (zone.current.type === 'village' && 'king' in zone.current.pois),
+  || !!kingPoi.value,
 )
 const arenaPoi = computed(() =>
   zone.current.type === 'village'
@@ -33,10 +38,12 @@ const miniGamePoi = computed(() =>
     ? zone.current.pois.minigame
     : undefined,
 )
-const hasPoulailler = computed(() =>
+const poulaillerPoi = computed(() =>
   zone.current.type === 'village'
-  && 'poulailler' in zone.current.pois,
+    ? zone.current.pois.poulailler
+    : undefined,
 )
+const hasPoulailler = computed(() => !!poulaillerPoi.value)
 const arenaCompleted = computed(() => progress.isArenaCompleted(zone.current.id))
 const currentArenaData = computed(() =>
   zone.current.type === 'village' ? getArenaByZoneId(zone.current.id) : undefined,

--- a/src/components/zone/ButtonVillage.vue
+++ b/src/components/zone/ButtonVillage.vue
@@ -70,10 +70,7 @@ function classes() {
     <div class="h-4 flex items-center justify-center gap-2">
       <div v-if="arenaCompleted" class="i-mdi:sword-cross h-4 w-4" />
       <div
-        v-else-if="
-          props.zone.type === 'village'
-            && 'arena' in props.zone.pois
-        "
+        v-else-if="props.zone.type === 'village' && props.zone.pois.arena"
         class="i-mdi:sword-cross h-4 w-4 opacity-50 grayscale"
       />
     </div>

--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -74,7 +74,7 @@ export function useMapMarkers(map: LeafletMap) {
       const crown = kingDefeated.value ? '<div class="i-game-icons:crown h-3 w-3"></div>' : ''
       const arena = arenaCompleted.value
         ? '<div class="i-mdi:sword-cross h-3 w-3"></div>'
-        : zone.type === 'village' && 'arena' in zone.pois
+        : zone.type === 'village' && zone.pois.arena
           ? '<div class="i-mdi:sword-cross h-3 w-3 opacity-50 grayscale"></div>'
           : ''
       const icons = [ball, crown, arena].filter(Boolean).join('')

--- a/src/composables/useZoneCompletion.ts
+++ b/src/composables/useZoneCompletion.ts
@@ -27,7 +27,7 @@ export function useZoneCompletion(zone: Zone) {
   const kingDefeated = computed(() => {
     const hasKing
         = zone.type === 'sauvage'
-          || (zone.type === 'village' && 'king' in zone.pois)
+          || (zone.type === 'village' && zone.pois.king)
     return hasKing && progress.isKingDefeated(zone.id)
   })
 

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -44,7 +44,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
 
   const accessibleShopLevel = computed(() =>
     accessibleZones.value
-      .filter(z => z.type === 'village' && 'shop' in z.pois)
+      .filter(z => z.type === 'village' && Object.values(z.pois).some(p => p.type === 'shop'))
       .reduce((m, z) => Math.max(m, z.minLevel), 0),
   )
 

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -3,7 +3,6 @@ import type { SavageZoneId, Zone, ZoneId } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { kings as kingsData } from '~/data/kings'
 import { zonesData } from '~/data/zones'
-import { useZoneProgressStore } from './zoneProgress'
 
 export const useZoneStore = defineStore('zone', () => {
   const zones = ref<Zone[]>(zonesData)
@@ -41,11 +40,6 @@ export const useZoneStore = defineStore('zone', () => {
   function getZoneForLevel(level: number): Zone | undefined {
     const candidates = xpZones.value.filter(z => level >= z.minLevel)
     return candidates[candidates.length - 1]
-  }
-
-  function completeArena(id: string) {
-    const progress = useZoneProgressStore()
-    progress.completeArena(id)
   }
 
   const rewardMultiplier = computed(() => {
@@ -88,7 +82,6 @@ export const useZoneStore = defineStore('zone', () => {
     getKing,
     getZoneRank,
     getZoneForLevel,
-    completeArena,
     reset,
   }
 }, {


### PR DESCRIPTION
## Summary
- derive zone actions and markers from direct POI keys
- remove zone store arena completion helper; use zone progress instead
- compute shop access using POI records

## Testing
- `pnpm eslint src/components/developer/SettingsModal.vue src/components/dialog/ArenaVictoryDialog.vue src/components/village/VillageMap.spec.ts src/components/village/ZoneActions.vue src/components/zone/ButtonVillage.vue src/composables/leaflet/useMapMarkers.ts src/composables/useZoneCompletion.ts src/stores/shlagedex.ts src/stores/zone.ts`
- `pnpm lint` *(fails: Expected indentation of 8 spaces but found 6 spaces)*
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688f1b525b74832a925b684e78493d16