### PR TITLE
fix: align inventory badges color

### DIFF
--- a/changelog-fr.md
+++ b/changelog-fr.md
@@ -3,6 +3,12 @@
 Toutes les modifications importantes de ce projet seront documentées dans ce fichier.
 Le format s'inspire de [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 
+## [0.3.10] - 2025-08-03
+
+### Corrigé
+
+- La couleur du badge du panneau d'inventaire correspond désormais à celle des onglets de l'inventaire.
+
 ## [0.3.9] - 2025-08-02
 
 ### Modifié

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.10] - 2025-08-03
+
+### Fixed
+
+- Inventory panel badge color now matches inventory tab badge.
+
 ## [0.3.9] - 2025-08-02
 
 ### Changed

--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -95,6 +95,7 @@ const bottomBadgeColor = computed<BadgeColor>(() => {
     case 'zones':
       return 'danger'
     case 'inventory':
+      return 'primary'
     case 'dex':
     default:
       return 'info'
@@ -128,7 +129,7 @@ const bottomBadgeHandler = computed(() => {
           class="overflow-hidden"
           :is-locked="lockStore.isInventoryLocked"
           :badge="newItemCount"
-          badge-color="info"
+          badge-color="primary"
           :badge-click="usage.markAllUsed"
         >
           <template #icon>


### PR DESCRIPTION
## Summary
- use primary color for inventory panel badge to match tab indicators
- document badge color fix

## Testing
- `npx eslint src/components/layout/GameGrid.vue changelog.md changelog-fr.md`
- `pnpm test:unit --run` *(fails: Snapshot `component Header.vue > should render 1` mismatched; expected null to be '/fr/shlagedex')*

------
https://chatgpt.com/codex/tasks/task_e_688fcffcfe40832a94336cdf1febf8ca