### PR TITLE
fix: enforce locale from URL during SSG

### DIFF
--- a/src/modules/localeFromPath.ts
+++ b/src/modules/localeFromPath.ts
@@ -14,21 +14,24 @@ export const install: UserModule = ({ router, isClient, head }) => {
 
   router.beforeEach(async (to) => {
     const target = to.meta.locale as Locale | undefined
-    if (target && target !== store.locale) {
-      store.setLocale(target)
-      await loadLanguageAsync(target)
+    if (!target)
+      return true
 
-      if (!isClient) {
-        head?.push({
-          htmlAttrs: { lang: target },
-          link: [
-            {
-              rel: 'manifest',
-              href: `/${target}/manifest.webmanifest`,
-            },
-          ],
-        })
-      }
+    if (store.locale !== target)
+      store.setLocale(target)
+
+    await loadLanguageAsync(target)
+
+    if (!isClient) {
+      head?.push({
+        htmlAttrs: { lang: target },
+        link: [
+          {
+            rel: 'manifest',
+            href: `/${target}/manifest.webmanifest`,
+          },
+        ],
+      })
     }
     return true
   })


### PR DESCRIPTION
## Summary
- always load i18n messages based on the route locale

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: component Header.vue snapshot mismatch, useLangSwitch path assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6890ad807cbc832a93daebaf12a96db5