### PR TITLE
fix: enable BattleCapture store test

### DIFF
--- a/test/battlecapture.test.ts
+++ b/test/battlecapture.test.ts
@@ -11,7 +11,7 @@ import { useShlagedexStore } from '../src/stores/shlagedex'
 import * as captureUtils from '../src/utils/capture'
 import { createDexShlagemon } from '../src/utils/dexFactory'
 
-describe.skip('battleCapture', () => {
+describe('battleCapture', () => {
   it('updates store on successful capture', async () => {
     vi.useFakeTimers()
     const pinia = createPinia()
@@ -30,7 +30,12 @@ describe.skip('battleCapture', () => {
     vi.spyOn(captureUtils, 'tryCapture').mockReturnValue(true)
 
     const wrapper = mount(BattleCapture, {
-      props: { enemy, enemyHp: enemy.hp, stopBattle: vi.fn() },
+      props: {
+        enemy,
+        enemyHp: enemy.hp,
+        playerHp: 100,
+        stopBattle: vi.fn(),
+      },
       global: {
         plugins: [pinia],
         stubs: ['ImageByBackground', 'ShlagemonImage'],


### PR DESCRIPTION
## Summary
- enable and correct `battlecapture` unit test
- provide required `playerHp` prop to capture component

## Testing
- `CI=1 pnpm test test/battlecapture.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890f535d1ac832ab5278c8ab086ae56