### PR TITLE
fix: guard missing route meta in i18n install

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -62,7 +62,7 @@ export const install: UserModule = ({ app, isClient, route }) => {
   const localeStore = useLocaleStore()
 
   if (!isClient) {
-    const routeLocale = route.meta.locale as Locale | undefined
+    const routeLocale = route?.meta?.locale as Locale | undefined
     if (routeLocale)
       localeStore.setLocale(routeLocale)
   }

--- a/test/i18n-ssg-locale.test.ts
+++ b/test/i18n-ssg-locale.test.ts
@@ -17,4 +17,15 @@ describe('i18n ssg locale', () => {
     await loadLanguageAsync(useLocaleStore().locale)
     expect(i18n.global.locale.value).toBe('fr')
   })
+
+  it('falls back gracefully when no route is provided', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    expect(() =>
+      installI18n({
+        app: { use: () => {} } as any,
+        isClient: false,
+      } as any),
+    ).not.toThrow()
+  })
 })


### PR DESCRIPTION
## Summary
- avoid runtime error when route is undefined during server-side generation
- test i18n install without a route

## Testing
- `pnpm test test/i18n-ssg-locale.test.ts`
- `pnpm test test/useLangSwitch.test.ts` *(fails: expected null to be '/fr/shlagedex')*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6890bbeb1b74832a9747c02ab8eb39f6