### PR TITLE
refactor: use type ids for resistances

### DIFF
--- a/src/components/shlagemon/TypeChart.vue
+++ b/src/components/shlagemon/TypeChart.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import type { TypeName } from '~/type'
 import { shlagemonTypes } from '~/data/shlagemons-type'
 
 const props = defineProps<{ highlight?: string | null }>()
 
-const types = Object.values(shlagemonTypes)
+const typeIds = Object.keys(shlagemonTypes) as TypeName[]
 
 // --- Scroll horizontal à la molette
 const tableContainer = ref<HTMLDivElement | null>(null)
@@ -23,10 +24,12 @@ onBeforeUnmount(() => {
 })
 
 // --- Table logique
-function getMultiplier(att: typeof types[number], def: typeof types[number]) {
-  if (def.weakness.some(w => w.id === att.id))
+function getMultiplier(att: TypeName, def: TypeName) {
+  const attack = shlagemonTypes[att]
+  const defend = shlagemonTypes[def]
+  if (defend.weakness.includes(attack.id))
     return 1.5
-  if (def.resistance.some(r => r.id === att.id))
+  if (defend.resistance.includes(attack.id))
     return 0.5
   return 1
 }
@@ -52,30 +55,30 @@ function getMultiplier(att: typeof types[number], def: typeof types[number]) {
             </div>
           </th>
           <th
-            v-for="t in types"
-            :key="t.id"
+            v-for="t in typeIds"
+            :key="t"
             class="sticky top-0 z-20 bg-white p-1 dark:bg-gray-900"
             style="box-shadow: 0 2px 0 0 rgba(0,0,0,0.03);"
           >
-            <ShlagemonType :value="t" />
+            <ShlagemonType :value="shlagemonTypes[t]" />
           </th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="atk in types" :key="atk.id">
+        <tr v-for="atk in typeIds" :key="atk">
           <th
             class="sticky left-0 z-10 bg-white p-1 text-right dark:bg-gray-900"
             style="box-shadow: 2px 0 0 0 rgba(0,0,0,0.03);"
           >
-            <ShlagemonType :value="atk" />
+            <ShlagemonType :value="shlagemonTypes[atk]" />
           </th>
           <td
-            v-for="def in types"
-            :key="def.id"
+            v-for="def in typeIds"
+            :key="def"
             class="border border-gray-200 p-1 dark:border-gray-700"
             :class="{
-              'bg-blue-200 dark:bg-blue-800': props.highlight === atk.id || props.highlight === def.id,
-              'font-bold': props.highlight === atk.id && props.highlight === def.id,
+              'bg-blue-200 dark:bg-blue-800': props.highlight === atk || props.highlight === def,
+              'font-bold': props.highlight === atk && props.highlight === def,
             }"
           >
             {{ getMultiplier(atk, def) }}

--- a/src/data/shlagemons-type.ts
+++ b/src/data/shlagemons-type.ts
@@ -1,6 +1,4 @@
-import type { ShlagemonType } from '../type'
-
-export type TypeName = 'normal' | 'feu' | 'eau' | 'plante' | 'roche' | 'electrique' | 'vol' | 'combat' | 'spectre' | 'darksasuke' | 'psy' | 'poison' | 'metal' | 'sol' | 'fee' | 'dragon' | 'glace' | 'insecte'
+import type { ShlagemonType, TypeName } from '../type'
 
 export const normal: ShlagemonType = {
   id: 'normal',
@@ -8,7 +6,7 @@ export const normal: ShlagemonType = {
   description: 'Type complètement inintéressant et trop pourri.',
   color: '#A8A878',
   resistance: [],
-  weakness: [],
+  weakness: ['combat'],
   tags: ['banal', 'fade'],
   passiveEffects: [],
 }
@@ -18,8 +16,8 @@ export const feu: ShlagemonType = {
   name: 'Cramé',
   description: 'Type brûlant qui réduit tout en cendres.',
   color: '#e25822',
-  resistance: [],
-  weakness: [],
+  resistance: ['plante', 'metal', 'fee'],
+  weakness: ['eau', 'sol'],
   tags: ['brûlant'],
   passiveEffects: [],
 }
@@ -29,8 +27,8 @@ export const eau: ShlagemonType = {
   name: 'Mouillé',
   description: 'Type humide qui éteint facilement les ardeurs.',
   color: '#3b83bd',
-  resistance: [],
-  weakness: [],
+  resistance: ['feu', 'roche', 'eau'],
+  weakness: ['plante', 'electrique'],
   tags: ['humide'],
   passiveEffects: [],
 }
@@ -40,8 +38,8 @@ export const plante: ShlagemonType = {
   name: 'Moisi',
   description: 'Type végétal en décomposition.',
   color: '#769958',
-  resistance: [],
-  weakness: [],
+  resistance: ['sol', 'electrique', 'eau'],
+  weakness: ['feu', 'plante', 'poison', 'vol'],
   tags: ['fongique'],
   passiveEffects: [],
 }
@@ -51,8 +49,8 @@ export const electrique: ShlagemonType = {
   name: 'Électrochiasse',
   description: 'Type chargé d\'électricité statique.',
   color: '#f9e743',
-  resistance: [],
-  weakness: [],
+  resistance: ['vol', 'electrique', 'eau'],
+  weakness: ['sol'],
   tags: ['électrique'],
   passiveEffects: [],
 }
@@ -62,8 +60,8 @@ export const roche: ShlagemonType = {
   name: 'Caillasse',
   description: 'Type roc très coriace.',
   color: '#a79f94',
-  resistance: [],
-  weakness: [],
+  resistance: ['feu', 'vol', 'poison', 'fee'],
+  weakness: ['combat', 'eau', 'plante', 'sol', 'metal'],
   tags: ['solide'],
   passiveEffects: [],
 }
@@ -73,8 +71,8 @@ export const vol: ShlagemonType = {
   name: 'AirEction',
   description: 'Type aérien mais qui sent la teub.',
   color: '#A4C2F4',
-  resistance: [],
-  weakness: [],
+  resistance: ['combat', 'plante', 'eau'],
+  weakness: ['roche', 'electrique', 'plante'],
   tags: ['aérien'],
   passiveEffects: [],
 }
@@ -84,8 +82,8 @@ export const combat: ShlagemonType = {
   name: 'Castagne',
   description: 'Type bagarreur qui tape sans réfléchir.',
   color: '#C03028',
-  resistance: [],
-  weakness: [],
+  resistance: ['roche', 'darksasuke', 'poison'],
+  weakness: ['vol', 'psy', 'fee'],
   tags: ['bourrin'],
   passiveEffects: [],
 }
@@ -95,8 +93,8 @@ export const spectre: ShlagemonType = {
   name: 'Spectranus',
   description: 'Type chelou qui fout les jetons.',
   color: '#705898',
-  resistance: [],
-  weakness: [],
+  resistance: ['poison', 'combat'],
+  weakness: ['darksasuke', 'spectre'],
   tags: ['ectoplasmique'],
   passiveEffects: [],
 }
@@ -106,8 +104,8 @@ export const darksasuke: ShlagemonType = {
   name: 'DarkSasuke',
   description: 'Type victime, gothique et émo qui cours avec les bras en arrière.',
   color: '#4D4D4D',
-  resistance: [],
-  weakness: [],
+  resistance: ['spectre', 'psy', 'plante'],
+  weakness: ['combat', 'fee'],
   tags: ['malsain'],
   passiveEffects: [],
 }
@@ -117,8 +115,8 @@ export const psy: ShlagemonType = {
   name: 'Psytrance',
   description: `Un fan de musique de merde, il ne sait pas s'amuser sans prendre de drogue.`,
   color: '#FF66CC',
-  resistance: [],
-  weakness: [],
+  resistance: ['combat', 'fee'],
+  weakness: ['darksasuke', 'spectre', 'poison'],
   tags: ['mental'],
   passiveEffects: [],
 }
@@ -128,8 +126,8 @@ export const poison: ShlagemonType = {
   name: 'Poisonet',
   description: 'Type toxique qui t’envoie des mails louches.',
   color: '#A040A0',
-  resistance: [],
-  weakness: [],
+  resistance: ['plante', 'combat', 'fee'],
+  weakness: ['sol', 'psy'],
   tags: ['toxique'],
   passiveEffects: [],
 }
@@ -139,8 +137,8 @@ export const metal: ShlagemonType = {
   name: 'Ferraille',
   description: 'Type blindé mais rouillé qui couine à chaque pas.',
   color: '#B8B8D0',
-  resistance: [],
-  weakness: [],
+  resistance: ['poison', 'eau', 'electrique', 'plante', 'psy', 'roche', 'fee', 'vol'],
+  weakness: ['combat', 'feu', 'sol'],
   tags: ['métal'],
   passiveEffects: [],
 }
@@ -150,8 +148,8 @@ export const sol: ShlagemonType = {
   name: 'Cradouze',
   description: 'Type terreux qui gratte les pieds.',
   color: '#E0C068',
-  resistance: [],
-  weakness: [],
+  resistance: ['electrique', 'poison', 'feu', 'roche'],
+  weakness: ['plante', 'eau'],
   tags: ['sale', 'boueux'],
   passiveEffects: [],
 }
@@ -162,7 +160,7 @@ export const fee: ShlagemonType = {
   description: 'Type sucré en apparence, mais colle aux doigts.',
   color: '#EE99AC',
   resistance: [],
-  weakness: [],
+  weakness: ['poison', 'metal'],
   tags: ['collant'],
   passiveEffects: [],
 }
@@ -172,8 +170,8 @@ export const dragon: ShlagemonType = {
   name: 'DragonDorf',
   description: 'Type majestueux mais trop sûr de lui, qui finit toujours battu à la fin.',
   color: '#7038F8', // couleur violette proche du type Dragon
-  resistance: [],
-  weakness: [],
+  resistance: ['feu', 'eau', 'electrique', 'plante'],
+  weakness: ['dragon', 'glace', 'fee'],
   tags: ['mythique'],
   passiveEffects: [],
 }
@@ -183,8 +181,8 @@ export const glace: ShlagemonType = {
   name: 'Glaconasse',
   description: 'Type froid comme ton ex, glissant et imprévisible.',
   color: '#98d8d8',
-  resistance: [],
-  weakness: [],
+  resistance: ['glace'],
+  weakness: ['feu', 'roche', 'combat', 'metal'],
   tags: ['gelé', 'froid'],
   passiveEffects: [],
 }
@@ -194,46 +192,11 @@ export const insecte: ShlagemonType = {
   name: 'Mouchtik',
   description: 'Type grouillant, souvent poilu, toujours dérangeant. Il gratte la nuit et te juge en silence.',
   color: '#a8b820',
-  resistance: [],
-  weakness: [],
+  resistance: ['combat', 'plante', 'sol'],
+  weakness: ['feu', 'poison', 'vol', 'roche'],
   tags: ['grattant', 'antenne', 'multisegmenté'],
   passiveEffects: [],
 }
-
-normal.weakness.push(combat)
-feu.weakness.push(eau, sol)
-feu.resistance.push(plante, metal, fee)
-eau.weakness.push(plante, electrique)
-eau.resistance.push(feu, roche, eau)
-plante.weakness.push(feu, plante, poison, vol)
-plante.resistance.push(sol, electrique, eau)
-electrique.weakness.push(sol)
-electrique.resistance.push(vol, electrique, eau)
-roche.weakness.push(combat, eau, plante, sol, metal)
-roche.resistance.push(feu, vol, poison, fee)
-vol.weakness.push(roche, electrique, plante)
-vol.resistance.push(combat, plante, eau)
-combat.weakness.push(vol, psy, fee)
-combat.resistance.push(roche, darksasuke, poison)
-spectre.weakness.push(darksasuke, spectre)
-spectre.resistance.push(poison, combat)
-darksasuke.weakness.push(combat, fee)
-darksasuke.resistance.push(spectre, psy, plante)
-psy.weakness.push(darksasuke, spectre, poison)
-psy.resistance.push(combat, fee)
-poison.weakness.push(sol, psy)
-poison.resistance.push(plante, combat, fee)
-metal.weakness.push(combat, feu, sol)
-metal.resistance.push(poison, eau, electrique, plante, psy, roche, fee, vol)
-sol.weakness.push(plante, eau)
-sol.resistance.push(electrique, poison, feu, roche)
-fee.weakness.push(poison, metal)
-dragon.weakness.push(dragon, glace, fee)
-dragon.resistance.push(feu, eau, electrique, plante)
-glace.weakness.push(feu, roche, combat, metal)
-glace.resistance.push(glace)
-insecte.weakness.push(feu, poison, vol, roche)
-insecte.resistance.push(combat, plante, sol)
 
 // liste exportée
 export const shlagemonTypes: { [typeName in TypeName]: ShlagemonType } = {

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -35,8 +35,8 @@ export const useBattleStore = defineStore('battle', () => {
     isPlayerDefender = false,
     reduced = false,
   ): AttackResult {
-    const atkType = attacker.base.types[0]
-    const defTypes = defender.base.types
+    const atkType = attacker.base.types[0].id
+    const defTypes = defender.base.types.map(t => t.id)
     const atkBonus = isPlayerAttacker ? 1 + dex.bonusPercent / 100 : 1
     const musicBonus = audio.isMusicEnabled ? 1.1 : 1
     const shinyBonus = attacker.isShiny ? 1.15 : 1

--- a/src/stores/egg.ts
+++ b/src/stores/egg.ts
@@ -1,6 +1,5 @@
 import type { PersistedStateOptions } from 'pinia-plugin-persistedstate'
-import type { TypeName } from '~/data/shlagemons-type'
-import type { BaseShlagemon } from '~/type'
+import type { BaseShlagemon, TypeName } from '~/type'
 import { defineStore } from 'pinia'
 import { baseShlagemons } from '~/data/shlagemons'
 import { generateRarity } from '~/utils/dexFactory'

--- a/src/type/shlagemonType.ts
+++ b/src/type/shlagemonType.ts
@@ -1,10 +1,47 @@
+/**
+ * Union of all valid Shlagémon type identifiers.
+ */
+export type TypeName
+  = 'normal'
+    | 'feu'
+    | 'eau'
+    | 'plante'
+    | 'roche'
+    | 'electrique'
+    | 'vol'
+    | 'combat'
+    | 'spectre'
+    | 'darksasuke'
+    | 'psy'
+    | 'poison'
+    | 'metal'
+    | 'sol'
+    | 'fee'
+    | 'dragon'
+    | 'glace'
+    | 'insecte'
+
+/**
+ * Describes a Shlagémon elemental type.
+ */
 export interface ShlagemonType {
-  id: string
+  /** Unique identifier of the type. */
+  id: TypeName
+  /** Display name used in UI. */
   name: string
+  /** i18n key describing the type. */
   description: string
+  /** Hex color associated with the type. */
   color: string
-  resistance: ShlagemonType[]
-  weakness: ShlagemonType[]
+  /**
+   * Type identifiers resisted by this type.
+   * Using identifiers avoids circular references between type objects.
+   */
+  resistance: TypeName[]
+  /** Type identifiers that deal extra damage to this type. */
+  weakness: TypeName[]
+  /** Additional tags used for filtering or search. */
   tags: string[]
+  /** Passive effects granted by this type. */
   passiveEffects: string[]
 }

--- a/src/utils/combat.ts
+++ b/src/utils/combat.ts
@@ -1,17 +1,20 @@
-import type { ShlagemonType } from '~/type'
+import type { TypeName } from '~/type'
+import { shlagemonTypes } from '~/data/shlagemons-type'
 
 /**
  * Retourne le multiplicateur de dégâts et l'effet visuel associé
  */
 export function getTypeMultiplier(
-  attackType: ShlagemonType,
-  targetType: ShlagemonType,
+  attackType: TypeName,
+  targetType: TypeName,
 ): { multiplier: number, effect: 'super' | 'not' | 'normal' } {
+  const atk = shlagemonTypes[attackType]
+  const def = shlagemonTypes[targetType]
   let base = 1
 
-  if (targetType.weakness.some(w => w.id === attackType.id))
+  if (def.weakness.includes(atk.id))
     base = 1.5 // La cible est faible contre ce type
-  else if (targetType.resistance.some(r => r.id === attackType.id))
+  else if (def.resistance.includes(atk.id))
     base = 0.5 // La cible résiste à ce type
 
   const effect: 'super' | 'not' | 'normal'
@@ -25,8 +28,8 @@ export function getTypeMultiplier(
  */
 export function computeDamage(
   base: number,
-  attackType: ShlagemonType,
-  targetTypes: ShlagemonType | ShlagemonType[],
+  attackType: TypeName,
+  targetTypes: TypeName | TypeName[],
 ): { damage: number, effect: 'super' | 'not' | 'normal', crit: 'critical' | 'weak' | 'normal' } {
   const types = Array.isArray(targetTypes) ? targetTypes : [targetTypes]
   const typeMultiplier = types

--- a/test/computeDamage.test.ts
+++ b/test/computeDamage.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { shlagemonTypes } from '../src/data/shlagemons-type'
 import { computeDamage } from '../src/utils/combat'
 
 describe('computeDamage dual type', () => {
   it('applies multipliers from both target types', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
-    const result = computeDamage(100, shlagemonTypes.poison, [shlagemonTypes.fee, shlagemonTypes.normal])
+    const result = computeDamage(100, 'poison', ['fee', 'normal'])
     expect(result.damage).toBe(150)
     expect(result.effect).toBe('super')
     expect(result.crit).toBe('normal')
@@ -13,7 +12,7 @@ describe('computeDamage dual type', () => {
 
   it('handles resistance and weakness', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
-    const result = computeDamage(100, shlagemonTypes.combat, [shlagemonTypes.normal, shlagemonTypes.vol])
+    const result = computeDamage(100, 'combat', ['normal', 'vol'])
     expect(result.damage).toBe(75)
     expect(result.effect).toBe('not')
     expect(result.crit).toBe('normal')

--- a/test/type-serialization.test.ts
+++ b/test/type-serialization.test.ts
@@ -1,0 +1,15 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { sacdepates } from '../src/data/shlagemons/01-05/sacdepates'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
+
+describe('shlagedex serialization', () => {
+  it('allows JSON serialization of state', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    dex.captureShlagemon(sacdepates)
+    expect(() => JSON.stringify(dex.$state)).not.toThrow()
+  })
+})

--- a/test/typechart.test.ts
+++ b/test/typechart.test.ts
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import TypeChart from '../src/components/shlagemon/TypeChart.vue'
+import { shlagemonTypes } from '../src/data/shlagemons-type'
+
+describe('type chart', () => {
+  it('renders correct multipliers using type identifiers', () => {
+    const wrapper = mount(TypeChart, {
+      global: {
+        stubs: {
+          ShlagemonType: { template: '<div />' },
+        },
+      },
+    })
+    const ids = Object.keys(shlagemonTypes)
+    const poisonRow = wrapper.findAll('tbody tr')[ids.indexOf('poison')]
+    const feeColIndex = ids.indexOf('fee')
+    const poisonCells = poisonRow.findAll('td')
+    expect(poisonCells[feeColIndex].text()).toBe('1.5')
+
+    const electricRow = wrapper.findAll('tbody tr')[ids.indexOf('electrique')]
+    const solColIndex = ids.indexOf('sol')
+    const electricCells = electricRow.findAll('td')
+    expect(electricCells[solColIndex].text()).toBe('0.5')
+  })
+})


### PR DESCRIPTION
## Summary
- refactor `ShlagemonType` to reference type ids instead of nested type objects
- adjust type chart and combat logic to resolve ids through `shlagemonTypes`
- add regression tests for computeDamage, TypeChart, and type serialization

## Testing
- `pnpm eslint src/type/shlagemonType.ts src/data/shlagemons-type.ts src/utils/combat.ts src/components/shlagemon/TypeChart.vue src/stores/battle.ts src/stores/egg.ts test/computeDamage.test.ts test/typechart.test.ts test/type-serialization.test.ts`
- `pnpm vitest run test/computeDamage.test.ts test/typechart.test.ts test/type-serialization.test.ts`
- `pnpm test:unit` *(fails: component.test.ts snapshot mismatch, useLangSwitch.test.ts returns null)*

------
https://chatgpt.com/codex/tasks/task_e_6890eca5c8f0832a9cee728414c3e20c