### PR TITLE
fix: guard zone visit mark

### DIFF
--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -62,7 +62,8 @@ export const useZoneStore = defineStore('zone', () => {
       if (dex.activeShlagemon && !same)
         dex.activeShlagemon.hpCurrent = dex.maxHp(dex.activeShlagemon)
       const visit = useZoneVisitStore()
-      visit.markVisited(id)
+      if (typeof visit.markVisited === 'function')
+        visit.markVisited(id)
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid crash when markVisited unavailable

## Testing
- `pnpm vitest run test/zone.test.ts test/zone-visit.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6890fb6e86a8832a921595743dc513e4