### PR TITLE
feat: enhance map marker badges

### DIFF
--- a/src/composables/useZoneCompletion.ts
+++ b/src/composables/useZoneCompletion.ts
@@ -40,15 +40,13 @@ export function useZoneCompletion(zone: Zone) {
     })
   })
 
-  const kingDefeated = computed(() => {
-    const hasKing
-        = zone.type === 'sauvage'
-          ? zone.hasKing !== false
-          : !!zone.pois.king
-    return hasKing && progress.isKingDefeated(zone.id)
-  })
+  const hasKing = computed(() => (zone.type === 'sauvage'
+    ? zone.hasKing !== false
+    : !!zone.pois.king))
+
+  const kingDefeated = computed(() => hasKing.value && progress.isKingDefeated(zone.id))
 
   const arenaCompleted = computed(() => progress.isArenaCompleted(zone.id))
 
-  return { allCaptured, perfectZone, allShiny, kingDefeated, arenaCompleted }
+  return { allCaptured, perfectZone, allShiny, hasKing, kingDefeated, arenaCompleted }
 }

--- a/src/utils/iconStyles.ts
+++ b/src/utils/iconStyles.ts
@@ -1,0 +1,5 @@
+/**
+ * Shared CSS filter strings for marker badges.
+ */
+export const GREY_FILTER = 'filter:grayscale(1) opacity(0.9);'
+export const GOLD_FILTER = 'filter:brightness(1.08) drop-shadow(0 0 2px #facc15) drop-shadow(0 0 4px #facc15) drop-shadow(0 0 6px #facc15);'

--- a/test/map-marker-tooltip.test.ts
+++ b/test/map-marker-tooltip.test.ts
@@ -48,6 +48,7 @@ describe('useMapMarkers', () => {
       allCaptured: ref(true),
       perfectZone: ref(false),
       allShiny: ref(false),
+      hasKing: ref(true),
       kingDefeated: ref(false),
       arenaCompleted: ref(false),
     })
@@ -59,11 +60,12 @@ describe('useMapMarkers', () => {
     )
   })
 
-  it('omits icon container for non-village zones', () => {
+  it('renders badge container for non-village zones', () => {
     useZoneCompletionMock.mockReturnValue({
       allCaptured: ref(true),
       perfectZone: ref(false),
       allShiny: ref(false),
+      hasKing: ref(true),
       kingDefeated: ref(true),
       arenaCompleted: ref(false),
     })
@@ -71,7 +73,7 @@ describe('useMapMarkers', () => {
     const { addMarker } = useMapMarkers(dummyMap)
     addMarker(zone)
     const html = useLeafletMarkerMock.mock.calls[0][0].html as string
-    expect(html).not.toContain('bg-dark/75')
+    expect(html).toContain('bg-dark/75')
   })
 
   it('does not render grey arena icon when village lacks an arena', () => {
@@ -79,6 +81,7 @@ describe('useMapMarkers', () => {
       allCaptured: ref(true),
       perfectZone: ref(false),
       allShiny: ref(false),
+      hasKing: ref(false),
       kingDefeated: ref(false),
       arenaCompleted: ref(false),
     })
@@ -103,6 +106,7 @@ describe('useMapMarkers', () => {
       allCaptured: ref(false),
       perfectZone: ref(false),
       allShiny: ref(false),
+      hasKing: ref(true),
       kingDefeated: ref(false),
       arenaCompleted: ref(false),
     })
@@ -118,6 +122,7 @@ describe('useMapMarkers', () => {
       allCaptured: ref(true),
       perfectZone: ref(true),
       allShiny: ref(true),
+      hasKing: ref(true),
       kingDefeated: ref(false),
       arenaCompleted: ref(false),
     })
@@ -126,6 +131,22 @@ describe('useMapMarkers', () => {
     addMarker(zone)
     const html = useLeafletMarkerMock.mock.calls[0][0].html as string
     expect(html).toContain('mask-rainbow')
-    expect(html).toContain('drop-shadow(0 0 2px #facc15)')
+    expect(html).not.toContain('drop-shadow(0 0 2px #facc15)')
+  })
+
+  it('hides crown when zone has no king', () => {
+    useZoneCompletionMock.mockReturnValue({
+      allCaptured: ref(true),
+      perfectZone: ref(false),
+      allShiny: ref(false),
+      hasKing: ref(false),
+      kingDefeated: ref(false),
+      arenaCompleted: ref(false),
+    })
+    const dummyMap = {} as LeafletMap
+    const { addMarker } = useMapMarkers(dummyMap)
+    addMarker(zone)
+    const html = useLeafletMarkerMock.mock.calls[0][0].html as string
+    expect(html).not.toContain('queen-crown')
   })
 })


### PR DESCRIPTION
## Summary
- derive capture and king states for map markers and apply golden/grey filters
- render crown, arena, and shlageball badges with prioritized styling
- add utilities and tests for marker badge behavior

## Testing
- `pnpm eslint src/composables/useZoneCompletion.ts src/composables/leaflet/useMapMarkers.ts src/components/leaflet/MarkerIcon.vue src/utils/iconStyles.ts test/map-marker-tooltip.test.ts`
- `pnpm test:unit test/map-marker-tooltip.test.ts` *(fails: Command failed with exit code 130 after successful run)*

------
https://chatgpt.com/codex/tasks/task_e_689713c3d458832aa5767e0fead6a648