### PR TITLE
fix: capitalize English shlagemon names

### DIFF
--- a/src/data/shlagemons/55-60/pauvreetcon.i18n.yml
+++ b/src/data/shlagemons/55-60/pauvreetcon.i18n.yml
@@ -1,6 +1,6 @@
 en:
   description: Pooretcon is a heap of wobbly polygons from a computer bug. He clumsily floats by looking for his Wi-Fi connection and displays a blue screen from time to time as a cry.
-  name: pooranddumb
+  name: Pooranddumb
 fr:
   description: Pauvreetcon est un amas de polygones bancals issu d’un bug informatique. Il flotte maladroitement en cherchant sa connexion Wi-Fi et affiche de temps en temps un écran bleu en guise de cri.
   name: Pauvreetcon

--- a/src/data/shlagemons/80-85/lecocu.i18n.yml
+++ b/src/data/shlagemons/80-85/lecocu.i18n.yml
@@ -1,6 +1,6 @@
 en:
   description: 'Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness.'
-  name: cheated
+  name: Cheated
 fr:
   description: 'Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.'
   name: Lecocu

--- a/src/data/shlagemons/evolutions/gravaglaire.i18n.yml
+++ b/src/data/shlagemons/evolutions/gravaglaire.i18n.yml
@@ -11,4 +11,4 @@ en:
     By smoking poor quality shit, he spends his days coughing and spitting viscous mucus on his enemies. Sometimes a thin smoke still escapes from its nostrils or its mouth. He drags packages of dirty handkerchiefs and wiped the muzzle of a rocky arm.
     ** Signature attack: ***Jet of mucus* - GRAVAGLAIRE expels an enormous mugging and toxic mucus that sticks to the target, slows down and disgusts all the shlagemons around.
     It is said that no one wants to sit next to him, even in abandoned squats. But, despite his filth and his mucus, he always keeps his eternal cap and an even more holes.
-  name: phlegm
+  name: Phlegm

--- a/src/data/shlagemons/evolutions/parasecte.i18n.yml
+++ b/src/data/shlagemons/evolutions/parasecte.i18n.yml
@@ -13,4 +13,4 @@ en:
     He does not fight. He *evangelized *. His disciples, nicknamed "ferments", spread his word in underground pipes and parking lots. Their initiation ritual? Sleep 48 hours in a damp tupperware while listening to mumbled sermons through a used surgical mask.
     His signature attack, *Revelation Sporal *, releases an explosion of spores which forces the enemy to meditate on the sense of mold. The attack * fungal blessing * heals all the allies, but replaces their free will with an irrepressible desire to recite texts in a low voice in laundry rooms.
     Parasect does not seek victory. He is looking for *universal humidity *. And you, are you ready to hear the Call of the Total Champi?
-  name: cultleader
+  name: Cultleader

--- a/src/data/shlagemons/evolutions/tuberculi.i18n.yml
+++ b/src/data/shlagemons/evolutions/tuberculi.i18n.yml
@@ -3,4 +3,4 @@ fr:
   name: Tuberculi
 en:
   description: Permanently traveled by sickly sparks, Tuberculi coughs electric arches on his opponents.
-  name: tuberculosis
+  name: Tuberculosis


### PR DESCRIPTION
## Summary
- capitalize English names for Pauvreetcon, Gravaglaire, Tuberculi, Parasecte, and Lecocu

## Testing
- `pnpm lint` *(fails: Strings must use singlequote, and more)*
- `pnpm test:unit` *(fails: battle item cooldown, capture mechanics, router redirect, sort item, and others)*

------
https://chatgpt.com/codex/tasks/task_e_6896847590c0832a9c62dd14b611c63c