### PR TITLE
test: ensure zone buttons present when locked

### DIFF
--- a/test/feature-lock.test.ts
+++ b/test/feature-lock.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from 'vitest'
 import InventoryPanel from '../src/components/panel/Inventory.vue'
 import ZonePanel from '../src/components/panel/Zone.vue'
 import ShlagemonList from '../src/components/shlagemon/List.vue'
+// Zone button components must be registered explicitly in tests because
+// automatic component registration is not available in the unit test environment.
+import ZoneButtonVillage from '../src/components/zone/ButtonVillage.vue'
+import ZoneButtonWild from '../src/components/zone/ButtonWild.vue'
 import { potion } from '../src/data/items'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useFeatureLockStore } from '../src/stores/featureLock'
@@ -21,6 +25,7 @@ describe('feature lock flags', () => {
         plugins: [pinia],
         provide: { selectZone: vi.fn() },
         directives: { tooltip: () => {} },
+        components: { ZoneButtonWild, ZoneButtonVillage },
       },
     })
     await wrapper.vm.$nextTick()


### PR DESCRIPTION
## Summary
- explicitly import and register `ZoneButtonWild` and `ZoneButtonVillage` in feature lock tests
- document manual registration rationale

## Testing
- `pnpm vitest run test/feature-lock.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890f58c8b6c832a8a3ea0267560ba67