### PR TITLE
Merge evolution stats when evolution already owned

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -432,17 +432,23 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const existing = shlagemons.value.find(m => m.base.id === to.id && m.id !== mon.id)
     if (existing) {
       existing.captureCount += 1
-      if (existing.rarity < 100) {
+      // Merge attributes with existing evolution, keeping the best stats.
+      if (mon.rarity > existing.rarity && existing.rarity < 100) {
         const before = existing.rarity
-        existing.rarity += 1
+        existing.rarity = mon.rarity
         maybePlayRaritySfx(existing, before)
         toast(i18n.global.t('stores.shlagedex.rarityReached', {
           name: i18n.global.t(existing.base.name),
           rarity: existing.rarity,
         }))
       }
-      existing.lvl = 1
-      existing.xp = 0
+      if (mon.lvl > existing.lvl) {
+        existing.lvl = mon.lvl
+        existing.xp = mon.xp
+      }
+      else if (mon.lvl === existing.lvl) {
+        existing.xp = Math.max(existing.xp, mon.xp)
+      }
       applyStats(existing)
       applyCurrentStats(existing)
       existing.hpCurrent = maxHp(existing)

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -65,6 +65,25 @@ describe('evolution', () => {
     expect(existing.isShiny).toBe(true)
   })
 
+  it('keeps highest rarity and level when evolution already owned', async () => {
+    setActivePinia(createPinia())
+    const zone = useZoneStore()
+    const dex = useShlagedexStore()
+    const evo = useEvolutionStore()
+    vi.spyOn(evo, 'requestEvolution').mockResolvedValue(true)
+    zone.setZone('plaine-kekette')
+    const existing = dex.createShlagemon(kadavrebras)
+    existing.rarity = 5
+    existing.lvl = 10
+    const mon = dex.createShlagemon(abraquemar)
+    mon.rarity = 20
+    mon.lvl = 45
+    await dex.gainXp(mon, xpForLevel(mon.lvl))
+    expect(dex.shlagemons.length).toBe(1)
+    expect(existing.rarity).toBe(20)
+    expect(existing.lvl).toBe(46)
+  })
+
   it('processes only the first evolution when multiple levels are gained', async () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()


### PR DESCRIPTION
## Summary
- merge duplicate evolutions by keeping highest rarity, level, and shiny state
- add regression test for evolution stat merging

## Testing
- `pnpm lint` *(fails: strings must use singlequote in locales/en.yml)*
- `npx eslint src/stores/shlagedex.ts test/evolution.test.ts`
- `pnpm typecheck` *(fails: Property 'maxLevel' does not exist on type...)*
- `npx tsc --noEmit src/stores/shlagedex.ts test/evolution.test.ts` *(fails: Overload signatures must all be optional or required)*
- `pnpm test` *(fails: 7 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689681f10c74832abff5f7cb14801d2a