### PR TITLE
refactor i18n install locale resolution

### DIFF
--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -3,7 +3,7 @@ import type { UserModule } from '~/types'
 import { useHead } from '@unhead/vue'
 import { getCurrentInstance } from 'vue'
 import { createI18n } from 'vue-i18n'
-import { defaultLocale } from '~/constants/locales'
+import { availableLocales, defaultLocale } from '~/constants/locales'
 import { useLocaleStore } from '~/stores/locale'
 
 // Import i18n resources
@@ -62,16 +62,20 @@ export const install: UserModule = ({ app, isClient, routePath }) => {
   const localeStore = useLocaleStore()
 
   if (!isClient) {
-    const routeLocale = routePath?.split('/')[1] as Locale | undefined
-    if (routeLocale)
-      localeStore.setLocale(routeLocale)
+    const pathLocale = routePath?.split('/')[1] as Locale | undefined
+    const locale = availableLocales.includes(pathLocale as Locale)
+      ? (pathLocale as Locale)
+      : defaultLocale
+    localeStore.setLocale(locale)
+    loadLanguageAsync(localeStore.locale)
+    return
   }
-  else if (!localStorage.getItem('locale')) {
+
+  if (!localStorage.getItem('locale')) {
     const navigatorLanguage = navigator.language.toLowerCase()
     const fallback = navigatorLanguage.startsWith('fr') ? 'fr' : defaultLocale
     localeStore.setLocale(fallback)
   }
 
-  console.log('locale : ', localeStore.locale)
   loadLanguageAsync(localeStore.locale)
 }

--- a/test/i18n-ssg-locale.test.ts
+++ b/test/i18n-ssg-locale.test.ts
@@ -4,13 +4,13 @@ import { i18n, install as installI18n, loadLanguageAsync } from '../src/modules/
 import { useLocaleStore } from '../src/stores/locale'
 
 describe('i18n ssg locale', () => {
-  it('uses route meta locale during generation', async () => {
+  it('derives locale from route path during generation', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     installI18n({
       app: { use: () => {} } as any,
       isClient: false,
-      route: { meta: { locale: 'fr' } },
+      routePath: '/fr/about',
     } as any)
 
     expect(useLocaleStore().locale).toBe('fr')


### PR DESCRIPTION
## Summary
- derive SSR locale from route path with default fallback
- ensure translations load after store update
- align i18n tests with route-path locale resolution

## Testing
- `pnpm test:unit test/i18n-ssg-locale.test.ts test/page-locale-ssr.test.ts test/router-locale.test.ts test/useLangSwitch.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_6891de21eb34832aa6d7b0786ce9483b