### PR TITLE
fix mobile panel interactions

### DIFF
--- a/src/components/layout/MobileMenu.vue
+++ b/src/components/layout/MobileMenu.vue
@@ -35,6 +35,20 @@ function onZones() {
   mobile.toggle('zones')
 }
 
+function onGame() {
+  mobile.toggleGame((tab) => {
+    if (tab === 'dex')
+      return !dexDisabled.value
+    if (tab === 'inventory')
+      return !inventoryDisabled.value
+    if (tab === 'zones')
+      return !zoneDisabled.value
+    if (tab === 'achievements')
+      return !achievementsDisabled.value
+    return true
+  })
+}
+
 // Pour focus-ring personnalisés UnoCSS only
 const focusRing = 'outline-none focus-visible:ring-2 focus-visible:ring-teal-400 dark:focus-visible:ring-teal-300'
 
@@ -181,7 +195,7 @@ function handleContextMenu(hasBadge: boolean, handler?: () => void) {
         menuDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
       ]"
       style="box-shadow: 0 2px 12px -2px #14b8a6a9, 0 0px 0px #0000"
-      @click="mobile.set('game')"
+      @click="onGame"
     >
       <div class="i-carbon-game-console text-2xl" aria-hidden="true" />
     </button>

--- a/src/stores/dexDetailModal.ts
+++ b/src/stores/dexDetailModal.ts
@@ -2,7 +2,9 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { defineStore } from 'pinia'
 
 export const useDexDetailModalStore = defineStore('dexDetailModal', () => {
-  const { isVisible, open: openModal, close } = createModalStore('dex')
+  // Keep the current mobile tab so opening the modal doesn't hide
+  // the secondary panel on small screens
+  const { isVisible, open: openModal, close } = createModalStore()
   const mon = ref<DexShlagemon | null>(null)
 
   function open(target: DexShlagemon) {

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -47,6 +47,8 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     if (dex.activeShlagemon)
       dex.activeShlagemon.hpCurrent = dex.maxHp(dex.activeShlagemon)
     current.value = 'trainerBattle'
+    if (ui.isMobile)
+      mobile.set('inventory')
   }
 
   function showMiniGame() {

--- a/src/stores/mobileTab.ts
+++ b/src/stores/mobileTab.ts
@@ -9,13 +9,38 @@ export type MobileTab
 
 export const useMobileTabStore = defineStore('mobileTab', () => {
   const current = ref<MobileTab>('game')
+  const last = ref<Exclude<MobileTab, 'game'> | null>(null)
+
   function set(tab: MobileTab) {
+    if (tab !== 'game')
+      last.value = tab
     current.value = tab
   }
+
   function toggle(tab: MobileTab) {
-    current.value = current.value === tab ? 'game' : tab
+    if (current.value === tab)
+      set('game')
+    else
+      set(tab)
   }
-  return { current, set, toggle }
+
+  /**
+   * Toggles between the game view and the previously active secondary tab.
+   * Optionally checks if the stored tab can be reopened.
+   *
+   * @param canOpen - Predicate returning true when the tab is allowed.
+   */
+  function toggleGame(canOpen?: (tab: Exclude<MobileTab, 'game'>) => boolean) {
+    if (current.value === 'game') {
+      if (last.value && (!canOpen || canOpen(last.value)))
+        current.value = last.value
+    }
+    else {
+      current.value = 'game'
+    }
+  }
+
+  return { current, last, set, toggle, toggleGame }
 }, {
   persist: true,
 })

--- a/test/dex-detail-modal-tab.test.ts
+++ b/test/dex-detail-modal-tab.test.ts
@@ -1,0 +1,27 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useDexDetailModalStore } from '../src/stores/dexDetailModal'
+import { useMobileTabStore } from '../src/stores/mobileTab'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('dex detail modal', () => {
+  it('does not change mobile tab when opened', () => {
+    const pinia = createPinia()
+    const app = createApp({})
+    app.use(pinia)
+    setActivePinia(pinia)
+
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+
+    const mobile = useMobileTabStore()
+    mobile.set('inventory')
+
+    const modal = useDexDetailModalStore()
+    modal.open(mon)
+
+    expect(mobile.current).toBe('inventory')
+  })
+})

--- a/test/mobile-home-button.test.ts
+++ b/test/mobile-home-button.test.ts
@@ -1,0 +1,32 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { useMobileTabStore } from '../src/stores/mobileTab'
+
+describe('mobile home button behaviour', () => {
+  it('reopens last tab when toggled twice', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const mobile = useMobileTabStore()
+
+    mobile.toggle('dex')
+    expect(mobile.current).toBe('dex')
+
+    mobile.toggleGame()
+    expect(mobile.current).toBe('game')
+
+    mobile.toggleGame(() => true)
+    expect(mobile.current).toBe('dex')
+  })
+
+  it('does not reopen tab when predicate returns false', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const mobile = useMobileTabStore()
+
+    mobile.toggle('inventory')
+    mobile.toggleGame()
+
+    mobile.toggleGame(() => false)
+    expect(mobile.current).toBe('game')
+  })
+})

--- a/test/trainer-battle-inventory-open.test.ts
+++ b/test/trainer-battle-inventory-open.test.ts
@@ -1,0 +1,40 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { createApp } from 'vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useMainPanelStore } from '../src/stores/mainPanel'
+import { useMobileTabStore } from '../src/stores/mobileTab'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('trainer battle inventory panel', () => {
+  it('opens inventory tab at start', () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: true,
+      media: '',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as any
+
+    const pinia = createPinia()
+    const app = createApp({})
+    app.use(pinia)
+    setActivePinia(pinia)
+
+    const dex = useShlagedexStore()
+    dex.createShlagemon(carapouffe)
+
+    const panel = useMainPanelStore()
+    const mobile = useMobileTabStore()
+
+    panel.showTrainerBattle()
+
+    expect(mobile.current).toBe('inventory')
+
+    window.matchMedia = originalMatchMedia
+  })
+})


### PR DESCRIPTION
## Summary
- prevent dex detail modal from forcing Shlagedex panel
- remember last mobile panel and restore via home button
- auto-open inventory for trainer battles
- add regression tests for mobile panels

## Testing
- `pnpm test:unit test/mobile-home-button.test.ts test/trainer-battle-inventory-open.test.ts test/dex-detail-modal-tab.test.ts`
- `pnpm test:unit` *(fails: battle-item-cooldown.test.ts, capture.test.ts, page-locale-ssr.test.ts, router-redirect.test.ts, router-redirect.test.ts, router-redirect.test.ts)*
- `pnpm lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68945ca655b4832abae200d547483776