### PR TITLE
Fix Multi Exp button visibility when equipped

### DIFF
--- a/src/components/shlagemon/List.spec.ts
+++ b/src/components/shlagemon/List.spec.ts
@@ -72,11 +72,10 @@ describe('shlagemon List Multi Exp button', () => {
     inventoryStore.items = {}
   })
 
-  it('renders the multi exp button when equipped', () => {
+  it('renders the multi exp button when equipped even if not in inventory', () => {
     const mon = createMon(multiExp.id)
     shlagemons.value.push(mon)
     holders.value[multiExp.id] = mon.id
-    inventoryStore.items[multiExp.id] = 1
     const wrapper = mount(List, { props: { mons: [mon], isMainShlagedex: true }, global: { stubs } })
     expect(wrapper.find('button').exists()).toBe(true)
   })
@@ -85,7 +84,6 @@ describe('shlagemon List Multi Exp button', () => {
     const mon = createMon(multiExp.id)
     shlagemons.value.push(mon)
     holders.value[multiExp.id] = mon.id
-    inventoryStore.items[multiExp.id] = 1
     const wrapper = mount(List, { props: { mons: [mon], isMainShlagedex: true }, global: { stubs } })
     await wrapper.find('button').trigger('click')
     expect(openSpy).toHaveBeenCalledWith(mon)

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -44,13 +44,12 @@ const multiExpHolder = computed(() => {
 })
 
 /**
- * Whether the player owns the Multi Exp.
+ * Whether the player owns the Multi Exp, either in inventory or equipped.
  */
-const hasMultiExp = computed(() => (inventory.items[multiExp.id] || 0) > 0)
+const ownsMultiExp = computed(() => {
+  return (inventory.items[multiExp.id] || 0) > 0 || Boolean(multiExpHolder.value)
+})
 
-/**
- * Open the detail modal for the Shlagémon holding the Multi Exp.
- */
 /**
  * Handle click on the Multi Exp button.
  * If equipped, opens the detail modal of the holder; otherwise, opens the equip modal.
@@ -211,7 +210,7 @@ watch(
             :placeholder="t('components.shlagemon.List.search')"
           />
           <UiButton
-            v-if="isMainShlagedex && hasMultiExp"
+            v-if="isMainShlagedex && ownsMultiExp"
             v-tooltip="t(multiExp.name)" icon size="xs" variant="outline" type="primary" @click="handleMultiExpClick"
           >
             <span :class="[multiExp.icon, multiExp.iconClass]" />


### PR DESCRIPTION
## Summary
- show Multi Exp button even when it's currently equipped
- open holder details when clicking the button
- update tests for equipped vs owned Multi Exp

## Testing
- `pnpm test:unit` *(fails: SyntaxError: Missing closing 'quote' in locales/fr.yml)*

------
https://chatgpt.com/codex/tasks/task_e_6894d547c82c832ab60a7031d99bea8d