### PR TITLE
Use dex info modal for enemy shlagemon

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -37,7 +37,7 @@ const nextEnemy = ref<DexShlagemon | null>(null)
 
 const showOwnedBall = computed(() => zone.current.type === 'sauvage')
 
-const enemyOwned = computed<boolean>(() =>
+const enemyCaptured = computed<boolean>(() =>
   displayedEnemy.value ? dex.capturedBaseIds.has(displayedEnemy.value.base.id) : false,
 )
 
@@ -228,6 +228,7 @@ function onClick(_e: MouseEvent) {
           :disease="disease.active"
           :disease-remaining="disease.remaining"
           owned
+          belongs-to-player
           @faint-end="onPlayerFaintEnd"
         >
           <BattleToast v-if="playerEffect" :message="playerEffect" :variant="playerVariant" />
@@ -252,7 +253,7 @@ function onClick(_e: MouseEvent) {
             :fainted="enemyFainted"
             :flash="flashEnemy"
             :show-ball="showOwnedBall"
-            :owned="enemyOwned"
+            :owned="enemyCaptured"
             @faint-end="onEnemyFaintEnd"
           >
             <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />

--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -15,6 +15,7 @@ const props = withDefaults(defineProps<Props>(), {
   levelPosition: 'bottom',
   showBall: false,
   owned: false,
+  belongsToPlayer: false,
   effects: () => [],
   disease: false,
   diseaseRemaining: 0,
@@ -34,6 +35,11 @@ interface Props {
   levelPosition?: 'top' | 'bottom'
   showBall?: boolean
   owned?: boolean
+  /**
+   * Indicates if the Shlagemon is controlled by the player.
+   * When true, opening the info will show the detailed modal instead of the dex info.
+   */
+  belongsToPlayer?: boolean
   effects?: ActiveEffect[]
   disease?: boolean
   diseaseRemaining?: number
@@ -89,7 +95,7 @@ function showTypeChart() {
 }
 
 function openInfo() {
-  if (props.owned)
+  if (props.belongsToPlayer)
     detailModal.open(props.mon)
   else
     infoModal.open(props.mon)

--- a/test/battle-shlagemon-info-button.test.ts
+++ b/test/battle-shlagemon-info-button.test.ts
@@ -11,7 +11,7 @@ import { useShlagedexStore } from '../src/stores/shlagedex'
 const messages = { en: { components: { battle: { Shlagemon: { infoTooltip: 'info' } } } } }
 
 describe('battle shlagemon info button', () => {
-  it('opens detail modal when shlagemon is owned', async () => {
+  it('opens detail modal when shlagemon belongs to player', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     const dex = useShlagedexStore()
@@ -22,7 +22,7 @@ describe('battle shlagemon info button', () => {
     const i18n = createI18n({ legacy: false, locale: 'en', messages })
 
     const wrapper = mount(BattleShlagemon, {
-      props: { mon, hp: 10, owned: true },
+      props: { mon, hp: 10, belongsToPlayer: true },
       global: {
         plugins: [pinia, i18n],
         stubs: {
@@ -40,7 +40,7 @@ describe('battle shlagemon info button', () => {
     expect(spy).toHaveBeenCalledWith(mon)
   })
 
-  it('opens info modal when shlagemon is not owned', async () => {
+  it('opens info modal for enemy shlagemon', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     const dex = useShlagedexStore()
@@ -51,7 +51,7 @@ describe('battle shlagemon info button', () => {
     const i18n = createI18n({ legacy: false, locale: 'en', messages })
 
     const wrapper = mount(BattleShlagemon, {
-      props: { mon, hp: 10 },
+      props: { mon, hp: 10, owned: true },
       global: {
         plugins: [pinia, i18n],
         stubs: {


### PR DESCRIPTION
## Summary
- always show Dex info modal for enemy shlagemon in battle
- keep detail modal for player's shlagemon
- update related battle info tests

## Testing
- `pnpm lint` *(fails: Strings must use singlequote in YAML)*
- `pnpm typecheck` *(fails: Property 'id' does not exist on type 'Ball', etc.)*
- `pnpm test:unit test/battle-shlagemon-info-button.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68910c369628832ab4dc036c6a0083fa