### PR TITLE
fix: clean translations and reference prior mons

### DIFF
--- a/src/data/shlagemons/05-10/chenipaon.i18n.yml
+++ b/src/data/shlagemons/05-10/chenipaon.i18n.yml
@@ -1,20 +1,20 @@
 en:
-  description: "Caterpeacock is a flamboyant larva, an unlikely fruit of a miteuser and a peacock far too narcissistic. He moves slowly, dragging behind him a train of multicolored feathers which he himself stuck with saliva on his soft back. These feathers are useless, except to make \"dramatic tapping\" when it turns suddenly.
+  description: |-
+    Caterpeacock is a flamboyant larva, an unlikely offspring of a shabby caterpillar and a peacock far too narcissistic. It moves slowly, dragging a train of multicolored feathers that it glued to its soft back with saliva. These feathers are useless, except to make "dramatic tapping" when it turns suddenly.
 
-    His nuptial parade is a choreographic disaster where he turns on himself by screaming \"Graaaaaaah-Paon\", which has the effect of scaring 90% of living things nearby, including stones. The rare opponents who remain are hypnotized by the fascinating ugliness of his dance, which gives Caterpeacock a short strategic advantage.
+    Its nuptial parade is a choreographic disaster where it spins around screaming "Graaaaaaah-Paon", scaring 90% of nearby life, including stones. The rare opponents who remain are hypnotized by the fascinating ugliness of its dance, which gives Caterpeacock a brief strategic advantage.
 
-    His official cry is recorded in databases like *\"Krrr-Paitius\" Krrr-Païïïïïïïïïïire *, but each specimen seems to invent his on the moment, generally accompanied by a sound effect of disordered flute and a humid sneezing.
+    Its official cry is recorded in databases as *"Krrr-Paitius Krrr-Païïïïïïïïïïïre"*, but each specimen invents its own on the spot, generally accompanied by a dissonant flute sound and a wet sneeze.
 
-    It has the special attack *rolls on colored soil *, which inflicts random damage and leaves toxic feathers on the battlefi\r
-
-    578\r
-
-    eld. He can also use *false charisma *, which briefly increases his criticism according to the number of dismayed looks he receives."
+    It has the special attack *Rolls on Colored Soil*, which inflicts random damage and leaves toxic feathers on the battlefield. It can also use *False Charisma*, briefly increasing its critical rate according to the number of dismayed looks it receives.
   name: Caterpeacock
 fr:
   description: |-
     Chenipaon est une larve flamboyante, fruit improbable d’une chenille miteuse et d’un paon beaucoup trop narcissique. Il se déplace lentement, en traînant derrière lui une traîne de plumes multicolores qu’il a lui-même collées à la salive sur son dos mou. Ces plumes ne servent à rien, sauf à faire des "claquettes dramatiques" quand il se retourne brusquement.
+
     Sa parade nuptiale est un désastre chorégraphique où il tourne sur lui-même en hurlant "GRAAAAAAAH-PAOON", ce qui a pour effet de faire fuir 90% des êtres vivants à proximité, y compris les pierres. Les rares adversaires qui restent sont hypnotisés par la laideur fascinante de sa danse, ce qui donne à Chenipaon un court avantage stratégique.
+
     Son cri officiel est enregistré dans les bases de données comme *"KRRRR-païïïïïïïïïïïïïïïïïn"*, mais chaque spécimen semble inventer le sien sur le moment, généralement accompagné d’un effet sonore de flûte désaccordée et d’un éternuement humide.
+
     Il possède l’attaque spéciale *Roule Par Terre Coloré*, qui inflige des dégâts aléatoires et laisse des plumes toxiques sur le champ de bataille. Il peut également utiliser *Faux Charisme*, qui augmente brièvement son taux de critique en fonction du nombre de regards consternés qu’il reçoit.
   name: Chenipaon

--- a/src/data/shlagemons/35-40/psykonaute.i18n.yml
+++ b/src/data/shlagemons/35-40/psykonaute.i18n.yml
@@ -1,8 +1,8 @@
 en:
   description: |-
