### PR TITLE
fix: expose shlageball items

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -24,7 +24,8 @@ import {
   xpRing,
 } from './items/wearables/xpRing'
 
-export { hyperShlageball, shlageball, superShlageball } from './items/shlageball'
+// Explicitly re-export shlageballs to ensure proper availability in all environments
+export { hyperShlageball, shlageball, superShlageball }
 
 // @unocss-include
 export const defensePotion: Item = {


### PR DESCRIPTION
## Summary
- explicitly re-export shlageball variants from the items module

## Testing
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/inventory.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890fb4e3e60832a8b42fe92a3a28bec