### PR TITLE
refactor: replace floating-ui with floating-vue for tooltip

### DIFF
--- a/src/components/ui/Tooltip.vue
+++ b/src/components/ui/Tooltip.vue
@@ -1,110 +1,41 @@
 <script setup lang="ts">
-import type { Placement } from '@floating-ui/dom'
+import type { Placement } from 'floating-vue'
 import type { PropType } from 'vue'
-import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom'
-import { onUnmounted, ref } from 'vue'
+import { Tooltip as FloatingTooltip } from 'floating-vue'
 
+/**
+ * Wrapper around `floating-vue` tooltip with theme-aware styling.
+ */
 const props = defineProps({
+  /** Tooltip text to display. */
   text: { type: String, required: true },
+  /** Whether the wrapped element should behave like a button. */
   asButton: { type: Boolean, default: false },
+  /** Tooltip placement around the trigger element. */
   placement: { type: String as PropType<Placement>, default: 'bottom' },
 })
-
-const isTouch = useMediaQuery('(pointer: coarse)')
-const wrapper = ref<HTMLElement | null>(null)
-const tooltip = ref<HTMLElement | null>(null)
-const visible = ref(false)
-let cleanup: (() => void) | undefined
-let timeout: ReturnType<typeof setTimeout> | undefined
-
-function show() {
-  visible.value = true
-  updatePosition()
-  if (isTouch.value) {
-    clearTimeout(timeout)
-    timeout = setTimeout(hide, 3000)
-  }
-}
-function hide() {
-  visible.value = false
-  if (timeout)
-    clearTimeout(timeout)
-  if (cleanup) {
-    cleanup()
-    cleanup = undefined
-  }
-}
-function updatePosition() {
-  const wrapperEl = wrapper.value
-  const tooltipEl = tooltip.value
-  if (!wrapperEl || !tooltipEl)
-    return
-  cleanup = autoUpdate(wrapperEl, tooltipEl, () => {
-    computePosition(wrapperEl, tooltipEl, {
-      placement: props.placement,
-      middleware: [offset(8), flip(), shift({ padding: 8 })],
-      strategy: 'fixed',
-    }).then(({ x, y }) => {
-      Object.assign(tooltipEl.style, {
-        left: `${x}px`,
-        top: `${y}px`,
-      })
-    })
-  })
-}
-onUnmounted(hide)
-function onKeyDown(e: KeyboardEvent) {
-  if (e.key === 'Escape')
-    hide()
-}
 </script>
 
 <template>
-  <span
-    ref="wrapper"
-    class="relative inline-flex items-center outline-none"
-    :tabindex="props.asButton ? 0 : undefined"
-    :aria-describedby="visible ? 'tooltip-content' : undefined"
-    :role="props.asButton ? 'button' : undefined"
-    :aria-label="props.asButton ? props.text : undefined"
-    @mouseenter="show"
-    @mouseleave="hide"
-    @focus="show"
-    @blur="hide"
-    @click="isTouch ? show() : undefined"
-    @keydown="onKeyDown"
-  >
-    <slot />
-    <Transition name="tooltip-fade">
+  <FloatingTooltip :placement="props.placement" :distance="8" :triggers="['hover', 'focus', 'touch']">
+    <span
+      class="relative inline-flex items-center outline-none"
+      :tabindex="props.asButton ? 0 : undefined"
+      :role="props.asButton ? 'button' : undefined"
+      :aria-label="props.asButton ? props.text : undefined"
+    >
+      <slot />
+    </span>
+    <template #popper>
       <span
-        v-if="visible"
-        id="tooltip-content"
-        ref="tooltip"
-        role="tooltip"
-        class="pointer-events-none fixed z-50 min-w-[2.5rem] translate-y-2 scale-95 select-none rounded-xl bg-neutral-900/90 px-2 py-1 text-xs text-neutral-50 font-medium opacity-0 shadow-lg transition-all duration-150 will-change-transform data-[show=true]:translate-y-0 data-[show=true]:scale-100 data-[show=true]:opacity-100"
-        :data-show="visible"
+        class="pointer-events-none z-50 rounded-xl bg-neutral-900/90 px-2 py-1 text-xs text-neutral-50 font-medium shadow-lg dark:bg-neutral-50 dark:text-neutral-900"
       >
         {{ props.text }}
       </span>
-    </Transition>
-  </span>
+    </template>
+  </FloatingTooltip>
 </template>
 
 <style scoped>
-.tooltip-fade-enter-active,
-.tooltip-fade-leave-active {
-  transition:
-    opacity 0.15s cubic-bezier(0.5, 1.5, 0.6, 1),
-    transform 0.15s cubic-bezier(0.5, 1.5, 0.6, 1);
-}
-.tooltip-fade-enter-from,
-.tooltip-fade-leave-to {
-  opacity: 0;
-  transform: scale(0.95) translateY(8px);
-}
-.tooltip-fade-enter-to,
-.tooltip-fade-leave-from {
-  opacity: 1;
-  transform: scale(1) translateY(0);
-}
+/* No additional styles needed; relying on FloatingVue defaults */
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import './styles/main.css'
 import './styles/battle.css'
 import 'uno.css'
 import 'vue3-toastify/dist/index.css'
+import 'floating-vue/dist/style.css'
 
 // https://github.com/antfu/vite-ssg
 export const createApp = ViteSSG(


### PR DESCRIPTION
## Summary
- replace custom positioning with `floating-vue`
- load `floating-vue` styles globally

## Testing
- `pnpm exec eslint src/components/ui/Tooltip.vue src/main.ts`
- `pnpm test:unit` *(fails: useLangSwitch > returns equivalent path in other locale)*

------
https://chatgpt.com/codex/tasks/task_e_688fe3640bc8832a92a7f49ca40d0a99