### PR TITLE
feat: parameterize item descriptions

### DIFF
--- a/src/components/inventory/ItemCard.vue
+++ b/src/components/inventory/ItemCard.vue
@@ -52,7 +52,10 @@ const ballFilter = computed(() =>
 
 // Infos pour la modale détaillée
 const details = computed(() =>
-  t(props.item.details ?? props.item.description),
+  t(
+    props.item.details ?? props.item.description,
+    props.item.details ? props.item.detailsParams : props.item.descriptionParams,
+  ),
 )
 
 // Libellé du bouton d'action selon le type d'item

--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -25,7 +25,7 @@ const { t } = useI18n()
 
     <div class="min-w-0 flex flex-col text-left">
       <span class="truncate font-bold">{{ t(props.item.name) }}</span>
-      <span class="text-xs text-gray-500 dark:text-gray-400">{{ t(props.item.description) }}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400">{{ t(props.item.description, props.item.descriptionParams) }}</span>
     </div>
 
     <template #right>

--- a/src/components/shop/ItemDetail.vue
+++ b/src/components/shop/ItemDetail.vue
@@ -47,7 +47,10 @@ function setMax() {
 }
 
 const details = computed(() =>
-  t(props.item.details ?? props.item.description),
+  t(
+    props.item.details ?? props.item.description,
+    props.item.details ? props.item.detailsParams : props.item.descriptionParams,
+  ),
 )
 </script>
 

--- a/src/data/items.i18n.yml
+++ b/src/data/items.i18n.yml
@@ -26,79 +26,79 @@ en:
   vitalityPotion:
     name: Vitality Potion
     description: Temporarily increases HP.
-    details: Increases your active Shlagémon's HP by 10% for a few minutes.
+    details: Increases your active Shlagémon's HP by {percent}% for a few minutes.
   superVitalityPotion:
     name: Super Vitality Potion
     description: Greatly increases HP.
-    details: Increases your active Shlagémon's HP by 25% for a few minutes.
+    details: Increases your active Shlagémon's HP by {percent}% for a few minutes.
   hyperVitalityPotion:
     name: Hyper Vitality Potion
     description: Maximizes HP temporarily.
-    details: Increases your active Shlagémon's HP by 50% for a few minutes.
+    details: Increases your active Shlagémon's HP by {percent}% for a few minutes.
   xpPotion:
     name: Experience Potion
     description: Temporarily increases XP gains.
-    details: Improves XP gained by 10% for a few minutes.
+    details: Improves XP gained by {percent}% for a few minutes.
   superXpPotion:
     name: Super Experience Potion
     description: Greatly increases XP gains.
-    details: Improves XP gained by 25% for a few minutes.
+    details: Improves XP gained by {percent}% for a few minutes.
   hyperXpPotion:
     name: Hyper Experience Potion
     description: Maximizes XP gains temporarily.
-    details: Improves XP gained by 50% for a few minutes.
+    details: Improves XP gained by {percent}% for a few minutes.
   capturePotion:
     name: Capture Potion
     description: Slightly increases capture chance.
-    details: Improves capture chance by 10% for a few minutes.
+    details: Improves capture chance by {percent}% for a few minutes.
   superCapturePotion:
     name: Super Capture Potion
     description: Greatly increases capture chance.
-    details: Improves capture chance by 25% for a few minutes.
+    details: Improves capture chance by {percent}% for a few minutes.
   hyperCapturePotion:
     name: Hyper Capture Potion
     description: Maximizes capture chance.
-    details: Improves capture chance by 50% for a few minutes.
+    details: Improves capture chance by {percent}% for a few minutes.
   potion:
     name: Gross Potion
-    description: Heals 50 HP of your Shlagémon.
-    details: Restores 50 HP to your active Shlagémon during battle.
+    description: Heals {hp} HP of your Shlagémon.
+    details: Restores {hp} HP to your active Shlagémon during battle.
   superPotion:
     name: Super Potion
-    description: Heals 250 HP of your Shlagémon.
-    details: Restores 250 HP to your active Shlagémon during battle.
+    description: Heals {hp} HP of your Shlagémon.
+    details: Restores {hp} HP to your active Shlagémon during battle.
   hyperPotion:
     name: Hyper Potion
-    description: Heals 1000 HP of your Shlagémon.
-    details: Restores 1000 HP to your active Shlagémon during battle.
+    description: Heals {hp} HP of your Shlagémon.
+    details: Restores {hp} HP to your active Shlagémon during battle.
   multiExp:
     name: Multi-EXP
     description: Shares XP with a Shlagémon.
-    details: Shares 50% of the XP earned in battle with the holder.
+    details: Shares {percent}% of the XP earned in battle with the holder.
   thunderStone:
     name: Thunder Stone
     description: Allows certain electric evolutions.
-    details: Evolves Pikachiant into Raïchiotte.
+    details: Evolves {from} into {to}.
   steroids:
     name: Steroids
     description: Enables certain "toxic bodybuilder" evolutions.
-    details: Evolves Macho into Masschopeur if he spent at least 3h at the gym.
+    details: Evolves {from} into {to} if he spent at least {hours}h at the gym.
   ultraSteroid:
     name: Ultra-Steroid
-    description: A substance banned in 97 countries.
-    details: Evolves Masschopeur into Macintosh, an irreversible hypertrophy.
+    description: A substance banned in {countries} countries.
+    details: Evolves {from} into {to}, an irreversible hypertrophy.
   lighter:
     name: Lighter
     description: Makes some Shlagémons love fire.
-    details: 'Lets Emboli turn into Pyrolise, because arson is fun.'
+    details: 'Lets {from} turn into {to}, because arson is fun.'
   pissBottle:
     name: Piss Bottle
     description: Smells awful but triggers aquatic diseases.
-    details: Lets Emboli mutate into Salmoneli after a good shower.
+    details: Lets {from} mutate into {to} after a good shower.
   defibrillator:
     name: Defibrillator
     description: Jolt your Shlagémon back to shocking life.
-    details: Needed for Emboli to evolve into Tuberculi.
+    details: Needed for {from} to evolve into {to}.
   badgeBox:
     name: Badge Box
     description: Stores all your badges.
@@ -169,55 +169,55 @@ fr:
   vitalityPotion:
     name: Potion de Vitalité
     description: Augmente temporairement les PV.
-    details: Augmente les PV de votre Shlagémon actif de 10% pendant quelques minutes.
+    details: Augmente les PV de votre Shlagémon actif de {percent}% pendant quelques minutes.
   superVitalityPotion:
     name: Super Potion de Vitalité
     description: Augmente beaucoup les PV.
-    details: Augmente les PV de votre Shlagémon actif de 25% pendant quelques minutes.
+    details: Augmente les PV de votre Shlagémon actif de {percent}% pendant quelques minutes.
   hyperVitalityPotion:
     name: Hyper Potion de Vitalité
     description: Maximise temporairement les PV.
-    details: Augmente les PV de votre Shlagémon actif de 50% pendant quelques minutes.
+    details: Augmente les PV de votre Shlagémon actif de {percent}% pendant quelques minutes.
   xpPotion:
     name: Potion d'Expérience
     description: Augmente temporairement les gains d'XP.
-    details: Améliore l'XP gagnée de 10% pendant quelques minutes.
+    details: Améliore l'XP gagnée de {percent}% pendant quelques minutes.
   superXpPotion:
     name: Super Potion d'Expérience
     description: Augmente beaucoup les gains d'XP.
-    details: Améliore l'XP gagnée de 25% pendant quelques minutes.
+    details: Améliore l'XP gagnée de {percent}% pendant quelques minutes.
   hyperXpPotion:
     name: Hyper Potion d'Expérience
     description: Maximise temporairement les gains d'XP.
-    details: Améliore l'XP gagnée de 50% pendant quelques minutes.
+    details: Améliore l'XP gagnée de {percent}% pendant quelques minutes.
   capturePotion:
     name: Potion de Capture
     description: Augmente légèrement les chances de capture.
-    details: Améliore la probabilité de capture de 10% pendant quelques minutes.
+    details: Améliore la probabilité de capture de {percent}% pendant quelques minutes.
   superCapturePotion:
     name: Super Potion de Capture
     description: Augmente beaucoup les chances de capture.
-    details: Améliore la probabilité de capture de 25% pendant quelques minutes.
+    details: Améliore la probabilité de capture de {percent}% pendant quelques minutes.
   hyperCapturePotion:
     name: Hyper Potion de Capture
     description: Maximise les chances de capture.
-    details: Améliore la probabilité de capture de 50% pendant quelques minutes.
+    details: Améliore la probabilité de capture de {percent}% pendant quelques minutes.
   potion:
     name: Potion Dégueulasse
-    description: Soigne 50 HP de votre Shlagémon.
-    details: Redonne 50 points de vie à votre Shlagémon actif pendant le combat.
+    description: Soigne {hp} HP de votre Shlagémon.
+    details: Redonne {hp} points de vie à votre Shlagémon actif pendant le combat.
   superPotion:
     name: Super Potion
-    description: Soigne 250 HP de votre Shlagémon.
-    details: Redonne 250 points de vie à votre Shlagémon actif pendant le combat.
+    description: Soigne {hp} HP de votre Shlagémon.
+    details: Redonne {hp} points de vie à votre Shlagémon actif pendant le combat.
   hyperPotion:
     name: Hyper Potion
-    description: Soigne 1000 HP de votre Shlagémon.
-    details: Redonne 1000 points de vie à votre Shlagémon actif pendant le combat.
+    description: Soigne {hp} HP de votre Shlagémon.
+    details: Redonne {hp} points de vie à votre Shlagémon actif pendant le combat.
   multiExp:
     name: Multi-EXP
     description: Partage l'XP avec un Shlagémon.
-    details: Permet de partager 50% de l'XP gagnée en combat avec le Shlagémon porteur.
+    details: Permet de partager {percent}% de l'XP gagnée en combat avec le Shlagémon porteur.
   thunderStone:
     name: Pierre Foutre
     description: Permet certaines évolutions de type électrique.
@@ -225,23 +225,23 @@ fr:
   steroids:
     name: Stéroïdes
     description: Permet certaines évolutions de type "gros beauf bodybuildé toxique".
-    details: Fait évoluer Macho en Masschopeur, à condition qu’il ait passé au moins 3h à la salle, sans jambes, évidemment.
+    details: Fait évoluer {from} en {to}, à condition qu’il ait passé au moins {hours}h à la salle, sans jambes, évidemment.
   ultraSteroid:
     name: Ultra-Stéroïde
-    description: Une substance interdite dans 97 pays, 2 dimensions et au moins une timeline.
-    details: Fait évoluer Masschopeur en Macintosh, une forme d’hypertrophie critique atteignant le point de non-retour. À manipuler avec des gants, une perche, et un avocat.
+    description: Une substance interdite dans {countries} pays, {dimensions} dimensions et au moins {timelines} timeline.
+    details: Fait évoluer {from} en {to}, une forme d’hypertrophie critique atteignant le point de non-retour. À manipuler avec des gants, une perche, et un avocat.
   lighter:
     name: Briquet
     description: Fait briller la pyromanie chez certains Shlagémons.
-    details: Permet à Emboli de se changer en Pyrolise pour tout cramer.
+    details: Permet à {from} de se changer en {to} pour tout cramer.
   pissBottle:
     name: Bouteille de Pisse
-    description: "Ça pue, mais c'est bourré de bactéries bien juteuses."
-    details: Transforme Emboli en Salmoneli après une bonne rasade.
+    description: 'Ça pue, mais c''est bourré de bactéries bien juteuses.'
+    details: Transforme {from} en {to} après une bonne rasade.
   defibrillator:
     name: Défibrillateur
     description: Un coup de jus pour repartir de travers.
-    details: "Nécessaire pour qu'Emboli évolue en Tuberculi."
+    details: 'Nécessaire pour que {from} évolue en {to}.'
   badgeBox:
     name: Boîte à badge
     description: Conserve tous tes badges.

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -130,6 +130,7 @@ export const vitalityPotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:magic-potion',
   iconClass: 'text-violet-500 dark:text-violet-400',
+  detailsParams: { percent: 10 },
 }
 
 export const superVitalityPotion: Item = {
@@ -145,6 +146,7 @@ export const superVitalityPotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:round-potion',
   iconClass: 'text-violet-600 dark:text-violet-500',
+  detailsParams: { percent: 25 },
 }
 
 export const hyperVitalityPotion: Item = {
@@ -160,6 +162,7 @@ export const hyperVitalityPotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:standing-potion',
   iconClass: 'text-violet-700 dark:text-violet-600',
+  detailsParams: { percent: 50 },
 }
 
 export const xpPotion: Item = {
@@ -175,6 +178,7 @@ export const xpPotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:magic-potion',
   iconClass: 'text-green-600 dark:text-green-400',
+  detailsParams: { percent: 10 },
 }
 
 export const superXpPotion: Item = {
@@ -190,6 +194,7 @@ export const superXpPotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:round-potion',
   iconClass: 'text-green-700 dark:text-green-500',
+  detailsParams: { percent: 25 },
 }
 
 export const hyperXpPotion: Item = {
@@ -205,6 +210,7 @@ export const hyperXpPotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:standing-potion',
   iconClass: 'text-green-800 dark:text-green-600',
+  detailsParams: { percent: 50 },
 }
 
 export const odorElixir: Item = {
@@ -230,6 +236,7 @@ export const capturePotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:magic-potion',
   iconClass: 'text-teal-600 dark:text-teal-400',
+  detailsParams: { percent: 10 },
 }
 
 export const superCapturePotion: Item = {
@@ -245,6 +252,7 @@ export const superCapturePotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:round-potion',
   iconClass: 'text-teal-700 dark:text-teal-500',
+  detailsParams: { percent: 25 },
 }
 
 export const hyperCapturePotion: Item = {
@@ -260,6 +268,7 @@ export const hyperCapturePotion: Item = {
   sfxId: 'items-passive-potion',
   icon: 'i-game-icons:standing-potion',
   iconClass: 'text-teal-800 dark:text-teal-600',
+  detailsParams: { percent: 50 },
 }
 
 export const potion: Item = {
@@ -276,6 +285,8 @@ export const potion: Item = {
   sfxId: 'items-active-potion',
   icon: 'i-game-icons:health-potion',
   iconClass: 'text-red-600 dark:text-red-400',
+  descriptionParams: { hp: 50 },
+  detailsParams: { hp: 50 },
 }
 
 export const superPotion: Item = {
@@ -284,14 +295,16 @@ export const superPotion: Item = {
   description: 'data.items.superPotion.description',
   details: 'data.items.superPotion.details',
   type: 'heal',
-  power: potion.power*5,
-  price: potion.price*10,
+  power: potion.power * 5,
+  price: potion.price * 10,
   currency: 'shlagidolar',
   category: 'battle',
-  battleCooldown: potion.battleCooldown*2,
+  battleCooldown: potion.battleCooldown * 2,
   sfxId: 'items-active-potion',
   icon: 'i-game-icons:health-potion',
   iconClass: 'text-violet-600 dark:text-violet-400',
+  descriptionParams: { hp: potion.power * 5 },
+  detailsParams: { hp: potion.power * 5 },
 }
 
 export const hyperPotion: Item = {
@@ -300,14 +313,16 @@ export const hyperPotion: Item = {
   description: 'data.items.hyperPotion.description',
   details: 'data.items.hyperPotion.details',
   type: 'heal',
-  power: superPotion.power*4,
-  price: superPotion.power*10,
+  power: superPotion.power * 4,
+  price: superPotion.power * 10,
   currency: 'shlagidolar',
   category: 'battle',
-  battleCooldown: superPotion.battleCooldown*2,
+  battleCooldown: superPotion.battleCooldown * 2,
   sfxId: 'items-active-potion',
   icon: 'i-game-icons:health-potion',
   iconClass: 'text-yellow-500 dark:text-yellow-300',
+  descriptionParams: { hp: superPotion.power * 4 },
+  detailsParams: { hp: superPotion.power * 4 },
 }
 
 export const multiExp: Item = {
@@ -322,6 +337,7 @@ export const multiExp: Item = {
   iconClass: 'text-orange-500 dark:text-orange-300',
   unique: true,
   wearable: true,
+  detailsParams: { percent: 50 },
 }
 
 export const thunderStone: Item = {
@@ -335,6 +351,7 @@ export const thunderStone: Item = {
   type: 'evolution',
   icon: 'i-carbon:flash-filled',
   iconClass: 'text-yellow-500 dark:text-yellow-300',
+  detailsParams: { from: 'Pikachiant', to: 'Raïchiotte' },
 }
 
 export const steroids: Item = {
@@ -348,6 +365,7 @@ export const steroids: Item = {
   type: 'evolution',
   icon: 'i-iconoir:potion',
   iconClass: 'text-orange-500 dark:text-orange-300',
+  detailsParams: { from: 'Macho', to: 'Masschopeur', hours: 3 },
 }
 
 export const ultraSteroid: Item = {
@@ -361,6 +379,8 @@ export const ultraSteroid: Item = {
   type: 'evolution',
   icon: 'i-iconoir:potion',
   iconClass: 'text-purple-500 dark:text-purple-300',
+  descriptionParams: { countries: 97, dimensions: 2, timelines: 1 },
+  detailsParams: { from: 'Masschopeur', to: 'Macintosh' },
 }
 
 export const lighter: Item = {
@@ -374,6 +394,7 @@ export const lighter: Item = {
   type: 'evolution',
   icon: 'i-game-icons:lighter',
   iconClass: 'text-red-500 dark:text-red-400',
+  detailsParams: { from: 'Emboli', to: 'Pyrolise' },
 }
 
 export const pissBottle: Item = {
@@ -387,6 +408,7 @@ export const pissBottle: Item = {
   type: 'evolution',
   icon: 'i-game-icons:soda-bottle',
   iconClass: 'text-yellow-700 dark:text-yellow-500',
+  detailsParams: { from: 'Emboli', to: 'Salmoneli' },
 }
 
 export const defibrillator: Item = {
@@ -400,6 +422,7 @@ export const defibrillator: Item = {
   type: 'evolution',
   icon: 'i-game-icons:tesla-coil',
   iconClass: 'text-green-600 dark:text-green-400',
+  detailsParams: { from: 'Emboli', to: 'Tuberculi' },
 }
 
 export const badgeBox: Item = {

--- a/src/type/item.ts
+++ b/src/type/item.ts
@@ -13,6 +13,10 @@ interface ItemBase {
    * When not provided, `description` will be used instead.
    */
   details?: I18nKey
+  /** Parameters for the `description` i18n key. */
+  descriptionParams?: Record<string, unknown>
+  /** Parameters for the `details` i18n key. */
+  detailsParams?: Record<string, unknown>
   price?: number
   /** Currency used to buy this item. Defaults to shlagidolar. */
   currency?: ItemCurrency


### PR DESCRIPTION
## Summary
- support passing variables for item descriptions and details
- use i18n placeholders for dynamic item values (percentages, HP, names)

## Testing
- `pnpm lint` *(fails: Strings must use singlequote)*
- `pnpm typecheck` *(fails: Property 'maxLevel' does not exist on type...)*
- `pnpm test:unit` *(fails: expected true to be false)*

------
https://chatgpt.com/codex/tasks/task_e_68937110cb60832aa390c53ae9c6dbc9