### PR TITLE
Close mobile panel for arena and minigame

### DIFF
--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -75,7 +75,6 @@ function onPoi(poi: VillagePOI) {
       if (poi.miniGame)
         mini.select(poi.miniGame)
       panel.showMiniGame()
-      mobile.set('game')
       break
     case 'arena': {
       const data = currentArenaData.value

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -5,7 +5,6 @@ import { getArenaByZoneId } from '~/data/arenas'
 const zone = useZoneStore()
 const panel = useMainPanelStore()
 const mini = useMiniGameStore()
-const mobile = useMobileTabStore()
 const progress = useZoneProgressStore()
 const trainerBattle = useTrainerBattleStore()
 const arena = useArenaStore()
@@ -65,7 +64,6 @@ function openMinigame() {
   if (miniGamePoi.value?.miniGame)
     mini.select(miniGamePoi.value.miniGame)
   panel.showMiniGame()
-  mobile.set('game')
 }
 
 function openArena() {

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -7,6 +7,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
   const dex = useShlagedexStore()
   const battle = useBattleStore()
   const arena = useArenaStore()
+  const ui = useUIStore()
+  const mobile = useMobileTabStore()
   const current = ref<MainPanel>('village')
 
   const isBattle = computed(() => current.value === 'battle' || current.value === 'trainerBattle')
@@ -51,6 +53,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     if (arena.inBattle)
       return
     current.value = 'miniGame'
+    if (ui.isMobile)
+      mobile.set('game')
   }
 
   function showPoulailler() {
@@ -63,6 +67,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     if (arena.inBattle)
       return
     current.value = 'arena'
+    if (ui.isMobile)
+      mobile.set('game')
   }
 
   function showVillage() {

--- a/test/main-panel-mobile-close.test.ts
+++ b/test/main-panel-mobile-close.test.ts
@@ -1,0 +1,43 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { createApp } from 'vue'
+import { useMainPanelStore } from '../src/stores/mainPanel'
+import { useMobileTabStore } from '../src/stores/mobileTab'
+
+describe('main panel mobile behaviour', () => {
+  it('closes mobile panel when entering arena or minigame but not shop', () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: true,
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as any
+
+    const pinia = createPinia()
+    const app = createApp({})
+    app.use(pinia)
+    setActivePinia(pinia)
+
+    const panel = useMainPanelStore()
+    const mobile = useMobileTabStore()
+
+    mobile.set('dex')
+    panel.showArena()
+    expect(mobile.current).toBe('game')
+
+    mobile.set('dex')
+    panel.showMiniGame()
+    expect(mobile.current).toBe('game')
+
+    mobile.set('dex')
+    panel.showShop()
+    expect(mobile.current).toBe('dex')
+
+    window.matchMedia = originalMatchMedia
+  })
+})


### PR DESCRIPTION
## Summary
- close secondary panel on mobile when entering arena or minigame
- test arena and minigame entry close secondary panel

## Testing
- `pnpm vitest run test/main-panel-mobile-close.test.ts`
- `pnpm test:unit` *(fails: battle-item-cooldown, main-panel-mobile-close, page-locale-ssr, rarity-info, router-redirect)*

------
https://chatgpt.com/codex/tasks/task_e_6893bd234afc832a9e7662a5ecdeef8b