### PR TITLE
feat: redirect unmatched routes by locale

### DIFF
--- a/test/router-redirect.test.ts
+++ b/test/router-redirect.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { defaultLocale } from '../src/constants/locales'
+import { redirect } from '../src/router'
+
+const originalNavigator = globalThis.navigator
+
+afterEach(() => {
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+    })
+  }
+  else {
+    delete (globalThis as any).navigator
+  }
+})
+
+describe('redirect', () => {
+  it('uses navigator language when available', () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { language: 'fr-FR' },
+      configurable: true,
+    })
+
+    const path = redirect({ params: { all: 'foo' } } as any)
+    expect(path).toBe('/fr/foo')
+  })
+
+  it('falls back to default locale for unsupported language', () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { language: 'es-ES' },
+      configurable: true,
+    })
+
+    const path = redirect({ params: { all: 'bar' } } as any)
+    expect(path).toBe(`/${defaultLocale}/bar`)
+  })
+
+  it('falls back to default locale when navigator missing', () => {
+    delete (globalThis as any).navigator
+
+    const path = redirect({ params: {} } as any)
+    expect(path).toBe(`/${defaultLocale}`)
+  })
+})


### PR DESCRIPTION
## Summary
- redirect non-matching paths to locale prefixed routes
- test redirect logic for navigator and server defaults

## Testing
- `pnpm eslint src/router/index.ts test/router-redirect.test.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6891ff659b8c832a9434bf2dfbd58e61