### PR TITLE
feat(arena): add selection confirmation

### DIFF
--- a/src/components/arena/EnemyStats.i18n.yml
+++ b/src/components/arena/EnemyStats.i18n.yml
@@ -3,8 +3,10 @@ fr:
   attack: Attaque
   defense: Défense
   smell: Puanteur
+  level: lvl {n}
 en:
   hp: HP
   attack: Attack
   defense: Defense
   smell: Smell
+  level: lvl {n}

--- a/src/components/arena/EnemyStatsCompact.vue
+++ b/src/components/arena/EnemyStatsCompact.vue
@@ -26,6 +26,9 @@ const stats = computed(() => [
       <div class="flex items-center justify-between">
         <h3 class="truncate text-base font-bold">
           {{ props.mon.base.name }}
+          <span class="ml-1 text-sm text-gray-600 font-medium dark:text-gray-400">
+            {{ t('components.arena.EnemyStats.level', { n: props.mon.lvl }) }}
+          </span>
         </h3>
         <ShlagemonRarityInfo :rarity="props.mon.rarity" class="ml-2 flex-shrink-0" />
       </div>

--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -55,13 +55,6 @@ function onMonSelected(mon: DexShlagemon) {
   showDex.value = false
 }
 
-watch(() => dex.activeShlagemon, (mon) => {
-  if (!showDex.value || activeSlot.value === null || !mon)
-    return
-  arena.selectPlayer(activeSlot.value, mon.id)
-  showDex.value = false
-})
-
 function quit() {
   arena.reset()
   panel.showVillage()

--- a/src/components/arena/SelectionModal.i18n.yml
+++ b/src/components/arena/SelectionModal.i18n.yml
@@ -1,4 +1,6 @@
 fr:
   title: Choisir un Shlagémon contre {name}
+  confirm: Valider
 en:
   title: Choose a Shlagemon against {name}
+  confirm: Confirm

--- a/src/components/arena/SelectionModal.vue
+++ b/src/components/arena/SelectionModal.vue
@@ -14,12 +14,20 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
+const candidate = ref<DexShlagemon | null>(null)
+
 function close() {
   emit('update:modelValue', false)
 }
 
 function onSelect(mon: DexShlagemon) {
-  emit('select', mon)
+  candidate.value = mon
+}
+
+function confirm() {
+  if (!candidate.value)
+    return
+  emit('select', candidate.value)
   close()
 }
 </script>
@@ -30,10 +38,12 @@ function onSelect(mon: DexShlagemon) {
       {{ t('components.arena.SelectionModal.title', { name: props.mon.base.name }) }}
     </h3>
     <ArenaEnemyStatsCompact :mon="props.mon" />
-    <div class="flex flex-1 overflow-hidden">
-      <div class="w-full">
-        <ShlagemonQuickSelect :selected="props.selected" @select="onSelect" />
-      </div>
+    <div class="flex-1 overflow-hidden">
+      <ShlagemonQuickSelect :selected="props.selected" @select="onSelect" />
     </div>
+    <ArenaEnemyStatsCompact v-if="candidate" :mon="candidate" />
+    <UiButton v-if="candidate" class="mt-2" type="primary" @click="confirm">
+      {{ t('components.arena.SelectionModal.confirm') }}
+    </UiButton>
   </div>
 </template>

--- a/test/arena-selection-modal.test.ts
+++ b/test/arena-selection-modal.test.ts
@@ -1,0 +1,84 @@
+import type { DexShlagemon } from '../src/type/shlagemon'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+
+import { createI18n } from 'vue-i18n'
+import SelectionModal from '../src/components/arena/SelectionModal.vue'
+import { shlagemonTypes } from '../src/data/shlagemons-type'
+
+function createMon(id: string, level: number): DexShlagemon {
+  return {
+    id,
+    base: {
+      id,
+      name: id,
+      description: '',
+      types: [shlagemonTypes.normal],
+      speciality: 'evolution0',
+    },
+    baseStats: { hp: 10, attack: 10, defense: 10, smelling: 10 },
+    captureDate: '',
+    captureCount: 1,
+    lvl: level,
+    xp: 0,
+    rarity: 1,
+    sex: 'male',
+    isShiny: false,
+    hpCurrent: 10,
+    allowEvolution: true,
+    hp: 10,
+    attack: 10,
+    defense: 10,
+    smelling: 10,
+  }
+}
+
+describe('arena selection modal', () => {
+  it('keeps modal open until confirmation', async () => {
+    const enemy = createMon('enemy', 5)
+    const candidate = createMon('candidate', 7)
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: {
+        en: {
+          components: {
+            arena: {
+              SelectionModal: { title: 'Choose a Shlagemon against {name}', confirm: 'Confirm' },
+              EnemyStats: { hp: 'HP', attack: 'Attack', defense: 'Defense', smell: 'Smell', level: 'lvl {n}' },
+            },
+            shlagemon: { RarityInfo: { tooltip: '' } },
+          },
+        },
+      },
+    })
+
+    const wrapper = mount(SelectionModal, {
+      props: { mon: enemy, selected: [] },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ShlagemonQuickSelect: { name: 'ShlagemonQuickSelect', template: '<div />' },
+          ShlagemonImage: true,
+          ShlagemonRarityInfo: { name: 'ShlagemonRarityInfo', template: '<div />' },
+          RarityInfo: { name: 'RarityInfo', template: '<div />' },
+          ShlagemonType: true,
+          UiButton: { name: 'UiButton', template: '<button><slot /></button>' },
+        },
+        directives: { tooltip: () => {} },
+      },
+    })
+
+    const qc = wrapper.findComponent({ name: 'ShlagemonQuickSelect' })
+    qc.vm.$emit('select', candidate)
+    await nextTick()
+
+    expect(wrapper.text()).toContain('lvl 7')
+    expect(wrapper.find('button').exists()).toBe(true)
+    expect(wrapper.emitted('select')).toBeUndefined()
+
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('select')?.[0]).toEqual([candidate])
+  })
+})


### PR DESCRIPTION
## Summary
- show selected shlagémon card with level in arena selection
- add confirmation button to finalize selection
- cover arena selection flow with unit test

## Testing
- `pnpm lint` *(fails: Strings must use singlequote, etc.)*
- `pnpm typecheck` *(fails: Property 'maxLevel' does not exist, etc.)*
- `pnpm test:unit` *(fails: unhandled Vue warnings, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68920eb40618832aaced4d154f4c99f9