### PR TITLE
feat: always include root route

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { setupLayouts } from 'virtual:generated-layouts'
 import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
-import { availableLocales, defaultLocale } from '~/constants/locales'
+import { availableLocales } from '~/constants/locales'
 import { localizedRoutes } from './localizedRoutes'
 
 /**
@@ -26,8 +26,6 @@ export function buildLocalizedRoutes(): RouteRecordRaw[] {
           layout: route.layout,
         },
       }
-      if (import.meta.env.SSG && locale === defaultLocale && route.name === 'home')
-        record.alias = '/'
       records.push(record)
     }
   }
@@ -36,15 +34,11 @@ export function buildLocalizedRoutes(): RouteRecordRaw[] {
 }
 
 export const routes: RouteRecordRaw[] = [
-  ...(!import.meta.env.SSG
-    ? [
-        {
-          path: '/',
-          name: 'root',
-          component: () => import('~/pages/root.vue'),
-        },
-      ]
-    : []),
+  {
+    path: '/',
+    name: 'root',
+    component: () => import('~/pages/root.vue'),
+  },
   ...buildLocalizedRoutes(),
 ]
 


### PR DESCRIPTION
## Summary
- always register `/` route so `root.vue` can redirect
- drop SSG alias for default locale

## Testing
- `pnpm lint` (fails: Strings must use singlequote, Unexpected console statement, 您 etc.)
- `pnpm typecheck` (fails: many TS errors, e.g. Argument of type 'string' not assignable to parameter of type 'Locale')
- `pnpm test:unit` (cancelled: Command failed with exit code 130)

------
https://chatgpt.com/codex/tasks/task_e_6891ee92858c832a8915d9ec5ce30c45