### PR TITLE
Fix serializer for missing shlagemon lists

### DIFF
--- a/src/utils/shlagedex-serialize.ts
+++ b/src/utils/shlagedex-serialize.ts
@@ -44,7 +44,9 @@ export const shlagedexSerializer: Serializer = {
     return JSON.stringify({
       ...data,
       effects: (data.effects || []).map(({ timeout, ...e }) => e),
-      shlagemons: data.shlagemons.map((mon) => {
+      // `data.shlagemons` may be absent when serializing legacy saves or
+      // during tests. Default to an empty array to avoid runtime errors.
+      shlagemons: (data.shlagemons || []).map((mon) => {
         const { base, heldItemId, ...rest } = mon
         const stored: StoredDexMon = {
           ...rest,


### PR DESCRIPTION
## Summary
- avoid runtime error when serializing saves without a `shlagemons` array

## Testing
- `pnpm vitest test/save-dedup.test.ts --run`
- `pnpm vitest test/component.test.ts test/useLangSwitch.test.ts --run` *(fails: snapshot mismatch and locale assertion)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6890fb5b9404832a9d5e02d5041cd1ae