### PR TITLE
feat: configure sitemap host

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 VITE_DEV_TOOLS=true
+VITE_SITE_URL=http://localhost:3333

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_DEV_TOOLS=false
+VITE_SITE_URL=https://shlagemon.aife.io


### PR DESCRIPTION
## Summary
- add VITE_SITE_URL env var for dev and prod
- load site URL in vite config and generate sitemap with prefix strategy

## Testing
- `pnpm lint` *(fails: style/indent and other existing errors)*
- `pnpm test` *(fails: snapshot mismatch, sort assertions)*

------
https://chatgpt.com/codex/tasks/task_e_688f3ec5df4c832ab561a4410e0c8f3d