### PR TITLE
fix: clean up disease listener on dispose

### DIFF
--- a/src/stores/disease.ts
+++ b/src/stores/disease.ts
@@ -35,7 +35,14 @@ export const useDiseaseStore = defineStore('disease', () => {
     }
   }
 
+  // Ensure the listener is not registered multiple times
+  events.off('battle:end', onBattleEnd)
   events.on('battle:end', onBattleEnd)
+
+  // Remove the listener when the store is disposed
+  onScopeDispose(() => {
+    events.off('battle:end', onBattleEnd)
+  })
 
   return { active, remaining, start, reset }
 }, {

--- a/test/disease-listener.test.ts
+++ b/test/disease-listener.test.ts
@@ -1,0 +1,30 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useDiseaseStore } from '../src/stores/disease'
+import { useEventStore } from '../src/stores/event'
+
+describe('disease event listener cleanup', () => {
+  it('removes listener on dispose and registers only one on recreate', () => {
+    setActivePinia(createPinia())
+    const events = useEventStore()
+    const firstStore = useDiseaseStore()
+
+    firstStore.start()
+    const firstRemaining = firstStore.remaining
+    events.emit('battle:end')
+    expect(firstStore.remaining).toBe(firstRemaining - 1)
+
+    firstStore.$dispose()
+    const remainingAfterDispose = firstStore.remaining
+    events.emit('battle:end')
+    expect(firstStore.remaining).toBe(remainingAfterDispose)
+
+    const secondStore = useDiseaseStore()
+    secondStore.start()
+    const secondRemaining = secondStore.remaining
+    events.emit('battle:end')
+
+    expect(firstStore.remaining).toBe(remainingAfterDispose)
+    expect(secondStore.remaining).toBe(secondRemaining - 1)
+  })
+})


### PR DESCRIPTION
## Summary
- remove stale battle:end listener on disease store dispose
- add unit test ensuring listener cleanup

## Testing
- `pnpm exec eslint src/stores/disease.ts test/disease-listener.test.ts`
- `pnpm test:unit test/disease-damage.test.ts test/disease-listener.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891148f9ca0832a86259d53ea805cda