### PR TITLE
fix: ensure wearable item modal opens on mobile

### DIFF
--- a/src/components/layout/GameGrid.vue
+++ b/src/components/layout/GameGrid.vue
@@ -210,6 +210,7 @@ const bottomBadgeHandler = computed(() => {
         </UiPanelWrapper>
       </div>
 
+      <InventoryWearableItemModal />
       <ShlagemonEvolutionModal />
       <ShlagemonTypeChartModal />
       <ShlagemonWearableEquipModal />

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -280,7 +280,6 @@ function onUse(item: Item) {
     </div>
   </section>
   <InventoryEvolutionItemModal />
-  <InventoryWearableItemModal />
   <InventoryOdorElixirModal />
   <InventoryItemShortcutModal />
   <EggBoxModal />


### PR DESCRIPTION
## Summary
- render wearable item modal at layout level
- remove wearable item modal from inventory panel

## Testing
- `pnpm lint src/components/layout/GameGrid.vue src/components/panel/Inventory.vue`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6895289e1438832a919fa4886cb0ed88