### PR TITLE
feat: add missing translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,7 +1,7 @@
 components:
   deck:
     DeckDetail:
-      evolution: "Evolution:"
+      evolution: 'Evolution:'
       level: lvl {n}
     DeckList:
       search: Search
@@ -9,7 +9,7 @@ components:
         name: Name
         type: Type
     Detail:
-      evolution: "Evolution:"
+      evolution: 'Evolution:'
       level: lvl {n}
     List:
       search: Search
@@ -48,13 +48,14 @@ components:
         name: Name
         date: Date unlocked
         progress: Progress
+      search: Search an achievement
     BonusDetails:
       intro1: The Shlagedex bonus matches your **potential ShlagéDex**. It represents the maximum bonus you could obtain by capturing all available Shlagémon.
       intro2: It is based on the completion rate of this potential Shlagedex as well as your team's average level.
       formula: Bonus = average level × 2 × (completion rate / 100) / 10
-      completion: "Completion:"
-      averageLevel: "Average level:"
-      currentBonus: "Current bonus:"
+      completion: 'Completion:'
+      averageLevel: 'Average level:'
+      currentBonus: 'Current bonus:'
     Inventory:
       sort:
         type: Type
@@ -67,8 +68,9 @@ components:
         activable: Activable
         battle: Battle
       equip: You equipped the {item}
+      search: Search an item
     PlayerInfos:
-      sick: "Sick: {n} battles left"
+      sick: 'Sick: {n} battles left'
       dex: ShlageDex
       averageLevel: Average level
       bonus: Bonus
@@ -130,7 +132,7 @@ components:
       defeat: Defeat...
       queen: queen
       king: king
-      zoneKingChallenge: "{label} zone challenge"
+      zoneKingChallenge: '{label} zone challenge'
       reward: +{amount} Shlagidiamonds
       retry: Retry
     CaptureLimitModal:
@@ -145,7 +147,7 @@ components:
       ownedTooltip: You already own this Shlagemon
       infoTooltip: View details
     DiseaseBadge:
-      tooltip: "Sick: {n} battles remaining"
+      tooltip: 'Sick: {n} battles remaining'
     EffectBadge:
       attack: Your attack is boosted for {remaining} more
       defense: Your defense is boosted for {remaining} more
@@ -230,7 +232,7 @@ components:
     Detail:
       equipItemTitle: Equip an item
       allowEvolution: Allow this Shlagemon to evolve?
-      firstCatch: "First capture: {date}"
+      firstCatch: 'First capture: {date}'
       obtainedTimes: Obtained {count} times
       release: Release
       main: Main
@@ -250,7 +252,7 @@ components:
       title: Choose an item to equip
       noAvailable: No item available.
     EvolutionModal:
-      evolveTitle: "{name} is evolving"
+      evolveTitle: '{name} is evolving'
       question: '"{from}" wants to evolve into "{to}", will you allow it or stop the spread of shlaguitude?'
       alreadyOwned: You already own this evolution
       yes: Yes
@@ -302,6 +304,9 @@ components:
       ok: Ok
     SelectOption:
       placeholder: Select…
+    SearchInput:
+      placeholder: Search
+      clear: Clear search
   dialog:
     AnotherShlagemonDialog:
       steps:
@@ -322,7 +327,7 @@ components:
           text: Congratulations! You triumphed at the arena.
           responses:
             collect: Collect the badge
-      toast: "{name} obtained!"
+      toast: '{name} obtained!'
     ArenaWelcomeDialog:
       steps:
         step1:
@@ -453,7 +458,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP."
+          text: 'As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP.'
           responses:
             back: Back
             next: Continue
@@ -577,7 +582,7 @@ components:
         step1:
           text: Impressive! You've captured at least {count} Shlagemons.
         step2:
-          text: "Here is a unique item: {name}."
+          text: 'Here is a unique item: {name}.'
         step3:
           text: It increases the holder's {stat} by {percent}%.
         step4:
@@ -750,7 +755,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "Let me tell you about a curious item: the Cuck Ring."
+          text: 'Let me tell you about a curious item: the Cuck Ring.'
           responses:
             back: Back
             next: Continue
@@ -760,7 +765,7 @@ components:
             back: Back
             next: Continue
         step4:
-          text: "It makes each attack unpredictable: double damage or healing the foe instead."
+          text: 'It makes each attack unpredictable: double damage or healing the foe instead.'
           responses:
             back: Back
             next: Continue