-    After he discovered the virtues of cheap shit and dubious herbs found under a bench in Lavanusville. Since then, he spends his days avoided on an old sofa, empty eye and ajar, staring at a screen that no longer captures any chain.
-    He sports a faded bob flocked "420", interdimensional dark circles and a lighter which he calls "his starter". It is said that his psychiatric powers are still there, but that he only uses them to make his cones levitate when he is lazy to catch them.
-    His signature attack, *Cosmic chichon *, envelops the arena with a dense and sweet cloud, drastically reducing the speed of all opponents. He can also launch *Telecantapé *, which prevents him from moving for 5 laps but returns his whole mental life (or almost).
+    Psykonaut is the deviant evolution of PsychoQuack (PsychoQuack). After discovering the virtues of cheap weed and dubious herbs found under a bench in Lavanusville, he now spends his days slumped on an old sofa, eyes half-open, staring at a screen that no longer captures any channel.
+    He sports a faded bob marked "420", interdimensional dark circles, and a lighter he calls "his starter." Rumor has it his psychic powers remain, but he only uses them to levitate his joints when he's too lazy to grab them.
+    His signature attack, *Cosmic Chichon*, envelops the arena in a dense, sweet cloud that drastically reduces the speed of all opponents. He can also launch *Telecouch*, which prevents him from moving for five turns but restores nearly all his mental life.
   name: Psykonaut
 fr:
   description: |-

--- a/src/data/shlagemons/55-60/amonichiasse.i18n.yml
+++ b/src/data/shlagemons/55-60/amonichiasse.i18n.yml
@@ -1,10 +1,12 @@
 en:
-  description: "Amonichiasses is a fossilized mollusk that stinks of aquatic diarrhea. Its sticky shell is covered with brownish spots, as if it had been used as a rescue bucket in a collective gastro. Two small globular eyes are softly exceeding his mucus, constantly fogged by the lukewarm steam which he releases. He advances slowly, leaving behind a suspicious and viscous trail. Some trainers say that he emits noise of intestinal gurgling when shaking him t\r
+  description: |-
+    Amonichiasses is a fossilized mollusk that stinks of aquatic diarrhea. Its sticky shell is covered with brownish spots, as if it had been used as a rescue bucket in a collective gastro. Two small globular eyes softly emerge from its mucus, constantly fogged by the lukewarm steam it releases.
 
-    ac4\r
-
-    oo hard."
+    It advances slowly, leaving behind a suspicious and viscous trail. Some trainers say it emits noises of intestinal gurgling when shaken too hard.
   name: Omapoop
 fr:
-  description: Amonichiasse est un mollusque fossilisé qui pue la diarrhée aquatique. Sa coquille gluante est couverte de taches brunâtres, comme si elle avait été utilisée comme seau de secours dans une gastro collective. Deux petits yeux globuleux dépassent mollement de son mucus, constamment embués par la vapeur tiède qu’il dégage. Il avance lentement, en laissant derrière lui une traînée suspecte et visqueuse. Certains dresseurs affirment qu’il émet des bruits de gargouillis intestinaux quand on le secoue trop fort.
+  description: |-
+    Amonichiasse est un mollusque fossilisé qui pue la diarrhée aquatique. Sa coquille gluante est couverte de taches brunâtres, comme si elle avait été utilisée comme seau de secours dans une gastro collective. Deux petits yeux globuleux dépassent mollement de son mucus, constamment embués par la vapeur tiède qu’il dégage.
+
+    Il avance lentement, en laissant derrière lui une traînée suspecte et visqueuse. Certains dresseurs affirment qu’il émet des bruits de gargouillis intestinaux quand on le secoue trop fort.
   name: Amonichiasse

--- a/src/data/shlagemons/evolutions/aerobite.i18n.yml
+++ b/src/data/shlagemons/evolutions/aerobite.i18n.yml
@@ -1,12 +1,12 @@
 fr:
   description: |-
