### PR TITLE
refactor: localize trainer and king dialogues

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2186,6 +2186,10 @@ data:
     insecte:
       name: Bugger
       description: Crawling, hairy and always annoying. It scratches at night and judges in silence.
+  trainers:
+    bob:
+      dialogBefore: Get ready to eat dust!
+      dialogAfter: No way... you beat me!
 pages:
   index:
     title: Shlagemon - It smells very strong

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2120,6 +2120,10 @@ data:
     insecte:
       name: Mouchtik
       description: Type grouillant, souvent poilu, toujours dérangeant. Il gratte la nuit et te juge en silence.
+  trainers:
+    bob:
+      dialogBefore: Prépare-toi à manger la poussière !
+      dialogAfter: "Pas possible... tu m'as battu !"
 pages:
   index:
     title: Shlagémon - Ça sent très fort

--- a/src/data/trainers.i18n.yml
+++ b/src/data/trainers.i18n.yml
@@ -1,0 +1,8 @@
+fr:
+  bob:
+    dialogBefore: Prépare-toi à manger la poussière !
+    dialogAfter: "Pas possible... tu m'as battu !"
+en:
+  bob:
+    dialogBefore: Get ready to eat dust!
+    dialogAfter: No way... you beat me!

--- a/src/data/trainers.ts
+++ b/src/data/trainers.ts
@@ -13,8 +13,8 @@ export const trainers: Trainer[] = [
   {
     id: 'bob',
     character: bobCharacter,
-    dialogBefore: 'Prépare-toi à manger la poussière !',
-    dialogAfter: 'Pas possible... tu m\'as battu !',
+    dialogBefore: 'data.trainers.bob.dialogBefore',
+    dialogAfter: 'data.trainers.bob.dialogAfter',
     reward: 3,
     shlagemons: [
       { baseId: carapouffe.id, level: 3 },


### PR DESCRIPTION
## Summary
- move trainer battle dialogue strings to i18n files
- add English and French entries for Bob's battle dialogue
- merge trainer and king dialogues into locale bundles under `data.*`

## Testing
- `pnpm test` *(canceled: test run cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68946480aca8832a94d3af78a42e9b83