### PR TITLE
feat: highlight shiny shlagemon names in battle

### DIFF
--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -164,7 +164,7 @@ const heldItem = computed(() => {
         alt="ball"
         class="h-4 w-4"
       >
-      <span class="font-bold">{{ props.mon.base.name }}</span>
+      <span class="font-bold" :class="{ 'shiny-text': props.mon.isShiny }">{{ props.mon.base.name }}</span>
     </div>
     <UiProgressBar
       :value="props.hp"

--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -232,27 +232,3 @@ const captureInfo = computed(() => {
     </div>
   </div>
 </template>
-
-<style scoped>
-.shiny-text {
-  background: linear-gradient(90deg, #ff00cc, #3333ff, #00ffff, #00ff00, #ffff00, #ff9900, #ff0000);
-  background-size: 400% 400%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: shiny-rainbow 5s linear infinite;
-  display: inline-block;
-}
-
-@keyframes shiny-rainbow {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-</style>

--- a/src/styles/text.css
+++ b/src/styles/text.css
@@ -12,3 +12,25 @@
     background-position: 360% 50%;
   }
 }
+
+.shiny-text {
+  background: linear-gradient(90deg, #ff00cc, #3333ff, #00ffff, #00ff00, #ffff00, #ff9900, #ff0000);
+  background-size: 400% 400%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shiny-rainbow 5s linear infinite;
+  display: inline-block;
+}
+
+@keyframes shiny-rainbow {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}

--- a/test/battle-shiny-name.test.ts
+++ b/test/battle-shiny-name.test.ts
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import BattleShlagemon from '../src/components/battle/Shlagemon.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+const messages = { en: { components: { battle: { Shlagemon: { infoTooltip: 'info' } } } } }
+
+describe('battle shlagemon shiny name', () => {
+  it('adds rainbow class when shlagemon is shiny', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.isShiny = true
+
+    const i18n = createI18n({ legacy: false, locale: 'en', messages })
+
+    const wrapper = mount(BattleShlagemon, {
+      props: { mon, hp: 10 },
+      global: {
+        plugins: [pinia, i18n],
+        stubs: {
+          EffectBadge: true,
+          DiseaseBadge: true,
+          InventoryWearableItemIcon: true,
+          ShlagemonImage: true,
+          UiProgressBar: true,
+        },
+        directives: { tooltip: () => {} },
+      },
+    })
+
+    expect(wrapper.get('span.font-bold').classes()).toContain('shiny-text')
+  })
+})


### PR DESCRIPTION
## Summary
- reuse the shiny rainbow animation globally
- show rainbow name for shiny Shlagemons during battle
- cover shiny name rendering with a unit test

## Testing
- `npx eslint src/styles/text.css src/components/battle/Shlagemon.vue src/components/shlagemon/Detail.vue test/battle-shiny-name.test.ts`
- `pnpm typecheck` *(fails: Property 'maxLevel' does not exist on type...)*
- `pnpm test:unit --run test/battle-shiny-name.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891efd1b2b0832aa1cb0dcd67935836