### PR TITLE
feat: add info acknowledgment for new shlagemons

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,7 +1,7 @@
 components:
   deck:
     DeckDetail:
-      evolution: "Evolution:"
+      evolution: 'Evolution:'
       level: lvl {n}
     DeckList:
       search: Search
@@ -9,7 +9,7 @@ components:
         name: Name
         type: Type
     Detail:
-      evolution: "Evolution:"
+      evolution: 'Evolution:'
       level: lvl {n}
     List:
       search: Search
@@ -51,9 +51,9 @@ components:
       intro1: The Shlagedex bonus matches your **potential ShlagéDex**. It represents the maximum bonus you could obtain by capturing all available Shlagémon.
       intro2: It is based on the completion rate of this potential Shlagedex as well as your team's average level.
       formula: Bonus = average level × 2 × (completion rate / 100) / 10
-      completion: "Completion:"
-      averageLevel: "Average level:"
-      currentBonus: "Current bonus:"
+      completion: 'Completion:'
+      averageLevel: 'Average level:'
+      currentBonus: 'Current bonus:'
     Inventory:
       sort:
         type: Type
@@ -67,7 +67,7 @@ components:
         battle: Battle
       equip: You equipped the {item}
     PlayerInfos:
-      sick: "Sick: {n} battles left"
+      sick: 'Sick: {n} battles left'
       dex: ShlageDex
       averageLevel: Average level
       bonus: Bonus
@@ -129,7 +129,7 @@ components:
       defeat: Defeat...
       queen: queen
       king: king
-      zoneKingChallenge: "{label} zone challenge"
+      zoneKingChallenge: '{label} zone challenge'
       reward: +{amount} Shlagidiamonds
       retry: Retry
     CaptureLimitModal:
@@ -213,7 +213,7 @@ components:
     Detail:
       equipItemTitle: Equip an item
       allowEvolution: Allow this Shlagemon to evolve?
-      firstCatch: "First capture: {date}"
+      firstCatch: 'First capture: {date}'
       obtainedTimes: Obtained {count} times
       release: Release
       main: Main
@@ -232,7 +232,7 @@ components:
       title: Choose an item to equip
       noAvailable: No item available.
     EvolutionModal:
-      evolveTitle: "{name} is evolving"
+      evolveTitle: '{name} is evolving'
       question: '"{from}" wants to evolve into "{to}", will you allow it or stop the spread of shlaguitude?'
       alreadyOwned: You already own this evolution
       yes: Yes
@@ -245,6 +245,8 @@ components:
       title: Shlagemon Info
     RarityInfo:
       tooltip: Rarity
+    List:
+      new: You have {n} new Shlagemon | You have {n} new Shlagemons
   LanguageSelector:
     label: Language
     en: English
@@ -260,6 +262,8 @@ components:
       descending: Descending sort
     LanguageToggle:
       label: Toggle language
+    Info:
+      ok: Ok
   dialog:
     AnotherShlagemonDialog:
       steps:
@@ -280,7 +284,7 @@ components:
           text: Congratulations! You triumphed at the arena.
           responses:
             collect: Collect the badge
-      toast: "{name} obtained!"
+      toast: '{name} obtained!'
     ArenaWelcomeDialog:
       steps:
         step1:
@@ -411,7 +415,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP."
+          text: 'As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP.'
           responses:
             back: Back
             next: Continue
@@ -535,7 +539,7 @@ components:
         step1:
           text: Impressive! You've captured at least {count} Shlagemons.
         step2:
-          text: "Here is a unique item: {name}."
+          text: 'Here is a unique item: {name}.'
         step3:
           text: It increases the holder's {stat} by {percent}%.
         step4:
@@ -708,7 +712,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "Let me tell you about a curious item: the Cuck Ring."
+          text: 'Let me tell you about a curious item: the Cuck Ring.'
           responses:
             back: Back
             next: Continue
