### PR TITLE
feat: hue rotate special shlageballs in shop

### DIFF
--- a/src/components/shop/ItemCard.vue
+++ b/src/components/shop/ItemCard.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
+import { ballHues } from '~/utils/ball'
 
 const props = defineProps<{ item: Item }>()
 
 const { t } = useI18n()
+
+// Visual effect if item is a capture ball
+const ballFilter = computed(() =>
+  'catchBonus' in props.item ? { filter: `hue-rotate(${ballHues[props.item.id]})` } : {},
+)
 </script>
 
 <template>
@@ -19,6 +25,7 @@ const { t } = useI18n()
           :src="props.item.image"
           :alt="t(props.item.name)"
           class="h-full w-full object-contain"
+          :style="ballFilter"
         >
       </div>
     </template>

--- a/src/components/shop/ItemDetail.vue
+++ b/src/components/shop/ItemDetail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Item } from '~/type/item'
+import { ballHues } from '~/utils/ball'
 
 const props = withDefaults(defineProps<{ item: Item, qty?: number }>(), { qty: 1 })
 
@@ -9,6 +10,11 @@ const { t } = useI18n()
 
 const game = useGameStore()
 const qty = ref(props.qty)
+
+// Visual effect if item is a capture ball
+const ballFilter = computed(() =>
+  'catchBonus' in props.item ? { filter: `hue-rotate(${ballHues[props.item.id]})` } : {},
+)
 
 const playerMoney = computed(() =>
   props.item.currency === 'shlagidiamond'
@@ -62,7 +68,13 @@ const details = computed(() =>
         class="h-10 w-10"
         :class="[props.item.iconClass, props.item.icon]"
       />
-      <img v-else-if="props.item.image" :src="props.item.image" :alt="t(props.item.name)" class="h-10 w-10 object-contain">
+      <img
+        v-else-if="props.item.image"
+        :src="props.item.image"
+        :alt="t(props.item.name)"
+        class="h-10 w-10 object-contain"
+        :style="ballFilter"
+      >
       <h3 class="text-lg font-bold">
         {{ t(props.item.name) }}
       </h3>

--- a/test/shop-ball-hue.test.ts
+++ b/test/shop-ball-hue.test.ts
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import ShopItemCard from '../src/components/shop/ItemCard.vue'
+import ShopItemDetail from '../src/components/shop/ItemDetail.vue'
+import { hyperShlageball, superShlageball } from '../src/data/items/shlageball'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('../src/stores/game', () => ({
+  useGameStore: () => ({ shlagidolar: 1000, shlagidiamond: 0 }),
+}))
+
+describe('shop ball hue rotation', () => {
+  it('applies hue rotation on super shlageball card', () => {
+    const wrapper = mount(ShopItemCard, {
+      props: { item: superShlageball },
+      global: {
+        stubs: {
+          UiListItem: { template: '<div><slot name="left"/><slot/><slot name="right"/></div>' },
+          UiCurrencyAmount: true,
+        },
+      },
+    })
+    const img = wrapper.get('img')
+    expect(img.attributes('style')).toContain('hue-rotate(120deg)')
+  })
+
+  it('applies hue rotation on hyper shlageball detail', () => {
+    const wrapper = mount(ShopItemDetail, {
+      props: { item: hyperShlageball },
+      global: {
+        stubs: {
+          UiCurrencyAmount: true,
+          UiButton: true,
+          UiNumberInput: true,
+        },
+      },
+    })
+    const img = wrapper.get('img')
+    expect(img.attributes('style')).toContain('hue-rotate(240deg)')
+  })
+})


### PR DESCRIPTION
## Summary
- tint super and hyper shlageball images in the shop using hue rotation
- cover shop ball tinting with unit tests

## Testing
- `pnpm exec eslint src/components/shop/ItemCard.vue src/components/shop/ItemDetail.vue test/shop-ball-hue.test.ts`
- `pnpm test:unit` *(fails: `battle-item-cooldown.test.ts`, `capture.test.ts`, `page-locale-ssr.test.ts`, `rarity-info.test.ts`, `router-redirect.test.ts`, `shlagedex.test.ts`, `sort-item.test.ts`)*
- `pnpm test:unit test/shop-ball-hue.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6894d5c41afc832a83039b68a74ff45a