### PR TITLE
fix: purge unknown badges on store load

### DIFF
--- a/src/stores/badgeBox.ts
+++ b/src/stores/badgeBox.ts
@@ -14,15 +14,26 @@ export const useBadgeBoxStore = defineStore('badgeBox', () => {
     'badge-buttered-toast': 'buttered-toast',
   }
 
+  /**
+   * Migrates badge identifiers from legacy values to the current identifiers.
+   */
   function normalizeBadges(): void {
-    badges.value = badges.value.map(b => ({
-      id: LEGACY_BADGE_IDS[b.id] ?? b.id,
-      name: b.name,
-      levelCap: b.levelCap,
+    badges.value = badges.value.map(badge => ({
+      id: LEGACY_BADGE_IDS[badge.id] ?? badge.id,
+      name: badge.name,
+      levelCap: badge.levelCap,
     }))
   }
 
+  /**
+   * Removes badges whose identifiers do not match any existing arena.
+   */
+  function removeUnknownBadges(): void {
+    badges.value = badges.value.filter(badge => Boolean(getArena(badge.id)))
+  }
+
   normalizeBadges()
+  removeUnknownBadges()
 
   function open() {
     isModalOpen.value = true
@@ -49,6 +60,9 @@ export const useBadgeBoxStore = defineStore('badgeBox', () => {
    * they are added here.
    */
   function syncWithPlayerBadges(): void {
+    normalizeBadges()
+    removeUnknownBadges()
+
     const player = usePlayerStore()
     for (const [arenaId, hasBadge] of Object.entries(player.arenaBadges)) {
       if (!hasBadge)

--- a/test/badge-box-sync.test.ts
+++ b/test/badge-box-sync.test.ts
@@ -1,3 +1,4 @@
+import type { ArenaBadge } from '../src/type'
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import { getArena } from '../src/data/arenas'
@@ -33,5 +34,17 @@ describe('badge box sync', () => {
     badgeBox.syncWithPlayerBadges()
 
     expect(badgeBox.badges).toHaveLength(1)
+  })
+
+  it('removes badges with unknown identifiers', () => {
+    setActivePinia(createPinia())
+    const badgeBox = useBadgeBoxStore()
+
+    badgeBox.badges.push({ id: 'does-not-exist', name: 'unknown', levelCap: 0 } as ArenaBadge)
+    expect(badgeBox.badges).toHaveLength(1)
+
+    badgeBox.syncWithPlayerBadges()
+
+    expect(badgeBox.badges).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- normalize legacy badge IDs and drop badges without matching arena when loading the badge box
- cover badge sanitization with unit test

## Testing
- `pnpm lint` *(fails: Strings must use singlequote in YAML files)*
- `npx eslint src/stores/badgeBox.ts test/badge-box-sync.test.ts`
- `npx vitest test/badge-box-sync.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689061fbf038832a9b37eed7e75be628