@@ -817,7 +822,7 @@ components:
         - You're one step away from a brain fart.
         - Rarely seen someone so pathetic.
       validate: Validate
-      attemptsLeft: "{n} attempts left"
+      attemptsLeft: '{n} attempts left'
       win: You've cracked a Shlag's mind!
       lose: Even a Grimer would have done it
       legend:
@@ -826,7 +831,7 @@ components:
         absent: Not in the combination
       selectSlot: Select a slot
     Pairs:
-      attempts: "{n} attempt | {n} attempts"
+      attempts: '{n} attempt | {n} attempts'
     masterMind:
       SelectionModal:
         title: Choose a Shlagemon
@@ -866,10 +871,10 @@ components:
       arena: Arena
       henhouse: Henhouse
       fightKing: Challenge the {label} of the zone
-      kingDefeated: "{label} defeated!"
+      kingDefeated: '{label} defeated!'
   zone:
     MonsModal:
-      title: "{zone} Shlagemons"
+      title: '{zone} Shlagemons'
   badge:
     BoxModal:
       title: Badge box
@@ -898,7 +903,7 @@ data:
         description: Cringeon was once cool. Cringeon spent too much time scratching minor chords at the edge of an extinct volcano. From now on, Cool's not cool wanders with a guitar too big for his wings, freckles crying, and a check shirt that smells wet grass and regrets. His plumage took on a sad rust colour, and his red wick hides a remorseful look, as if he constantly realized that he could have evolved into a legendary raptor, but preferred to release an independent EP. It's always a little cold around him, even in the summer. Its signature capacity, Refrain Getting into trouble, inflicts a deep discomfort on all the arena, reducing the accuracy of enemy attacks as long as they turn their eyes away. He's very good at driving wild Pokémons away… and dating.
         name: Cringeon
       sacdepates:
-        description: "Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Pastafreak undergoes a physical attack, he can wrap around the enemy to trap and immobilize."
+        description: 'Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Pastafreak undergoes a physical attack, he can wrap around the enemy to trap and immobilize.'
         name: Pastafreak
     05-10:
       aspigros:
@@ -923,7 +928,7 @@ data:
         description: A mass of foul mud that drags slowly. Where he passes, nothing grows because of his toxicity. It is made of a toxic mud. He pollutes everything he touches, even the ground becomes sterile. He stinks so much that people vanish just by crossing him. His body is a concentrate of toxins.
         name: Snotto
       ptitocard:
-        description: "Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure."
+        description: 'Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure.'
         name: Lamewag
     10-15:
       abraquemar:
@@ -1217,7 +1222,7 @@ data:
         description: Its endless language is dragging everywhere and is mainly used to slander. He likes to criticize his opponents until they abandon by weariness.
         name: Gossipbitch
       lecocu:
-        description: "Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness."
+        description: 'Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness.'
         name: cheated
       rhinofaringite:
         description: This sneezed rhinoceros sneezed from the rocks on its enemies. Its nose runs permanently, which makes it as slippery as it is unpredictable.
@@ -2286,7 +2291,7 @@ data:
       name: Pebble
       description: A tough rock-like type.
     vol:
-      name: AirEction
+      name: Flyass
       description: A flying type that reeks of musk.
     combat:
       name: Brawler
@@ -2399,7 +2404,7 @@ pages:
     title: Shlagedex
   privacy-policy:
     title: Privacy Policy – Shlagémon
-    lastUpdated: "Last updated: 06/08/2025"
+    lastUpdated: 'Last updated: 06/08/2025'
     sections:
       data:
         title: 1. Data collected
@@ -2427,24 +2432,37 @@ App:
   author: Shlagemon Team
 stores:
   achievements:
-    unlocked: "Achievement unlocked: {title}"
-    zoneShinyTitle: "{zone}: Rainbow Hunter"
+    unlocked: 'Achievement unlocked: {title}'
+    zoneShinyTitle: '{zone}: Rainbow Hunter'
     zoneShinyDescription: Capture every Shlagémon in {zone} in shiny form.
-    zoneRarityTitle: "{zone}: Perfectionist"
+    zoneRarityTitle: '{zone}: Perfectionist'
     zoneRarityDescription: Raise every Shlagémon in {zone} to rarity 100.
     zoneCompleteDescription: Capture every Shlagémon in {zone}.
