### PR TITLE
refactor: centralize arena completion tracking

### DIFF
--- a/src/components/developer/SettingsModal.vue
+++ b/src/components/developer/SettingsModal.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { getArenaByZoneId } from '~/data/arenas'
 import { allShlagemons } from '~/data/shlagemons'
 import { applyCurrentStats, applyStats, xpForLevel } from '~/utils/dexFactory'
 
@@ -89,10 +88,6 @@ function resetLevel() {
 }
 
 function completeArena(id: string) {
-  const arena = getArenaByZoneId(id)
-  if (!arena)
-    return
-  player.earnBadge(arena.id)
   progress.completeArena(id)
 }
 

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -9,7 +9,6 @@ const arena = useArenaStore()
 const player = usePlayerStore()
 const panel = useMainPanelStore()
 const zone = useZoneStore()
-const progress = useZoneProgressStore()
 const badgeBox = useBadgeBoxStore()
 const preparationMusic = getArenaTrack('preparation') ?? '/audio/musics/arenas/preparation.ogg'
 const exitTrack = ref(preparationMusic)
@@ -20,7 +19,7 @@ function collectBadge() {
     return
   player.earnBadge(arena.arenaData.id)
   badgeBox.addBadge(arena.arenaData.badge)
-  progress.completeArena(zone.current.id)
+  useZoneProgressStore().completeArena(zone.current.id)
   toast.success(`Badge ${arena.arenaData.badge.name} obtenu !`)
   arena.reset()
   panel.showVillage()

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -13,7 +13,6 @@ export type ArenaFactory = () => Arena
 
 export interface ZoneArena {
   readonly arena: Arena | ArenaFactory
-  completed: boolean
 }
 
 export interface Position {


### PR DESCRIPTION
## Summary
- remove obsolete `ZoneArena.completed` field
- use `useZoneProgressStore.completeArena` in arena victory dialog
- use zone progress store directly from developer settings

## Testing
- `pnpm lint` *(fails: Expected indentation of 8 spaces but found 6 spaces, etc.)*
- `pnpm typecheck` *(fails: Property 'maxLevel' does not exist on type ...)*
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_688f204bf8e4832a88f9d4feb3e94819