### PR TITLE
feat(layout): make panel footer optional

### DIFF
--- a/src/components/layout/TitledPanel.vue
+++ b/src/components/layout/TitledPanel.vue
@@ -3,10 +3,17 @@ interface Props {
   title: string
   exitText: string
   limitSize?: boolean
+  /**
+   * Whether to display the footer section and exit button.
+   *
+   * Defaults to `true`.
+   */
+  showFooter?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   limitSize: true,
+  showFooter: true,
 })
 const emit = defineEmits(['exit'])
 </script>
@@ -19,7 +26,7 @@ const emit = defineEmits(['exit'])
     <div class="flex flex-1 flex-col gap-2 overflow-hidden">
       <slot />
     </div>
-    <div class="flex flex-wrap justify-end gap-2 bg-white dark:bg-gray-900">
+    <div v-if="showFooter" class="flex flex-wrap justify-end gap-2 bg-white dark:bg-gray-900">
       <slot name="footer">
         <UiButton
           type="danger" variant="outline" class="flex gap-2 text-xs"

--- a/src/components/panel/MiniGame.vue
+++ b/src/components/panel/MiniGame.vue
@@ -48,6 +48,7 @@ const failure = computed(() => gameDef.value?.createFailure(leaveGame))
     v-if="gameDef"
     :title="gameDef.label"
     :exit-text="t('components.panel.MiniGame.exit')"
+    :show-footer="mini.phase === 'game'"
     @exit="leaveGame"
   >
     <div class="tiny-scrollbar flex flex-1 flex-col overflow-auto">

--- a/test/titled-panel-component.test.ts
+++ b/test/titled-panel-component.test.ts
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import LayoutTitledPanel from '../src/components/layout/TitledPanel.vue'
+
+describe('layoutTitledPanel', () => {
+  it('renders footer by default', () => {
+    const wrapper = mount(LayoutTitledPanel, {
+      props: {
+        title: 'Title',
+        exitText: 'Exit',
+      },
+    })
+    expect(wrapper.find('button').exists()).toBe(true)
+  })
+
+  it('hides footer when showFooter is false', () => {
+    const wrapper = mount(LayoutTitledPanel, {
+      props: {
+        title: 'Title',
+        exitText: 'Exit',
+        showFooter: false,
+      },
+    })
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add `showFooter` prop to `LayoutTitledPanel` to optionally render footer
- show footer only during MiniGame gameplay
- test TitledPanel footer visibility

## Testing
- `npx eslint src/components/layout/TitledPanel.vue src/components/panel/MiniGame.vue test/titled-panel-component.test.ts`
- `pnpm test run test/titled-panel-component.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_688f28815380832aa128341692b25f70