### PR TITLE
fix: stabilize trainer heal percentages

### DIFF
--- a/src/stores/trainerBattle.ts
+++ b/src/stores/trainerBattle.ts
@@ -2,11 +2,21 @@ import type { Trainer } from '~/types'
 import { defineStore } from 'pinia'
 import { trainers as trainersData } from '~/data/trainers'
 
+/**
+ * Percentage of missing health restored when a shlagemon levels up.
+ */
+const DEFAULT_LEVEL_UP_HEAL_PERCENT = 15
+
+/**
+ * Percentage of missing health restored after defeating a trainer.
+ */
+const DEFAULT_WIN_HEAL_PERCENT = 15
+
 export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   const queue = ref<Trainer[]>([])
   const currentIndex = ref(0)
-  const levelUpHealPercent = ref(15)
-  const winHealPercent = ref(15)
+  const levelUpHealPercent = ref(DEFAULT_LEVEL_UP_HEAL_PERCENT)
+  const winHealPercent = ref(DEFAULT_WIN_HEAL_PERCENT)
 
   function setQueue(list: Trainer[]) {
     queue.value = list


### PR DESCRIPTION
## Summary
- define explicit constants for level-up and victory heals in trainer battle store
- use constants to ensure default healing remains 15%

## Testing
- `npx vitest run test/trainer-store.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890fb6836f0832abb794cbbca408ae5