@@ -718,7 +722,7 @@ components:
             back: Back
             next: Continue
         step4:
-          text: "It makes each attack unpredictable: double damage or healing the foe instead."
+          text: 'It makes each attack unpredictable: double damage or healing the foe instead.'
           responses:
             back: Back
             next: Continue
@@ -748,11 +752,11 @@ components:
         - You're one step away from a brain fart.
         - Rarely seen someone so pathetic.
       validate: Validate
-      attemptsLeft: "{n} attempts left"
+      attemptsLeft: '{n} attempts left'
       win: You've cracked a Shlag's mind!
       lose: Even a Grimer would have done it
     Pairs:
-      attempts: "{n} attempt | {n} attempts"
+      attempts: '{n} attempt | {n} attempts'
     masterMind:
       SelectionModal:
         title: Choose a Shlagemon
@@ -790,10 +794,10 @@ components:
       arena: Arena
       henhouse: Henhouse
       fightKing: Challenge the {label} of the zone
-      kingDefeated: "{label} defeated!"
+      kingDefeated: '{label} defeated!'
   zone:
     MonsModal:
-      title: "{zone} Shlagemons"
+      title: '{zone} Shlagemons'
   badge:
     BoxModal:
       title: Badge box
@@ -815,7 +819,7 @@ data:
       rouxPasCool:
         description: Roux not Cool was once cool. Roux not Cool spent too much time scratching minor chords at the edge of an extinct volcano. From now on, Cool's not cool wanders with a guitar too big for his wings, freckles crying, and a check shirt that smells wet grass and regrets. His plumage took on a sad rust colour, and his red wick hides a remorseful look, as if he constantly realized that he could have evolved into a legendary raptor, but preferred to release an independent EP. It's always a little cold around him, even in the summer. Its signature capacity, Refrain Getting into trouble, inflicts a deep discomfort on all the arena, reducing the accuracy of enemy attacks as long as they turn their eyes away. He's very good at driving wild Pokémons away… and dating.
       sacdepates:
-        description: "Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Sacdepates undergoes a physical attack, he can wrap around the enemy to trap and immobilize."
+        description: 'Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Sacdepates undergoes a physical attack, he can wrap around the enemy to trap and immobilize.'
     05-10:
       aspigros:
         description: |-
@@ -839,7 +843,7 @@ data:
       metamorve:
         description: A mass of foul mud that drags slowly. Where he passes, nothing grows because of his toxicity. It is made of a toxic mud. He pollutes everything he touches, even the ground becomes sterile. He stinks so much that people vanish just by crossing him. His body is a concentrate of toxins.
       ptitocard:
-        description: "Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure."
+        description: 'Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure.'
     10-15:
       abraquemar:
         description: Abraquemar is a follower of transcendental nap and passive-aggressive flight. At the slightest social interaction, it disappears in a cloud of dust by mumbling "I do not feel, I shoot". His leakage rate is 100%, unless he hears a discussion on chakras or promotions on ethnic carpets. He is often seated in a suit, eyes in mid-open, between two posters from the universe stuck with chewing gum. He always wears a too large hood and a badly knotted scarf, and claims to be "between two stellar alignment planes". Its special capacity, *teleportation of discomfort *, allows you to exchange space with a nearby trash can. He also has the attack *forced serenity *, which lowers the enemy attack by energy guilt. Abraquemar evolves only when he stops saying "I don't want Fight, I am more in the vibe."
@@ -1077,7 +1081,7 @@ data:
       languedepute:
         description: Its endless language is dragging everywhere and is mainly used to slander. He likes to criticize his opponents until they abandon by weariness.
       lecocu:
-        description: "Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness."
+        description: 'Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness.'
       rhinofaringite:
         description: This sneezed rhinoceros sneezed from the rocks on its enemies. Its nose runs permanently, which makes it as slippery as it is unpredictable.
       smongol:
