### PR TITLE
feat(i18n): respect route locale during SSG

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -1,4 +1,4 @@
-import type { Locale } from 'vue-i18n'
+import type { Locale } from '~/constants/locales'
 import type { UserModule } from '~/types'
 import { useHead } from '@unhead/vue'
 import { getCurrentInstance } from 'vue'
@@ -57,14 +57,19 @@ export async function loadLanguageAsync(lang: Locale): Promise<Locale> {
   return setI18nLanguage(lang)
 }
 
-export const install: UserModule = ({ app, isClient }) => {
+export const install: UserModule = ({ app, isClient, route }) => {
   app.use(i18n)
   const localeStore = useLocaleStore()
 
-  if (isClient && !localStorage.getItem('locale')) {
-    const navigatorLang = navigator.language.toLowerCase()
-    const fallback = navigatorLang.startsWith('fr') ? 'fr' : defaultLocale
-    localeStore.setLocale(fallback as Locale)
+  if (!isClient) {
+    const routeLocale = route.meta.locale as Locale | undefined
+    if (routeLocale)
+      localeStore.setLocale(routeLocale)
+  }
+  else if (!localStorage.getItem('locale')) {
+    const navigatorLanguage = navigator.language.toLowerCase()
+    const fallback = navigatorLanguage.startsWith('fr') ? 'fr' : defaultLocale
+    localeStore.setLocale(fallback)
   }
 
   loadLanguageAsync(localeStore.locale)

--- a/test/i18n-ssg-locale.test.ts
+++ b/test/i18n-ssg-locale.test.ts
@@ -1,0 +1,20 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { i18n, install as installI18n, loadLanguageAsync } from '../src/modules/i18n'
+import { useLocaleStore } from '../src/stores/locale'
+
+describe('i18n ssg locale', () => {
+  it('uses route meta locale during generation', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    installI18n({
+      app: { use: () => {} } as any,
+      isClient: false,
+      route: { meta: { locale: 'fr' } },
+    } as any)
+
+    expect(useLocaleStore().locale).toBe('fr')
+    await loadLanguageAsync(useLocaleStore().locale)
+    expect(i18n.global.locale.value).toBe('fr')
+  })
+})


### PR DESCRIPTION
## Summary
- initialize i18n locale from route metadata during SSG
- add unit test ensuring SSG uses route locale

## Testing
- `pnpm lint`
- `pnpm test` *(fails: `component Header.vue > should render` snapshot mismatch; `useLangSwitch.test.ts` path expectation)*
- `pnpm test test/i18n-ssg-locale.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_6890b71c2c4c832a9f901f84e37a23b1