### PR TITLE
Ensure zone buttons exist during feature lock test

### DIFF
--- a/test/feature-lock.test.ts
+++ b/test/feature-lock.test.ts
@@ -18,6 +18,8 @@ describe('feature lock flags', () => {
   it('disables zone buttons when zones are locked', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    dex.createShlagemon(carapouffe)
     const featureLock = useFeatureLockStore()
     featureLock.lockZones()
     const wrapper = mount(ZonePanel, {


### PR DESCRIPTION
## Summary
- Initialize a Shlagédex entry before locking zones to ensure zone buttons are rendered in tests.

## Testing
- `pnpm test test/feature-lock.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890fb47a8e8832a9358581a7446dba9