-    zoneWinTitle: "{n} victories - {zone}"
+    zoneWinTitle: '{n} victories - {zone}'
     zoneWinDescription: Defeat {n} Shlagémon in {zone}.
+    shinyTitles:
+      '1': Shiny!
+      '10': 10 shinies
+      '100': 100 shinies
+      '1000': Living Legend
+    shinyDescription: Capture {n} extremely rare shiny Shlagémon.
+    itemTitles:
+      firstPurchase: First Purchase
+      serialBuyer: Serial Buyer
+      shopaholic: Confirmed Shopaholic
+      bankruptcy: Impending Bankruptcy
+      highRoller: Interstellar High Roller
+    itemDescription: Use {n} item{s} during your battles or explorations.
   disease:
     sick: Your Shlagemon is sick! It will be back to normal after winning {n} battles.
     cured: Your Shlagemon is no longer sick!
   shlagedex:
-    rarityReached: "{name} reached rarity {rarity}!"
-    evolved: "{name} evolved!"
+    rarityReached: '{name} reached rarity {rarity}!'
+    evolved: '{name} evolved!'
     obtained: You obtained {name}!
     alreadyMax: You already have this Shlagemon at max rarity
-    rarityChanged: "{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!"
-    released: "{name} was released!"
+    rarityChanged: '{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!'
+    released: '{name} was released!'
     point: point | points
     level: level | levels
   game:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -1,7 +1,7 @@
 components:
   deck:
     DeckDetail:
-      evolution: "Évolution :"
+      evolution: 'Évolution :'
       level: lvl {n}
     DeckList:
       search: Rechercher
@@ -9,7 +9,7 @@ components:
         name: Nom
         type: Type
     Detail:
-      evolution: "Évolution :"
+      evolution: 'Évolution :'
       level: lvl {n}
     List:
       search: Rechercher
@@ -48,13 +48,14 @@ components:
         name: Nom
         date: Date
         progress: Progression
+      search: Rechercher un succès
     BonusDetails:
       intro1: Le bonus du Shlagedex correspond à votre **ShlagéDex potentiel**. Il représente le bonus maximal que vous pourriez obtenir en capturant tous les Shlagémon accessibles.
       intro2: Il se base sur le pourcentage de complétion de ce ShlagéDex potentiel ainsi que sur le niveau moyen de votre équipe.
       formula: Bonus = niveau moyen × 2 × (taux de complétion / 100) / 10
-      completion: "Complétion :"
-      averageLevel: "Niveau moyen :"
-      currentBonus: "Bonus actuel :"
+      completion: 'Complétion :'
+      averageLevel: 'Niveau moyen :'
+      currentBonus: 'Bonus actuel :'
     Inventory:
       sort:
         type: Type
@@ -67,8 +68,9 @@ components:
         activable: Activable
         battle: Combat
       equip: Vous avez équipé la {item}
+      search: Rechercher un objet
     PlayerInfos:
-      sick: "Malade : {n} combats restants"
+      sick: 'Malade : {n} combats restants'
       dex: ShlagéDex
       averageLevel: Niveau moyen
       bonus: Bonus
@@ -145,7 +147,7 @@ components:
       ownedTooltip: Vous possédez déjà ce Shlagémon
       infoTooltip: Voir les détails
     DiseaseBadge:
-      tooltip: "Malade : {n} combats restants"
+      tooltip: 'Malade : {n} combats restants'
     EffectBadge:
       attack: Votre attaque est boostée pour encore {remaining}
       defense: Votre défense est boostée pour encore {remaining}
@@ -230,7 +232,7 @@ components:
     Detail:
       equipItemTitle: Équiper un objet
       allowEvolution: Autoriser ce Shlagémon à évoluer ?
-      firstCatch: "Première capture : {date}"
+      firstCatch: 'Première capture : {date}'
       obtainedTimes: Obtenu {count} fois
       release: Relâcher
       main: Principal
@@ -250,7 +252,7 @@ components:
       title: Choisir un objet à équiper
       noAvailable: Aucun objet disponible.
     EvolutionModal:
-      evolveTitle: "{name} évolue"
+      evolveTitle: '{name} évolue'
       question: « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
       yes: Oui
@@ -302,6 +304,9 @@ components:
       ok: Ok
     SelectOption:
       placeholder: Sélectionner…
