### PR TITLE
refactor: externalize achievements translations

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -362,6 +362,7 @@ declare global {
   const useToggle: typeof import('@vueuse/core')['useToggle']
   const useTrainerBattleStore: typeof import('./stores/trainerBattle')['useTrainerBattleStore']
   const useTransition: typeof import('@vueuse/core')['useTransition']
+  const useTranslate: typeof import('./composables/useTranslate')['useTranslate']
   const useTypeChartModalStore: typeof import('./stores/typeChartModal')['useTypeChartModalStore']
   const useUIStore: typeof import('./stores/ui')['useUIStore']
   const useUrlSearchParams: typeof import('@vueuse/core')['useUrlSearchParams']
@@ -422,6 +423,9 @@ declare global {
   // @ts-ignore
   export type { SlidingPuzzle, PuzzleDirection } from './composables/useSlidingPuzzle'
   import('./composables/useSlidingPuzzle')
+  // @ts-ignore
+  export type { TranslateFn } from './composables/useTranslate'
+  import('./composables/useTranslate')
   // @ts-ignore
   export type { Achievement, AchievementEvent } from './stores/achievements'
   import('./stores/achievements')
@@ -826,6 +830,7 @@ declare module 'vue' {
     readonly useToggle: UnwrapRef<typeof import('@vueuse/core')['useToggle']>
     readonly useTrainerBattleStore: UnwrapRef<typeof import('./stores/trainerBattle')['useTrainerBattleStore']>
     readonly useTransition: UnwrapRef<typeof import('@vueuse/core')['useTransition']>
+    readonly useTranslate: UnwrapRef<typeof import('./composables/useTranslate')['useTranslate']>
     readonly useTypeChartModalStore: UnwrapRef<typeof import('./stores/typeChartModal')['useTypeChartModalStore']>
     readonly useUIStore: UnwrapRef<typeof import('./stores/ui')['useUIStore']>
     readonly useUrlSearchParams: UnwrapRef<typeof import('@vueuse/core')['useUrlSearchParams']>

--- a/src/components/achievement/Item.vue
+++ b/src/components/achievement/Item.vue
@@ -7,6 +7,8 @@ const emit = defineEmits(['toggle'])
 const store = useAchievementsStore()
 const progress = computed(() => store.getProgress(props.achievement.id))
 
+const { translate } = useTranslate()
+
 function toggle() {
   emit('toggle')
 }
@@ -16,7 +18,7 @@ function toggle() {
   <UiListItem
     :color="props.achievement.achieved ? 'success' : 'locked'"
     role="button"
-    :aria-label="props.achievement.title"
+    :aria-label="translate(props.achievement.title, props.achievement.titleParams)"
     @click="toggle"
   >
     <template #left>
@@ -24,12 +26,12 @@ function toggle() {
     </template>
 
     <div class="min-w-0 w-full flex cursor-pointer items-center justify-between">
-      <span class="flex-1 truncate font-bold">{{ props.achievement.title }}</span>
+      <span class="flex-1 truncate font-bold">{{ translate(props.achievement.title, props.achievement.titleParams) }}</span>
       <div class="i-carbon-chevron-down ml-2 transition-transform" :class="props.opened ? '' : 'rotate-90'" />
     </div>
 
     <div v-show="props.opened" class="mt-1 w-full text-xs">
-      <p>{{ props.achievement.description }}</p>
+      <p>{{ translate(props.achievement.description, props.achievement.descriptionParams) }}</p>
       <div v-if="!props.achievement.achieved && progress" class="mt-1">
         <div class="mb-1 text-center">
           {{ progress.value.toLocaleString() }} / {{ progress.max.toLocaleString() }}

--- a/src/components/panel/Achievements.vue
+++ b/src/components/panel/Achievements.vue
@@ -5,6 +5,7 @@ const store = useAchievementsStore()
 const filter = useAchievementsFilterStore()
 
 const { t } = useI18n()
+const { translate } = useTranslate()
 const statusOptions = [
   { label: t('components.panel.Achievements.all'), value: 'all' },
   { label: t('components.panel.Achievements.unlocked'), value: 'unlocked' },
@@ -27,13 +28,18 @@ const searchedList = computed(() => {
   if (!filter.search.trim())
     return list.value
   const q = filter.search.toLowerCase()
-  return list.value.filter(a => a.title.toLowerCase().includes(q))
+  return list.value.filter((a) => {
+    const title = translate(a.title, a.titleParams).toLowerCase()
+    return title.includes(q)
+  })
 })
 const sortedList = computed(() => {
   const arr = searchedList.value.slice()
   switch (filter.sortBy) {
     case 'name':
-      arr.sort((a, b) => a.title.localeCompare(b.title))
+      arr.sort((a, b) =>
+        translate(a.title, a.titleParams).localeCompare(translate(b.title, b.titleParams)),
+      )
       break
     case 'date':
       arr.sort((a, b) => (a.unlockedAt || 0) - (b.unlockedAt || 0))

--- a/src/composables/useTranslate.ts
+++ b/src/composables/useTranslate.ts
@@ -1,0 +1,17 @@
+export function useTranslate() {
+  const { t, te } = useI18n()
+
+  function translate(key: string, params?: Record<string, unknown>): string {
+    const resolved: Record<string, unknown> = {}
+    if (params) {
+      for (const [name, value] of Object.entries(params)) {
+        resolved[name] = typeof value === 'string' && te(value) ? t(value) : value
+      }
+    }
+    return te(key) ? t(key, resolved) : key
+  }
+
+  return { translate }
+}
+
+export type TranslateFn = ReturnType<typeof useTranslate>['translate']


### PR DESCRIPTION
## Summary
- keep translation keys in achievements store and emit unlocked items for external handling
- translate texts in consumers using new `useTranslate` composable
- centralize unlock notifications in `notifyAchievement`

## Testing
- `pnpm test:unit` *(fails: SyntaxError: Invalid arguments, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6895f726c8cc832aba59c051a51c7781