### PR TITLE
feat: allow highlighting type from type chart modal

### DIFF
--- a/src/components/shlagemon/TypeChart.vue
+++ b/src/components/shlagemon/TypeChart.vue
@@ -2,8 +2,20 @@
 import type { TypeName } from '~/type'
 import { shlagemonTypes } from '~/data/shlagemons-type'
 
+/**
+ * Props for {@link ShlagemonTypeChart}.
+ */
+const props = defineProps<{ highlight: TypeName | null }>()
+
+/**
+ * Emits for {@link ShlagemonTypeChart}.
+ */
+const emit = defineEmits<{ (e: 'update:highlight', value: TypeName | null): void }>()
+
 const { t } = useI18n()
-const modal = useTypeChartModalStore()
+
+// Reactive reference to the highlighted type.
+const highlight = useVModel(props, 'highlight', emit)
 
 const typeIds = Object.keys(shlagemonTypes) as TypeName[]
 
@@ -35,8 +47,13 @@ function getMultiplier(att: TypeName, def: TypeName) {
   return 1
 }
 
+/**
+ * Toggles the highlighted type. Clicking again clears the selection.
+ *
+ * @param typeId - Type identifier to toggle.
+ */
 function toggleHighlight(typeId: TypeName) {
-  modal.highlight = modal.highlight === typeId ? null : typeId
+  highlight.value = highlight.value === typeId ? null : typeId
 }
 </script>
 
@@ -64,7 +81,7 @@ function toggleHighlight(typeId: TypeName) {
             :key="typeId"
             class="sticky top-0 z-20 bg-white p-1 dark:bg-gray-900"
             style="box-shadow: 0 2px 0 0 rgba(0,0,0,0.03);"
-            :class="{ 'bg-blue-200 dark:bg-blue-800': modal.highlight === typeId }"
+            :class="{ 'bg-blue-200 dark:bg-blue-800': highlight === typeId }"
           >
             <button
               type="button"
@@ -81,7 +98,7 @@ function toggleHighlight(typeId: TypeName) {
           <th
             class="sticky left-0 z-10 bg-white p-1 text-right dark:bg-gray-900"
             style="box-shadow: 2px 0 0 0 rgba(0,0,0,0.03);"
-            :class="{ 'bg-blue-200 dark:bg-blue-800': modal.highlight === atk }"
+            :class="{ 'bg-blue-200 dark:bg-blue-800': highlight === atk }"
           >
             <button
               type="button"
@@ -96,8 +113,8 @@ function toggleHighlight(typeId: TypeName) {
             :key="def"
             class="border border-gray-200 p-1 dark:border-gray-700"
             :class="{
-              'bg-blue-200 dark:bg-blue-800': modal.highlight === atk || modal.highlight === def,
-              'font-bold': modal.highlight === atk && modal.highlight === def,
+              'bg-blue-200 dark:bg-blue-800': highlight === atk || highlight === def,
+              'font-bold': highlight === atk && highlight === def,
             }"
           >
             {{ getMultiplier(atk, def) }}

--- a/src/components/shlagemon/TypeChartModal.vue
+++ b/src/components/shlagemon/TypeChartModal.vue
@@ -1,16 +1,14 @@
 <script setup lang="ts">
-import TypeChart from './TypeChart.vue'
-
 const { t } = useI18n()
 const modal = useTypeChartModalStore()
 </script>
 
 <template>
   <UiModal v-model="modal.isVisible">
-      <h3 class="text-lg font-bold flex items-center gap-2">
-        <div class="i-carbon-data-table" />
-        <div>{{t('components.shlagemon.TypeChartModal.title')}}</div>
-      </h3>
-      <TypeChart :highlight="modal.highlight" />
+    <h3 class="flex items-center gap-2 text-lg font-bold">
+      <div class="i-carbon-data-table" />
+      <div>{{ t('components.shlagemon.TypeChartModal.title') }}</div>
+    </h3>
+    <ShlagemonTypeChart v-model:highlight="modal.highlight" />
   </UiModal>
 </template>

--- a/src/stores/typeChartModal.ts
+++ b/src/stores/typeChartModal.ts
@@ -1,11 +1,20 @@
+import type { TypeName } from '~/type'
 import { defineStore } from 'pinia'
 
+/**
+ * Modal store controlling visibility of the Type Chart and the highlighted type.
+ */
 export const useTypeChartModalStore = defineStore('typeChartModal', () => {
   // Avoid switching mobile tabs to keep panels visible when opening the modal
   const { isVisible, open: openModal, close } = createModalStore()
-  const highlight = ref<string | null>(null)
+  const highlight = ref<TypeName | null>(null)
 
-  function open(typeId: string) {
+  /**
+   * Opens the modal and highlights the provided type.
+   *
+   * @param typeId - Identifier of the type to emphasize.
+   */
+  function open(typeId: TypeName) {
     highlight.value = typeId
     openModal()
   }

--- a/test/typechart.test.ts
+++ b/test/typechart.test.ts
@@ -1,3 +1,4 @@
+import type { TypeName } from '../src/type'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import TypeChart from '../src/components/shlagemon/TypeChart.vue'
@@ -6,6 +7,7 @@ import { shlagemonTypes } from '../src/data/shlagemons-type'
 describe('type chart', () => {
   it('renders correct multipliers using type identifiers', () => {
     const wrapper = mount(TypeChart, {
+      props: { highlight: null },
       global: {
         stubs: {
           ShlagemonType: { template: '<div />' },
@@ -26,6 +28,7 @@ describe('type chart', () => {
 
   it('highlights row and column on header click', async () => {
     const wrapper = mount(TypeChart, {
+      props: { highlight: null },
       global: {
         stubs: {
           ShlagemonType: { template: '<div />' },
@@ -37,6 +40,8 @@ describe('type chart', () => {
     // Highlight a row
     const poisonIndex = ids.indexOf('poison')
     await wrapper.findAll('tbody tr')[poisonIndex].find('th button').trigger('click')
+    let highlight = wrapper.emitted('update:highlight')?.at(-1)?.[0] as TypeName
+    await wrapper.setProps({ highlight })
     wrapper
       .findAll('tbody tr')[poisonIndex]
       .findAll('td')
@@ -45,6 +50,8 @@ describe('type chart', () => {
     // Highlight a column
     const feeIndex = ids.indexOf('fee')
     await wrapper.findAll('thead tr th')[feeIndex + 1].find('button').trigger('click')
+    highlight = wrapper.emitted('update:highlight')?.at(-1)?.[0] as TypeName
+    await wrapper.setProps({ highlight })
     wrapper.findAll('tbody tr').forEach((row) => {
       const cell = row.findAll('td')[feeIndex]
       expect(cell.classes()).toContain('bg-blue-200')


### PR DESCRIPTION
## Summary
- enable two-way highlight selection in TypeChart and its modal
- add TypeName typing to chart modal store
- extend unit test for highlight propagation

## Testing
- `pnpm exec eslint src/stores/typeChartModal.ts src/components/shlagemon/TypeChartModal.vue src/components/shlagemon/TypeChart.vue test/typechart.test.ts`
- `pnpm test:unit` *(fails: disease event listener cleanup)*

------
https://chatgpt.com/codex/tasks/task_e_689326bc4c5c832aafbe98c2282c3e06