### PR TITLE
feat: toast on dialogue rewards

### DIFF
--- a/src/components/dialog/AttackPotionDialog.vue
+++ b/src/components/dialog/AttackPotionDialog.vue
@@ -40,7 +40,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.AttackPotionDialog.steps.step4.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(attackPotion.id, 1)
+          inventory.add(attackPotion.id, 1, { toast: true })
           emit('done', 'attackPotion')
         },
       },

--- a/src/components/dialog/BadgeBoxDialog.vue
+++ b/src/components/dialog/BadgeBoxDialog.vue
@@ -18,7 +18,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         type: 'valid',
         action: () => {
           badgeBox.unlock()
-          inventory.add(badgeBoxItem.id)
+          inventory.add(badgeBoxItem.id, 1, { toast: true })
           emit('done', 'badgeBox')
         },
       },

--- a/src/components/dialog/CapturePotionDialog.vue
+++ b/src/components/dialog/CapturePotionDialog.vue
@@ -48,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.CapturePotionDialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(capturePotion.id, 1)
+          inventory.add(capturePotion.id, 1, { toast: true })
           emit('done', 'capturePotion')
         },
       },

--- a/src/components/dialog/CuckRingDialog.vue
+++ b/src/components/dialog/CuckRingDialog.vue
@@ -57,7 +57,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.CuckRingDialog.steps.step6.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(cuckRing.id, 1)
+          inventory.add(cuckRing.id, 1, { toast: true })
           emit('done', 'cuckRing')
         },
       },

--- a/src/components/dialog/DuplicateRarityDialog.vue
+++ b/src/components/dialog/DuplicateRarityDialog.vue
@@ -66,7 +66,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.DuplicateRarityDialog.steps.step6.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(superShlageball.id, 1)
+          inventory.add(superShlageball.id, 1, { toast: true })
           emit('done', 'rarityIntro')
         },
       },

--- a/src/components/dialog/EggBoxDialog.vue
+++ b/src/components/dialog/EggBoxDialog.vue
@@ -43,7 +43,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         action: () => {
           box.unlock()
           box.importFromInventory(inventory.items)
-          inventory.add(eggBox.id)
+          inventory.add(eggBox.id, 1, { toast: true })
           emit('done', 'eggBox')
         },
       },

--- a/src/components/dialog/FirstLossDialog.vue
+++ b/src/components/dialog/FirstLossDialog.vue
@@ -44,7 +44,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.FirstLossDialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(potion.id, 10)
+          inventory.add(potion.id, 10, { toast: true })
           emit('done', 'firstLoss')
         },
       },

--- a/src/components/dialog/FrogKingDialog.vue
+++ b/src/components/dialog/FrogKingDialog.vue
@@ -48,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.FrogKingDialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(frogKing.id, 1)
+          inventory.add(frogKing.id, 1, { toast: true })
           emit('done', 'frogKing')
         },
       },

--- a/src/components/dialog/HalfDexDialog.vue
+++ b/src/components/dialog/HalfDexDialog.vue
@@ -40,7 +40,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.HalfDexDialog.steps.step4.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(multiExp.id, 1)
+          inventory.add(multiExp.id, 1, { toast: true })
           emit('done', 'halfDex')
         },
       },

--- a/src/components/dialog/KingUnlockDialog.vue
+++ b/src/components/dialog/KingUnlockDialog.vue
@@ -48,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.KingUnlockDialog.steps.step6.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(defensePotion.id, 1)
+          inventory.add(defensePotion.id, 1, { toast: true })
           emit('done', 'kingUnlock')
         },
       },

--- a/src/components/dialog/Level5Dialog.vue
+++ b/src/components/dialog/Level5Dialog.vue
@@ -48,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.Level5Dialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(shlageball.id, 10)
+          inventory.add(shlageball.id, 10, { toast: true })
           emit('done', 'level5')
         },
       },

--- a/src/components/dialog/NewZoneDialog.vue
+++ b/src/components/dialog/NewZoneDialog.vue
@@ -41,7 +41,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.NewZoneDialog.steps.step4.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(xpPotion.id, 1)
+          inventory.add(xpPotion.id, 1, { toast: true })
           mobile.set('zones')
           emit('done', 'newZone')
         },

