### PR TITLE
feat: make audio store SSR-safe

### DIFF
--- a/src/data/sfx.ts
+++ b/src/data/sfx.ts
@@ -16,10 +16,16 @@ export const sfxUrls = Object.fromEntries(
 
 export type SfxId = keyof typeof sfxUrls
 
+/**
+ * Preload every registered sound effect.
+ *
+ * In test and SSR environments, lightweight stubs are returned instead of
+ * actual `Howl` instances to avoid accessing audio APIs.
+ */
 export function preloadSfx(): Record<SfxId, Howl> {
   const map = {} as Record<SfxId, Howl>
   for (const [id, url] of Object.entries(sfxUrls) as [SfxId, string][]) {
-    const howl = import.meta.env.VITEST
+    const howl = import.meta.env.VITEST || import.meta.env.SSR
       ? ({
           _src: url,
           play: () => {},

--- a/test/audio-ssr.test.ts
+++ b/test/audio-ssr.test.ts
@@ -1,0 +1,21 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useAudioStore } from '../src/stores/audio'
+
+/** Ensure audio store can be serialized during SSR. */
+describe('audio store SSR serialization', () => {
+  it('serializes pinia state', () => {
+    const original = import.meta.env.SSR
+    import.meta.env.SSR = true
+    try {
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      useAudioStore()
+      expect(() => JSON.stringify(pinia.state.value)).not.toThrow()
+    }
+    finally {
+      import.meta.env.SSR = original
+      setActivePinia(createPinia())
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- return stub Howl objects during SSR in `preloadSfx`
- avoid creating Howl instances on the server and keep `currentMusic` null
- add regression test ensuring the audio store serializes under SSR

## Testing
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched; expected '/fr/shlagedex' but received null)*
- `pnpm test:unit test/audio-ssr.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_6890ec957618832aaf7727c6ad2a2eee