### PR TITLE
fix: translate zone names in achievements

### DIFF
--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { zonesData } from '~/data/zones'
+import { i18n } from '~/modules/i18n'
 import { toast } from '~/modules/toast'
 
 export interface Achievement {
@@ -202,22 +203,25 @@ export const useAchievementsStore = defineStore('achievements', () => {
 
   const zoneWinThresholds = [10, 100, 1000]
   zonesData.forEach((z) => {
+    const zoneName = i18n.global.te(z.name) ? i18n.global.t(z.name) : z.name
+
     if (z.completionAchievement) {
       const def = {
         id: `zone-${z.id}-complete`,
         title: z.completionAchievement,
-        description: `Capturer tous les Shlagémon de ${z.name}.`,
+        description: `Capturer tous les Shlagémon de ${zoneName}.`,
         icon: 'mdi:map-marker-check',
       }
       defs.push(def)
       defMap[def.id] = def
     }
+
     if (z.type !== 'village') {
       zoneWinThresholds.forEach((n) => {
         const def = {
           id: `zone-${z.id}-win-${n}`,
-          title: `${n.toLocaleString()} victoires - ${z.name}`,
-          description: `Vaincre ${n.toLocaleString()} Shlagémon dans ${z.name}.`,
+          title: `${n.toLocaleString()} victoires - ${zoneName}`,
+          description: `Vaincre ${n.toLocaleString()} Shlagémon dans ${zoneName}.`,
           icon: 'carbon:sword',
         }
         defs.push(def)


### PR DESCRIPTION
## Summary
- translate zone names when building achievements

## Testing
- `pnpm test:unit` *(fails: battle item cooldown > prevents using multiple battle items during cooldown; shlagedex tests expecting untranslated names)*

------
https://chatgpt.com/codex/tasks/task_e_6894d3f9b4e0832ab6eb48b484d1e84d