@@ -2073,17 +2077,17 @@ App:
   author: Shlagemon Team
 stores:
   achievements:
-    unlocked: "Achievement unlocked: {title}"
+    unlocked: 'Achievement unlocked: {title}'
   disease:
     sick: Your Shlagemon is sick! It will be back to normal after winning {n} battles.
     cured: Your Shlagemon is no longer sick!
   shlagedex:
-    rarityReached: "{name} reached rarity {rarity}!"
-    evolved: "{name} evolved!"
+    rarityReached: '{name} reached rarity {rarity}!'
+    evolved: '{name} evolved!'
     obtained: You obtained {name}!
     alreadyMax: You already have this Shlagemon at max rarity
-    rarityChanged: "{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!"
-    released: "{name} was released!"
+    rarityChanged: '{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!'
+    released: '{name} was released!'
 layouts:
   NotFound:
     not-found: Page not found

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1,7 +1,7 @@
 components:
   deck:
     DeckDetail:
-      evolution: "Évolution :"
+      evolution: 'Évolution :'
       level: lvl {n}
     DeckList:
       search: Rechercher
@@ -9,7 +9,7 @@ components:
         name: Nom
         type: Type
     Detail:
-      evolution: "Évolution :"
+      evolution: 'Évolution :'
       level: lvl {n}
     List:
       search: Rechercher
@@ -51,9 +51,9 @@ components:
       intro1: Le bonus du Shlagedex correspond à votre **ShlagéDex potentiel**. Il représente le bonus maximal que vous pourriez obtenir en capturant tous les Shlagémon accessibles.
       intro2: Il se base sur le pourcentage de complétion de ce ShlagéDex potentiel ainsi que sur le niveau moyen de votre équipe.
       formula: Bonus = niveau moyen × 2 × (taux de complétion / 100) / 10
-      completion: "Complétion :"
-      averageLevel: "Niveau moyen :"
-      currentBonus: "Bonus actuel :"
+      completion: 'Complétion :'
+      averageLevel: 'Niveau moyen :'
+      currentBonus: 'Bonus actuel :'
     Inventory:
       sort:
         type: Type
@@ -67,7 +67,7 @@ components:
         battle: Combat
       equip: Vous avez équipé la {item}
     PlayerInfos:
-      sick: "Malade : {n} combats restants"
+      sick: 'Malade : {n} combats restants'
       dex: ShlagéDex
       averageLevel: Niveau moyen
       bonus: Bonus
@@ -213,7 +213,7 @@ components:
     Detail:
       equipItemTitle: Équiper un objet
       allowEvolution: Autoriser ce Shlagémon à évoluer ?
-      firstCatch: "Première capture : {date}"
+      firstCatch: 'Première capture : {date}'
       obtainedTimes: Obtenu {count} fois
       release: Relâcher
       main: Principal
@@ -232,7 +232,7 @@ components:
       title: Choisir un objet à équiper
       noAvailable: Aucun objet disponible.
     EvolutionModal:
-      evolveTitle: "{name} évolue"
+      evolveTitle: '{name} évolue'
       question: « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
       yes: Oui
@@ -245,6 +245,8 @@ components:
       title: Informations Shlagémon
     RarityInfo:
       tooltip: Rareté
+    List:
+      new: Vous avez {n} nouveau Shlagémon | Vous avez {n} nouveaux Shlagémons
   LanguageSelector:
     label: Langue
     en: Anglais
@@ -260,6 +262,8 @@ components:
       descending: Tri descendant
     LanguageToggle:
       label: Changer de langue
+    Info:
+      ok: Ok
   dialog:
     AnotherShlagemonDialog:
       steps:
@@ -280,7 +284,7 @@ components:
           text: Félicitations ! Tu as triomphé de l'arène.
           responses:
             collect: Récupérer le badge
-      toast: "{name} obtenu !"
+      toast: '{name} obtenu !'
     ArenaWelcomeDialog:
       steps:
         step1:
