### PR TITLE
feat: show icon-only tabs in settings

### DIFF
--- a/src/components/settings/SettingsModal.vue
+++ b/src/components/settings/SettingsModal.vue
@@ -76,6 +76,6 @@ watch(tabs, (val) => {
     <h2 class="mb-2 text-center text-lg font-bold">
       {{ t('components.settings.SettingsModal.title') }}
     </h2>
-    <UiTabs v-model="activeTab" :tabs="tabs" is-small class="mb-4 flex-1" />
+    <UiTabs v-model="activeTab" :tabs="tabs" is-small icons-only class="mb-4 flex-1" />
   </UiModal>
 </template>

--- a/src/components/ui/Tabs.vue
+++ b/src/components/ui/Tabs.vue
@@ -132,7 +132,7 @@ const transitionName = computed(() => direction.value === 'left' ? 'slide-left' 
     >
       <template v-for="(tab, i) in props.tabs" :key="i">
         <button
-          v-tooltip="tab.tooltip"
+          v-tooltip="props.iconsOnly ? tab.tooltip || tab.label.text : tab.tooltip"
           type="button"
           :tabindex="active === i ? 0 : -1"
           :aria-selected="active === i"

--- a/test/ui-tabs-icons-only-tooltip.test.ts
+++ b/test/ui-tabs-icons-only-tooltip.test.ts
@@ -1,0 +1,31 @@
+import type { Directive } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import UiTabs from '../src/components/ui/Tabs.vue'
+
+const tooltipDirective: Directive = {
+  mounted(el, binding) {
+    el.setAttribute('data-tooltip', String(binding.value))
+  },
+}
+
+describe('uiTabs icons-only tooltip', () => {
+  it('uses label text as tooltip when none provided and icons-only', () => {
+    const tabs = [
+      {
+        label: { text: 'Save', icon: 'i-carbon-save' },
+        component: defineComponent({ render: () => h('div') }),
+      },
+    ] as const
+
+    const wrapper = mount(UiTabs, {
+      props: { tabs, iconsOnly: true },
+      global: { directives: { tooltip: tooltipDirective } },
+    })
+
+    const button = wrapper.find('button')
+    expect(button.attributes('data-tooltip')).toBe('Save')
+    expect(button.text()).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- default tooltip to label when Tabs are icons-only
- show settings modal tabs using icons only
- test tooltip fallback for icon-only Tabs

## Testing
- `pnpm lint` *(fails: Strings must use singlequote in src/pwa/manifest.ts)*
- `npx eslint src/components/ui/Tabs.vue src/components/settings/SettingsModal.vue test/ui-tabs-icons-only-tooltip.test.ts`
- `pnpm test:unit test/ui-tabs-icons-only-tooltip.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68930b5e3ba4832aad8306b0e350f2f0