### PR TITLE
Handle optional king in savage zones

### DIFF
--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -50,11 +50,13 @@ watch(() => zone.current.id, () => {
   activePoiId.value = null
 })
 
-const kingPoi = computed(() =>
-  (zone.current as VillageZone).pois.king,
+const hasKing = computed(() =>
+  zone.current.type === 'sauvage'
+    ? zone.current.hasKing !== false
+    : !!(zone.current as VillageZone).pois.king,
 )
 const currentKing = computed(() =>
-  kingPoi.value ? zone.getKing(zone.current.id as SavageZoneId) : undefined,
+  hasKing.value ? zone.getKing(zone.current.id as SavageZoneId) : undefined,
 )
 const arenaCompleted = computed(() => progress.isArenaCompleted(zone.current.id))
 const currentArenaData = computed(() =>

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -13,14 +13,10 @@ const dialog = useDialogStore()
 const player = usePlayerStore()
 const { t } = useI18n()
 
-const kingPoi = computed(() =>
-  zone.current.type === 'village'
-    ? zone.current.pois.king
-    : undefined,
-)
 const hasKing = computed(() =>
   zone.current.type === 'sauvage'
-  || !!kingPoi.value,
+    ? zone.current.hasKing !== false
+    : !!zone.current.pois.king,
 )
 const arenaPoi = computed(() =>
   zone.current.type === 'village'

--- a/src/composables/useZoneCompletion.ts
+++ b/src/composables/useZoneCompletion.ts
@@ -27,7 +27,8 @@ export function useZoneCompletion(zone: Zone) {
   const kingDefeated = computed(() => {
     const hasKing
         = zone.type === 'sauvage'
-          || (zone.type === 'village' && zone.pois.king)
+          ? zone.hasKing !== false
+          : !!zone.pois.king
     return hasKing && progress.isKingDefeated(zone.id)
   })
 

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -54,6 +54,7 @@ interface BaseZoneCommon {
 export interface SavageZone extends BaseZoneCommon {
   readonly type: 'sauvage'
   readonly maxLevel: number
+  /** Whether this savage zone features a king battle. Defaults to true. */
   readonly hasKing?: boolean
 }
 


### PR DESCRIPTION
## Summary
- document optional `hasKing` flag on savage zone config
- respect `hasKing` when computing king presence and completion

## Testing
- `pnpm test` *(fails: Snapshots 1 failed; Test Files 5 failed | 69 passed | 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688f20144820832a98a92d878f7074d7