+    SearchInput:
+      placeholder: Rechercher
+      clear: Effacer la recherche
   dialog:
     AnotherShlagemonDialog:
       steps:
@@ -322,7 +327,7 @@ components:
           text: Félicitations ! Tu as triomphé de l'arène.
           responses:
             collect: Récupérer le badge
-      toast: "{name} obtenu !"
+      toast: '{name} obtenu !'
     ArenaWelcomeDialog:
       steps:
         step1:
@@ -577,7 +582,7 @@ components:
         step1:
           text: Impressionnant ! Tu as capturé au moins {count} Shlagémons.
         step2:
-          text: "Voici un objet unique : {name}."
+          text: 'Voici un objet unique : {name}.'
         step3:
           text: Il augmente {stat} du porteur de {percent}%.
         step4:
@@ -817,7 +822,7 @@ components:
         - T'es à deux doigts de faire un pet cérébral.
         - Rarement vu quelqu'un aussi merdique.
       validate: Valider
-      attemptsLeft: "{n} tentatives restantes"
+      attemptsLeft: '{n} tentatives restantes'
       win: T'as percé le cerveau d'un Shlag !
       lose: Même un Petmorv y serait arrivé
       legend:
@@ -826,7 +831,7 @@ components:
         absent: Absent de la combinaison
       selectSlot: Sélectionne une case
     Pairs:
-      attempts: "{n} tentative | {n} tentatives"
+      attempts: '{n} tentative | {n} tentatives'
     masterMind:
       SelectionModal:
         title: Choisis un Shlagémon
@@ -866,7 +871,7 @@ components:
       arena: Arène
       henhouse: Poulailler
       fightKing: Défier la {label} de la zone
-      kingDefeated: "{label} vaincu{suffix} !"
+      kingDefeated: '{label} vaincu{suffix} !'
   zone:
     MonsModal:
       title: Shlagémons de {zone}
@@ -898,7 +903,7 @@ data:
         description: Roux pas Cool était anciennement cool. Roux pas Cool a passé trop de temps à gratter des accords mineurs au bord d’un volcan éteint. Désormais, Roux pas Cool erre avec une guitare trop grande pour ses ailes, des taches de rousseur qui pleurent, et une chemise à carreaux qui sent l’herbe humide et les regrets. Son plumage a pris une teinte rouille triste, et sa mèche rousse cache un regard empli de remords, comme s’il réalisait constamment qu’il aurait pu évoluer en rapace légendaire, mais a préféré sortir un EP en indépendant. Il fait toujours un peu froid autour de lui, même en plein été. Sa capacité signature, Refrain Gênant, inflige un malaise profond à toute l’arène, réduisant la précision des attaques ennemies tant qu’ils détournent le regard. Il est très doué pour faire fuir les Pokémon sauvages… et les rendez-vous galants.
         name: Roux pas Cool
       sacdepates:
-        description: "Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser."
+        description: 'Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser.'
         name: Sac de Pâtes
     05-10:
       aspigros:
@@ -923,7 +928,7 @@ data:
         description: Une masse de boue nauséabonde qui se traîne lentement. Là où il passe, plus rien ne pousse à cause de sa toxicité. Il est fait d'une boue toxique. Il pollue tout ce qu’il touche, même le sol devient stérile. Il pue tellement que des gens s’évanouissent rien qu’en le croisant. Son corps est un concentré de toxines.
         name: Metamorve
       ptitocard:
-        description: "Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr."
+        description: 'Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr.'
         name: Ptitocard
     10-15:
       abraquemar:
@@ -1211,7 +1216,7 @@ data:
         description: Sa langue interminable traîne partout et sert principalement à médire. Il aime critiquer ses adversaires jusqu'à ce qu'ils abandonnent par lassitude.
         name: Languedepute
       lecocu:
-        description: "Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante."
+        description: 'Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.'
         name: Lecocu
       rhinofaringite:
         description: Ce rhinocéros enrhumé éternue des rochers sur ses ennemis. Son nez coule en permanence, ce qui le rend aussi glissant qu'imprévisible.
@@ -1264,7 +1269,7 @@ data:
         Aujourd’hui, Artichaud veille sur les zones de non-droit climatiques, où il impose son règne moite et frigorifié, entre deux éternuements fumants et des engelures de l’aisselle.
       name: Artichaud
     bulgrosboule:
