### PR TITLE
feat(ui): clear tab badges on right-click

### DIFF
--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -96,6 +96,18 @@ function getTabComponent(category: ItemCategory | 'all') {
   return comp
 }
 
+/**
+ * Marks all items of a given category as used to clear its badge.
+ *
+ * @param category - Target item category.
+ */
+function markCategoryUsed(category: ItemCategory) {
+  for (const { item } of inventory.list) {
+    if (item.category === category)
+      usage.markUsed(item.id)
+  }
+}
+
 const tabs = computed(() =>
   categories.value.map((cat) => {
     const count = newItemCountByCategory.value[cat.value] || 0
@@ -104,6 +116,7 @@ const tabs = computed(() =>
       component: getTabComponent(cat.value),
       highlight: count > 0,
       badge: count,
+      markAllSeen: () => markCategoryUsed(cat.value),
       disabled: cat.disabled,
     }
   }),

--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -7,6 +7,8 @@ interface Tab {
   'highlight'?: boolean
   /** Number of new items to display as a badge. */
   'badge'?: number
+  /** Marks all tab content as seen when the badge is cleared. */
+  'markAllSeen'?: () => void
   'disabled'?: boolean
   'aria-label'?: string
 }
@@ -53,6 +55,15 @@ const container = ref<HTMLElement>()
 const direction = ref<'left' | 'right'>('left')
 
 const currentFooter = computed<Component | undefined>(() => props.tabs[active.value]?.footer)
+
+/**
+ * Clears the badge of a tab without selecting it.
+ * Triggered on right click to mark all tab content as seen.
+ */
+function onContextMenu(tab: Tab) {
+  if (tab.badge && tab.badge > 0)
+    tab.markAllSeen?.()
+}
 
 function select(i: number) {
   if (i === active.value || props.tabs[i]?.disabled)
@@ -128,6 +139,7 @@ const transitionName = computed(() => direction.value === 'left' ? 'slide-left' 
         :disabled="tab.disabled"
         style="flex: 0 0 auto;"
         @click="select(i)"
+        @contextmenu.prevent="onContextMenu(tab)"
         @keydown.enter.space.prevent="select(i)"
       >
         <!-- Icone -->

--- a/test/ui-tabs-contextmenu.test.ts
+++ b/test/ui-tabs-contextmenu.test.ts
@@ -1,0 +1,19 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import UiTabs from '../src/components/ui/Tabs.vue'
+
+describe('uiTabs context menu', () => {
+  it('marks tab content as seen on right click without switching tabs', async () => {
+    const markAllSeen = vi.fn()
+    const tabs = ref([
+      { label: { text: 'A' }, component: defineComponent({ render: () => h('div') }) },
+      { label: { text: 'B' }, component: defineComponent({ render: () => h('div') }), badge: 2, markAllSeen },
+    ])
+    const wrapper = mount(UiTabs, { props: { tabs: tabs.value } })
+    const buttons = wrapper.findAll('button')
+    await buttons[1].trigger('contextmenu')
+    expect(markAllSeen).toHaveBeenCalledTimes(1)
+    expect(buttons[0].attributes('aria-selected')).toBe('true')
+  })
+})


### PR DESCRIPTION
## Summary
- allow UiTabs to clear a tab's badge on right-click via new `markAllSeen` callback
- inventory tabs implement `markAllSeen` to mark items as used
- add unit test for context menu handling

## Testing
- `pnpm lint` *(fails: Strings must use singlequote ...)*
- `pnpm typecheck` *(fails: Property 'id' does not exist on type 'Ball' ...)*
- `pnpm test` *(fails: Snapshot 1 failed, Test Files 5 failed ...)*

------
https://chatgpt.com/codex/tasks/task_e_688fb6859294832a819ad63b062d7fed