### PR TITLE
fix: guard tic tac toe ai move

### DIFF
--- a/src/composables/useTicTacToe.ts
+++ b/src/composables/useTicTacToe.ts
@@ -81,7 +81,8 @@ export function findBestMove(state: Cell[]): number {
       bestIdx = idx
     }
   }
-  return bestIdx
+  // fallback to first available cell if no move was selected
+  return bestIdx === -1 ? empty[0] : bestIdx
 }
 
 export function useTicTacToe() {
@@ -109,6 +110,8 @@ export function useTicTacToe() {
     if (!possible.length)
       return end(false)
     const idx = findBestMove(board.value)
+    if (idx < 0)
+      return end(false)
     board.value[idx] = 'ai'
     if (check(board.value, 'ai'))
       return end(false)

--- a/test/tictactoe-ai.test.ts
+++ b/test/tictactoe-ai.test.ts
@@ -69,4 +69,13 @@ describe('tic tac toe ai', () => {
       expect(result).not.toBe('player')
     }
   })
+
+  it('selects a valid move when options remain', () => {
+    const board = Array.from({ length: SIZE * SIZE }).fill(null) as (null | 'player' | 'ai')[]
+    board[12] = 'player'
+    const idx = findBestMove(board)
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(CENTER_CELLS).toContain(idx)
+    expect(board[idx]).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary
- prevent tic tac toe AI from playing invalid moves
- test tic tac toe AI move selection

## Testing
- `pnpm lint src/composables/useTicTacToe.ts test/tictactoe-ai.test.ts`
- `pnpm test test/tictactoe-ai.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_6890fb6202f4832a9c396c1281d61afd