### PR TITLE
Fix unclosed apostrophe in French translations

### DIFF
--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2416,7 +2416,7 @@ stores:
     obtained: Tu as obtenu {name} !
     alreadyMax: Vous avez déjà ce Shlagémon au maximum de sa rareté
     rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
-    released: '{name} a été relâché 
+    released: '{name} a été relâché'
     point: point | points
     level: niveau | niveaux
   game:


### PR DESCRIPTION
## Summary
- close missing apostrophe in `locales/fr.yml` so `pnpm run i18n` parses correctly

## Testing
- `pnpm run i18n`
- `pnpm exec eslint locales/fr.yml` *(fails: Strings must use singlequote, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894e0987e9c832a84a04ab9e196fc6e