### PR TITLE
feat: prevent multi exp equip from auto-selecting active

### DIFF
--- a/src/stores/equipment.ts
+++ b/src/stores/equipment.ts
@@ -11,6 +11,13 @@ export const useEquipmentStore = defineStore('equipment', () => {
     return vitalityIds.includes(id)
   }
 
+  /**
+   * Equip an item to a Shlagémon.
+   *
+   * The equipped Shlagémon becomes the active one unless the item is the
+   * Multi Exp, which is a passive team item and should not change the active
+   * selection.
+   */
   function equip(monId: string, itemId: string) {
     const mon = dex.shlagemons.find(m => m.id === monId)
     if (!mon)
@@ -41,7 +48,9 @@ export const useEquipmentStore = defineStore('equipment', () => {
     inventory.remove(itemId)
     if (isVitalityItem(itemId))
       mon.hpCurrent = dex.maxHp(mon)
-    if (itemId !== multiExp.id)
+
+    const shouldSelectActive = itemId !== multiExp.id
+    if (shouldSelectActive)
       dex.setActiveShlagemon(mon)
   }
 

--- a/test/equipment-multi-exp-active.test.ts
+++ b/test/equipment-multi-exp-active.test.ts
@@ -1,0 +1,25 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { multiExp } from '../src/data/items'
+import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
+import { useEquipmentStore } from '../src/stores/equipment'
+import { useInventoryStore } from '../src/stores/inventory'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('equipping multi exp', () => {
+  it('does not change the active shlagemon', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const inventory = useInventoryStore()
+    const equipment = useEquipmentStore()
+
+    const active = dex.createShlagemon(pikachiant)
+    const holder = dex.createShlagemon(pikachiant)
+    dex.setActiveShlagemon(active)
+    inventory.add(multiExp.id)
+
+    equipment.equip(holder.id, multiExp.id)
+
+    expect(dex.activeShlagemon?.id).toBe(active.id)
+  })
+})


### PR DESCRIPTION
## Summary
- document and guard against auto-selecting active shlagémon when equipping the Multi Exp
- add unit test ensuring equipping Multi Exp keeps current active shlagémon

## Testing
- `pnpm lint` *(fails: Strings must use singlequote in locales)*
- `pnpm exec eslint src/stores/equipment.ts test/equipment-multi-exp-active.test.ts`
- `pnpm test:unit test/equipment-multi-exp-active.test.ts`
- `pnpm typecheck` *(fails: Argument of type 'string' is not assignable to parameter of type 'Locale')*

------
https://chatgpt.com/codex/tasks/task_e_6896754cb7f4832a9d5c8593199f9a24