### PR TITLE
feat: add toast sound effects

### DIFF
--- a/src/components/battle/CaptureMenu.vue
+++ b/src/components/battle/CaptureMenu.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Ball, DexShlagemon } from '~/type'
-import { toast } from 'vue3-toastify'
 import { balls as ballData } from '~/data/items/shlageball'
+import { toast } from '~/modules/toast'
 import { tryCapture } from '~/utils/capture'
 
 const props = defineProps<{ enemy: DexShlagemon | null }>()

--- a/src/components/dialog/ArenaVictoryDialog.vue
+++ b/src/components/dialog/ArenaVictoryDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { DialogNode } from '~/type/dialog'
-import { toast } from 'vue3-toastify'
 import { getArenaTrack, getZoneTrack } from '~/data/music'
+import { toast } from '~/modules/toast'
 
 const emit = defineEmits(['done'])
 

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -3,7 +3,6 @@ import type { Component } from 'vue'
 import type { BallId } from '~/data/items/shlageball'
 import type { Item, ItemCategory } from '~/type/item'
 import { defineComponent, h } from 'vue'
-import { toast } from 'vue3-toastify'
 import {
   badgeBox as badgeBoxItem,
   eggBox as eggBoxItem,
@@ -12,6 +11,7 @@ import {
   odorElixir,
   specialPotion,
 } from '~/data/items'
+import { toast } from '~/modules/toast'
 import { useKingPotionStore } from '~/stores/kingPotion'
 import InventoryItemCard from '../inventory/ItemCard.vue'
 

--- a/src/components/settings/SaveTab.vue
+++ b/src/components/settings/SaveTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { toast } from 'vue3-toastify'
+import { toast } from '~/modules/toast'
 import { applySave, collectSave, exportSave, importSave } from '~/utils/save-code'
 
 const emit = defineEmits<{ (e: 'remove'): void }>()

--- a/src/composables/useShopPurchase.ts
+++ b/src/composables/useShopPurchase.ts
@@ -2,7 +2,7 @@
  * Composable handling purchase logic in the shop panel.
  */
 import type { Item } from '~/type/item'
-import { toast } from 'vue3-toastify'
+import { toast } from '~/modules/toast'
 
 export function useShopPurchase() {
   const game = useGameStore()

--- a/src/modules/toast.ts
+++ b/src/modules/toast.ts
@@ -1,0 +1,41 @@
+import type { ToastOptions } from 'vue3-toastify'
+import { toast as baseToast } from 'vue3-toastify'
+
+/**
+ * Toast utility playing a sound effect for each notification.
+ *
+ * Success toasts trigger the "toast-achievement" sound while all other
+ * notifications use the "toast-default" sound. Sound playback relies on the
+ * shared {@link useAudioStore} to respect user audio settings.
+ */
+function playToastSound(isSuccess: boolean): void {
+  const audio = useAudioStore()
+  audio.playSfx(isSuccess ? 'toast-achievement' : 'toast-default')
+}
+
+function isSuccess(options?: ToastOptions): boolean {
+  return options?.type === baseToast.TYPE.SUCCESS
+}
+
+/**
+ * Proxy wrapping vue3-toastify's `toast` to add sound effects.
+ */
+export const toast: typeof baseToast = new Proxy(baseToast, {
+  apply(target, thisArg, argArray) {
+    const options = argArray[1] as ToastOptions | undefined
+    playToastSound(isSuccess(options))
+    return Reflect.apply(target, thisArg, argArray)
+  },
+  get(target, prop, receiver) {
+    const value = Reflect.get(target, prop, receiver)
+    if (typeof value !== 'function')
+      return value
+    return (...args: any[]) => {
+      if (!['dismiss', 'clearAll', 'update', 'done'].includes(String(prop))) {
+        const options = args[1] as ToastOptions | undefined
+        playToastSound(prop === 'success' || isSuccess(options))
+      }
+      return value.apply(target, args)
+    }
+  },
+})

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
-import { toast } from 'vue3-toastify'
 import { zonesData } from '~/data/zones'
+import { toast } from '~/modules/toast'
 
 export interface Achievement {
   id: string

--- a/src/stores/disease.ts
+++ b/src/stores/disease.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { toast } from 'vue3-toastify'
+import { toast } from '~/modules/toast'
 
 export const useDiseaseStore = defineStore('disease', () => {
   const active = ref(false)

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
-import { toast } from 'vue3-toastify'
 import { i18n } from '~/modules/i18n'
+import { toast } from '~/modules/toast'
 
 export const useGameStore = defineStore('game', () => {
   const shlagidolar = ref(0)

--- a/src/stores/inventory.ts
+++ b/src/stores/inventory.ts
@@ -1,7 +1,6 @@
 import type { ItemId } from '~/data/items'
 import type { Item, ItemCategory } from '~/type/item'
 import { defineStore } from 'pinia'
-import { toast } from 'vue3-toastify'
 import {
   allItems,
   badgeBox as badgeBoxItem,
@@ -11,6 +10,7 @@ import {
 import { hyperShlageball, shlageball, superShlageball } from '~/data/items/shlageball'
 import { allShlagemons } from '~/data/shlagemons'
 import { i18n } from '~/modules/i18n'
+import { toast } from '~/modules/toast'
 import { useAudioStore } from './audio'
 import { useOdorElixirStore } from './odorElixir'
 

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -3,9 +3,9 @@ import type { ActiveEffect } from '~/type/effect'
 import type { Item, WearableItem } from '~/type/item'
 import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
-import { toast } from 'vue3-toastify'
 import { allItems } from '~/data/items'
 import { allShlagemons } from '~/data/shlagemons'
+import { toast } from '~/modules/toast'
 import { useWildLevelStore } from '~/stores/wildLevel'
 import {
   applyCurrentStats,

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -1,8 +1,8 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
-import { toast } from 'vue3-toastify'
 import { sacdepates } from '../src/data/shlagemons/01-05/sacdepates'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { toast } from '../src/modules/toast'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import {
   applyCurrentStats,
@@ -13,7 +13,12 @@ import {
   xpForLevel,
 } from '../src/utils/dexFactory'
 
-vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
+vi.mock('../src/modules/toast', () => {
+  const fn: any = vi.fn()
+  fn.success = vi.fn()
+  fn.POSITION = { TOP_CENTER: 'top-center' }
+  return { toast: fn }
+})
 
 const toastMock = vi.mocked(toast)
 

--- a/test/type-serialization.test.ts
+++ b/test/type-serialization.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi } from 'vitest'
 import { sacdepates } from '../src/data/shlagemons/01-05/sacdepates'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 
-vi.mock('vue3-toastify', () => ({ toast: vi.fn() }))
+vi.mock('../src/modules/toast', () => {
+  const fn: any = vi.fn()
+  fn.success = vi.fn()
+  fn.POSITION = { TOP_CENTER: 'top-center' }
+  return { toast: fn }
+})
 
 describe('shlagedex serialization', () => {
   it('allows JSON serialization of state', () => {


### PR DESCRIPTION
## Summary
- play audio for toast notifications, using achievement sound for success messages
- update all toast usages to new wrapper and adjust tests

## Testing
- `pnpm exec eslint src/modules/toast.ts src/composables/useShopPurchase.ts src/components/battle/CaptureMenu.vue src/components/settings/SaveTab.vue src/components/panel/Inventory.vue src/stores/inventory.ts src/stores/shlagedex.ts src/components/dialog/ArenaVictoryDialog.vue src/stores/achievements.ts src/stores/disease.ts src/stores/game.ts test/shlagedex.test.ts test/type-serialization.test.ts`
- `pnpm exec vitest test/shlagedex.test.ts test/type-serialization.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6893b17f9a1c832a91e3153e40bc0ee6