### PR TITLE
fix: floor defense computation

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -133,10 +133,16 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     return Math.round(mon.attack * (1 + bonus / 100))
   }
 
+  /**
+   * Compute the current defense value for a shlagemon.
+   *
+   * Bonuses from active potions and equipped items are applied and the
+   * result is floored to avoid inflating the statistic.
+   */
   function effectiveDefense(mon: DexShlagemon): number {
     const bonus = defenseBonusPercent.value
       + wearableBonus(mon.heldItemId, 'defense')
-    return Math.round(mon.defense * (1 + bonus / 100))
+    return Math.floor(mon.defense * (1 + bonus / 100))
   }
 
   function maxHp(mon: DexShlagemon): number {

--- a/test/potion-timer.test.ts
+++ b/test/potion-timer.test.ts
@@ -22,7 +22,7 @@ describe('potion timer', () => {
     dex.boostDefense(25)
     expect(dex.effects.length).toBe(1)
     expect(dex.effects[0].percent).toBe(25)
-    expect(dex.effectiveDefense(mon)).toBe(Math.round(baseDefense * (1 + 25 / 100)))
+    expect(dex.effectiveDefense(mon)).toBe(Math.floor(baseDefense * (1 + 25 / 100)))
 
     vi.advanceTimersByTime(600_000)
     vi.runOnlyPendingTimers()


### PR DESCRIPTION
## Summary
- avoid rounding up defense values when applying potion or item bonuses
- test potion timer using floored defense calculation

## Testing
- `pnpm test test/potion-timer.test.ts`
- `pnpm test` *(fails: useLangSwitch.test.ts – expected null to be '/fr/shlagedex')*

------
https://chatgpt.com/codex/tasks/task_e_6890fb554484832a89585dff9f590308