### PR TITLE
fix: generate english sitemap root

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,7 +137,10 @@ export default defineConfig({
         dynamicRoutes: getAllLocalizedPaths(),
         i18n: {
           languages: ['fr', 'en'],
-          defaultLanguage: 'fr',
+          // The root path `/` must always reflect the English locale.
+          // Default sitemap language is therefore set to English
+          // to match the SSG output and avoid cross-locale content.
+          defaultLanguage: 'en',
         },
       })
     },


### PR DESCRIPTION
## Summary
- ensure sitemap uses English as default language so `/` corresponds to `en`

## Testing
- `pnpm test --run test/useLangSwitch.test.ts` *(fails: No match found for location with path "/")*


------
https://chatgpt.com/codex/tasks/task_e_6890a876fdb8832a9e8017f9c0982ebe