### PR TITLE
fix: blur focused tooltip when hidden

### DIFF
--- a/src/utils/tooltipAccessibility.ts
+++ b/src/utils/tooltipAccessibility.ts
@@ -17,6 +17,7 @@ export function observeTooltipAccessibility(
   root: Document | HTMLElement = document,
 ): MutationObserver {
   const container = root instanceof Document ? root.body : root
+  const doc = root instanceof Document ? root : root.ownerDocument ?? document
 
   /**
    * Applies `tabindex` and `inert` attributes based on the current
@@ -24,10 +25,14 @@ export function observeTooltipAccessibility(
    */
   function applyAttributes(popper: HTMLElement) {
     popper.setAttribute('tabindex', '-1')
-    if (popper.getAttribute('aria-hidden') === 'true')
+    if (popper.getAttribute('aria-hidden') === 'true') {
+      if (popper.contains(doc.activeElement))
+        (doc.activeElement as HTMLElement | null)?.blur()
       popper.setAttribute('inert', '')
-    else
+    }
+    else {
       popper.removeAttribute('inert')
+    }
   }
 
   /**

--- a/test/tooltip-accessibility.test.ts
+++ b/test/tooltip-accessibility.test.ts
@@ -27,4 +27,26 @@ describe('observeTooltipAccessibility', () => {
 
     observer.disconnect()
   })
+
+  it('blurs focused elements when a popper is hidden', async () => {
+    const observer = observeTooltipAccessibility()
+
+    const popper = document.createElement('div')
+    popper.className = 'v-popper__popper'
+    popper.setAttribute('aria-hidden', 'false')
+
+    const button = document.createElement('button')
+    popper.appendChild(button)
+    document.body.appendChild(popper)
+
+    button.focus()
+    expect(document.activeElement).toBe(button)
+
+    popper.setAttribute('aria-hidden', 'true')
+    await flush()
+    expect(document.activeElement).toBe(document.body)
+
+    popper.remove()
+    observer.disconnect()
+  })
 })


### PR DESCRIPTION
## Summary
- blur focused tooltip content when hidden and ensure inert is applied
- test that hidden poppers release focus

## Testing
- `pnpm test:unit --run` *(fails: battle item cooldown > prevents using multiple battle items during cooldown)*
- `npx eslint src/utils/tooltipAccessibility.ts test/tooltip-accessibility.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68931640325c832a96c1feb41cc04462