### PR TITLE
feat: scroll to top when equipping shlagmon

### DIFF
--- a/src/components/layout/ScrollablePanel.vue
+++ b/src/components/layout/ScrollablePanel.vue
@@ -1,9 +1,28 @@
+<script setup lang="ts">
+const contentRef = ref<HTMLDivElement | null>(null)
+const prefersReducedMotion = usePreferredReducedMotion()
+
+/**
+ * Scrolls the panel content to the top.
+ * Respects the user's reduced motion preference.
+ */
+function scrollToTop(): void {
+  const behavior: ScrollBehavior = prefersReducedMotion.value ? 'auto' : 'smooth'
+  contentRef.value?.scrollTo({ top: 0, behavior })
+}
+
+defineExpose({ scrollToTop })
+</script>
+
 <template>
   <section class="h-full w-full flex flex-col gap-2 overflow-hidden">
     <div class="flex flex-wrap gap-2 px-1">
       <slot name="header" />
     </div>
-    <div class="tiny-scrollbar flex flex-col gap-1 overflow-x-hidden overflow-y-auto p-1">
+    <div
+      ref="contentRef"
+      class="tiny-scrollbar flex flex-col gap-1 overflow-x-hidden overflow-y-auto p-1"
+    >
       <slot name="content" />
     </div>
   </section>

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -26,6 +26,7 @@ const isLocked = computed(() => props.locked ?? featureLock.isShlagedexLocked)
 const items = Object.fromEntries(allItems.map(i => [i.id, i])) as Record<string, typeof allItems[number]>
 const { t } = useI18n()
 const newCount = computed(() => dex.newCount)
+const panelRef = ref<{ scrollToTop: () => void } | null>(null)
 
 // Options de tri
 const sortOptions = [
@@ -147,10 +148,17 @@ function changeActive(mon: DexShlagemon) {
     return
   dex.setActiveShlagemon(mon)
 }
+
+watch(
+  () => dex.activeShlagemon?.id,
+  () => {
+    nextTick(() => panelRef.value?.scrollToTop())
+  },
+)
 </script>
 
 <template>
-  <LayoutScrollablePanel>
+  <LayoutScrollablePanel ref="panelRef">
     <template #header>
       <div class="sticky top-0 z-10 w-full flex flex-col gap-1 bg-white/70 backdrop-blur-lg dark:bg-gray-900/70">
         <div class="flex items-center gap-1">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3,6 +3,16 @@
 @import './text.css';
 @import './animations.css';
 
+html {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto !important;
+  }
+}
+
 html,
 body,
 #app {


### PR DESCRIPTION
## Summary
- scroll to top after selecting an active Shlagémon
- expose scrollToTop helper on scrollable panels
- enable smooth scrolling with reduced-motion fallback

## Testing
- `pnpm exec eslint src/components/layout/ScrollablePanel.vue src/components/shlagemon/List.vue src/styles/main.css`
- `pnpm test:unit` *(fails: expected null to be '/fr/shlagedex')*
- `pnpm typecheck` *(fails: Property 'id' does not exist on type 'Ball', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688fd6bf7ebc832aa8b032e646f05d53