### PR TITLE
Adjust capture chance for triple attempts

### DIFF
--- a/src/utils/capture.ts
+++ b/src/utils/capture.ts
@@ -15,10 +15,14 @@ export function getCaptureChance(enemy: DexShlagemon, ball: Ball): number {
   const rarityMod = rarityModifier(enemy.rarity)
   const levelPenalty = levelDifficultyMultiplier(enemy.lvl)
   const captureMod = captureBonusMultiplier()
-  return Math.min(
+  const chance = Math.min(
     100,
     hpChance * levelBonus * rarityMod * captureMod * levelPenalty,
   )
+  // The capture sequence performs up to three attempts. Dividing the
+  // probability by three keeps the overall success rate aligned with the
+  // computed chance value.
+  return chance / 3
 }
 
 export function tryCapture(enemy: DexShlagemon, ball: Ball): boolean {

--- a/test/capture-potion.test.ts
+++ b/test/capture-potion.test.ts
@@ -12,10 +12,12 @@ describe('capture potion', () => {
     const mon = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(mon)
 
-    dex.boostCapture(50)
     const ball = { id: 'test', name: 't', description: '', price: 0, catchBonus: 1, animation: '' }
     mon.hpCurrent = 0
-    vi.spyOn(Math, 'random').mockReturnValue(0.49)
+    mon.rarity = 99
+    vi.spyOn(Math, 'random').mockReturnValue(0.1)
+    expect(tryCapture(mon, ball)).toBe(false)
+    dex.boostCapture(50)
     expect(tryCapture(mon, ball)).toBe(true)
     vi.useRealTimers()
   })

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -64,12 +64,12 @@ describe('capture mechanics', () => {
     expect(chanceHyper).toBeGreaterThan(chanceSuper)
   })
 
-  it('hyper ball versus strong foe gives around 25% chance', () => {
+  it('hyper ball versus strong foe gives around 9% chance', () => {
     const mon = createDexShlagemon(carapouffe, false, 80)
     mon.hp = 100
     mon.hpCurrent = 62
     mon.rarity = 1
     const chance = getCaptureChance(mon, balls[2])
-    expect(chance).toBeCloseTo(26.6, 1)
+    expect(chance).toBeCloseTo(8.9, 1)
   })
 })


### PR DESCRIPTION
## Summary
- Divide computed capture chance by three so three attempts keep overall odds consistent
- Update capture tests and potion bonus test for new probability scale

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689200d399b4832abf7d7c3d333df4cf