-      description: "Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller."
+      description: 'Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller.'
       name: Bulgrosboule
     carapouffe:
       description: Carapouffe s'est enfoncée dans sa propre carapace moelleuse, elle ne se déplace qu’en roulant lentement, laissant derrière elle une traînée de paillettes et de gloss fondu. Son maquillage dégouline en permanence, formant une couche protectrice impénétrable — les scientifiques appellent ça le « fard d’armure ». Dotée d’un regard mi-séduisant, mi-comateux, elle hypnotise ses adversaires en leur lançant des œillades flasques, accompagnées d’un soupir de lassitude cosmique. Elle passe ses journées à se recoiffer sans bouger la tête, grâce à un système complexe de brosses dissimulées dans son chignon. Sa voix est rauque, son parfum est toxique, et sa principale attaque, "Écrasement Moussant", consiste à s’écrouler violemment sur son ennemi en faisant claquer ses faux ongles.
@@ -2273,7 +2278,7 @@ data:
       name: Caillasse
       description: Type roc très coriace.
     vol:
-      name: AirEction
+      name: Flyass
       description: Type aérien mais qui sent la teub.
     combat:
       name: Castagne
@@ -2386,7 +2391,7 @@ pages:
     title: Shlagédex
   privacy-policy:
     title: Politique de Confidentialité – Shlagémon
-    lastUpdated: "Dernière mise à jour : 06/08/2025"
+    lastUpdated: 'Dernière mise à jour : 06/08/2025'
     sections:
       data:
         title: 1. Données collectées
@@ -2414,24 +2419,37 @@ App:
   author: Shlagémon Team
 stores:
   achievements:
-    unlocked: "Succès déverrouillé : {title}"
+    unlocked: 'Succès déverrouillé : {title}'
     zoneShinyTitle: "{zone} : Chasseur d'arc-en-ciel"
     zoneShinyDescription: Capturer tous les Shlagémon de {zone} en version shiny.
-    zoneRarityTitle: "{zone} : Perfectionniste"
+    zoneRarityTitle: '{zone} : Perfectionniste'
     zoneRarityDescription: Amener tous les Shlagémon de {zone} à la rareté 100.
     zoneCompleteDescription: Capturer tous les Shlagémon de {zone}.
-    zoneWinTitle: "{n} victoires - {zone}"
+    zoneWinTitle: '{n} victoires - {zone}'
     zoneWinDescription: Vaincre {n} Shlagémon dans {zone}.
+    shinyTitles:
+      '1': Shiny!
+      '10': 10 shinies
+      '100': 100 shinies
+      '1000': Légende vivante
+    shinyDescription: Capturer {n} Shlagémon shiny extrêmement rares.
+    itemTitles:
+      firstPurchase: Premier craquage
+      serialBuyer: Acheteur en série
+      shopaholic: Shopaholic confirmé
+      bankruptcy: Banqueroute imminente
+      highRoller: Flambeur intersidéral
+    itemDescription: Utiliser {n} objet{s} pendant vos combats ou explorations.
   disease:
     sick: Votre Shlagémon est malade ! Il reviendra à la normal après avoir gagné {n} combats.
     cured: Votre Shlagémon n'est plus malade !
   shlagedex:
-    rarityReached: "{name} atteint la rareté {rarity} !"
-    evolved: "{name} a évolué !"
+    rarityReached: '{name} atteint la rareté {rarity} !'
+    evolved: '{name} a évolué !'
     obtained: Tu as obtenu {name} !
     alreadyMax: Vous avez déjà ce Shlagémon au maximum de sa rareté
-    rarityChanged: "{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !"
-    released: "{name} a été relâché !"
+    rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
+    released: '{name} a été relâché !'
     point: point | points
     level: niveau | niveaux
   game:

--- a/src/components/panel/Achievements.i18n.yml
+++ b/src/components/panel/Achievements.i18n.yml
@@ -2,6 +2,7 @@ fr:
   all: Tous
   unlocked: Débloqués
   locked: À débloquer
+  search: Rechercher un succès
   sort:
     name: Nom
     date: Date
@@ -10,6 +11,7 @@ en:
   all: All
   unlocked: Unlocked
   locked: To unlock
+  search: Search an achievement
   sort:
     name: Name
     date: Date unlocked

