### PR TITLE
feat: add accessibility option for tooltip auto-hide

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -215,8 +215,13 @@ components:
         shortcuts: Shortcuts
         support: Support
         interface: Interface
+        accessibility: Accessibility
     InterfaceTab:
       villagesOnMap: Show villages on the map
+    AccessibilityTab:
+      autoHide:
+        label: Automatically hide tooltips
+        description: Tooltips close automatically after a short delay. Disable this option to keep them visible until you click elsewhere.
   shlagemon:
     Detail:
       equipItemTitle: Equip an item
@@ -2134,6 +2139,13 @@ stores:
     alreadyMax: You already have this Shlagemon at max rarity
     rarityChanged: '{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!'
     released: '{name} was released!'
+  game:
+    toast:
+      shlagidolar: You receive {amount} Shlagidollars!
+      shlagidiamond: You receive {amount} Shlagidiamonds!
+  inventory:
+    toast:
+      item: You obtained {qty} {item} ({category})!
 layouts:
   NotFound:
     not-found: Page not found

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -215,8 +215,13 @@ components:
         shortcuts: Raccourcis
         support: Soutien
         interface: Interface
+        accessibility: Accessibilité
     InterfaceTab:
       villagesOnMap: Afficher les villages sur la carte
+    AccessibilityTab:
+      autoHide:
+        label: Masquer automatiquement les infobulles
+        description: Les infobulles se ferment automatiquement après un court délai. Désactivez cette option pour les garder visibles jusqu'à ce que vous cliquiez ailleurs.
   shlagemon:
     Detail:
       equipItemTitle: Équiper un objet
@@ -2068,6 +2073,13 @@ stores:
     alreadyMax: Vous avez déjà ce Shlagémon au maximum de sa rareté
     rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
     released: '{name} a été relâché !'
+  game:
+    toast:
+      shlagidolar: Tu reçois {amount} Shlagédollars !
+      shlagidiamond: Tu reçois {amount} Shlagédiamants !
+  inventory:
+    toast:
+      item: Tu obtiens {qty} {item} ({category}) !
 layouts:
   NotFound:
     not-found: Page introuvable