-    Aérobite est l’évolution honteusement assumée de GrosMitoss. Une créature ailée qui plane dans les airs… en toute impunité. Il a troqué son pelage pour une pilosité sélective : le torse rasé de près, mais le bas… comment dire… *aéré*. Et ça ne le dérange pas, bien au contraire — il revendique une "liberté corporelle totale".
+    Aérobite est l’évolution honteusement assumée de GrosMitoss (Fattroll). Une créature ailée qui plane dans les airs… en toute impunité. Il a troqué son pelage pour une pilosité sélective : le torse rasé de près, mais le bas… comment dire… *aéré*. Et ça ne le dérange pas, bien au contraire — il revendique une "liberté corporelle totale".
     D’une impudeur sans faille, Aérobite adore surgir sans prévenir dans des lieux publics, déclenchant malaise et regards fuyants. Il clame haut et fort que “le corps, c’est naturel”, tout en déployant ses ailes à paillettes façon exhibition de foire.
     Son attaque signature *Claqueburnes* inflige des dégâts sonores et psychologiques, tandis que *Vent Glacial* laisse souvent les adversaires tétanisés — pas à cause du froid, mais du traumatisme visuel. On dit qu’aucun dresseur n’est jamais vraiment prêt à le voir voler au ralenti… jambes écartées.
   name: Aérobite
 en:
   description: |-
-    Aerobite is the shamefully assumed evolution of largemitoss. A winged creature that hovers in the air ... with impunity. He swapped his coat for a selective hair: the torso shaved closely, but the bottom ... how to say ... *ventilated *. And that doesn't bother him, quite the contrary - he claims "total bodily freedom".
+    Aerobite is the shamefully assumed evolution of GrosMitoss (Fattroll). A winged creature that hovers in the air ... with impunity. He swapped his coat for a selective hair: the torso shaved closely, but the bottom ... how to say ... *ventilated*. And that doesn't bother him, quite the contrary – he claims "total bodily freedom".
     With a flawless immodesty, Aérobite loves to arise without warning in public places, triggering discomfort and fleeting glances. He claims loudly that "the body is natural", while deploying his glitter wings like an exhibition of fair.
     Its signature attack * Claqueburnes * inflicts sound and psychological damage, while * freezing wind * often leaves the paralyzed adversaries - not because of the cold, but the visual trauma. It is said that no trainer is never really ready to see him stolen in slow motion ... legs apart.
   name: Dickmoth

--- a/src/data/shlagemons/evolutions/draco-con.i18n.yml
+++ b/src/data/shlagemons/evolutions/draco-con.i18n.yml
@@ -1,23 +1,20 @@
 fr:
   description: |-
-    Draco-con est la dernière forme de l’ancienne lignée des Salamiches. En apparence, c’est un dragon colossal, avec des ailes de moto-tuning, des flammes arc-en-bouse et des muscles qui crient "anabolisés". Mais derrière cette façade volcanique se cache une stupidité abyssale.
+    Draco-con est la dernière forme de l’ancienne lignée des Salamiches (Chaboobs). En apparence, c’est un dragon colossal, avec des ailes de moto-tuning, des flammes arc-en-bouse et des muscles qui crient "anabolisés". Mais derrière cette façade volcanique se cache une stupidité abyssale.
     Il confond souvent ses propres attaques avec celles de l’adversaire, et peut littéralement s’auto-cramer en tentant un *Jet d’Feu Vers le Vent*. Son cri de guerre est un mélange d’aboiement rauque et de rot mal digéré, et il ne comprend pas pourquoi les autres fuient quand il parle stratégie.
     Draco-con adore faire des lives en pleine arène pour dire "yo la team" à ses 3 abonnés imaginaires. Il pense que ses écailles brillent parce qu’il est rare, alors qu’en réalité, c’est juste de la graisse de kebab incrustée.
     Il possède la capacité *Combo Kéké*, qui mélange toutes ses attaques en un seul mouvement incohérent, mais bruyant. Résultat : les ennemis sont plus confus que blessés, et parfois, ils tombent simplement d’ennui.
     On dit que même le Professeur Merdant a arrêté d’essayer de l’étudier : "trop con pour la science", selon ses notes.
   name: Draco Con
 en:
-  description: "Draco-Con is the last form of the old Salamiches line. Apparently, it’s a colossal dragon, with motorcycle-tuning wings, arch-in-noise flames and muscles that cry out \"anabolized. But behind this volcanic facade hides an abysmal stupidity.
+  description: |-
+    Draco-Con is the last form of the old Salamiches (Chaboobs) line. Apparently, it is a colossal dragon with motorcycle-tuning wings, manure-colored flames, and muscles that scream "anabolized." But behind this volcanic façade hides abysmal stupidity.
 
