### PR TITLE
Refactor badge handling and translations

### DIFF
--- a/src/components/badge/BoxModal.vue
+++ b/src/components/badge/BoxModal.vue
@@ -18,10 +18,14 @@ const { t } = useI18n()
         >
           <template #left>
             <div class="flex items-center gap-1">
-              <div v-if="badge.image" class="h-6 w-6">
-                <img :src="badge.image" :alt="badge.name" class="h-full w-full object-contain">
+              <div class="h-6 w-6">
+                <img
+                  :src="`/icons/badges/${badge.id}.webp`"
+                  :alt="t(badge.name)"
+                  class="h-full w-full object-contain"
+                >
               </div>
-              <span class="text-sm">{{ badge.name }}</span>
+              <span class="text-sm">{{ t(badge.name) }}</span>
             </div>
           </template>
           <template #right>

--- a/src/components/dialog/ArenaVictoryDialog.i18n.yml
+++ b/src/components/dialog/ArenaVictoryDialog.i18n.yml
@@ -1,10 +1,12 @@
 fr:
+  toast: '{name} obtenu !'
   steps:
     step1:
       text: Félicitations ! Tu as triomphé de l'arène.
       responses:
         collect: Récupérer le badge
 en:
+  toast: '{name} obtained!'
   steps:
     step1:
       text: Congratulations! You triumphed at the arena.

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -20,7 +20,7 @@ function collectBadge() {
   player.earnBadge(arena.arenaData.id)
   badgeBox.addBadge(arena.arenaData.badge)
   useZoneProgressStore().completeArena(zone.current.id)
-  toast.success(`Badge ${arena.arenaData.badge.name} obtenu !`)
+  toast.success(t('components.dialog.ArenaVictoryDialog.toast', { name: t(arena.arenaData.badge.name) }))
   arena.reset()
   panel.showVillage()
   exitTrack.value = getZoneTrack(zone.current.id, zone.current.type) ?? preparationMusic

--- a/src/data/arenas.i18n.yml
+++ b/src/data/arenas.i18n.yml
@@ -1,0 +1,26 @@
+fr:
+  arena20:
+    badge:
+      name: Badge Couillasse
+  arena40:
+    badge:
+      name: Badge Chaussette
+  arena60:
+    badge:
+      name: Badge Oignon Mystique
+  arena80:
+    badge:
+      name: Badge Tartine Beurrée
+en:
+  arena20:
+    badge:
+      name: Couillasse Badge
+  arena40:
+    badge:
+      name: Sock Badge
+  arena60:
+    badge:
+      name: Mystic Onion Badge
+  arena80:
+    badge:
+      name: Buttered Toast Badge

--- a/src/data/arenas.ts
+++ b/src/data/arenas.ts
@@ -60,10 +60,9 @@ export const arena20: Arena = createArena({
   character: profMerdant,
   level: 21,
   badge: {
-    id: 'badge-merdant',
-    name: 'Badge Couillasse',
+    id: 'couillasse',
+    name: 'data.arenas.arena20.badge.name',
     levelCap: 39,
-    image: '',
   },
 })
 
@@ -73,10 +72,9 @@ export const arena40: Arena = createArena({
   character: profMerdant,
   level: 41,
   badge: {
-    id: 'badge-sock',
-    name: 'Badge Chaussette',
+    id: 'sock',
+    name: 'data.arenas.arena40.badge.name',
     levelCap: 59,
-    image: '',
   },
   requiredBadgeId: 'arena20',
 })
@@ -87,10 +85,9 @@ export const arena60: Arena = createArena({
   character: profMerdant,
   level: 61,
   badge: {
-    id: 'badge-mystic-onion',
-    name: 'Badge Oignon Mystique',
+    id: 'mystic-onion',
+    name: 'data.arenas.arena60.badge.name',
     levelCap: 79,
-    image: '',
   },
   requiredBadgeId: 'arena40',
 })
@@ -101,10 +98,9 @@ export const arena80: Arena = createArena({
   character: profMerdant,
   level: 81,
   badge: {
-    id: 'badge-buttered-toast',
-    name: 'Badge Tartine Beurrée',
+    id: 'buttered-toast',
+    name: 'data.arenas.arena80.badge.name',
     levelCap: 99,
-    image: '',
   },
   requiredBadgeId: 'arena60',
 })

--- a/src/stores/badgeBox.ts
+++ b/src/stores/badgeBox.ts
@@ -7,6 +7,23 @@ export const useBadgeBoxStore = defineStore('badgeBox', () => {
   const badges = ref<ArenaBadge[]>([])
   const isModalOpen = ref(false)
 
+  const LEGACY_BADGE_IDS: Record<string, ArenaBadge['id']> = {
+    'badge-merdant': 'couillasse',
+    'badge-sock': 'sock',
+    'badge-mystic-onion': 'mystic-onion',
+    'badge-buttered-toast': 'buttered-toast',
+  }
+
+  function normalizeBadges(): void {
+    badges.value = badges.value.map(b => ({
+      id: LEGACY_BADGE_IDS[b.id] ?? b.id,
+      name: b.name,
+      levelCap: b.levelCap,
+    }))
+  }
+
+  normalizeBadges()
+
   function open() {
     isModalOpen.value = true
   }

--- a/src/type/arena.ts
+++ b/src/type/arena.ts
@@ -1,11 +1,26 @@
 import type { Character } from './character'
 import type { BaseShlagemon } from './shlagemon'
 
+/**
+ * Identifiers for every arena badge.
+ *
+ * These identifiers also match the corresponding icon filenames located in
+ * `public/icons/badges`.
+ */
+export type ArenaBadgeId = 'couillasse' | 'sock' | 'mystic-onion' | 'buttered-toast'
+
+/**
+ * Metadata describing an arena badge.
+ *
+ * `name` is an i18n key that must be translated at render time.
+ * The badge image can be derived from the `id` and is therefore omitted here.
+ */
 export interface ArenaBadge {
-  id: string
+  id: ArenaBadgeId
+  /** Translation key for the badge name. */
   name: string
+  /** Maximum capture level allowed after earning this badge. */
   levelCap: number
-  image?: string
 }
 
 export type LineupFactory = () => BaseShlagemon[]


### PR DESCRIPTION
## Summary
- remove badge image property and derive icon path from ID
- translate badge names and toast messages
- normalize legacy badge IDs and expose a union type

## Testing
- `pnpm test` *(fails: Snapshot `component Header.vue > should render 1` mismatched, and 4 others)*
- `npx vitest test/arena-required-badge.test.ts`
- `pnpm lint` *(fails: Expected indentation of 8 spaces but found 6 spaces and others)*
- `pnpm eslint src/type/arena.ts src/data/arenas.ts src/stores/badgeBox.ts src/components/badge/BoxModal.vue src/components/dialog/ArenaVictoryDialog.vue`

------
https://chatgpt.com/codex/tasks/task_e_688f5cb14514832a8d6277ffb188d3eb