### PR TITLE
feat: use right-click to mark panel content seen

### DIFF
--- a/src/components/ui/PanelWrapper.vue
+++ b/src/components/ui/PanelWrapper.vue
@@ -77,12 +77,17 @@ const titleClasses = computed(() => {
 
 const showBadge = computed(() => (props.badge ?? 0) > 0)
 
-function onTitleClick(e: MouseEvent) {
-  if (showBadge.value && props.badgeClick) {
-    e.stopPropagation()
-    props.badgeClick()
-  }
+function onTitleClick() {
   toggle()
+}
+
+/**
+ * Marks all panel content as seen when right-clicking the title.
+ * Uses context menu event to avoid toggling panel state.
+ */
+function onTitleContextMenu() {
+  if (showBadge.value)
+    props.badgeClick?.()
 }
 
 function clickPrevented(e: MouseEvent) {
@@ -96,7 +101,13 @@ function clickPrevented(e: MouseEvent) {
 
 <template>
   <div class="panel-wrapper" v-bind="$attrs" :class="wrapperClasses">
-    <div v-if="props.title" class="flex items-center justify-between p-2" :class="titleClasses" @click="onTitleClick">
+    <div
+      v-if="props.title"
+      class="flex items-center justify-between p-2"
+      :class="titleClasses"
+      @click="onTitleClick"
+      @contextmenu.prevent="onTitleContextMenu"
+    >
       <div class="flex items-center gap-1">
         <slot name="icon" />
         <span class="relative pr-4 font-bold">{{ props.title }}

--- a/test/panel-wrapper-contextmenu.test.ts
+++ b/test/panel-wrapper-contextmenu.test.ts
@@ -1,0 +1,30 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import PanelWrapper from '../src/components/ui/PanelWrapper.vue'
+
+// Mock UI store to avoid full Pinia setup
+vi.mock('../src/stores/ui', () => ({
+  useUIStore: () => ({ isMobile: ref(false) }),
+}))
+
+describe('panel wrapper context menu', () => {
+  it('marks content as seen on right click without toggling panel', async () => {
+    const badgeClick = vi.fn()
+    const wrapper = mount(PanelWrapper, {
+      props: { title: 'Title', badge: 1, badgeClick },
+      slots: { default: '<div>Hello</div>' },
+      global: { stubs: ['UiBadge'] },
+    })
+
+    const title = wrapper.find('.panel-wrapper > div')
+    await title.trigger('contextmenu')
+    expect(badgeClick).toHaveBeenCalledTimes(1)
+    expect((wrapper.vm as any).opened).toBe(true)
+
+    await title.trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(badgeClick).toHaveBeenCalledTimes(1)
+    expect((wrapper.vm as any).opened).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- open panels with left click and mark unseen content with right click
- test right-click behavior on panel headers

## Testing
- `pnpm lint` (fails: Strings must use singlequote)
- `pnpm exec eslint src/components/ui/PanelWrapper.vue test/panel-wrapper-contextmenu.test.ts`
- `pnpm test` (fails: multiple failing tests)
- `pnpm exec vitest test/panel-wrapper-contextmenu.test.ts`
- `pnpm typecheck` (fails: Property 'id' does not exist on type 'Ball')

------
https://chatgpt.com/codex/tasks/task_e_688fcc3715a8832ab17a0afb559e3a5d