### PR TITLE
fix: prevent tooltip plugin crash during ssr

### DIFF
--- a/src/modules/vue-tooltip.ts
+++ b/src/modules/vue-tooltip.ts
@@ -2,7 +2,11 @@ import type { UserModule } from '~/types'
 import FloatingVue from 'floating-vue'
 import { observeTooltipAccessibility } from '~/utils/tooltipAccessibility'
 
-export const install: UserModule = ({ app }) => {
+export const install: UserModule = ({ app, isClient }) => {
+  // FloatingVue depends on browser APIs; bail out during SSR to avoid runtime freezes
+  if (!isClient)
+    return
+
   app.use(FloatingVue, {
     // Disable popper components
     disabled: false,
@@ -104,6 +108,5 @@ export const install: UserModule = ({ app }) => {
     updateOptions,
   )
 
-  if (typeof window !== 'undefined')
-    observeTooltipAccessibility()
+  observeTooltipAccessibility()
 }


### PR DESCRIPTION
## Summary
- guard `FloatingVue` tooltip plugin from executing during SSR

## Testing
- `pnpm test:unit` *(fails: disease event listener cleanup > removes listener on dispose and registers only one on recreate)*


------
https://chatgpt.com/codex/tasks/task_e_68911dc1dffc832a99d2d990bd925945