@@ -535,7 +539,7 @@ components:
         step1:
           text: Impressionnant ! Tu as capturé au moins {count} Shlagémons.
         step2:
-          text: "Voici un objet unique : {name}."
+          text: 'Voici un objet unique : {name}.'
         step3:
           text: Il augmente {stat} du porteur de {percent}%.
         step4:
@@ -748,11 +752,11 @@ components:
         - T'es à deux doigts de faire un pet cérébral.
         - Rarement vu quelqu'un aussi merdique.
       validate: Valider
-      attemptsLeft: "{n} tentatives restantes"
+      attemptsLeft: '{n} tentatives restantes'
       win: T'as percé le cerveau d'un Shlag !
       lose: Même un Petmorv y serait arrivé
     Pairs:
-      attempts: "{n} tentative | {n} tentatives"
+      attempts: '{n} tentative | {n} tentatives'
     masterMind:
       SelectionModal:
         title: Choisis un Shlagémon
@@ -790,7 +794,7 @@ components:
       arena: Arène
       henhouse: Poulailler
       fightKing: Défier la {label} de la zone
-      kingDefeated: "{label} vaincu{suffix} !"
+      kingDefeated: '{label} vaincu{suffix} !'
   zone:
     MonsModal:
       title: Shlagémons de {zone}
@@ -815,7 +819,7 @@ data:
       rouxPasCool:
         description: Roux pas Cool était anciennement cool. Roux pas Cool a passé trop de temps à gratter des accords mineurs au bord d’un volcan éteint. Désormais, Roux pas Cool erre avec une guitare trop grande pour ses ailes, des taches de rousseur qui pleurent, et une chemise à carreaux qui sent l’herbe humide et les regrets. Son plumage a pris une teinte rouille triste, et sa mèche rousse cache un regard empli de remords, comme s’il réalisait constamment qu’il aurait pu évoluer en rapace légendaire, mais a préféré sortir un EP en indépendant. Il fait toujours un peu froid autour de lui, même en plein été. Sa capacité signature, Refrain Gênant, inflige un malaise profond à toute l’arène, réduisant la précision des attaques ennemies tant qu’ils détournent le regard. Il est très doué pour faire fuir les Pokémon sauvages… et les rendez-vous galants.
       sacdepates:
-        description: "Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser."
+        description: 'Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser.'
     05-10:
       aspigros:
         description: |-
@@ -833,7 +837,7 @@ data:
       metamorve:
         description: Une masse de boue nauséabonde qui se traîne lentement. Là où il passe, plus rien ne pousse à cause de sa toxicité. Il est fait d'une boue toxique. Il pollue tout ce qu’il touche, même le sol devient stérile. Il pue tellement que des gens s’évanouissent rien qu’en le croisant. Son corps est un concentré de toxines.
       ptitocard:
-        description: "Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr."
+        description: 'Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr.'
     10-15:
       abraquemar:
         description: Abraquemar est adepte de la sieste transcendantale et de la fuite passive-agressive. À la moindre interaction sociale, il disparaît dans un nuage de poussière en marmonnant "j’te sens pas, j’me tire". Son taux de fuite est de 100%, sauf s’il entend une discussion sur les chakras ou les promos sur les tapis ethniques. On le trouve souvent assis en tailleur, les yeux mi-ouverts, entre deux posters de l’Univers collés avec du chewing-gum. Il porte toujours une capuche trop grande et une écharpe mal nouée, et prétend être "entre deux plans d’alignement stellaire". Sa capacité spéciale, *Téléportation du Malaise*, permet d’échanger de place avec une poubelle proche. Il possède aussi l’attaque *Sérénité Forcée*, qui fait baisser l’attaque ennemie par culpabilité énergétique. Abraquemar évolue uniquement quand il arrête de dire “j’ai pas envie de fight, moi je suis plus dans la vibe.”
