### PR TITLE
feat: add PWA screenshots to manifest

### DIFF
--- a/src/pwa/manifest.ts
+++ b/src/pwa/manifest.ts
@@ -26,6 +26,33 @@ export function getPwaManifest(locale: Locale): ManifestOptions {
         purpose: 'any maskable',
       },
     ],
+    screenshots: [
+      {
+        src: '/screenshots/battle.jpg',
+        sizes: '1200x800',
+        type: 'image/jpeg',
+      },
+      {
+        src: '/screenshots/detail.jpg',
+        sizes: '1200x800',
+        type: 'image/jpeg',
+      },
+      {
+        src: '/screenshots/dialog.jpg',
+        sizes: '1200x800',
+        type: 'image/jpeg',
+      },
+      {
+        src: '/screenshots/shop.jpg',
+        sizes: '1200x800',
+        type: 'image/jpeg',
+      },
+      {
+        src: '/screenshots/with-map.jpg',
+        sizes: '1200x800',
+        type: 'image/jpeg',
+      },
+    ],
   }
 
   if (locale === 'fr') {

--- a/test/pwa-manifest.test.ts
+++ b/test/pwa-manifest.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { getPwaManifest } from '../src/pwa/manifest'
 
 const locales = ['fr', 'en'] as const
+const expectedScreenshots = [
+  '/screenshots/battle.jpg',
+  '/screenshots/detail.jpg',
+  '/screenshots/dialog.jpg',
+  '/screenshots/shop.jpg',
+  '/screenshots/with-map.jpg',
+] as const
 
 describe('getPwaManifest', () => {
   for (const locale of locales) {
@@ -24,6 +31,15 @@ describe('getPwaManifest', () => {
         expect(manifest.description).toBe(
           'Catch all the Shlagemons before they rot the whole world.',
         )
+      }
+
+      expect(manifest.screenshots).toHaveLength(expectedScreenshots.length)
+
+      for (const [index, src] of expectedScreenshots.entries()) {
+        const screenshot = manifest.screenshots?.[index]
+        expect(screenshot?.src).toBe(src)
+        expect(screenshot?.sizes).toBe('1200x800')
+        expect(screenshot?.type).toBe('image/jpeg')
       }
     })
   }


### PR DESCRIPTION
## Summary
- add five screenshots to PWA manifest
- test manifest includes screenshots for each locale

## Testing
- `pnpm lint` *(fails: Strings must use singlequote in various YAML files)*
- `pnpm typecheck` *(fails: cannot find properties like `maxLevel` and missing types)*
- `pnpm test` *(fails: snapshot mismatch and lang switch test)*

------
https://chatgpt.com/codex/tasks/task_e_6890a5f6a3a8832ab7e2ad0bafbd0a0c