### PR TITLE
fix: translate zone names

### DIFF
--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -158,7 +158,7 @@ function onCapture() {
       @capture="onCapture"
     >
       <template #header>
-        <BattleHeader :zone-name="zone.current.name" />
+        <BattleHeader :zone-name="t(zone.current.name)" />
       </template>
     </BattleRound>
     <ZoneMonsModal />

--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -116,7 +116,7 @@ function leaveVillage() {
 
 <template>
   <LayoutTitledPanel
-    :title="zone.current.name"
+    :title="t(zone.current.name)"
     :exit-text="t('components.panel.Village.exit')"
     @exit="leaveVillage"
   >


### PR DESCRIPTION
## Summary
- ensure zone names are translated before rendering in battle header
- translate village panel titles via `t`

## Testing
- `pnpm lint` *(fails: 356 problems)*
- `pnpm test` *(fails: shlagedex capture and capture mechanics tests)*

------
https://chatgpt.com/codex/tasks/task_e_6894cb7dd898832a81c883f367a46d6b