@@ -1061,7 +1065,7 @@ data:
       languedepute:
         description: Sa langue interminable traîne partout et sert principalement à médire. Il aime critiquer ses adversaires jusqu'à ce qu'ils abandonnent par lassitude.
       lecocu:
-        description: "Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante."
+        description: 'Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.'
       rhinofaringite:
         description: Ce rhinocéros enrhumé éternue des rochers sur ses ennemis. Son nez coule en permanence, ce qui le rend aussi glissant qu'imprévisible.
       smongol:
@@ -1102,7 +1106,7 @@ data:
         Autrefois vénéré comme le “Gardien du Micro-ondes Sacré”, il aurait été banni du royaume des Shlagémons nobles pour avoir tenté de cuire des raviolis surgelés… sans enlever l’opercule métallique.
         Aujourd’hui, Artichaud veille sur les zones de non-droit climatiques, où il impose son règne moite et frigorifié, entre deux éternuements fumants et des engelures de l’aisselle.
     bulgrosboule:
-      description: "Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller."
+      description: 'Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller.'
     carapouffe:
       description: Carapouffe s'est enfoncée dans sa propre carapace moelleuse, elle ne se déplace qu’en roulant lentement, laissant derrière elle une traînée de paillettes et de gloss fondu. Son maquillage dégouline en permanence, formant une couche protectrice impénétrable — les scientifiques appellent ça le « fard d’armure ». Dotée d’un regard mi-séduisant, mi-comateux, elle hypnotise ses adversaires en leur lançant des œillades flasques, accompagnées d’un soupir de lassitude cosmique. Elle passe ses journées à se recoiffer sans bouger la tête, grâce à un système complexe de brosses dissimulées dans son chignon. Sa voix est rauque, son parfum est toxique, et sa principale attaque, "Écrasement Moussant", consiste à s’écrouler violemment sur son ennemi en faisant claquer ses faux ongles.
     electhordu:
@@ -2007,17 +2011,17 @@ App:
   author: Shlagémon Team
 stores:
   achievements:
-    unlocked: "Succès déverrouillé : {title}"
+    unlocked: 'Succès déverrouillé : {title}'
   disease:
     sick: Votre Shlagémon est malade ! Il reviendra à la normal après avoir gagné {n} combats.
     cured: Votre Shlagémon n'est plus malade !
   shlagedex:
-    rarityReached: "{name} atteint la rareté {rarity} !"
-    evolved: "{name} a évolué !"
+    rarityReached: '{name} atteint la rareté {rarity} !'
+    evolved: '{name} a évolué !'
     obtained: Tu as obtenu {name} !
     alreadyMax: Vous avez déjà ce Shlagémon au maximum de sa rareté
-    rarityChanged: "{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !"
-    released: "{name} a été relâché !"
+    rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
+    released: '{name} a été relâché !'
 layouts:
   NotFound:
     not-found: Page introuvable

--- a/src/components/shlagemon/List.i18n.yml
+++ b/src/components/shlagemon/List.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  new: 'Vous avez {n} nouveau Shlagémon | Vous avez {n} nouveaux Shlagémons'
+en:
+  new: 'You have {n} new Shlagemon | You have {n} new Shlagemons'

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -24,6 +24,8 @@ const dex = useShlagedexStore()
 const featureLock = useFeatureLockStore()
 const isLocked = computed(() => props.locked ?? featureLock.isShlagedexLocked)
 const items = Object.fromEntries(allItems.map(i => [i.id, i])) as Record<string, typeof allItems[number]>
