### PR TITLE
Ensure stats refresh at max rarity

### DIFF
--- a/src/utils/dexFactory.ts
+++ b/src/utils/dexFactory.ts
@@ -108,7 +108,7 @@ export function generateRarity(max = 99, min = 1): number {
 }
 
 export function statWithRarity(base: number, rarity: number): number {
-  const rarityBoost = 1 + 0.5 * (rarity - 1) / 99 // 1.0 → 1.5
+  const rarityBoost = 1 + (rarity - 1) / 99 // 1.0 → 2.0
   const finalValue = base * rarityBoost
   return Math.floor(finalValue / 5) * 5 // arrondi au multiple de 5 inférieur
 }

--- a/test/__snapshots__/component.test.ts.snap
+++ b/test/__snapshots__/component.test.ts.snap
@@ -1,21 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`component Header.vue > should render 1`] = `
-"<header class="h-12 flex items-center justify-between bg-gray-100 p-4 dark:bg-gray-800">
-  <div class="flex items-center gap-2"><img src="/logo.png" alt="Logo Shlagémon" class="h-20 select-none -my-4"></div>
-  <div class="flex items-center gap-2"><button aria-label="Changer de thème" class="relative h-6 w-12 rounded-full bg-gray-200 transition-colors dark:bg-gray-700" type="button"><span class="absolute left-0.5 top-0.5 h-5 w-5 flex items-center justify-center rounded-full bg-white text-yellow-500 transition-all dark:bg-gray-900 dark:text-yellow-300"><div class="i-carbon-sun"></div></span></button><button class="inline-flex items-center justify-center shadow transition-transform duration-150 ease-out active:translate-y-[1px] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 hover:-translate-y-[1px] rounded-full p-2 bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600" aria-label="Audio">
-      <div class="i-carbon-volume-up"></div>
-    </button>
+"<header data-v-243d8871="" id="main-header" style="height: 44px; min-height: 44px; max-height: 44px;" class="flex items-center justify-between bg-gray-50/80 dark:bg-gray-900/90 px-2 sm:px-3 backdrop-blur shadow-xs transition-colors select-none z-50 relative" role="banner" tabindex="-1" aria-label="Header">
+  <div data-v-243d8871="" class="h-full min-w-0 flex items-center"><img data-v-243d8871="" src="/logo.png" alt="Logo Shlagémon" class="block h-full w-auto select-none transition-transform duration-200 hover:scale-105" draggable="false" style="max-height: 44px; min-height: 44px;"></div>
+  <nav data-v-243d8871="" class="h-full flex items-center gap-1" aria-label="Header actions"><button data-v-243d8871="" type="button" aria-label="Changer de thème" aria-pressed="false" class="group shadow-input relative h-8 w-16 inline-flex select-none items-center rounded-full bg-gray-200 p-1 outline-none transition-colors duration-300 dark:bg-gray-800 bg-gray-200 dark:bg-gray-800" tabindex="0">
+      <!-- Barre de fond animée --><span class="pointer-events-none absolute inset-0 rounded-full transition-colors duration-300 bg-gradient-to-r from-yellow-200 via-yellow-50 to-white opacity-60"></span><!-- Pastille / Thumb --><span class="ring-primary relative z-10 h-6 w-6 flex items-center justify-center rounded-full bg-white shadow-md ring-offset-2 transition-transform duration-300 dark:bg-gray-900 group-focus-visible:ring-2 translate-x-0"><div class="text-lg transition-colors duration-200 i-carbon-sun text-yellow-500"></div></span><!-- Bordure focus accessible -->
+      <!--v-if-->
+      <!-- Optionnel : label pour accessibilité screen-reader --><span class="sr-only">Changer de thème</span>
+    </button><button data-v-243d8871="" type="button" aria-label="Audio" tabindex="0" class="inline-flex items-center justify-center font-semibold outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 transition-all duration-150 ease-out shadow-sm active:translate-y-[1px] active:scale-[0.98] hover:-translate-y-0.5 disabled:opacity-50 disabled:pointer-events-none select-none rounded-full aspect-square text-xs px-2 py-1 min-h-[1.75rem] min-w-[1.75rem]
+      bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200
+      hover:bg-gray-200 dark:hover:bg-gray-700
+      focus-visible:ring-2 focus-visible:ring-cyan-400"><span class="h-full w-full flex items-center justify-center text-base" aria-hidden="true"><div data-v-243d8871="" class="i-carbon-volume-up text-green-500 dark:text-green-400 transition-colors duration-150" aria-live="polite"></div></span></button>
     <!--teleport start-->
-    <!--teleport end--><button class="inline-flex items-center justify-center shadow transition-transform duration-150 ease-out active:translate-y-[1px] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 hover:-translate-y-[1px] rounded-full p-2 bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600" aria-label="Paramètres">
-      <div class="i-carbon-settings"></div>
-    </button>
+    <!--teleport end--><button data-v-243d8871="" type="button" aria-label="Paramètres" tabindex="0" class="inline-flex items-center justify-center font-semibold outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 transition-all duration-150 ease-out shadow-sm active:translate-y-[1px] active:scale-[0.98] hover:-translate-y-0.5 disabled:opacity-50 disabled:pointer-events-none select-none rounded-full aspect-square text-xs px-2 py-1 min-h-[1.75rem] min-w-[1.75rem]
+      bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200
+      hover:bg-gray-200 dark:hover:bg-gray-700
+      focus-visible:ring-2 focus-visible:ring-cyan-400"><span class="h-full w-full flex items-center justify-center text-base" aria-hidden="true"><div data-v-243d8871="" class="i-carbon-settings"></div></span></button>
     <!--teleport start-->
     <!--teleport end-->
-    <!--v-if--><button class="inline-flex items-center justify-center shadow transition-transform duration-150 ease-out active:translate-y-[1px] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 hover:-translate-y-[1px] rounded-full p-2 bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600" aria-label="Plein écran">
-      <div class="i-carbon-maximize"></div>
-    </button>
     <!--v-if-->
-  </div>
+    <!--v-if-->
+    <!-- Plein écran : même hauteur/largeur/visuel que les autres ! --><button data-v-243d8871="" type="button" aria-label="Plein écran" tabindex="0" class="inline-flex items-center justify-center font-semibold outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 transition-all duration-150 ease-out shadow-sm active:translate-y-[1px] active:scale-[0.98] hover:-translate-y-0.5 disabled:opacity-50 disabled:pointer-events-none select-none rounded-full aspect-square text-xs px-2 py-1 min-h-[1.75rem] min-w-[1.75rem]
+      bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200
+      hover:bg-gray-200 dark:hover:bg-gray-700
+      focus-visible:ring-2 focus-visible:ring-cyan-400"><span class="h-full w-full flex items-center justify-center text-base" aria-hidden="true"><div class="i-carbon-maximize"></div></span></button>
+  </nav>
 </header>"
 `;

