### PR TITLE
feat: translate zone names with i18n keys

### DIFF
--- a/src/components/zone/ButtonVillage.vue
+++ b/src/components/zone/ButtonVillage.vue
@@ -12,6 +12,7 @@ const featureLock = useFeatureLockStore()
 const visit = useZoneVisitStore()
 const { arenaCompleted } = useZoneCompletion(props.zone)
 const dex = useShlagedexStore()
+const { t } = useI18n()
 const { canAccess } = useZoneAccess(toRef(dex, 'highestLevel'))
 
 const zoneButtonsDisabled = computed(
@@ -65,7 +66,7 @@ function classes() {
       <div class="i-game-icons:village h-6 w-6" />
     </div>
     <div class="text-btn flex-center">
-      <span>{{ props.zone.name }}</span>
+      <span>{{ t(props.zone.name) }}</span>
     </div>
     <div class="h-4 flex items-center justify-center gap-2">
       <div v-if="arenaCompleted" class="i-mdi:sword-cross h-4 w-4" />

--- a/src/components/zone/ButtonWild.vue
+++ b/src/components/zone/ButtonWild.vue
@@ -83,7 +83,7 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
       <div class="i-game-icons:forest h-6 w-6" />
     </div>
     <div class="flex-center">
-      <span class="text-2xs">{{ props.zone.name }}</span>
+      <span class="text-2xs">{{ t(props.zone.name) }}</span>
     </div>
     <div class="flex items-center justify-center gap-2">
       <img

--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -3,6 +3,7 @@ import type { Zone, ZoneId } from '~/type'
 import { DivIcon } from 'leaflet'
 import { computed, watch } from 'vue'
 import { useZoneCompletion } from '~/composables/useZoneCompletion'
+import { i18n } from '~/modules/i18n'
 import { useZoneVisitStore } from '~/stores/zoneVisit'
 import { useLeafletMarker } from './useLeafletMarker'
 
@@ -104,7 +105,7 @@ export function useMapMarkers(map: LeafletMap) {
       size: markerSize,
       anchorY,
       interactive: true,
-      title: zone.name,
+      title: i18n.global.t(zone.name),
     })
 
     watch([allCaptured, perfectZone, allShiny, kingDefeated, arenaCompleted, visited], () => {

--- a/src/data/zones/savages/01-plaine-kekette.i18n.yml
+++ b/src/data/zones/savages/01-plaine-kekette.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Plaine Kékette
+fr:
+  name: Plaine Kékette

--- a/src/data/zones/savages/01-plaine-kekette.ts
+++ b/src/data/zones/savages/01-plaine-kekette.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage01: Zone = {
   id: 'plaine-kekette',
-  name: 'Plaine Kékette',
+  name: 'data.zones.savages.01-plaine-kekette.name',
   type: 'sauvage',
   position: { lat: -24.24453346540599, lng: 130.0249991878924 },
   completionAchievement: 'Fendeur de la Plaine Kékette',

--- a/src/data/zones/savages/05-bois-de-bouffon.i18n.yml
+++ b/src/data/zones/savages/05-bois-de-bouffon.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Bois des Bouffons
+fr:
+  name: Bois des Bouffons

--- a/src/data/zones/savages/05-bois-de-bouffon.ts
+++ b/src/data/zones/savages/05-bois-de-bouffon.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage05: Zone = {
   id: 'bois-de-bouffon',
-  name: 'Bois des Bouffons',
+  name: 'data.zones.savages.05-bois-de-bouffon.name',
   type: 'sauvage',
   position: { lat: -42.49047583148054, lng: 103.92369727047145 },
   completionAchievement: 'Bûcheron du Bois de Bouffon',

--- a/src/data/zones/savages/10-chemin-du-slip.i18n.yml
+++ b/src/data/zones/savages/10-chemin-du-slip.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Chemin du Slip
+fr:
+  name: Chemin du Slip

--- a/src/data/zones/savages/10-chemin-du-slip.ts
+++ b/src/data/zones/savages/10-chemin-du-slip.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage10: Zone = {
   id: 'chemin-du-slip',
-  name: 'Chemin du Slip',
+  name: 'data.zones.savages.10-chemin-du-slip.name',
   type: 'sauvage',
   position: { lat: -61.48619277344812, lng: 145.9028535980149 },
   completionAchievement: 'Explorateur de la Grotte du Slip',

--- a/src/data/zones/savages/15-ravin-fesse-molle.i18n.yml
+++ b/src/data/zones/savages/15-ravin-fesse-molle.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Ravin de la Fesse Molle
+fr:
+  name: Ravin de la Fesse Molle

--- a/src/data/zones/savages/15-ravin-fesse-molle.ts
+++ b/src/data/zones/savages/15-ravin-fesse-molle.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage15: Zone = {
   id: 'ravin-fesse-molle',
-  name: 'Ravin de la Fesse Molle',
+  name: 'data.zones.savages.15-ravin-fesse-molle.name',
   type: 'sauvage',
   position: { lat: -66.48506565291328, lng: 175.63808933002483 },
   completionAchievement: 'Sauveur du Ravin de la Fesse Molle',

--- a/src/data/zones/savages/20-precipice-nanard.i18n.yml
+++ b/src/data/zones/savages/20-precipice-nanard.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Précipice du Vieux Nanard
+fr:
+  name: Précipice du Vieux Nanard

--- a/src/data/zones/savages/20-precipice-nanard.ts
+++ b/src/data/zones/savages/20-precipice-nanard.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage20: Zone = {
   id: 'precipice-nanard',
-  name: 'Précipice du Vieux Nanard',
+  name: 'data.zones.savages.20-precipice-nanard.name',
   type: 'sauvage',
   position: { lat: -71.23399488840516, lng: 119.66588089330025 },
   completionAchievement: 'Dénicheur du Vieux Nanard',

--- a/src/data/zones/savages/25-marais-moudugenou.i18n.yml
+++ b/src/data/zones/savages/25-marais-moudugenou.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Marais Moudugenou
+fr:
+  name: Marais Moudugenou

--- a/src/data/zones/savages/25-marais-moudugenou.ts
+++ b/src/data/zones/savages/25-marais-moudugenou.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage25: Zone = {
   id: 'marais-moudugenou',
-  name: 'Marais Moudugenou',
+  name: 'data.zones.savages.25-marais-moudugenou.name',
   type: 'sauvage',
   position: { lat: -54.98765803014342, lng: 77.18697270471463 },
   completionAchievement: 'Épurateur du Marais Moudugenou',

--- a/src/data/zones/savages/30-forteresse-petmoalfiak.i18n.yml
+++ b/src/data/zones/savages/30-forteresse-petmoalfiak.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Forteresse Pètmoalfiak
+fr:
+  name: Forteresse Pètmoalfiak

--- a/src/data/zones/savages/30-forteresse-petmoalfiak.ts
+++ b/src/data/zones/savages/30-forteresse-petmoalfiak.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage30: Zone = {
   id: 'forteresse-petmoalfiak',
-  name: 'Forteresse Pètmoalfiak',
+  name: 'data.zones.savages.30-forteresse-petmoalfiak.name',
   type: 'sauvage',
   position: { lat: -68.98450209264584, lng: 99.18995037220844 },
   completionAchievement: 'Conquérant de la Forteresse Pètmoalfiak',

--- a/src/data/zones/savages/35-route-du-nawak.i18n.yml
+++ b/src/data/zones/savages/35-route-du-nawak.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Route du Nawak
+fr:
+  name: Route du Nawak

--- a/src/data/zones/savages/35-route-du-nawak.ts
+++ b/src/data/zones/savages/35-route-du-nawak.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage35: Zone = {
   id: 'route-du-nawak',
-  name: 'Route du Nawak',
+  name: 'data.zones.savages.35-route-du-nawak.name',
   type: 'sauvage',
   position: { lat: -80.23196607144244, lng: 61.694665012406944 },
   completionAchievement: 'Voyageur de la Route du Nawak',

--- a/src/data/zones/savages/40-mont-dracatombe.i18n.yml
+++ b/src/data/zones/savages/40-mont-dracatombe.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Mont Cul
+fr:
+  name: Mont Cul

--- a/src/data/zones/savages/40-mont-dracatombe.ts
+++ b/src/data/zones/savages/40-mont-dracatombe.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage40: Zone = {
   id: 'mont-dracatombe',
-  name: 'Mont Cul',
+  name: 'data.zones.savages.40-mont-dracatombe.name',
   type: 'sauvage',
   position: { lat: -87.23038810269365, lng: 41.95446650124069 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/45-catacombes-merdifientes.i18n.yml
+++ b/src/data/zones/savages/45-catacombes-merdifientes.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Catacombes Merdifientes
+fr:
+  name: Catacombes Merdifientes

--- a/src/data/zones/savages/45-catacombes-merdifientes.ts
+++ b/src/data/zones/savages/45-catacombes-merdifientes.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage45: Zone = {
   id: 'catacombes-merdifientes',
-  name: 'Catacombes Merdifientes',
+  name: 'data.zones.savages.45-catacombes-merdifientes.name',
   type: 'sauvage',
   position: { lat: -100.97728852122282, lng: 14.218238213399502 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/50-route-aguicheuse.i18n.yml
+++ b/src/data/zones/savages/50-route-aguicheuse.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Route Aguicheuse
+fr:
+  name: Route Aguicheuse

--- a/src/data/zones/savages/50-route-aguicheuse.ts
+++ b/src/data/zones/savages/50-route-aguicheuse.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage50: Zone = {
   id: 'route-aguicheuse',
-  name: 'Route Aguicheuse',
+  name: 'data.zones.savages.50-route-aguicheuse.name',
   type: 'sauvage',
   position: { lat: -99.97751394532979, lng: 72.68920595533498 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/55-vallee-des-chieurs.i18n.yml
+++ b/src/data/zones/savages/55-vallee-des-chieurs.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Vallée des Chieurs
+fr:
+  name: Vallée des Chieurs

--- a/src/data/zones/savages/55-vallee-des-chieurs.ts
+++ b/src/data/zones/savages/55-vallee-des-chieurs.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage55: Zone = {
   id: 'vallee-des-chieurs',
-  name: 'Vallée des Chieurs',
+  name: 'data.zones.savages.55-vallee-des-chieurs.name',
   type: 'sauvage',
   position: { lat: -109.72531606028684, lng: 92.67928039702232 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/60-trou-du-bide.i18n.yml
+++ b/src/data/zones/savages/60-trou-du-bide.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Trou du Bide
+fr:
+  name: Trou du Bide

--- a/src/data/zones/savages/60-trou-du-bide.ts
+++ b/src/data/zones/savages/60-trou-du-bide.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage60: Zone = {
   id: 'trou-du-bide',
-  name: 'Trou du Bide',
+  name: 'data.zones.savages.60-trou-du-bide.name',
   type: 'sauvage',
   position: { lat: -118.72328724332411, lng: 48.45124069478908 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/65-lac-aux-relous.i18n.yml
+++ b/src/data/zones/savages/65-lac-aux-relous.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Lac aux Relous
+fr:
+  name: Lac aux Relous

--- a/src/data/zones/savages/65-lac-aux-relous.ts
+++ b/src/data/zones/savages/65-lac-aux-relous.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage65: Zone = {
   id: 'lac-aux-relous',
-  name: 'Lac aux Relous',
+  name: 'data.zones.savages.65-lac-aux-relous.name',
   type: 'sauvage',
   position: { lat: -140.96827155694405, lng: 36.45719602977667 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/70-zone-giga-zob.i18n.yml
+++ b/src/data/zones/savages/70-zone-giga-zob.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Aire du Giga Zob
+fr:
+  name: Aire du Giga Zob

--- a/src/data/zones/savages/70-zone-giga-zob.ts
+++ b/src/data/zones/savages/70-zone-giga-zob.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage70: Zone = {
   id: 'zone-giga-zob',
-  name: 'Aire du Giga Zob',
+  name: 'data.zones.savages.70-zone-giga-zob.name',
   type: 'sauvage',
   position: { lat: -151.2159609598476, lng: 58.94602977667493 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/80-mont-kouillasse.i18n.yml
+++ b/src/data/zones/savages/80-mont-kouillasse.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Mont Kouillasse
+fr:
+  name: Mont Kouillasse

--- a/src/data/zones/savages/80-mont-kouillasse.ts
+++ b/src/data/zones/savages/80-mont-kouillasse.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage80: Zone = {
   id: 'mont-kouillasse',
-  name: 'Mont Kouillasse',
+  name: 'data.zones.savages.80-mont-kouillasse.name',
   type: 'sauvage',
   position: { lat: -145.97988089845296, lng: 78.68610421836229 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/85-paturage-crado.i18n.yml
+++ b/src/data/zones/savages/85-paturage-crado.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Pâturage Crado
+fr:
+  name: Pâturage Crado

--- a/src/data/zones/savages/85-paturage-crado.ts
+++ b/src/data/zones/savages/85-paturage-crado.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage85: Zone = {
   id: 'paturage-crado',
-  name: 'Pâturage Crado',
+  name: 'data.zones.savages.85-paturage-crado.name',
   type: 'sauvage',
   position: { lat: -146.00878391249714, lng: 98.67630272952854 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/90-canyon-a-la-derp.i18n.yml
+++ b/src/data/zones/savages/90-canyon-a-la-derp.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Canyon à la Derp
+fr:
+  name: Canyon à la Derp

--- a/src/data/zones/savages/90-canyon-a-la-derp.ts
+++ b/src/data/zones/savages/90-canyon-a-la-derp.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage90: Zone = {
   id: 'canyon-a-la-derp',
-  name: 'Canyon à la Derp',
+  name: 'data.zones.savages.90-canyon-a-la-derp.name',
   type: 'sauvage',
   position: { lat: -191.42375029581757, lng: 84.11421646610381 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/savages/95-cratere-des-legends.i18n.yml
+++ b/src/data/zones/savages/95-cratere-des-legends.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Cratère des Légends
+fr:
+  name: Cratère des Légends

--- a/src/data/zones/savages/95-cratere-des-legends.ts
+++ b/src/data/zones/savages/95-cratere-des-legends.ts
@@ -2,7 +2,7 @@ import type { BaseShlagemon, Zone } from '~/type'
 
 export const savage95: Zone = {
   id: 'cratere-des-legends',
-  name: 'Cratère des Légends',
+  name: 'data.zones.savages.95-cratere-des-legends.name',
   type: 'sauvage',
   position: { lat: -209.1195616434194, lng: 87.64014121687441 },
   shlagemons: Object.entries(import.meta.glob<{ default: BaseShlagemon }>(

--- a/src/data/zones/villages/village10.i18n.yml
+++ b/src/data/zones/villages/village10.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Veaux du Gland sur Marne
+fr:
+  name: Veaux du Gland sur Marne

--- a/src/data/zones/villages/village10.ts
+++ b/src/data/zones/villages/village10.ts
@@ -14,7 +14,7 @@ import { savage05 } from '../savages/05-bois-de-bouffon'
 
 export const village10: Zone = {
   id: 'village-veaux-du-gland',
-  name: 'Veaux du Gland sur Marne',
+  name: 'data.zones.villages.village10.name',
   type: 'village',
   villageType: 'basic',
   position: move.top(savage05.position, VILLAGE_OFFSET),

--- a/src/data/zones/villages/village100.i18n.yml
+++ b/src/data/zones/villages/village100.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Citadelle Giga-Schlag
+fr:
+  name: Citadelle Giga-Schlag

--- a/src/data/zones/villages/village100.ts
+++ b/src/data/zones/villages/village100.ts
@@ -30,7 +30,7 @@ import { savage95 } from '../savages/95-cratere-des-legends'
 
 export const village100: Zone = {
   id: 'village-giga-schlag',
-  name: 'Citadelle Giga-Schlag',
+  name: 'data.zones.villages.village100.name',
   type: 'village',
   villageType: 'hyper',
   position: move.right(savage95.position, VILLAGE_OFFSET),

--- a/src/data/zones/villages/village20.i18n.yml
+++ b/src/data/zones/villages/village20.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Village Sux-Mais-Bouls
+fr:
+  name: Village Sux-Mais-Bouls

--- a/src/data/zones/villages/village20.ts
+++ b/src/data/zones/villages/village20.ts
@@ -15,7 +15,7 @@ import { savage15 } from '../savages/15-ravin-fesse-molle'
 
 export const village20: Zone = {
   id: 'village-boule',
-  name: 'Village Sux-Mais-Bouls',
+  name: 'data.zones.villages.village20.name',
   type: 'village',
   villageType: 'basic',
   position: move.bottom(savage15.position, VILLAGE_OFFSET),

--- a/src/data/zones/villages/village40.i18n.yml
+++ b/src/data/zones/villages/village40.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Village Paumé du cul
+fr:
+  name: Village Paumé du cul

--- a/src/data/zones/villages/village40.ts
+++ b/src/data/zones/villages/village40.ts
@@ -23,7 +23,7 @@ import { savage35 } from '../savages/35-route-du-nawak'
 
 export const village40: Zone = {
   id: 'village-paume',
-  name: 'Village Paumé du cul',
+  name: 'data.zones.villages.village40.name',
   type: 'village',
   villageType: 'super',
   position: move.top(savage35.position, VILLAGE_OFFSET),

--- a/src/data/zones/villages/village50.i18n.yml
+++ b/src/data/zones/villages/village50.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Village Fiente-sur-Mer
+fr:
+  name: Village Fiente-sur-Mer

--- a/src/data/zones/villages/village50.ts
+++ b/src/data/zones/villages/village50.ts
@@ -25,7 +25,7 @@ import { savage45 } from '../savages/45-catacombes-merdifientes'
 
 export const village50: Zone = {
   id: 'village-caca-boudin',
-  name: 'Village Fiente-sur-Mer',
+  name: 'data.zones.villages.village50.name',
   type: 'village',
   villageType: 'super',
   position: move.top(savage45.position, VILLAGE_OFFSET),

--- a/src/data/zones/villages/village60.i18n.yml
+++ b/src/data/zones/villages/village60.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Village des Cassos
+fr:
+  name: Village des Cassos

--- a/src/data/zones/villages/village60.ts
+++ b/src/data/zones/villages/village60.ts
@@ -25,7 +25,7 @@ import { savage55 } from '../savages/55-vallee-des-chieurs'
 
 export const village60: Zone = {
   id: 'village-cassos-land',
-  name: 'Village des Cassos',
+  name: 'data.zones.villages.village60.name',
   type: 'village',
   villageType: 'hyper',
   position: move.top(savage55.position, VILLAGE_OFFSET),

--- a/src/data/zones/villages/village80.i18n.yml
+++ b/src/data/zones/villages/village80.i18n.yml
@@ -1,0 +1,4 @@
+en:
+  name: Clito Land
+fr:
+  name: Clito Land

--- a/src/data/zones/villages/village80.ts
+++ b/src/data/zones/villages/village80.ts
@@ -30,7 +30,7 @@ import { savage75 } from '../savages/75-route-so-dom'
 
 export const village80: Zone = {
   id: 'village-clitoland',
-  name: 'Clito Land',
+  name: 'data.zones.villages.village80.name',
   type: 'village',
   villageType: 'hyper',
   position: move.right(savage75.position, VILLAGE_OFFSET),

--- a/test/map-marker-tooltip.test.ts
+++ b/test/map-marker-tooltip.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { useLeafletMarker } from '../src/composables/leaflet/useLeafletMarker'
 import { useMapMarkers } from '../src/composables/leaflet/useMapMarkers'
+import { i18n } from '../src/modules/i18n'
 
 const { useLeafletMarkerMock, useZoneCompletionMock } = vi.hoisted(() => ({
   useLeafletMarkerMock: vi.fn(() => ({
@@ -30,7 +31,7 @@ vi.mock('../src/stores/zoneVisit', () => ({
 describe('useMapMarkers', () => {
   const zone: Zone = {
     id: 'test-zone',
-    name: 'Test Zone',
+    name: 'test.zone.name',
     type: 'sauvage',
     position: { lat: 0, lng: 0 },
     minLevel: 1,
@@ -53,7 +54,7 @@ describe('useMapMarkers', () => {
     const { addMarker } = useMapMarkers(dummyMap)
     addMarker(zone)
     expect(useLeafletMarker).toHaveBeenCalledWith(
-      expect.objectContaining({ title: zone.name }),
+      expect.objectContaining({ title: i18n.global.t(zone.name) }),
     )
   })
 


### PR DESCRIPTION
## Summary
- localize all zone names via i18n keys and YAML translation files
- render zone names using `t()` in zone components and Leaflet markers
- adjust unit test for translated zone names

## Testing
- `pnpm test test/map-marker-tooltip.test.ts --run`
- `pnpm lint` *(fails: Expected object keys to be in ascending order in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689496262fd8832a9b4614c6760a4663