### PR TITLE
feat: localize PWA manifest per language

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,16 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#1865ab" />
     <meta name="msapplication-TileColor" content="#1865ab" />
     <meta name="theme-color" content="#1865ab" />
+    <link id="pwa-manifest" rel="manifest" href="/en/manifest.webmanifest" />
+    <script>
+      ;(function () {
+        const supported = ['fr', 'en']
+        const pathLocale = location.pathname.split('/')[1]
+        const locale = supported.includes(pathLocale) ? pathLocale : 'en'
+        const manifestLink = document.getElementById('pwa-manifest')
+        if (manifestLink) manifestLink.setAttribute('href', `/${locale}/manifest.webmanifest`)
+      })()
+    </script>
     <script>
       ;(function () {
         const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches

--- a/src/pwa/manifest.ts
+++ b/src/pwa/manifest.ts
@@ -6,7 +6,6 @@ import type { Locale } from '~/constants/locales'
  */
 export function getPwaManifest(locale: Locale): ManifestOptions {
   const base: ManifestOptions = {
-    short_name: 'Shlagémon',
     theme_color: '#1865ab',
     background_color: '#1865ab',
     icons: [
@@ -33,6 +32,7 @@ export function getPwaManifest(locale: Locale): ManifestOptions {
     return {
       ...base,
       lang: 'fr',
+      short_name: 'Shlagémon',
       name: 'Shlagémon - Ça sent très fort',
       description: 'Attrape tous les Shlagémons pour éviter qu\'ils ne pourrissent la terre entière.',
       start_url: '/fr/',
@@ -43,6 +43,7 @@ export function getPwaManifest(locale: Locale): ManifestOptions {
   return {
     ...base,
     lang: 'en',
+    short_name: 'Shlagemon',
     name: 'Shlagemon - It smells very strong',
     description: 'Catch all the Shlagemons before they rot the whole world.',
     start_url: '/en/',

--- a/test/pwa-manifest.test.ts
+++ b/test/pwa-manifest.test.ts
@@ -7,8 +7,24 @@ describe('getPwaManifest', () => {
   for (const locale of locales) {
     it(`returns manifest for ${locale}`, () => {
       const manifest = getPwaManifest(locale)
+
       expect(manifest.lang).toBe(locale)
       expect(manifest.start_url).toBe(`/${locale}/`)
+
+      if (locale === 'fr') {
+        expect(manifest.short_name).toBe('Shlagémon')
+        expect(manifest.name).toBe('Shlagémon - Ça sent très fort')
+        expect(manifest.description).toBe(
+          'Attrape tous les Shlagémons pour éviter qu\'ils ne pourrissent la terre entière.',
+        )
+      }
+      else {
+        expect(manifest.short_name).toBe('Shlagemon')
+        expect(manifest.name).toBe('Shlagemon - It smells very strong')
+        expect(manifest.description).toBe(
+          'Catch all the Shlagemons before they rot the whole world.',
+        )
+      }
     })
   }
 })


### PR DESCRIPTION
## Summary
- generate manifest with translated fields for each locale
- link the correct manifest on initial load and update it based on URL
- cover manifest localization in unit tests

## Testing
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched; expected null to be '/fr/shlagedex')*
- `pnpm test:unit test/pwa-manifest.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68909d5590d4832a904a9bccc1b55304