### PR TITLE
feat: add info button for battle shlagemon

### DIFF
--- a/src/components/battle/Shlagemon.i18n.yml
+++ b/src/components/battle/Shlagemon.i18n.yml
@@ -1,4 +1,6 @@
 fr:
   ownedTooltip: Vous possédez déjà ce Shlagémon
+  infoTooltip: Voir les détails
 en:
   ownedTooltip: You already own this Shlagemon
+  infoTooltip: View details

--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -125,6 +125,16 @@ const heldItem = computed(() => {
       :item="heldItem"
       class="absolute bottom-9 left-0 z-150 h-6 w-6"
     />
+    <UiButton
+      v-tooltip="t('components.battle.Shlagemon.infoTooltip')"
+      type="icon"
+      size="xs"
+      class="absolute bottom-9 right-0 z-150"
+      :aria-label="t('components.battle.Shlagemon.infoTooltip')"
+      @click="openInfo"
+    >
+      <div i-carbon-information />
+    </UiButton>
     <ShlagemonImage
       :id="props.mon.base.id"
       :alt="props.mon.base.name"

--- a/test/battle-shlagemon-info-button.test.ts
+++ b/test/battle-shlagemon-info-button.test.ts
@@ -1,0 +1,71 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import BattleShlagemon from '../src/components/battle/Shlagemon.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useDexDetailModalStore } from '../src/stores/dexDetailModal'
+import { useDexInfoModalStore } from '../src/stores/dexInfoModal'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+const messages = { en: { components: { battle: { Shlagemon: { infoTooltip: 'info' } } } } }
+
+describe('battle shlagemon info button', () => {
+  it('opens detail modal when shlagemon is owned', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const detailModal = useDexDetailModalStore()
+    const spy = vi.spyOn(detailModal, 'open')
+    const mon = dex.createShlagemon(carapouffe)
+
+    const i18n = createI18n({ legacy: false, locale: 'en', messages })
+
+    const wrapper = mount(BattleShlagemon, {
+      props: { mon, hp: 10, owned: true },
+      global: {
+        plugins: [pinia, i18n],
+        stubs: {
+          EffectBadge: true,
+          DiseaseBadge: true,
+          InventoryWearableItemIcon: true,
+          ShlagemonImage: true,
+          UiProgressBar: true,
+        },
+        directives: { tooltip: () => {} },
+      },
+    })
+
+    await wrapper.find('button').trigger('click')
+    expect(spy).toHaveBeenCalledWith(mon)
+  })
+
+  it('opens info modal when shlagemon is not owned', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const infoModal = useDexInfoModalStore()
+    const spy = vi.spyOn(infoModal, 'open')
+    const mon = dex.createShlagemon(carapouffe)
+
+    const i18n = createI18n({ legacy: false, locale: 'en', messages })
+
+    const wrapper = mount(BattleShlagemon, {
+      props: { mon, hp: 10 },
+      global: {
+        plugins: [pinia, i18n],
+        stubs: {
+          EffectBadge: true,
+          DiseaseBadge: true,
+          InventoryWearableItemIcon: true,
+          ShlagemonImage: true,
+          UiProgressBar: true,
+        },
+        directives: { tooltip: () => {} },
+      },
+    })
+
+    await wrapper.find('button').trigger('click')
+    expect(spy).toHaveBeenCalledWith(mon)
+  })
+})


### PR DESCRIPTION
## Summary
- add info icon button on battle shlagemon to open detail modal
- localize new info tooltip
- test battle shlagemon info button

## Testing
- `pnpm lint`
- `pnpm typecheck` (fails: Property 'id' does not exist on type 'Ball'.)
- `pnpm test` (fails: Snapshot `component Header.vue > should render 1` mismatched)


------
https://chatgpt.com/codex/tasks/task_e_6891005e90c4832ab46a8c9a3559d2ca