-    He often confuses his own attacks with those of the opponent, and can literally self-clam while trying a *fiery jet towards the wind *. His war cry is a mixture of raucous ba\r
+    He often confuses his own attacks with those of the opponent and can literally burn himself while trying a *Fiery Jet to the Wind*. His war cry is a mixture of raucous barking and poorly digested belch, and he does not understand why others flee when he talks strategy.
 
-    af0\r
+    Draco-Con loves to stream in the middle of an arena to say "yo la team" to his three imaginary subscribers. He thinks his scales shine because he is rare, when in reality it's just embedded kebab grease.
 
-    rking and poorly digested rot, and he does not understand why others flee when he speaks strategy.
+    It has the ability *Kéké Combo*, which mixes all its attacks into a single incoherent but noisy move. Result: enemies are more confused than hurt, and sometimes they simply fall from boredom.
 
-    Draco-Con loves to make lives in full arena to say \"Yo la Team\" to his 3 imaginary subscribers. He thinks that his scales shine because he is rare, when in reality, it's just inlaid kebab fat.
-
-    It has the capacity *Kéké *combo, which mixes all its attacks in a single incoherent, but noisy movement. Result: enemies are more confused than injured, and sometimes they simply fall from boredom.
-
-    It is said that even Professor Merdant stopped trying to study it: \"Too stupid for science\", according to his notes."
+    It is said that even Professor Merdant stopped trying to study it: "Too stupid for science," according to his notes.
   name: Dumbzard

--- a/src/data/shlagemons/evolutions/feunouille.i18n.yml
+++ b/src/data/shlagemons/evolutions/feunouille.i18n.yml
@@ -1,13 +1,13 @@
 fr:
   description: |-
-    Feunouille est une erreur de casting dans l’évolution de Goupichiant. Persuadé d’être un Pokémon légendaire, il parade avec ses neuf queues en synthétique mal accrochées, achetées sur Vinted dans une vente privée de furries déchus.
+    Feunouille est une erreur de casting dans l’évolution de Goubite (Vulpdick). Persuadé d’être un Pokémon légendaire, il parade avec ses neuf queues en synthétique mal accrochées, achetées sur Vinted dans une vente privée de furries déchus.
     Son pelage est cramé par endroits à cause de ses propres attaques ratées, et il porte un piercing lumineux au museau qui clignote en rythme avec ses crises d’égo. Il utilise *Flamme AutoBronzante* pour se donner un teint de feu, mais finit souvent orange carotte.
     Feunouille attaque rarement, sauf si on critique son style ou qu’on dit que Ninetales est "mieux designé". Dans ce cas, il enchaîne *Queue-Slap TikTok* et *Souffle de Théorie Fumeuse*, une combinaison qui désoriente tous les Shlagémons normaux.
     Il est persuadé d’être l’élu d’une prophétie inventée par lui-même. Aucun autre Shlagémon ne valide.
   name: Feunouille
 en:
   description: |-
-    Feunouille is a casting error in the evolution of Goupichiant. Convinced to be a legendary Pokémon, he parades with his nine badly hung synthetic tails, bought on Vinted in a private sale of fallen furies.
+    Feunouille is a casting error in the evolution of Goubite (Vulpdick). Convinced to be a legendary Pokémon, he parades with his nine badly hung synthetic tails, bought on Vinted in a private sale of fallen furies.
     His coat is burnt in places because of his own failed attacks, and he wears a bright piercing in the muzzle that flashes in rhythm with his ego attacks. He uses * self -tanning flame * to give himself a fire complexion, but often ends up orange carrot.
     Feunouille rarely attacks, unless you criticize its style or that you say that NineTales is "better designed". In this case, he continues *tail-Slap tiktok *and *breath of smoky theory *, a combination that disorients all normal shlagemons.
     He is convinced to be the elected representative of a prophecy invented by himself. No other shlagémon validates.