--- a/test/router-locale.test.ts
+++ b/test/router-locale.test.ts
@@ -24,5 +24,5 @@ describe('router locale', () => {
   it('updates store locale from URL', async () => {
     await setup('/fr/shlagedex')
     expect(useLocaleStore().locale).toBe('fr')
-  })
+  }, 10000)
 })

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -4,7 +4,14 @@ import { toast } from 'vue3-toastify'
 import { sacdepates } from '../src/data/shlagemons/01-05/sacdepates'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useShlagedexStore } from '../src/stores/shlagedex'
-import { applyCurrentStats, applyStats, createDexShlagemon, xpForLevel } from '../src/utils/dexFactory'
+import {
+  applyCurrentStats,
+  applyStats,
+  baseStats,
+  createDexShlagemon,
+  statWithRarity,
+  xpForLevel,
+} from '../src/utils/dexFactory'
 
 vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
 
@@ -187,6 +194,26 @@ describe('duplicate capture at max rarity with both methods', () => {
     expect(toastMock).toHaveBeenCalledWith(
       'Vous avez déjà ce Shlagémon au maximum de sa rareté',
     )
+  })
+})
+
+describe('rarity 100 coefficient update', () => {
+  it('updates stats when rarity hits 100', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.rarity = 99
+    applyStats(mon)
+    applyCurrentStats(mon)
+    const enemy = createDexShlagemon(carapouffe, false, 1)
+    enemy.rarity = 100
+    applyStats(enemy)
+    applyCurrentStats(enemy)
+    dex.captureEnemy(enemy)
+    expect(mon.rarity).toBe(100)
+    const expected = statWithRarity(baseStats.defense, 100)
+    expect(mon.baseStats.defense).toBe(expected)
+    expect(mon.defense).toBe(expected)
   })
 })
 

--- a/test/useLangSwitch.test.ts
+++ b/test/useLangSwitch.test.ts
@@ -6,14 +6,15 @@ import { useLangSwitch } from '../src/composables/useLangSwitch'
 import { buildLocalizedRoutes } from '../src/router'
 import { useLocaleStore } from '../src/stores/locale'
 
-function setup(routePath: string) {
+async function setup(routePath: string) {
   const pinia = createPinia()
   setActivePinia(pinia)
   const router = createRouter({
     history: createWebHistory(),
     routes: buildLocalizedRoutes(),
   })
-  router.push(routePath)
+  await router.push(routePath)
+  await router.isReady()
   return {
     pinia,
     router,
@@ -26,11 +27,10 @@ function setup(routePath: string) {
 
 describe('useLangSwitch', () => {
   it('returns equivalent path in other locale', async () => {
-    const { router, wrapper } = setup('/en/shlagedex')
-    await router.isReady()
+    const { wrapper } = await setup('/en/shlagedex')
 
     const path = await wrapper.vm.switchLang('fr')
     expect(path).toBe('/fr/shlagedex')
     expect(useLocaleStore().locale).toBe('fr')
-  })
+  }, 10000)
 })


### PR DESCRIPTION
## Summary
- double rarity scaling so stats reach 2× at rarity 100
- add regression test for stat update when reaching max rarity
- await router navigation in locale tests and relax timeouts

## Testing
- `pnpm test:unit --run test/useLangSwitch.test.ts test/router-locale.test.ts test/shlagedex.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6890fb5ef27c832aabaa30d59253a2fa