### PR TITLE
chore: translate shlagemon types

### DIFF
--- a/src/components/shlagemon/Type.vue
+++ b/src/components/shlagemon/Type.vue
@@ -14,6 +14,7 @@ const props = withDefaults(defineProps<{
 
 // Store modal typé (à adapter selon ton architecture)
 const typeChart = useTypeChartModalStore()
+const { t } = useI18n()
 
 // Taillez responsive : clampé pour éviter des extrêmes
 const sizeStyle = computed(() => {
@@ -42,6 +43,8 @@ const textColor = computed(() => {
   return yiq >= 160 ? '#1a1a1a' : '#fff'
 })
 
+const typeName = computed(() => t(props.value.name))
+
 function handleClick() {
   if (props.openOnClick)
     typeChart.open(props.value.id)
@@ -54,8 +57,8 @@ function handleClick() {
     :tabindex="props.openOnClick ? 0 : undefined"
     :role="props.openOnClick ? 'button' : undefined"
     :aria-pressed="props.openOnClick ? 'false' : undefined"
-    :aria-label="`Type ${props.value.name}`"
-    :name="props.value.name"
+    :aria-label="typeName"
+    :name="typeName"
     :style="{
       backgroundColor: props.value.color,
       color: textColor,
@@ -65,7 +68,7 @@ function handleClick() {
     @keydown.enter.space.prevent="handleClick"
   >
     <span class="pointer-events-none w-full truncate text-center leading-none">
-      {{ props.value.name }}
+      {{ typeName }}
     </span>
   </span>
 </template>

--- a/src/data/shlagemons-type.i18n.yml
+++ b/src/data/shlagemons-type.i18n.yml
@@ -1,0 +1,110 @@
+fr:
+  normal:
+    name: Normy
+    description: Type complètement inintéressant et trop pourri.
+  feu:
+    name: Cramé
+    description: Type brûlant qui réduit tout en cendres.
+  eau:
+    name: Mouillé
+    description: Type humide qui éteint facilement les ardeurs.
+  plante:
+    name: Moisi
+    description: Type végétal en décomposition.
+  electrique:
+    name: Électrochiasse
+    description: Type chargé d'électricité statique.
+  roche:
+    name: Caillasse
+    description: Type roc très coriace.
+  vol:
+    name: AirEction
+    description: Type aérien mais qui sent la teub.
+  combat:
+    name: Castagne
+    description: Type bagarreur qui tape sans réfléchir.
+  spectre:
+    name: Spectranus
+    description: Type chelou qui fout les jetons.
+  darksasuke:
+    name: DarkSasuke
+    description: Type victime, gothique et émo qui cours avec les bras en arrière.
+  psy:
+    name: Psytrance
+    description: Un fan de musique de merde, il ne sait pas s'amuser sans prendre de drogue.
+  poison:
+    name: Poisonet
+    description: Type toxique qui t’envoie des mails louches.
+  metal:
+    name: Ferraille
+    description: Type blindé mais rouillé qui couine à chaque pas.
+  sol:
+    name: Cradouze
+    description: Type terreux qui gratte les pieds.
+  fee:
+    name: FéeLation
+    description: Type sucré en apparence, mais colle aux doigts.
+  dragon:
+    name: DragonDorf
+    description: Type majestueux mais trop sûr de lui, qui finit toujours battu à la fin.
+  glace:
+    name: Glaconasse
+    description: Type froid comme ton ex, glissant et imprévisible.
+  insecte:
+    name: Mouchtik
+    description: Type grouillant, souvent poilu, toujours dérangeant. Il gratte la nuit et te juge en silence.
+en:
+  normal:
+    name: Normy
+    description: A completely uninteresting and pathetic type.
+  feu:
+    name: Crispy
+    description: A blazing type that reduces everything to ashes.
+  eau:
+    name: Soggy
+    description: A wet type that easily dampens any enthusiasm.
+  plante:
+    name: Moldy
+    description: A decaying plant-based type.
+  electrique:
+    name: Electropoop
+    description: A type charged with static electricity.
+  roche:
+    name: Pebble
+    description: A tough rock-like type.
+  vol:
+    name: AirEction
+    description: A flying type that reeks of musk.
+  combat:
+    name: Brawler
+    description: A brutish type that punches before thinking.
+  spectre:
+    name: Spectranus
+    description: A creepy type that gives you the chills.
+  darksasuke:
+    name: DarkSasuke
+    description: An emo goth victim running with arms behind.
+  psy:
+    name: Psytrance
+    description: A music addict who cannot have fun without drugs.
+  poison:
+    name: Poisonet
+    description: A toxic type that sends sketchy emails.
+  metal:
+    name: Scrapmetal
+    description: A heavy type, rusted and squeaky with every step.
+  sol:
+    name: Filth
+    description: An earthy type that scratches your feet.
+  fee:
+    name: FairyLick
+    description: Sweet at first glance, but sticks to your fingers.
+  dragon:
+    name: DragonDorf
+    description: A majestic yet overconfident type that always loses in the end.
+  glace:
+    name: Frostbite
+    description: As cold as your ex, slippery and unpredictable.
+  insecte:
+    name: Bugger
+    description: Crawling, hairy and always annoying. It scratches at night and judges in silence.

--- a/src/data/shlagemons-type.ts
+++ b/src/data/shlagemons-type.ts
@@ -2,8 +2,8 @@ import type { ShlagemonType, TypeName } from '../type'
 
 export const normal: ShlagemonType = {
   id: 'normal',
-  name: 'Normy',
-  description: 'Type complètement inintéressant et trop pourri.',
+  name: 'data.shlagemons-type.normal.name',
+  description: 'data.shlagemons-type.normal.description',
   color: '#A8A878',
   resistance: [],
   weakness: ['combat'],
@@ -13,8 +13,8 @@ export const normal: ShlagemonType = {
 
 export const feu: ShlagemonType = {
   id: 'feu',
-  name: 'Cramé',
-  description: 'Type brûlant qui réduit tout en cendres.',
+  name: 'data.shlagemons-type.feu.name',
+  description: 'data.shlagemons-type.feu.description',
   color: '#e25822',
   resistance: ['plante', 'metal', 'fee'],
   weakness: ['eau', 'sol'],
@@ -24,8 +24,8 @@ export const feu: ShlagemonType = {
 
 export const eau: ShlagemonType = {
   id: 'eau',
-  name: 'Mouillé',
-  description: 'Type humide qui éteint facilement les ardeurs.',
+  name: 'data.shlagemons-type.eau.name',
+  description: 'data.shlagemons-type.eau.description',
   color: '#3b83bd',
   resistance: ['feu', 'roche', 'eau'],
   weakness: ['plante', 'electrique'],
@@ -35,8 +35,8 @@ export const eau: ShlagemonType = {
 
 export const plante: ShlagemonType = {
   id: 'plante',
-  name: 'Moisi',
-  description: 'Type végétal en décomposition.',
+  name: 'data.shlagemons-type.plante.name',
+  description: 'data.shlagemons-type.plante.description',
   color: '#769958',
   resistance: ['sol', 'electrique', 'eau'],
   weakness: ['feu', 'plante', 'poison', 'vol'],
@@ -46,8 +46,8 @@ export const plante: ShlagemonType = {
 
 export const electrique: ShlagemonType = {
   id: 'electrique',
-  name: 'Électrochiasse',
-  description: 'Type chargé d\'électricité statique.',
+  name: 'data.shlagemons-type.electrique.name',
+  description: 'data.shlagemons-type.electrique.description',
   color: '#f9e743',
   resistance: ['vol', 'electrique', 'eau'],
   weakness: ['sol'],
@@ -57,8 +57,8 @@ export const electrique: ShlagemonType = {
 
 export const roche: ShlagemonType = {
   id: 'roche',
-  name: 'Caillasse',
-  description: 'Type roc très coriace.',
+  name: 'data.shlagemons-type.roche.name',
+  description: 'data.shlagemons-type.roche.description',
   color: '#a79f94',
   resistance: ['feu', 'vol', 'poison', 'fee'],
   weakness: ['combat', 'eau', 'plante', 'sol', 'metal'],
@@ -68,8 +68,8 @@ export const roche: ShlagemonType = {
 
 export const vol: ShlagemonType = {
   id: 'vol',
-  name: 'AirEction',
-  description: 'Type aérien mais qui sent la teub.',
+  name: 'data.shlagemons-type.vol.name',
+  description: 'data.shlagemons-type.vol.description',
   color: '#A4C2F4',
   resistance: ['combat', 'plante', 'eau'],
   weakness: ['roche', 'electrique', 'plante'],
@@ -79,8 +79,8 @@ export const vol: ShlagemonType = {
 
 export const combat: ShlagemonType = {
   id: 'combat',
-  name: 'Castagne',
-  description: 'Type bagarreur qui tape sans réfléchir.',
+  name: 'data.shlagemons-type.combat.name',
+  description: 'data.shlagemons-type.combat.description',
   color: '#C03028',
   resistance: ['roche', 'darksasuke', 'poison'],
   weakness: ['vol', 'psy', 'fee'],
@@ -90,8 +90,8 @@ export const combat: ShlagemonType = {
 
 export const spectre: ShlagemonType = {
   id: 'spectre',
-  name: 'Spectranus',
-  description: 'Type chelou qui fout les jetons.',
+  name: 'data.shlagemons-type.spectre.name',
+  description: 'data.shlagemons-type.spectre.description',
   color: '#705898',
   resistance: ['poison', 'combat'],
   weakness: ['darksasuke', 'spectre'],
@@ -101,8 +101,8 @@ export const spectre: ShlagemonType = {
 
 export const darksasuke: ShlagemonType = {
   id: 'darksasuke',
-  name: 'DarkSasuke',
-  description: 'Type victime, gothique et émo qui cours avec les bras en arrière.',
+  name: 'data.shlagemons-type.darksasuke.name',
+  description: 'data.shlagemons-type.darksasuke.description',
   color: '#4D4D4D',
   resistance: ['spectre', 'psy', 'plante'],
   weakness: ['combat', 'fee'],
@@ -112,8 +112,8 @@ export const darksasuke: ShlagemonType = {
 
 export const psy: ShlagemonType = {
   id: 'psy',
-  name: 'Psytrance',
-  description: `Un fan de musique de merde, il ne sait pas s'amuser sans prendre de drogue.`,
+  name: 'data.shlagemons-type.psy.name',
+  description: 'data.shlagemons-type.psy.description',
   color: '#FF66CC',
   resistance: ['combat', 'fee'],
   weakness: ['darksasuke', 'spectre', 'poison'],
@@ -123,8 +123,8 @@ export const psy: ShlagemonType = {
 
 export const poison: ShlagemonType = {
   id: 'poison',
-  name: 'Poisonet',
-  description: 'Type toxique qui t’envoie des mails louches.',
+  name: 'data.shlagemons-type.poison.name',
+  description: 'data.shlagemons-type.poison.description',
   color: '#A040A0',
   resistance: ['plante', 'combat', 'fee'],
   weakness: ['sol', 'psy'],
@@ -134,8 +134,8 @@ export const poison: ShlagemonType = {
 
 export const metal: ShlagemonType = {
   id: 'metal',
-  name: 'Ferraille',
-  description: 'Type blindé mais rouillé qui couine à chaque pas.',
+  name: 'data.shlagemons-type.metal.name',
+  description: 'data.shlagemons-type.metal.description',
   color: '#B8B8D0',
   resistance: ['poison', 'eau', 'electrique', 'plante', 'psy', 'roche', 'fee', 'vol'],
   weakness: ['combat', 'feu', 'sol'],
@@ -145,8 +145,8 @@ export const metal: ShlagemonType = {
 
 export const sol: ShlagemonType = {
   id: 'sol',
-  name: 'Cradouze',
-  description: 'Type terreux qui gratte les pieds.',
+  name: 'data.shlagemons-type.sol.name',
+  description: 'data.shlagemons-type.sol.description',
   color: '#E0C068',
   resistance: ['electrique', 'poison', 'feu', 'roche'],
   weakness: ['plante', 'eau'],
@@ -156,8 +156,8 @@ export const sol: ShlagemonType = {
 
 export const fee: ShlagemonType = {
   id: 'fee',
-  name: 'FéeLation',
-  description: 'Type sucré en apparence, mais colle aux doigts.',
+  name: 'data.shlagemons-type.fee.name',
+  description: 'data.shlagemons-type.fee.description',
   color: '#EE99AC',
   resistance: [],
   weakness: ['poison', 'metal'],
@@ -167,8 +167,8 @@ export const fee: ShlagemonType = {
 
 export const dragon: ShlagemonType = {
   id: 'dragon',
-  name: 'DragonDorf',
-  description: 'Type majestueux mais trop sûr de lui, qui finit toujours battu à la fin.',
+  name: 'data.shlagemons-type.dragon.name',
+  description: 'data.shlagemons-type.dragon.description',
   color: '#7038F8', // couleur violette proche du type Dragon
   resistance: ['feu', 'eau', 'electrique', 'plante'],
   weakness: ['dragon', 'glace', 'fee'],
@@ -178,8 +178,8 @@ export const dragon: ShlagemonType = {
 
 export const glace: ShlagemonType = {
   id: 'glace',
-  name: 'Glaconasse',
-  description: 'Type froid comme ton ex, glissant et imprévisible.',
+  name: 'data.shlagemons-type.glace.name',
+  description: 'data.shlagemons-type.glace.description',
   color: '#98d8d8',
   resistance: ['glace'],
   weakness: ['feu', 'roche', 'combat', 'metal'],
@@ -189,8 +189,8 @@ export const glace: ShlagemonType = {
 
 export const insecte: ShlagemonType = {
   id: 'insecte',
-  name: 'Mouchtik',
-  description: 'Type grouillant, souvent poilu, toujours dérangeant. Il gratte la nuit et te juge en silence.',
+  name: 'data.shlagemons-type.insecte.name',
+  description: 'data.shlagemons-type.insecte.description',
   color: '#a8b820',
   resistance: ['combat', 'plante', 'sol'],
   weakness: ['feu', 'poison', 'vol', 'roche'],

--- a/src/type/shlagemonType.ts
+++ b/src/type/shlagemonType.ts
@@ -1,3 +1,5 @@
+import type { I18nKey } from './i18n'
+
 /**
  * Union of all valid Shlagémon type identifiers.
  */
@@ -27,10 +29,10 @@ export type TypeName
 export interface ShlagemonType {
   /** Unique identifier of the type. */
   id: TypeName
-  /** Display name used in UI. */
-  name: string
-  /** i18n key describing the type. */
-  description: string
+  /** Translation key for the display name. */
+  name: I18nKey
+  /** Translation key describing the type. */
+  description: I18nKey
   /** Hex color associated with the type. */
   color: string
   /**


### PR DESCRIPTION
## Summary
- add i18n support for shlagemon elemental types
- render type names through translation function

## Testing
- `pnpm test:unit --run`
- `npx eslint src/type/shlagemonType.ts src/data/shlagemons-type.ts src/components/shlagemon/Type.vue src/data/shlagemons-type.i18n.yml`


------
https://chatgpt.com/codex/tasks/task_e_68930bcc9e18832a93650bb053f9c006