--- a/src/data/shlagemons/evolutions/flaclodoss.i18n.yml
+++ b/src/data/shlagemons/evolutions/flaclodoss.i18n.yml
@@ -6,15 +6,9 @@ fr:
     On raconte que Flaclodoss possède le secret pour ouvrir toutes les poubelles à un seul doigt, et qu’il médite souvent sur la vie en fixant les pigeons. Sa philosophie ? “Tant qu’il y a un banc, y’a de l’espoir…”
   name: Flaclodoss
 en:
-  description: "Flaclodoss wanders along the gutters, dragging its shell that has become a shabby sleeping bag, constelled with suspicious tasks and crushed chewing gum. Formerly promised to a good evolution, he was rejuvenated to all the arenas and ended up electing home under a bus shelter, where the rain puddles become his makeshift mirror.
-
-    His fur turned to dirty gray, his gaze floats vague as if he was looking for the bus that will never come. On its back, there is an old rusty canned box or a deflated tire, a ves\r
-
-    af0\r
-
-    tige of its urban galleys. His jogging has become coverage, his mismatched socks hold miraculously thanks to three staples and an elastic recovered from an expired metro ticket.
-
-    His signature attack, *cloud of misery *, gives off an aura of fatigue and old sandwiches, plunging his opponents into an intense demotivation state.
-
-    It is said that Flaclodoss has the secret to open all the garbage cans with one finger, and that it often meditates on life by fixing the pigeons. His philosophy? \"As long as there is a bench, there is hope ...\""
+  description: |-
+    Flaclodoss wanders along the gutters, dragging its shell that has become a shabby sleeping bag speckled with suspicious stains and crushed chewing gum. Once promised a bright evolution, it was rejected by every arena and finally made its home under a bus shelter, where rain puddles serve as a makeshift mirror.
+    Its fur has turned dirty gray, its gaze floating vaguely as if searching for a bus that will never come. On its back you might find an old rusty tin can or a deflated tire, vestiges of its urban hardships. Its tracksuit has become a blanket, and its mismatched socks hold together thanks to three staples and an elastic salvaged from an expired metro ticket.
+    Its signature attack, *Cloud of Misery*, emits an aura of fatigue and old sandwiches, plunging opponents into intense demotivation.
+    Rumor has it that Flaclodoss knows how to open any trash can with a single finger and often meditates on life while staring at pigeons. Its philosophy? "As long as there is a bench, there is hope..."
   name: Flaclodoss

--- a/src/data/shlagemons/evolutions/meladolphe.i18n.yml
+++ b/src/data/shlagemons/evolutions/meladolphe.i18n.yml
@@ -1,12 +1,12 @@
 fr:
   description: |-
-    Méladolphe est l’évolution contestée de Mélofoutre, fruit d’une mutation auditive après trop de soirées karaoké entre beaufs autoritaires. Il a troqué sa douceur poisseuse contre un costume trop repassé, une raie bien tracée, et une passion suspecte pour les discours gênants.
+    Méladolphe est l’évolution contestée de Mélofoutre (Spaffairy), fruit d’une mutation auditive après trop de soirées karaoké entre beaufs autoritaires. Il a troqué sa douceur poisseuse contre un costume trop repassé, une raie bien tracée, et une passion suspecte pour les discours gênants.
     Il chante faux mais fort, avec des paroles douteuses qui font fuir les autres Shlagémons. Son attaque signature, *Chant Fascinazif*, oblige ses ennemis à se ranger en file indienne et à marcher au pas jusqu'à l'épuisement. Il peut aussi déclencher *Micro de Propagande*, un cri strident qui inflige des dégâts psychologiques même à travers les murs.
     Son aura autoritaire et son parfum de naphtaline lui valent d’être banni de plusieurs régions. Malgré tout, certains dresseurs le trouvent “charismatique”, mais ils ont souvent de drôles d’idées derrière la tête.
   name: Méladolphe
 en:
   description: |-