--- a/src/components/dialog/OdorElixirDialog.vue
+++ b/src/components/dialog/OdorElixirDialog.vue
@@ -48,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.OdorElixirDialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(odorElixir.id, 1)
+          inventory.add(odorElixir.id, 1, { toast: true })
           emit('done', 'odorElixir')
         },
       },

--- a/src/components/dialog/PreyAmuletDialog.vue
+++ b/src/components/dialog/PreyAmuletDialog.vue
@@ -40,7 +40,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.PreyAmuletDialog.steps.step4.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(preyAmulet.id, 1)
+          inventory.add(preyAmulet.id, 1, { toast: true })
           emit('done', 'preyAmulet')
         },
       },

--- a/src/components/dialog/RainbowPotionDialog.vue
+++ b/src/components/dialog/RainbowPotionDialog.vue
@@ -48,7 +48,7 @@ const dialogTree = computed<DialogNode[]>(() => [
         label: t('components.dialog.RainbowPotionDialog.steps.step5.responses.valid'),
         type: 'valid',
         action: () => {
-          inventory.add(specialPotion.id, 1)
+          inventory.add(specialPotion.id, 1, { toast: true })
           emit('done', 'rainbowPotion')
         },
       },

--- a/src/components/dialog/WearableItemDialog.vue
+++ b/src/components/dialog/WearableItemDialog.vue
@@ -31,7 +31,7 @@ const dialogTree = computed(() =>
     t('components.dialog.WearableItemDialog.steps.step5.text'),
     t('components.dialog.WearableItemDialog.steps.step6.text'),
   ], () => {
-    inventory.add(props.item.id, 1)
+    inventory.add(props.item.id, 1, { toast: true })
     emit('done', props.finishId)
   }),
 )

--- a/src/stores/game.i18n.yml
+++ b/src/stores/game.i18n.yml
@@ -1,0 +1,8 @@
+fr:
+  toast:
+    shlagidolar: 'Tu reçois {amount} Shlagédollars !'
+    shlagidiamond: 'Tu reçois {amount} Shlagédiamants !'
+en:
+  toast:
+    shlagidolar: 'You receive {amount} Shlagidollars!'
+    shlagidiamond: 'You receive {amount} Shlagidiamonds!'

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,15 +1,25 @@
 import { defineStore } from 'pinia'
+import { toast } from 'vue3-toastify'
+import { i18n } from '~/modules/i18n'
 
 export const useGameStore = defineStore('game', () => {
   const shlagidolar = ref(0)
   const shlagidiamond = ref(0)
 
-  function addShlagidolar(amount: number) {
-    shlagidolar.value = Math.ceil(shlagidolar.value + amount)
+  interface CurrencyOptions {
+    toast?: boolean
   }
 
-  function addShlagidiamond(amount: number) {
+  function addShlagidolar(amount: number, options: CurrencyOptions = {}) {
+    shlagidolar.value = Math.ceil(shlagidolar.value + amount)
+    if (amount > 0 && options.toast)
+      toast.success(i18n.global.t('stores.game.toast.shlagidolar', { amount }))
+  }
+
+  function addShlagidiamond(amount: number, options: CurrencyOptions = {}) {
     shlagidiamond.value += amount
+    if (amount > 0 && options.toast)
+      toast.success(i18n.global.t('stores.game.toast.shlagidiamond', { amount }))
   }
 
   function reset() {

--- a/src/stores/inventory.i18n.yml
+++ b/src/stores/inventory.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  toast:
+    item: 'Tu obtiens {qty} {item} ({category}) !'
+en:
+  toast:
+    item: 'You obtained {qty} {item} ({category})!'


### PR DESCRIPTION
## Summary
- show toast when inventory items or currency are awarded
- add reward notifications to dialogue endings

## Testing
- `pnpm lint`
- `pnpm test` *(fails: snapshot mismatch, expected path)*
- `pnpm typecheck` *(fails: TS2339, TS2322, TS2312, TS7016)*

------
https://chatgpt.com/codex/tasks/task_e_6890eff7c9dc832a80c30d30e9c42fcd