### PR TITLE
feat(ssg): generate root page

### DIFF
--- a/src/composables/useSeoHead.ts
+++ b/src/composables/useSeoHead.ts
@@ -18,18 +18,22 @@ interface AlternateLink {
 export function useSeoHead() {
   const route = useRoute()
 
-  const canonicalUrl = computed(() => `${SITE_URL}${route.path}`)
+  const locale = computed(() => String(route.meta.locale))
+  const baseName = computed(() => String(route.name).replace(`${locale.value}-`, ''))
+  const entry = computed(() => localizedRoutes.find(r => r.name === baseName.value))
+
+  const canonicalUrl = computed(() => {
+    const path = entry.value?.paths[locale.value] ?? route.path
+    return `${SITE_URL}${path}`
+  })
 
   const alternateLinks = computed<AlternateLink[]>(() => {
-    const locale = String(route.meta.locale)
-    const baseName = String(route.name).replace(`${locale}-`, '')
-    const entry = localizedRoutes.find(r => r.name === baseName)
-    if (!entry)
+    if (!entry.value)
       return []
 
     return availableLocales
       .map((loc) => {
-        const path = entry.paths[loc]
+        const path = entry.value!.paths[loc]
         if (!path)
           return null
         return {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { setupLayouts } from 'virtual:generated-layouts'
 import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
-import { availableLocales } from '~/constants/locales'
+import { availableLocales, defaultLocale } from '~/constants/locales'
 import { localizedRoutes } from './localizedRoutes'
 
 /**
@@ -16,7 +16,7 @@ export function buildLocalizedRoutes(): RouteRecordRaw[] {
       const path = route.paths[locale]
       if (!path)
         continue
-      records.push({
+      const record: RouteRecordRaw = {
         path,
         name: `${locale}-${route.name}`,
         component: route.component,
@@ -25,7 +25,10 @@ export function buildLocalizedRoutes(): RouteRecordRaw[] {
           i18nKey: route.i18nKey,
           layout: route.layout,
         },
-      })
+      }
+      if (import.meta.env.SSG && locale === defaultLocale && route.name === 'home')
+        record.alias = '/'
+      records.push(record)
     }
   }
 
@@ -33,11 +36,15 @@ export function buildLocalizedRoutes(): RouteRecordRaw[] {
 }
 
 export const routes: RouteRecordRaw[] = [
-  {
-    path: '/',
-    name: 'root',
-    component: () => import('~/pages/root.vue'),
-  },
+  ...(!import.meta.env.SSG
+    ? [
+        {
+          path: '/',
+          name: 'root',
+          component: () => import('~/pages/root.vue'),
+        },
+      ]
+    : []),
   ...buildLocalizedRoutes(),
 ]
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ import { localizedRoutes } from './src/router/localizedRoutes'
 import 'vitest/config'
 
 function getAllLocalizedPaths(): string[] {
-  return localizedRoutes.flatMap(route => Object.values(route.paths))
+  return ['/', ...localizedRoutes.flatMap(route => Object.values(route.paths))]
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- generate `/` during SSG like `/en`
- resolve canonical and alternate URLs from localized route mapping
- skip runtime redirect when pre-rendering

## Testing
- `pnpm lint` *(fails: Strings must use singlequote in locales)*
- `pnpm test` *(fails: snapshot mismatches and assertions)*

------
https://chatgpt.com/codex/tasks/task_e_688f76ddf648832abeed2336662834a0