-    Clefadolphe is the disputed evolution of Spaffairy, the fruit of a hearing mutation after too many karaoke evenings between authoritarian beautiful. He swapped his sticky sweetness against an overly ironed costume, a well -traced line, and a suspicious passion for annoying speeches.
+    Clefadolphe is the disputed evolution of Mélofoutre (Spaffairy), the fruit of a hearing mutation after too many karaoke evenings between authoritarian beaux. He swapped his sticky sweetness for an overly ironed suit, a well-traced part, and a suspicious passion for embarrassing speeches.
     He sings false but strong, with dubious words that scare away other shlagemons. His signature attack, *fascina -song song *, forces his enemies to line up in Indian file and to walk in step until exhaustion. It can also trigger *microphone of propaganda *, a strident cry which inflicts psychological damage even through the walls.
     His authoritarian aura and his naphthalin scent earned him to be banished from several regions. Despite everything, some trainers find it "charismatic", but they often have funny ideas behind their heads.
   name: Clefadolphe

--- a/src/data/shlagemons/evolutions/raichiotte.i18n.yml
+++ b/src/data/shlagemons/evolutions/raichiotte.i18n.yml
@@ -1,12 +1,12 @@
 fr:
   description: |-
-    Raïchiotte est l’aboutissement tragique de l’évolution de Pikachiant. Il a absorbé tellement d’ondes négatives et de câbles de contrefaçon qu’il est devenu littéralement instable : chaque mouvement déclenche des étincelles involontaires et un léger bruit de chasse d’eau. Il porte en permanence une banane fluo où il range ses powerbanks, ses amendes impayées et quelques trottinettes volées.
+    Raïchiotte est l’aboutissement tragique de l’évolution de Pikachiant (Pikannoying). Il a absorbé tellement d’ondes négatives et de câbles de contrefaçon qu’il est devenu littéralement instable : chaque mouvement déclenche des étincelles involontaires et un léger bruit de chasse d’eau. Il porte en permanence une banane fluo où il range ses powerbanks, ses amendes impayées et quelques trottinettes volées.
     Sa queue est devenue un paratonnerre inversé qui attire les problèmes, et son rire grésille comme un haut-parleur saturé. Il attaque avec *Coup de Jus Verbal*, une insulte électrique qui te paralyse de gêne. On le reconnaît facilement grâce à son regard vide, son haleine d’écran brûlé, et sa capacité à pirater un interphone avec une paille.
     Même les bornes de recharge refusent de le connecter. Il est considéré comme un bug vivant du Pokédex, et certains dresseurs le fuient, non pas pour sa puissance… mais pour sa conversation.
   name: Raïchiotte
 en:
   description: |-
-    Raïchiotte is the tragic culmination of Pikachiant's evolution. He absorbed so much negative waves and counterfeit cables that he has literally become unstable: each movement triggers involuntary sparks and a slight flush noise. He permanently carries a fluorescent banana where he puts his powerbanks, his unpaid fines and a few stolen scooters.
+    Raïchiotte is the tragic culmination of Pikachiant (Pikannoying)'s evolution. He absorbed so much negative waves and counterfeit cables that he has literally become unstable: each movement triggers involuntary sparks and a slight flush noise. He permanently carries a fluorescent banana where he puts his powerbanks, his unpaid fines and a few stolen scooters.
     Its tail has become an inverted lightning rod that attracts problems, and its laughing laughs like a saturated speaker. He attacks with *verbal juice *, an electric insult that paralyzes you with embarrassment. It is easily recognized thanks to its empty look, its burnt screen breath, and its ability to hack an intercom with a straw.
     Even the charging stations refuse to connect it. He is considered a living bug of the Pokédex, and certain trainers flee, not for his power ... but for his conversation.
   name: Raïchiotte

--- a/src/data/shlagemons/evolutions/roux-pignolage.i18n.yml
+++ b/src/data/shlagemons/evolutions/roux-pignolage.i18n.yml
@@ -1,20 +1,14 @@
 fr:
   description: |-
