### PR TITLE
Handle hidden-tab faint animations

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -145,7 +145,11 @@ function attack() {
   coreAttack()
 }
 
+const { start: startEnemyFaintFallback, stop: stopEnemyFaintFallback } = useTimeoutFn(onEnemyFaintEnd, 600, { immediate: false })
+const { start: startPlayerFaintFallback, stop: stopPlayerFaintFallback } = useTimeoutFn(onPlayerFaintEnd, 600, { immediate: false })
+
 function onEnemyFaintEnd() {
+  stopEnemyFaintFallback()
   if (enemyFainted.value)
     handleEnd()
   if (nextEnemy.value) {
@@ -155,6 +159,7 @@ function onEnemyFaintEnd() {
 }
 
 async function onPlayerFaintEnd() {
+  stopPlayerFaintFallback()
   if (playerFainted.value)
     handleEnd()
   await nextTick()
@@ -164,6 +169,20 @@ async function onPlayerFaintEnd() {
     startBattle()
   }
 }
+
+watch(enemyFainted, (val) => {
+  if (val)
+    startEnemyFaintFallback()
+  else
+    stopEnemyFaintFallback()
+})
+
+watch(playerFainted, (val) => {
+  if (val)
+    startPlayerFaintFallback()
+  else
+    stopPlayerFaintFallback()
+})
 
 function onMouseMove(e: MouseEvent) {
   cursorX.value = e.clientX

--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -62,6 +62,21 @@ watch(
   },
 )
 
+const documentVisibility = useDocumentVisibility()
+
+watch(
+  () => props.fainted,
+  (fainted) => {
+    if (fainted && documentVisibility.value === 'hidden')
+      emit('faintEnd')
+  },
+)
+
+watch(documentVisibility, (state) => {
+  if (state === 'hidden' && props.fainted)
+    emit('faintEnd')
+})
+
 function onAnimationEnd() {
   if (props.fainted)
     emit('faintEnd')

--- a/test/round-faint-timeout.test.ts
+++ b/test/round-faint-timeout.test.ts
@@ -1,0 +1,69 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import Round from '../src/components/battle/Round.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+const playerFainted = ref(false)
+const enemyFainted = ref(false)
+const playerHp = ref(0)
+const enemyHp = ref(1)
+
+vi.mock('../src/composables/useBattleCore', () => ({
+  useBattleCore: () => ({
+    playerHp,
+    enemyHp,
+    flashPlayer: ref(false),
+    flashEnemy: ref(false),
+    playerFainted,
+    enemyFainted,
+    showAttackCursor: ref(false),
+    cursorX: ref(0),
+    cursorY: ref(0),
+    cursorClicked: ref(false),
+    playerEffect: ref(null),
+    enemyEffect: ref(null),
+    playerVariant: ref(''),
+    enemyVariant: ref(''),
+    startBattle: vi.fn(),
+    stopBattle: vi.fn(),
+    attack: vi.fn(),
+  }),
+}))
+
+describe('battle round faint fallback', () => {
+  it('emits end if faintEnd not received within animation duration', async () => {
+    vi.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const player = dex.createShlagemon(carapouffe)
+    const enemy = dex.createShlagemon(carapouffe)
+    const wrapper = mount(Round, {
+      props: { player, enemy },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          BattleAttackCursor: true,
+          BattleToast: true,
+          ShlagemonXpBar: true,
+          BattleShlagemon: { template: '<div />' },
+        },
+        directives: { tooltip: () => {} },
+      },
+    })
+
+    playerFainted.value = true
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(600)
+
+    const events = wrapper.emitted('end')
+    expect(events).toBeTruthy()
+    expect(events![0][0]).toBe('lose')
+
+    wrapper.unmount()
+    vi.useRealTimers()
+  })
+})

--- a/test/shlagemon-faint-visibility.test.ts
+++ b/test/shlagemon-faint-visibility.test.ts
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import BattleShlagemon from '../src/components/battle/Shlagemon.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('battle shlagemon faint visibility', () => {
+  it('emits faintEnd immediately when document is hidden', async () => {
+    const original = Object.getOwnPropertyDescriptor(document, 'visibilityState')
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' })
+
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+
+    const wrapper = mount(BattleShlagemon, {
+      props: { mon, hp: 10, fainted: false },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          EffectBadge: true,
+          DiseaseBadge: true,
+          InventoryWearableItemIcon: true,
+          ShlagemonImage: true,
+          UiProgressBar: true,
+        },
+        directives: { tooltip: () => {} },
+      },
+    })
+
+    await wrapper.setProps({ fainted: true })
+    await nextTick()
+
+    expect(wrapper.emitted('faintEnd')).toBeTruthy()
+
+    wrapper.unmount()
+    if (original)
+      Object.defineProperty(document, 'visibilityState', original)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure faint animations complete when tab is hidden by emitting `faintEnd` immediately
- fallback in battle round to resolve faint animations with a timeout
- add unit tests covering hidden visibility and timeout fallback

## Testing
- `pnpm exec eslint src/components/battle/Shlagemon.vue src/components/battle/Round.vue test/shlagemon-faint-visibility.test.ts test/round-faint-timeout.test.ts`
- `pnpm test:unit test/shlagemon-faint-visibility.test.ts test/round-faint-timeout.test.ts`
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched; expected '/fr/shlagedex', received null)*

------
https://chatgpt.com/codex/tasks/task_e_6890f3082ed0832ab4ff20763ebca369