--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -134,6 +134,7 @@ declare global {
   const unref: typeof import('vue')['unref']
   const unrefElement: typeof import('@vueuse/core')['unrefElement']
   const until: typeof import('@vueuse/core')['until']
+  const useAccessibilityStore: typeof import('./stores/accessibility')['useAccessibilityStore']
   const useAchievementsFilterStore: typeof import('./stores/achievementsFilter')['useAchievementsFilterStore']
   const useAchievementsStore: typeof import('./stores/achievements')['useAchievementsStore']
   const useActiveElement: typeof import('@vueuse/core')['useActiveElement']
@@ -600,6 +601,7 @@ declare module 'vue' {
     readonly unref: UnwrapRef<typeof import('vue')['unref']>
     readonly unrefElement: UnwrapRef<typeof import('@vueuse/core')['unrefElement']>
     readonly until: UnwrapRef<typeof import('@vueuse/core')['until']>
+    readonly useAccessibilityStore: UnwrapRef<typeof import('./stores/accessibility')['useAccessibilityStore']>
     readonly useAchievementsFilterStore: UnwrapRef<typeof import('./stores/achievementsFilter')['useAchievementsFilterStore']>
     readonly useAchievementsStore: UnwrapRef<typeof import('./stores/achievements')['useAchievementsStore']>
     readonly useActiveElement: UnwrapRef<typeof import('@vueuse/core')['useActiveElement']>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -115,6 +115,7 @@ declare module 'vue' {
     PanelZone: typeof import('./components/panel/Zone.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    SettingsAccessibilityTab: typeof import('./components/settings/AccessibilityTab.vue')['default']
     SettingsInterfaceTab: typeof import('./components/settings/InterfaceTab.vue')['default']
     SettingsLanguageTab: typeof import('./components/settings/LanguageTab.vue')['default']
     SettingsSaveTab: typeof import('./components/settings/SaveTab.vue')['default']

--- a/src/components/settings/AccessibilityTab.i18n.yml
+++ b/src/components/settings/AccessibilityTab.i18n.yml
@@ -1,0 +1,8 @@
+fr:
+  autoHide:
+    label: Masquer automatiquement les infobulles
+    description: Les infobulles se ferment automatiquement après un court délai. Désactivez cette option pour les garder visibles jusqu'à ce que vous cliquiez ailleurs.
+en:
+  autoHide:
+    label: Automatically hide tooltips
+    description: Tooltips close automatically after a short delay. Disable this option to keep them visible until you click elsewhere.

--- a/src/components/settings/AccessibilityTab.vue
+++ b/src/components/settings/AccessibilityTab.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+
+const { t } = useI18n()
+const accessibility = useAccessibilityStore()
+const { autoHideTooltips } = storeToRefs(accessibility)
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <UiCheckBox v-model="autoHideTooltips">
+      {{ t('components.settings.AccessibilityTab.autoHide.label') }}
+    </UiCheckBox>
+    <p class="text-xs opacity-80">
+      {{ t('components.settings.AccessibilityTab.autoHide.description') }}
+    </p>
+  </div>
+</template>

--- a/src/components/settings/SettingsModal.i18n.yml
+++ b/src/components/settings/SettingsModal.i18n.yml
@@ -5,6 +5,7 @@ fr:
     language: Langue
     shortcuts: Raccourcis
     interface: Interface
+    accessibility: Accessibilité
     support: Soutien
 en:
   title: Settings
@@ -13,4 +14,5 @@ en:
     language: Language
     shortcuts: Shortcuts
     interface: Interface
+    accessibility: Accessibility
     support: Support

--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
+import AccessibilityTab from './AccessibilityTab.vue'
 import InterfaceTab from './InterfaceTab.vue'
 import LanguageTab from './LanguageTab.vue'
 import SaveTab from './SaveTab.vue'
@@ -40,6 +41,7 @@ const tabs = computed(() => {
     },
     { label: { text: t('components.settings.SettingsModal.tabs.language'), icon: 'i-carbon-language' }, component: LanguageTab },
     { label: { text: t('components.settings.SettingsModal.tabs.interface'), icon: 'i-carbon-display' }, component: InterfaceTab },
+    { label: { text: t('components.settings.SettingsModal.tabs.accessibility'), icon: 'i-carbon-accessibility' }, component: AccessibilityTab },
   ]
 
   if (!isMobile.value) {

--- a/src/modules/vue-tooltip.ts
+++ b/src/modules/vue-tooltip.ts
@@ -81,4 +81,22 @@ export const install: UserModule = ({ app }) => {
       },
     },
   })
+
+  const accessibility = useAccessibilityStore()
+  const ui = useUIStore()
+
+  function updateOptions() {
+    FloatingVue.options.autoHideOnMousedown = !accessibility.autoHideTooltips
+    FloatingVue.options.themes.tooltip.autoHide = accessibility.autoHideTooltips
+    FloatingVue.options.themes.tooltip.hideTriggers = accessibility.autoHideTooltips
+      ? (events: string[]) => [...events, 'click']
+      : () => []
+    FloatingVue.options.themes.tooltip.delay = {
+      show: 200,
+      hide: ui.isMobile && accessibility.autoHideTooltips ? 2250 : 0,
+    }
+  }
+
+  updateOptions()
+  watch([accessibility.autoHideTooltips, ui.isMobile], updateOptions)
 }

--- a/src/stores/accessibility.ts
+++ b/src/stores/accessibility.ts
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia'
+
+/**
+ * Accessibility preferences controlling optional UI behaviours.
+ */
+export const useAccessibilityStore = defineStore('accessibility', () => {
+  /**
+   * Whether tooltips automatically close after a delay.
+   * Defaults to true for classic behaviour.
+   */
+  const autoHideTooltips = ref(true)
+
+  function setAutoHideTooltips(value: boolean) {
+    autoHideTooltips.value = value
+  }
+
+  return { autoHideTooltips, setAutoHideTooltips }
+}, {
+  persist: true,
+})

--- a/test/accessibility-store.test.ts
+++ b/test/accessibility-store.test.ts
@@ -1,0 +1,18 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useAccessibilityStore } from '../src/stores/accessibility'
+
+describe('accessibility store', () => {
+  it('auto hides tooltips by default', () => {
+    setActivePinia(createPinia())
+    const store = useAccessibilityStore()
+    expect(store.autoHideTooltips).toBe(true)
+  })
+
+  it('updates auto hide preference', () => {
+    setActivePinia(createPinia())
+    const store = useAccessibilityStore()
+    store.setAutoHideTooltips(false)
+    expect(store.autoHideTooltips).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add Accessibility settings tab with option to auto-hide tooltips
- persist tooltip auto-hide preference
- adapt tooltip behaviour on mobile with 2250ms timeout

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: expected null to be '/fr/shlagedex' and snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_689102b3a2ac832aa1741dbe1f7b21d5