-    Roux Pignolage est l’évolution finale et tragique de Roux pas Cool. Il a troqué sa guitare pour un clavier graisseux, et sa passion pour l’indé est devenue une fixette sur les archives "non censurées" des forums Shlagépédia. Il vit recroquevillé dans une carapace de mauvaise foi, de miettes de chips, et de regrets sociaux profonds.
-    Ses plumes sont ternes, collées par des fluides suspects et du gel pour cheveux périmé. Il parle peu, mais quand il le fait, c’est pour balancer des monologues confus sur la liberté d’expression, les caméras planquées, et "ce que les gens veulent pas entendre". Il se pignole. Beaucoup. Trop. Il appelle ça du "recentrage énergétique". Les autres appellent ça un délit.
+    Roux Pignolage est l’évolution finale et tragique de Roux pas Cool (Cringeon). Il a troqué sa guitare pour un clavier graisseux, et sa passion pour l’indé est devenue une fixette sur les archives "non censurées" des forums Shlagépédia. Il vit recroquevillé dans une carapace de mauvaise foi, de miettes de chips et de regrets sociaux profonds.
+    Ses plumes sont ternes, collées par des fluides suspects et du gel pour cheveux périmé. Il parle peu, mais quand il le fait, c’est pour balancer des monologues confus sur la liberté d’expression, les caméras planquées et "ce que les gens veulent pas entendre". Il se pignole. Beaucoup. Trop. Il appelle ça du "recentrage énergétique". Les autres appellent ça un délit.
     Sa capacité signature, *Stimulation Solitaire*, le soigne légèrement à chaque tour… mais inflige un malus de moral à toute l’équipe alliée. Il utilise aussi *Main Moite*, une attaque de type contact qui a 30% de chance de faire fuir directement l’ennemi par gêne viscérale.
     On le croise rarement en public, sauf dans des commentaires de vidéos floues ou à 3h du matin dans des zones Wi-Fi libres. Il prétend être incompris, mais en vérité, tout le monde le comprend très bien… et c’est ça le problème.
   name: Roux Pignolage
 en:
-  description: "Red Redshot is the final and tragic evolution of Roux not cool. He swapped his guitar for a greasy keyboard, and his passion for the indie has become a fixette on the \"uncon censored\" archives of the Shlagépédia forums. He saw curled up in a shell of bad faith, crumbs of chips, and deep social regrets.
-
-    Its feathers are dull, glued by suspicious fluids and expired hair gel. He speaks little, but when he does it,\r
-
-    578\r
-
-    \ it is to swing confused monologues on freedom of expression, the planted cameras, and \"what people do not want to hear\". He is pignool. A lot. Too much. He calls it \"energy refocusing\". The others call it an offense.
-
-    Its signature capacity, *solitary stimulation *, heals it slightly on each turn ... but inflicts a morale penalty on the whole allied team. He also uses Moite *, a contact type attack that is 30% chance of driving the enemy directly by visceral discomfort.
-
-    We rarely come across it in public, except in blurred videos comments or at 3 a.m. in free Wi-Fi areas. He claims to be misunderstood, but in truth, everyone understands it very well ... And that's the problem."
+  description: |-
+    Pignolagegeot is the final and tragic evolution of Roux pas Cool (Cringeon). He swapped his guitar for a greasy keyboard, and his passion for indie music has become an obsession with the "uncensored" archives of the Shlagépédia forums. He curls up in a shell of bad faith, chip crumbs, and deep social regrets.
+    Its feathers are dull, glued by suspicious fluids and expired hair gel. He speaks little, but when he does, it's to deliver confused monologues about freedom of expression, hidden cameras, and "what people don't want to hear." He pignols. A lot. Too much. He calls it "energy refocusing." Others call it a crime.
+    His signature ability, *Solitary Stimulation*, heals him slightly each turn but inflicts a morale penalty on the entire allied team. He also uses *Moist Hand*, a contact attack that has a 30% chance to make the enemy flee out of visceral embarrassment.
+    He is rarely seen in public, except in blurry video comments or at 3 a.m. in free Wi-Fi zones. He claims to be misunderstood, but in truth, everyone understands him perfectly... and that's the problem.
   name: Pignolagegeot


### PR DESCRIPTION
## Summary
- Remove stray carriage returns from several shlagemon translations
- Add French/English names for previous-evolution references
- Refresh Psykonaut English description

## Testing
- `pnpm test:unit` *(fails: expected true to be false, SyntaxError: Invalid arguments, snapshot mismatch, TypeError redirect not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6894a5c0b374832a933768d674c0e1c7