### PR TITLE
fix(ssr): register tooltip directive during build

### DIFF
--- a/src/modules/vue-tooltip.ts
+++ b/src/modules/vue-tooltip.ts
@@ -1,11 +1,22 @@
 import type { UserModule } from '~/types'
 import FloatingVue from 'floating-vue'
-import { observeTooltipAccessibility } from '~/utils/tooltipAccessibility'
 
 export const install: UserModule = ({ app, isClient }) => {
-  // FloatingVue depends on browser APIs; bail out during SSR to avoid runtime freezes
-  if (!isClient)
+  // FloatingVue depends on browser APIs. During SSR we still need the
+  // `v-tooltip` directive to be registered so the renderer can resolve it
+  // without throwing. Register a no-op directive when `isClient` is false
+  // and let the real plugin take over on the client.
+  if (!isClient) {
+    app.directive('tooltip', {
+      /**
+       * Vue's server renderer expects directives to expose `getSSRProps`.
+       * Returning an empty object avoids runtime errors while rendering the
+       * static markup.
+       */
+      getSSRProps: () => ({}),
+    })
     return
+  }
 
   app.use(FloatingVue, {
     // Disable popper components


### PR DESCRIPTION
## Summary
- ensure `v-tooltip` is registered in SSR with a no-op directive to prevent build crashes

## Testing
- `pnpm lint` *(fails: Strings must use singlequote; test descriptions)*
- `pnpm typecheck` *(fails: several TS2339 errors and missing declarations)*
- `pnpm test:unit` *(fails: unhandled rejections in achievements store)*
- `pnpm test:e2e` *(fails: missing Xvfb dependency)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68912c4b7aa4832a99a58413f79e341a