### PR TITLE
fix: trigger zone achievements on species change

### DIFF
--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -381,7 +381,14 @@ export const useAchievementsStore = defineStore('achievements', () => {
     })
   }
 
-  watch(() => dex.shlagemons.length, () => checkZoneCompletion(), { immediate: true })
+  // Track the set of captured Shlagémon IDs instead of only the array length.
+  // Watching the length alone misses cases where a different species replaces
+  // an existing one without changing the overall count.
+  const capturedIds = computed(() =>
+    dex.shlagemons.map(m => m.base.id).sort().join(','),
+  )
+
+  watch(capturedIds, () => checkZoneCompletion(), { immediate: true })
   watch(progress.wins, (val) => {
     zonesData.forEach((z) => {
       if (z.type === 'village')


### PR DESCRIPTION
## Summary
- ensure zone achievements watch captured species IDs instead of just dex length

## Testing
- `pnpm test:unit --run test/achievements.test.ts`
- `pnpm test:unit` *(fails: Snapshot `component Header.vue > should render 1` mismatched; AssertionError: expected null to be '/fr/shlagedex')*

------
https://chatgpt.com/codex/tasks/task_e_6890f530cedc832a83989bda7b5f5dc7