### PR TITLE
test: stabilize battle capture timing

### DIFF
--- a/test/battlecapture.test.ts
+++ b/test/battlecapture.test.ts
@@ -44,8 +44,7 @@ describe('battleCapture', () => {
     })
 
     await wrapper.get('button').trigger('click')
-    await Promise.resolve()
-    vi.runOnlyPendingTimers()
+    await vi.advanceTimersByTimeAsync(2000)
     expect(captureSpy).toHaveBeenCalledWith(enemy)
     expect(dex.shlagemons.some(m => m.base.id === enemy.base.id)).toBe(true)
     vi.useRealTimers()


### PR DESCRIPTION
## Summary
- ensure battle capture test waits for all capture timers to run

## Testing
- `pnpm eslint test/battlecapture.test.ts`
- `pnpm vitest run test/battlecapture.test.ts`
- `pnpm vitest run` *(fails: snapshot mismatch in Header, useLangSwitch expectation)*

------
https://chatgpt.com/codex/tasks/task_e_6890fb417bdc832ab3aa487ef7e4b600