--- a/src/components/panel/Achievements.vue
+++ b/src/components/panel/Achievements.vue
@@ -82,7 +82,11 @@ function toggleItem(id: string) {
           v-model:sort-asc="filter.sortAsc"
           :options="sortOptions"
         />
-        <UiSearchInput v-model="filter.search" class="min-w-22 flex-1" />
+        <UiSearchInput
+          v-model="filter.search"
+          class="min-w-22 flex-1"
+          :placeholder="t('components.panel.Achievements.search')"
+        />
       </div>
     </template>
 

--- a/src/components/panel/Inventory.i18n.yml
+++ b/src/components/panel/Inventory.i18n.yml
@@ -1,4 +1,5 @@
 fr:
+  search: Rechercher un objet
   sort:
     type: Type
     name: Nom
@@ -11,6 +12,7 @@ fr:
     battle: Combat
   equip: 'Vous avez équipé la {item}'
 en:
+  search: Search an item
   sort:
     type: Type
     name: Name

--- a/src/components/panel/Inventory.vue
+++ b/src/components/panel/Inventory.vue
@@ -253,7 +253,11 @@ function onUse(item: Item) {
         v-model:sort-asc="filter.sortAsc"
         :options="sortOptions"
       />
-      <UiSearchInput v-model="filter.search" class="min-w-22 flex-1" />
+      <UiSearchInput
+        v-model="filter.search"
+        class="min-w-22 flex-1"
+        :placeholder="t('components.panel.Inventory.search')"
+      />
     </div>
     <UiTabs
       v-if="availableCategories.length > 0"

--- a/src/components/ui/SearchInput.i18n.yml
+++ b/src/components/ui/SearchInput.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  placeholder: Rechercher
+  clear: Effacer la recherche
+en:
+  placeholder: Search
+  clear: Clear search

--- a/src/components/ui/SearchInput.vue
+++ b/src/components/ui/SearchInput.vue
@@ -5,13 +5,12 @@ const props = withDefaults(defineProps<{
   disabled?: boolean
   isCompact?: boolean
 }>(), {
-  placeholder: 'Recherche',
   modelValue: '',
   disabled: false,
   isCompact: true,
 })
 const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>()
-
+const { t } = useI18n()
 function onInput(e: Event) {
   emit('update:modelValue', (e.target as HTMLInputElement).value)
 }
@@ -25,7 +24,7 @@ function clear() {
     <input
       :value="props.modelValue"
       type="text"
-      :placeholder="props.placeholder"
+      :placeholder="props.placeholder ?? t('placeholder')"
       :disabled="props.disabled"
       class="w-full border-2 border-slate-400 rounded-lg bg-white pr-10 text-sm text-slate-800 shadow-sm transition-all dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-sky-500" :class="[
         props.isCompact
@@ -42,7 +41,7 @@ function clear() {
           ? 'h-5 w-5 text-base'
           : 'h-6 w-6 text-lg',
       ]"
-      aria-label="Effacer la recherche"
+      :aria-label="t('clear')"
       :tabindex="0"
       @click="clear"
     >

--- a/src/components/ui/SortControls.vue
+++ b/src/components/ui/SortControls.vue
@@ -11,6 +11,8 @@ const emit = defineEmits<{
   (e: 'update:sortAsc', value: boolean): void
 }>()
 
+const { t } = useI18n()
+
 function updateSortBy(value: string | number) {
   emit('update:sortBy', value)
 }
@@ -29,7 +31,7 @@ function toggleAsc() {
     />
     <button
       class="icon-btn ml-1 text-lg"
-      :aria-label="props.sortAsc ? 'Tri ascendant' : 'Tri descendant'"
+      :aria-label="props.sortAsc ? t('components.ui.SortControls.ascending') : t('components.ui.SortControls.descending')"
       @click="toggleAsc"
     >
       <div :class="props.sortAsc ? 'i-carbon-sort-ascending' : 'i-carbon-sort-descending'" />

--- a/src/data/shlagemons-type.i18n.yml
+++ b/src/data/shlagemons-type.i18n.yml
@@ -18,7 +18,7 @@ fr:
     name: Caillasse
     description: Type roc très coriace.
   vol:
-    name: AirEction
+    name: Flyass
     description: Type aérien mais qui sent la teub.
   combat:
     name: Castagne
@@ -73,7 +73,7 @@ en:
     name: Pebble
     description: A tough rock-like type.
   vol:
-    name: AirEction
+    name: Flyass
     description: A flying type that reeks of musk.
   combat:
     name: Brawler

--- a/src/stores/achievements.i18n.yml
+++ b/src/stores/achievements.i18n.yml
@@ -7,6 +7,19 @@ fr:
   zoneCompleteDescription: 'Capturer tous les Shlagémon de {zone}.'
   zoneWinTitle: '{n} victoires - {zone}'
   zoneWinDescription: 'Vaincre {n} Shlagémon dans {zone}.'
+  shinyTitles:
+    1: Shiny!
+    10: 10 shinies
+    100: 100 shinies
+    1000: Légende vivante
+  shinyDescription: 'Capturer {n} Shlagémon shiny extrêmement rares.'
+  itemTitles:
+    firstPurchase: Premier craquage
+    serialBuyer: Acheteur en série
+    shopaholic: Shopaholic confirmé
+    bankruptcy: Banqueroute imminente
+    highRoller: Flambeur intersidéral
+  itemDescription: 'Utiliser {n} objet{s} pendant vos combats ou explorations.'
 en:
   unlocked: 'Achievement unlocked: {title}'
   zoneShinyTitle: '{zone}: Rainbow Hunter'
@@ -16,3 +29,16 @@ en:
   zoneCompleteDescription: 'Capture every Shlagémon in {zone}.'
   zoneWinTitle: '{n} victories - {zone}'
   zoneWinDescription: 'Defeat {n} Shlagémon in {zone}.'
+  shinyTitles:
+    1: Shiny!
+    10: 10 shinies
+    100: 100 shinies
+    1000: Living Legend
+  shinyDescription: 'Capture {n} extremely rare shiny Shlagémon.'
+  itemTitles:
+    firstPurchase: First Purchase
+    serialBuyer: Serial Buyer
+    shopaholic: Confirmed Shopaholic
+    bankruptcy: Impending Bankruptcy
+    highRoller: Interstellar High Roller
+  itemDescription: 'Use {n} item{s} during your battles or explorations.'

--- a/src/stores/achievements.ts
+++ b/src/stores/achievements.ts
@@ -160,8 +160,9 @@ export const useAchievementsStore = defineStore('achievements', () => {
   shinyThresholds.forEach((n) => {
     const def = {
       id: `shiny-${n}`,
-      title: n === 1 ? 'Shiny!' : `${n.toLocaleString()} shiny`,
-      description: `Capturer ${n.toLocaleString()} Shlagémon shiny extrêmement rares.`,
+      title: `stores.achievements.shinyTitles.${n}`,
+      description: 'stores.achievements.shinyDescription',
+      descriptionParams: { n: n.toLocaleString() },
       icon: 'carbon:star',
     }
     defs.push(def)
@@ -169,18 +170,19 @@ export const useAchievementsStore = defineStore('achievements', () => {
   })
 
   const itemThresholds = [1, 10, 100, 1000, 10000]
-  const itemTitles: Record<number, string> = {
-    1: 'Premier craquage',
-    10: 'Acheteur en série',
-    100: 'Shopaholic confirmé',
-    1000: 'Banqueroute imminente',
-    10000: 'Flambeur intersidéral',
+  const itemTitleKeys: Record<number, string> = {
+    1: 'firstPurchase',
+    10: 'serialBuyer',
+    100: 'shopaholic',
+    1000: 'bankruptcy',
+    10000: 'highRoller',
   }
   itemThresholds.forEach((n) => {
     const def = {
       id: `item-${n}`,
-      title: itemTitles[n],
-      description: `Utiliser ${n.toLocaleString()} objet${n > 1 ? 's' : ''} pendant vos combats ou explorations.`,
+      title: `stores.achievements.itemTitles.${itemTitleKeys[n]}`,
+      description: 'stores.achievements.itemDescription',
+      descriptionParams: { n: n.toLocaleString(), s: n > 1 ? 's' : '' },
       icon: 'carbon:shopping-bag',
     }
     defs.push(def)


### PR DESCRIPTION
## Summary
- translate sort order controls and search input
- localize inventory and achievements search placeholders
- rename AirEction type to Flyass and expose achievement titles

## Testing
- `pnpm test` *(fails: battle-item-cooldown.test.ts, capture.test.ts, page-locale-ssr.test.ts, rarity-info.test.ts, router-redirect.test.ts, sort-item.test.ts)*
- `pnpm lint` *(fails: Strings must use singlequote etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6896052474a4832abe54bd0f3f2a82b3