### PR TITLE
fix: hide arena icons for zones without arena

### DIFF
--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -65,36 +65,39 @@ export function useMapMarkers(map: LeafletMap) {
 
     function buildHtml() {
       const highlight = !visited.value && !locked ? 'animate-pulse-alt' : ''
-      const icon = `<img src="${iconPath(zone)}" class="w-${iconClassSize} h-${iconClassSize} block ${highlight}" />`
-      const ballStyle = !allCaptured.value
-        ? 'filter: grayscale(1) opacity(0.9);'
-        : perfectZone.value
-          ? 'filter: brightness(1.1) drop-shadow(0 0 2px #facc15) drop-shadow(0 0 4px #facc15) drop-shadow(0 0 6px #facc15);'
-          : ''
-      const ball = zone.type !== 'village'
-        ? `<img src="/items/shlageball/shlageball.webp" class="h-3 w-3" style="${ballStyle}" />`
-        : ''
-      const shiny = allShiny.value
+
+      let iconStyle = ''
+      if (zone.type !== 'village') {
+        iconStyle = !allCaptured.value
+          ? 'filter: grayscale(1) opacity(0.9);'
+          : perfectZone.value
+            ? 'filter: brightness(1.1) drop-shadow(0 0 2px #facc15) drop-shadow(0 0 4px #facc15) drop-shadow(0 0 6px #facc15);'
+            : ''
+      }
+      const baseIcon = `<img src="${iconPath(zone)}" class="w-${iconClassSize} h-${iconClassSize} block ${highlight}" style="${iconStyle}" />`
+      const shiny = zone.type !== 'village' && allShiny.value
         ? '<div class="i-mdi:star h-2 w-2 mask-rainbow absolute -top-1 -right-1"></div>'
         : ''
-      let fullBall
-      if (allShiny) {
-        fullBall = `<div class="relative">${ball} ${shiny}</div>`
-      }
-      else {
-        fullBall = ball
-      }
-      const crown = kingDefeated.value ? '<div class="i-game-icons:crown h-3 w-3"></div>' : ''
-      const arena = arenaCompleted.value
-        ? '<div class="i-mdi:sword-cross h-3 w-3"></div>'
-        : zone.type === 'village' && zone.pois.arena
-          ? '<div class="i-mdi:sword-cross h-3 w-3 opacity-50 grayscale"></div>'
-          : ''
+      const icon = shiny ? `<div class="relative">${baseIcon}${shiny}</div>` : baseIcon
 
-      const icons = [fullBall, crown, arena].filter(Boolean).join('')
+      let icons = ''
+      if (zone.type === 'village') {
+        const crown = kingDefeated.value ? '<div class="i-game-icons:crown h-3 w-3"></div>' : ''
+        let arena = ''
+        if (arenaCompleted.value)
+          arena = '<div class="i-mdi:sword-cross h-3 w-3"></div>'
+        else if (zone.pois?.arena)
+          arena = '<div class="i-mdi:sword-cross h-3 w-3 opacity-50 grayscale"></div>'
+        icons = [crown, arena].filter(Boolean).join('')
+      }
+
+      const iconsContainer = icons
+        ? `<div class="flex gap-0.5 -mt-1 bg-dark/75 px-2 py-1 rounded-full">${icons}</div>`
+        : ''
+
       return `<div class="flex flex-col items-center ${locked ? 'grayscale opacity-50' : ''}">
         ${icon}
-        <div class="flex gap-0.5 -mt-1 bg-dark/75 px-2 py-1 rounded-full">${icons}</div>
+        ${iconsContainer}
       </div>`
     }
 

--- a/test/map-marker-tooltip.test.ts
+++ b/test/map-marker-tooltip.test.ts
@@ -40,11 +40,12 @@ describe('useMapMarkers', () => {
 
   beforeEach(() => {
     useLeafletMarkerMock.mockClear()
+    useZoneCompletionMock.mockReset()
   })
 
   it('assigns zone name as marker title', () => {
     useZoneCompletionMock.mockReturnValue({
-      allCaptured: ref(false),
+      allCaptured: ref(true),
       perfectZone: ref(false),
       allShiny: ref(false),
       kingDefeated: ref(false),
@@ -58,10 +59,64 @@ describe('useMapMarkers', () => {
     )
   })
 
-  it('renders shiny star when all mons are shiny', () => {
+  it('omits icon container for non-village zones', () => {
     useZoneCompletionMock.mockReturnValue({
       allCaptured: ref(true),
       perfectZone: ref(false),
+      allShiny: ref(false),
+      kingDefeated: ref(true),
+      arenaCompleted: ref(false),
+    })
+    const dummyMap = {} as LeafletMap
+    const { addMarker } = useMapMarkers(dummyMap)
+    addMarker(zone)
+    const html = useLeafletMarkerMock.mock.calls[0][0].html as string
+    expect(html).not.toContain('bg-dark/75')
+  })
+
+  it('does not render grey arena icon when village lacks an arena', () => {
+    useZoneCompletionMock.mockReturnValue({
+      allCaptured: ref(true),
+      perfectZone: ref(false),
+      allShiny: ref(false),
+      kingDefeated: ref(false),
+      arenaCompleted: ref(false),
+    })
+    const dummyMap = {} as LeafletMap
+    const { addMarker } = useMapMarkers(dummyMap)
+    const village: Zone = {
+      id: 'test-village',
+      name: 'test.village.name',
+      type: 'village',
+      villageType: 'basic',
+      position: { lat: 0, lng: 0 },
+      minLevel: 1,
+      pois: {},
+    }
+    addMarker(village)
+    const html = useLeafletMarkerMock.mock.calls[0][0].html as string
+    expect(html).not.toContain('i-mdi:sword-cross')
+  })
+
+  it('applies grayscale style when zone not fully captured', () => {
+    useZoneCompletionMock.mockReturnValue({
+      allCaptured: ref(false),
+      perfectZone: ref(false),
+      allShiny: ref(false),
+      kingDefeated: ref(false),
+      arenaCompleted: ref(false),
+    })
+    const dummyMap = {} as LeafletMap
+    const { addMarker } = useMapMarkers(dummyMap)
+    addMarker(zone)
+    const html = useLeafletMarkerMock.mock.calls[0][0].html as string
+    expect(html).toContain('grayscale(1)')
+  })
+
+  it('adds shiny star and perfect zone effects when applicable', () => {
+    useZoneCompletionMock.mockReturnValue({
+      allCaptured: ref(true),
+      perfectZone: ref(true),
       allShiny: ref(true),
       kingDefeated: ref(false),
       arenaCompleted: ref(false),
@@ -71,20 +126,6 @@ describe('useMapMarkers', () => {
     addMarker(zone)
     const html = useLeafletMarkerMock.mock.calls[0][0].html as string
     expect(html).toContain('mask-rainbow')
-  })
-
-  it('adds golden aura to ball when zone is perfect', () => {
-    useZoneCompletionMock.mockReturnValue({
-      allCaptured: ref(true),
-      perfectZone: ref(true),
-      allShiny: ref(false),
-      kingDefeated: ref(false),
-      arenaCompleted: ref(false),
-    })
-    const dummyMap = {} as LeafletMap
-    const { addMarker } = useMapMarkers(dummyMap)
-    addMarker(zone)
-    const html = useLeafletMarkerMock.mock.calls[0][0].html as string
     expect(html).toContain('drop-shadow(0 0 2px #facc15)')
   })
 })


### PR DESCRIPTION
## Summary
- apply completion styles for wild zones without rendering icon container
- ensure villages still show crown or arena icons when applicable
- cover zone completion visuals in map marker tests

## Testing
- `pnpm lint` *(fails: Expected indentation of 4 spaces but found 2, etc.)*
- `pnpm test` *(fails: battle-item-cooldown, page-locale-ssr, router-redirect, sort-item, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68967581ffbc832a80267aff8afd9e8c