+const { t } = useI18n()
+const newCount = computed(() => dex.newCount)
 
 // Options de tri
 const sortOptions = [
@@ -167,12 +169,14 @@ function changeActive(mon: DexShlagemon) {
 
     <template #content>
       <TransitionGroup name="fade-list" tag="div" class="grid grid-cols-1 gap-1">
-        <div class="mb-1">
+        <div v-if="newCount > 0" class="mb-1">
           <UiInfo
             color="info"
             class="col-span-2 row-start-3"
+            ok-button
+            @ok="dex.markAllSeen"
           >
-            Vous avez xxx nouveaux Shlagémons
+            {{ t('components.shlagemon.List.new', newCount) }}
           </UiInfo>
         </div>
         <ShlagemonListItem

--- a/src/components/ui/Info.i18n.yml
+++ b/src/components/ui/Info.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  ok: Ok
+en:
+  ok: Ok

--- a/src/components/ui/Info.vue
+++ b/src/components/ui/Info.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 import type { InfoColor } from '~/type/info'
 
-const props = withDefaults(defineProps<{ color?: InfoColor }>(), { color: 'info' })
+const props = withDefaults(
+  defineProps<{ color?: InfoColor, okButton?: boolean }>(),
+  { color: 'info', okButton: false },
+)
+
+const emit = defineEmits<{ (e: 'ok'): void }>()
+
+const { t } = useI18n()
 
 const colorClasses = computed(() => {
   const map: Record<InfoColor, string> = {
@@ -17,6 +24,15 @@ const colorClasses = computed(() => {
 
 <template>
   <div class="border rounded p-2 text-sm" :class="colorClasses">
-    <slot />
+    <div class="flex items-center justify-between gap-2">
+      <slot />
+      <UiButton
+        v-if="props.okButton"
+        size="sm"
+        @click="emit('ok')"
+      >
+        {{ t('components.ui.Info.ok') }}
+      </UiButton>
+    </div>
   </div>
 </template>

--- a/test/sort-evolution.test.ts
+++ b/test/sort-evolution.test.ts
@@ -46,7 +46,7 @@ describe('shlagedex sort evolution', () => {
       },
     })
 
-    const items = wrapper.findAll('div.relative')
+    const items = wrapper.findAll('button.relative')
     expect(items.length).toBe(4)
     expect(items[0].text()).toContain('Pikachiant')
     expect(items[1].text()).toContain('Carapouffe')

--- a/test/sort-item.test.ts
+++ b/test/sort-item.test.ts
@@ -33,7 +33,7 @@ describe('shlagedex sort item', () => {
       },
     })
 
-    const items = wrapper.findAll('div.relative')
+    const items = wrapper.findAll('button.relative')
     expect(items.length).toBe(2)
     // Active Shlagemon should remain first regardless of sort
     expect(items[0].text()).toContain(withoutItem.base.name)

--- a/test/sort-shiny.test.ts
+++ b/test/sort-shiny.test.ts
@@ -31,7 +31,7 @@ describe('shlagedex sort', () => {
       },
     })
 
-    const items = wrapper.findAll('div.relative')
+    const items = wrapper.findAll('button.relative')
     expect(items.length).toBe(2)
     // The first item is the active Shlagemon
     expect(items[1].text()).toContain('Sac de Pâtes')


### PR DESCRIPTION
## Summary
- show number of new shlagemons in list with i18n text and acknowledge button
- emit ok event from info banner to mark shlagemons as seen
- update tests for new list markup and provide translations

## Testing
- `pnpm exec eslint src/components/shlagemon/List.vue src/components/ui/Info.vue src/components/shlagemon/List.i18n.yml src/components/ui/Info.i18n.yml test/sort-evolution.test.ts test/sort-item.test.ts test/sort-shiny.test.ts`
- `pnpm exec vitest run test/sort-evolution.test.ts test/sort-item.test.ts test/sort-shiny.test.ts`
- `pnpm exec vitest run test/useLangSwitch.test.ts` *(fails: expected null to be '/fr/shlagedex')*
- `pnpm typecheck` *(fails: Property 'id' does not exist on type 'Ball' and others)*

------
https://chatgpt.com/codex/tasks/task_e_688fc9c0375c832a8d755afa70e341b2