### PR TITLE
feat: show zone name in map marker tooltip

### DIFF
--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -91,6 +91,7 @@ export function useMapMarkers(map: LeafletMap) {
       size: markerSize,
       anchorY,
       interactive: true,
+      title: zone.name,
     })
 
     watch([allCaptured, perfectZone, kingDefeated, arenaCompleted, visited], () => {

--- a/test/map-marker-tooltip.test.ts
+++ b/test/map-marker-tooltip.test.ts
@@ -1,0 +1,46 @@
+import type { LeafletMap } from 'leaflet'
+import type { Zone } from '../src/type'
+import { describe, expect, it, vi } from 'vitest'
+import { useLeafletMarker } from '../src/composables/leaflet/useLeafletMarker'
+import { useMapMarkers } from '../src/composables/leaflet/useMapMarkers'
+
+vi.mock('../src/composables/leaflet/useLeafletMarker', () => ({
+  useLeafletMarker: vi.fn(() => ({
+    on: vi.fn(),
+    off: vi.fn(),
+    setIcon: vi.fn(),
+    getElement: vi.fn(() => document.createElement('div')),
+  })),
+}))
+
+vi.mock('../src/composables/useZoneCompletion', () => ({
+  useZoneCompletion: () => ({
+    allCaptured: { value: false },
+    perfectZone: { value: false },
+    kingDefeated: { value: false },
+    arenaCompleted: { value: false },
+  }),
+}))
+
+vi.mock('../src/stores/zoneVisit', () => ({
+  useZoneVisitStore: () => ({ visited: {} }),
+}))
+
+describe('useMapMarkers', () => {
+  it('assigns zone name as marker title', () => {
+    const dummyMap = {} as LeafletMap
+    const { addMarker } = useMapMarkers(dummyMap)
+    const zone: Zone = {
+      id: 'test-zone',
+      name: 'Test Zone',
+      type: 'sauvage',
+      position: { lat: 0, lng: 0 },
+      minLevel: 1,
+      maxLevel: 2,
+    }
+    addMarker(zone)
+    expect(useLeafletMarker).toHaveBeenCalledWith(
+      expect.objectContaining({ title: zone.name }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- display zone name on map markers via native tooltip
- test marker creation to ensure zone name is passed as title

## Testing
- `pnpm lint` *(fails: Strings must use singlequote)*
- `pnpm test:unit` *(fails: snapshot `component Header.vue > should render 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_689062e8ce64832a9264f5bfbd71a6d1