### PR TITLE
refactor: use vueuse fullscreen composable

### DIFF
--- a/src/components/ui/FullscreenToggle.vue
+++ b/src/components/ui/FullscreenToggle.vue
@@ -1,19 +1,10 @@
 <script setup lang="ts">
-const isFullscreen = ref(false)
+import { useFullscreen } from '@vueuse/core'
+
 const { t } = useI18n()
 
-function toggle() {
-  if (!isFullscreen.value) {
-    document.documentElement.requestFullscreen?.()
-  }
-  else {
-    document.exitFullscreen?.()
-  }
-}
-
-useEventListener(document, 'fullscreenchange', () => {
-  isFullscreen.value = !!document.fullscreenElement
-})
+const target = typeof document !== 'undefined' ? document.documentElement : null
+const { isFullscreen, toggle } = useFullscreen(target)
 </script>
 
 <template>

--- a/test/fullscreen-toggle-ssr.test.ts
+++ b/test/fullscreen-toggle-ssr.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { i18n, loadLanguageAsync } from '../src/modules/i18n'
+
+describe('fullscreenToggle SSR', () => {
+  it('renders without ReferenceError when SSR is true', async () => {
+    vi.stubEnv('SSR', true)
+    const originalDocument = globalThis.document
+    // @ts-expect-error simulate SSR environment
+    globalThis.document = undefined
+
+    try {
+      await loadLanguageAsync('fr')
+      const { default: FullscreenToggle } = await import('../src/components/ui/FullscreenToggle.vue')
+      const app = createSSRApp(FullscreenToggle)
+      app.use(i18n)
+      const html = await renderToString(app)
+      expect(html).toBeTypeOf('string')
+    }
+    finally {
+      globalThis.document = originalDocument
+      vi.unstubAllEnvs()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- refactor FullscreenToggle to leverage useFullscreen and avoid direct document access on the server
- add SSR unit test ensuring FullscreenToggle renders without document

## Testing
- `pnpm eslint src/components/ui/FullscreenToggle.vue test/fullscreen-toggle-ssr.test.ts`
- `pnpm test:unit test/fullscreen-toggle-ssr.test.ts --run`
- `pnpm test:unit` *(fails: snapshot mismatch and other existing failures)*

------
https://chatgpt.com/codex/tasks/task_e_6890ec7f64dc832ab3201d3202d88c6f