### PR TITLE
test: cover hyper ball chance

### DIFF
--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -63,4 +63,13 @@ describe('capture mechanics', () => {
     expect(chanceSuper).toBeGreaterThan(0)
     expect(chanceHyper).toBeGreaterThan(chanceSuper)
   })
+
+  it('hyper ball versus strong foe gives around 25% chance', () => {
+    const mon = createDexShlagemon(carapouffe, false, 80)
+    mon.hp = 100
+    mon.hpCurrent = 62
+    mon.rarity = 1
+    const chance = getCaptureChance(mon, balls[2])
+    expect(chance).toBeCloseTo(26.6, 1)
+  })
 })


### PR DESCRIPTION
## Summary
- add regression test verifying hyper ball capture odds against high-level foes

## Testing
- `pnpm lint test/capture.test.ts`
- `pnpm typecheck` *(fails: Property 'id' does not exist on type 'Ball', etc.)*
- `pnpm test:unit --run test/capture.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890f53962b0832a8e7fff196cfdf031