### PR TITLE
fix(arena): show current selection when reopening

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -16,6 +16,7 @@ const enemyTeam = computed(() => arena.lineup)
 const enemyDexTeam = computed(() => arena.lineupDex)
 const showDex = ref(false)
 const activeSlot = ref<number | null>(null)
+const currentSelection = ref<DexShlagemon | null>(null)
 const selectedEnemy = computed(() =>
   activeSlot.value !== null ? enemyDexTeam.value[activeSlot.value] : undefined,
 )
@@ -41,6 +42,7 @@ const playerSelection = computed(() =>
 
 function openDex(i: number) {
   activeSlot.value = i
+  currentSelection.value = playerSelection.value[i] ?? null
   showDex.value = true
 }
 
@@ -122,25 +124,25 @@ onUnmounted(() => {
         v-for="(enemy, i) in enemyTeam"
         :key="enemy.id"
         type="danger"
-        class="w-18 aspect-square p-0!"
+        class="aspect-square w-18 p-0!"
         circle
         @click="openEnemy(i)"
       >
         <ShlagemonImage :id="enemy.id" :alt="enemy.name" class="h-full w-full object-contain" />
       </UiButton>
       <div v-for="enemy in enemyTeam" :key="enemy.id" class="flex-center flex-col gap-1 color-red-600">
-        <div class="i-game-icons:battle-axe text-xl animate-pulse-alt" />
+        <div class="i-game-icons:battle-axe animate-pulse-alt text-xl" />
         <div class="text-sm">
           VS
         </div>
-        <div class="i-carbon:chevron-down text-xs animate-bounce" />
+        <div class="i-carbon:chevron-down animate-bounce text-xs" />
       </div>
 
       <UiButton
         v-for="(_, i) in enemyTeam"
         :key="i"
         :variant="playerSelection[i] ? 'outline' : undefined"
-        class="w-18 aspect-square p-0!"
+        class="aspect-square w-18 p-0!"
         circle
         @click="openDex(i)"
       >
@@ -201,6 +203,7 @@ onUnmounted(() => {
             v-if="selectedEnemy"
             :mon="selectedEnemy"
             :selected="arena.selections.filter(Boolean) as string[]"
+            :initial="currentSelection"
             @select="onMonSelected"
           />
         </UiModal>

--- a/src/components/arena/SelectionModal.vue
+++ b/src/components/arena/SelectionModal.vue
@@ -4,9 +4,15 @@ import type { DexShlagemon } from '~/type/shlagemon'
 interface Props {
   mon: DexShlagemon
   selected: string[]
+  /**
+   * Currently selected Shlagemon for the opened slot.
+   */
+  initial?: DexShlagemon | null
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  initial: null,
+})
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'select', mon: DexShlagemon): void
@@ -14,7 +20,14 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const candidate = ref<DexShlagemon | null>(null)
+const candidate = ref<DexShlagemon | null>(props.initial)
+
+watch(
+  () => props.initial,
+  (val) => {
+    candidate.value = val
+  },
+)
 
 function close() {
   emit('update:modelValue', false)
@@ -38,7 +51,7 @@ function confirm() {
       {{ t('components.arena.SelectionModal.title', { name: props.mon.base.name }) }}
     </h3>
     <ArenaEnemyStatsCompact :mon="props.mon" enemy />
-      <ShlagemonQuickSelect class="flex-1" :selected="props.selected" @select="onSelect" />
+    <ShlagemonQuickSelect class="flex-1" :selected="props.selected" @select="onSelect" />
     <ArenaEnemyStatsCompact v-if="candidate" :mon="candidate" />
     <UiButton v-if="candidate" class="mt-2" type="primary" @click="confirm">
       {{ t('components.arena.SelectionModal.confirm') }}


### PR DESCRIPTION
## Summary
- keep selection modal in sync with the slot's current Shlagemon
- pass current slot selection from arena panel to selection modal
- test modal initialization and update behaviour

## Testing
- `pnpm exec eslint src/components/arena/SelectionModal.vue src/components/arena/Panel.vue test/arena-selection-modal.test.ts`
- `pnpm exec vue-tsc --noEmit src/components/arena/SelectionModal.vue src/components/arena/Panel.vue test/arena-selection-modal.test.ts` *(fails: ReferenceError: parseJsonConfigFileContent is not defined)*
- `pnpm test:unit test/arena-selection-modal.test.ts --run`

------
https://chatgpt.com/codex/tasks/task_e_6893005f70fc832aa3ec43dec4cc3edf