### PR TITLE
feat: add uuid fallback

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -15,6 +15,7 @@ import {
   xpRewardForLevel,
 } from '~/utils/dexFactory'
 import { shlagedexSerializer } from '~/utils/shlagedex-serialize'
+import { generateUuid } from '~/utils/uuid'
 
 export const useShlagedexStore = defineStore('shlagedex', () => {
   const shlagemons = ref<DexShlagemon[]>([])
@@ -624,7 +625,7 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     }
     const captured: DexShlagemon = {
       ...enemy,
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       hpCurrent: enemy.hp,
       captureDate: new Date().toISOString(),
       captureCount: 1,

--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -2,6 +2,7 @@ import type { Stats } from '~/type'
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import { specialityBonus } from '~/constants/speciality'
 import marginal from '~/data/shlagemons/50-55/marginal'
+import { generateUuid } from './uuid'
 
 export const baseStats: Stats = {
   hp: 250,
@@ -63,7 +64,7 @@ export function createDexShlagemon(
     rarityFollowsLevel = true
   }
   const mon: DexShlagemon = {
-    id: crypto.randomUUID(),
+    id: generateUuid(),
     base,
     baseStats: {
       hp: statWithRarity(baseStats.hp, rarity),

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,33 @@
+/**
+ * Generate a RFC 4122 version 4 UUID.
+ *
+ * Uses the native `crypto.randomUUID` when available. If not, it falls back to
+ * `crypto.getRandomValues` and, as a last resort, to `Math.random`.
+ *
+ * The fallback paths are not meant to be cryptographically secure but ensure the
+ * application continues to work on older browsers.
+ */
+export function generateUuid(): string {
+  const nativeUuid = globalThis.crypto?.randomUUID?.()
+  if (nativeUuid)
+    return nativeUuid
+
+  const crypto = globalThis.crypto
+  if (crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16)
+    crypto.getRandomValues(bytes)
+    // Set version to 4 --- 0100
+    bytes[6] = (bytes[6] & 0x0F) | 0x40
+    // Set variant to RFC 4122 --- 10xx
+    bytes[8] = (bytes[8] & 0x3F) | 0x80
+    const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+  }
+
+  // Non-secure fallback
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/test/uuid.test.ts
+++ b/test/uuid.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { generateUuid } from '~/utils/uuid'
+
+describe('generateUuid', () => {
+  it('returns a RFC4122 v4 UUID', () => {
+    const uuid = generateUuid()
+    const pattern = /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i
+    expect(uuid).toMatch(pattern)
+  })
+
+  it('generates unique values', () => {
+    const first = generateUuid()
+    const second = generateUuid()
+    expect(first).not.toBe(second)
+  })
+})


### PR DESCRIPTION
## Summary
- create `generateUuid` helper that falls back to `crypto.getRandomValues` or `Math.random`
- use `generateUuid` when creating dex entries and capturing Shlagemon
- add unit test for UUID utility

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: sort-evolution.test.ts, sort-item.test.ts, sort-shiny.test.ts, useLangSwitch.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688fbc0f2d64832ab6c4c3537bef246f