### PR TITLE
feat: prevent hidden tooltips from retaining focus

### DIFF
--- a/src/modules/vue-tooltip.ts
+++ b/src/modules/vue-tooltip.ts
@@ -1,5 +1,6 @@
 import type { UserModule } from '~/types'
 import FloatingVue from 'floating-vue'
+import { observeTooltipAccessibility } from '~/utils/tooltipAccessibility'
 
 export const install: UserModule = ({ app }) => {
   app.use(FloatingVue, {
@@ -102,4 +103,7 @@ export const install: UserModule = ({ app }) => {
     () => [accessibility.autoHideTooltips, ui.isMobile],
     updateOptions,
   )
+
+  if (typeof window !== 'undefined')
+    observeTooltipAccessibility()
 }

--- a/src/utils/tooltipAccessibility.ts
+++ b/src/utils/tooltipAccessibility.ts
@@ -1,0 +1,61 @@
+/**
+ * Observes tooltip popper elements created by FloatingVue and ensures they
+ * remain accessible. The observer enforces two rules:
+ *
+ * 1. Tooltip poppers are removed from the tab order by setting
+ *    `tabindex="-1"`.
+ * 2. When a popper is hidden (`aria-hidden="true"`), the `inert` attribute
+ *    is applied to prevent it from receiving focus.
+ *
+ * The observation starts immediately and returns the `MutationObserver` so it
+ * can be disconnected if needed (mainly for tests).
+ *
+ * @param root - Document or root element to observe. Defaults to the current
+ * document.
+ */
+export function observeTooltipAccessibility(
+  root: Document | HTMLElement = document,
+): MutationObserver {
+  const container = root instanceof Document ? root.body : root
+
+  /**
+   * Applies `tabindex` and `inert` attributes based on the current
+   * `aria-hidden` state of the popper.
+   */
+  function applyAttributes(popper: HTMLElement) {
+    popper.setAttribute('tabindex', '-1')
+    if (popper.getAttribute('aria-hidden') === 'true')
+      popper.setAttribute('inert', '')
+    else
+      popper.removeAttribute('inert')
+  }
+
+  /**
+   * Observe a single popper for attribute changes so the accessibility
+   * attributes stay in sync with `aria-hidden`.
+   */
+  function watchPopper(popper: HTMLElement) {
+    applyAttributes(popper)
+    new MutationObserver(() => applyAttributes(popper)).observe(popper, {
+      attributes: true,
+      attributeFilter: ['aria-hidden', 'tabindex'],
+    })
+  }
+
+  // Apply to any existing poppers
+  container.querySelectorAll<HTMLElement>('.v-popper__popper').forEach(watchPopper)
+
+  // Watch for new poppers being added to the DOM
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node instanceof HTMLElement && node.classList.contains('v-popper__popper'))
+          watchPopper(node)
+      }
+    }
+  })
+
+  observer.observe(container, { childList: true, subtree: true })
+
+  return observer
+}

--- a/test/tooltip-accessibility.test.ts
+++ b/test/tooltip-accessibility.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { observeTooltipAccessibility } from '../src/utils/tooltipAccessibility'
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('observeTooltipAccessibility', () => {
+  it('removes poppers from tab order and toggles inert', async () => {
+    const root = document.createElement('div')
+    const observer = observeTooltipAccessibility(root)
+
+    const popper = document.createElement('div')
+    popper.className = 'v-popper__popper'
+    popper.setAttribute('aria-hidden', 'true')
+    root.appendChild(popper)
+
+    await flush()
+    expect(popper.getAttribute('tabindex')).toBe('-1')
+    expect(popper.hasAttribute('inert')).toBe(true)
+
+    popper.setAttribute('aria-hidden', 'false')
+    await flush()
+    expect(popper.hasAttribute('inert')).toBe(false)
+
+    popper.setAttribute('tabindex', '0')
+    await flush()
+    expect(popper.getAttribute('tabindex')).toBe('-1')
+
+    observer.disconnect()
+  })
+})


### PR DESCRIPTION
## Summary
- ensure tooltip poppers become inert and are removed from tab order
- integrate accessibility observer into tooltip module
- cover observer with unit test

## Testing
- `pnpm test:unit` *(fails: warn lines? but we show output)*

------
https://chatgpt.com/codex/tasks/task_e_68910bf17458832a8676eb8abf6ecbc0