### PR TITLE
feat: notify zone achievements on capture

### DIFF
--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -308,6 +308,10 @@ export const useAchievementsStore = defineStore('achievements', () => {
         counters.captures += 1
         if (e.shiny)
           counters.shiny += 1
+        // Ensure zone-related achievements are evaluated for each capture
+        // to immediately unlock completion rewards when the last required
+        // Shlagémon of a zone is obtained.
+        checkZoneCompletion()
         break
       case 'battle-win':
         counters.wins += 1

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -523,12 +523,23 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
       mon.xp = 0
   }
 
+  /**
+   * Create and register a new Shlagémon in the player's Shlagédex.
+   *
+   * The function also notifies the achievements system so that capture and
+   * zone-completion achievements are evaluated immediately.
+   *
+   * @param base - Base data of the Shlagémon to create.
+   * @param shiny - Whether the created Shlagémon is shiny.
+   * @returns The created DexShlagémon instance.
+   */
   function createShlagemon(base: BaseShlagemon, shiny = false) {
     const mon = createDexShlagemon(base, shiny, 1, wildLevel.highestWildLevel)
     mon.captureDate = new Date().toISOString()
     mon.captureCount = 1
     addShlagemon(mon)
     updateHighestLevel(mon)
+    notifyAchievement({ type: 'capture', shiny })
     toast(`Tu as obtenu ${base.name} !`)
     return mon
   }


### PR DESCRIPTION
## Summary
- re-check zone completion whenever a shlagémon is captured
- notify achievements system on shlagémon creation

## Testing
- `pnpm test:unit test/achievements.test.ts`
- `pnpm test:unit --run` *(fails: component Header.vue snapshot mismatch; useLangSwitch returns equivalent path in other locale)*

------
https://chatgpt.com/codex/tasks/task_e_6890fb3ec7dc832a840c69d75d5e0bf1