### PR TITLE
feat: show multi exp holder button

### DIFF
--- a/src/components/shlagemon/List.spec.ts
+++ b/src/components/shlagemon/List.spec.ts
@@ -1,0 +1,90 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { multiExp } from '~/data/items'
+import List from './List.vue'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+const filterStore = { search: ref(''), sortBy: ref('level'), sortAsc: ref(false) }
+vi.mock('~/stores/dexFilter', () => ({ useDexFilterStore: () => filterStore }))
+
+const featureLockStore = { isShlagedexLocked: false }
+vi.mock('~/stores/featureLock', () => ({ useFeatureLockStore: () => featureLockStore }))
+
+const shlagemons = ref<any[]>([])
+const dexStore = { shlagemons, activeShlagemon: ref(null), newCount: 0, setActiveShlagemon: vi.fn(), markAllSeen: vi.fn() }
+vi.mock('~/stores/shlagedex', () => ({ useShlagedexStore: () => dexStore }))
+
+const holders = ref<Record<string, string | null>>({})
+const equipmentStore = { holders, getHolder: (id: string) => holders.value[id] || null }
+vi.mock('~/stores/equipment', () => ({ useEquipmentStore: () => equipmentStore }))
+
+const openSpy = vi.fn()
+vi.mock('~/stores/dexDetailModal', () => ({ useDexDetailModalStore: () => ({ open: openSpy }) }))
+
+const type = { id: 'normal', name: 't', description: 'd', color: '#000', resistance: [], weakness: [], tags: [], passiveEffects: [] }
+function createMon(heldItemId?: string) {
+  return {
+    id: 'm1',
+    base: { id: 'b1', name: 'test', description: 'd', types: [type], speciality: 'unique' },
+    baseStats: { hp: 1, attack: 1, defense: 1, smelling: 1 },
+    captureDate: '2024-01-01',
+    captureCount: 1,
+    lvl: 1,
+    xp: 0,
+    rarity: 1,
+    sex: 'male',
+    isShiny: false,
+    hpCurrent: 1,
+    allowEvolution: false,
+    hp: 1,
+    attack: 1,
+    defense: 1,
+    smelling: 1,
+    heldItemId,
+  }
+}
+
+const stubs = {
+  LayoutScrollablePanel: { template: '<div><slot name="header"></slot><slot name="content"></slot></div>' },
+  UiSortControls: { template: '<div></div>' },
+  UiSearchInput: { template: '<input />' },
+  UiButton: { template: '<button><slot /></button>' },
+  UiInfo: { template: '<div><slot /></div>' },
+  ShlagemonListItem: { template: '<div></div>' },
+  TransitionGroup: { template: '<div><slot /></div>' },
+}
+
+describe('shlagemon List Multi Exp button', () => {
+  beforeEach(() => {
+    shlagemons.value = []
+    holders.value = {}
+    openSpy.mockClear()
+  })
+
+  it('renders the multi exp button when equipped', () => {
+    const mon = createMon(multiExp.id)
+    shlagemons.value.push(mon)
+    holders.value[multiExp.id] = mon.id
+    const wrapper = mount(List, { props: { mons: [mon], isMainShlagedex: true }, global: { stubs } })
+    expect(wrapper.find('button').exists()).toBe(true)
+  })
+
+  it('opens the holder modal on click', async () => {
+    const mon = createMon(multiExp.id)
+    shlagemons.value.push(mon)
+    holders.value[multiExp.id] = mon.id
+    const wrapper = mount(List, { props: { mons: [mon], isMainShlagedex: true }, global: { stubs } })
+    await wrapper.find('button').trigger('click')
+    expect(openSpy).toHaveBeenCalledWith(mon)
+  })
+
+  it('hides the multi exp button when not equipped', () => {
+    const mon = createMon()
+    shlagemons.value.push(mon)
+    const wrapper = mount(List, { props: { mons: [mon], isMainShlagedex: true }, global: { stubs } })
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+})

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -24,11 +24,29 @@ const props = withDefaults(defineProps<Props>(), {
 const filter = useDexFilterStore()
 const dex = useShlagedexStore()
 const featureLock = useFeatureLockStore()
+const equipment = useEquipmentStore()
+const dexDetailModal = useDexDetailModalStore()
 const isLocked = computed(() => props.locked ?? featureLock.isShlagedexLocked)
 const items = Object.fromEntries(allItems.map(i => [i.id, i])) as Record<string, typeof allItems[number]>
 const { t } = useI18n()
 const newCount = computed(() => dex.newCount)
 const panelRef = ref<{ scrollToTop: () => void } | null>(null)
+
+/**
+ * Shlagémon currently holding the Multi Exp, if any.
+ */
+const multiExpHolder = computed(() => {
+  const holderId = equipment.getHolder(multiExp.id)
+  return holderId ? dex.shlagemons.find(m => m.id === holderId) || null : null
+})
+
+/**
+ * Open the detail modal for the Shlagémon holding the Multi Exp.
+ */
+function openMultiExpHolder() {
+  if (multiExpHolder.value)
+    dexDetailModal.open(multiExpHolder.value)
+}
 
 // Options de tri
 const sortOptions = [
@@ -173,10 +191,10 @@ watch(
             {{ displayedMons.length }} / {{ props.mons.length }}
           </span>
         </div>
-        <div v-if="isMainShlagedex && false" class="flex gap-1">
+        <div v-if="isMainShlagedex && multiExpHolder" class="flex gap-1">
           <UiSearchInput v-model="filter.search" />
-          <UiButton icon size="xs" variant="outline">
-            <span :class="multiExp.icon"></span>
+          <UiButton icon size="xs" variant="outline" @click="openMultiExpHolder">
+            <span :class="multiExp.icon" />
           </UiButton>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show Multi Exp button in Shlagemon list when equipped by a Shlagémon
- add unit tests covering Multi Exp button behaviour

## Testing
- `pnpm lint`
- `pnpm test:unit --run` *(fails: battle-item-cooldown.test.ts; page-locale-ssr.test.ts)*
- `pnpm typecheck` *(fails: type errors in unrelated modules)*


------
https://chatgpt.com/codex/tasks/task_e_689321d39104832abb6ede466d8a2b81