### PR TITLE
feat(settings): display tab titles

### DIFF
--- a/src/components/settings/AccessibilityTab.vue
+++ b/src/components/settings/AccessibilityTab.vue
@@ -7,7 +7,10 @@ const { autoHideTooltips } = storeToRefs(accessibility)
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-4">
+    <h3 class="text-center text-lg font-bold">
+      {{ t('components.settings.SettingsModal.tabs.accessibility') }}
+    </h3>
     <UiCheckBox v-model="autoHideTooltips">
       {{ t('components.settings.AccessibilityTab.autoHide.label') }}
     </UiCheckBox>

--- a/src/components/settings/InterfaceTab.vue
+++ b/src/components/settings/InterfaceTab.vue
@@ -8,6 +8,9 @@ const { showVillagesOnMap } = storeToRefs(interfaceStore)
 
 <template>
   <div class="flex flex-col gap-4">
+    <h3 class="text-center text-lg font-bold">
+      {{ t('components.settings.SettingsModal.tabs.interface') }}
+    </h3>
     <UiCheckBox
       v-model="showVillagesOnMap"
       :label="t('components.settings.InterfaceTab.villagesOnMap')"

--- a/src/components/settings/LanguageTab.vue
+++ b/src/components/settings/LanguageTab.vue
@@ -3,7 +3,10 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div class="flex flex-col items-center gap-2">
+  <div class="flex flex-col items-center gap-4">
+    <h3 class="text-center text-lg font-bold">
+      {{ t('components.settings.SettingsModal.tabs.language') }}
+    </h3>
     <label class="text-sm font-bold">
       {{ t('components.settings.LanguageTab.label') }}
     </label>

--- a/src/components/settings/SaveTab.vue
+++ b/src/components/settings/SaveTab.vue
@@ -76,6 +76,9 @@ function loadFromFile(event: Event) {
 
 <template>
   <div class="flex flex-col gap-6">
+    <h3 class="text-center text-lg font-bold">
+      {{ t('components.settings.SettingsModal.tabs.save') }}
+    </h3>
     <p class="text-center">
       {{ t('components.settings.SaveTab.playtime', { minutes: playtime.minutes }) }}
     </p>

--- a/src/components/settings/ShortcutsTab.vue
+++ b/src/components/settings/ShortcutsTab.vue
@@ -32,7 +32,10 @@ function removeShortcut(index: number) {
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-4">
+    <h3 class="text-center text-lg font-bold">
+      {{ t('components.settings.SettingsModal.tabs.shortcuts') }}
+    </h3>
     <UiListItem
       v-for="(sc, idx) in store.shortcuts"
       :key="idx"

--- a/src/components/settings/SupportTab.vue
+++ b/src/components/settings/SupportTab.vue
@@ -34,9 +34,9 @@ function openLink(url: string) {
     class="mx-auto max-w-sm w-full flex flex-col items-center gap-8 py-4"
     aria-labelledby="support-title"
   >
-    <h2 id="support-title" class="sr-only">
-      Support
-    </h2>
+    <h3 id="support-title" class="text-center text-lg font-bold">
+      {{ t('components.settings.SettingsModal.tabs.support') }}
+    </h3>
     <ul class="w-full flex flex-col gap-6">
       <li
         v-for="link in SUPPORT_LINKS"


### PR DESCRIPTION
## Summary
- show translated heading on each settings tab for clarity
- ensure Support tab title is visible instead of screen-reader only

## Testing
- `pnpm lint` (fails: style/space-infix-ops, quotes, comma-dangle, etc.)
- `pnpm test:unit` (fails: 2 failed tests, 10 errors)


------
https://chatgpt.com/codex/tasks/task_e_689315ba9ee4832a8eb49bf49993717e