### PR TITLE
fix: add missing battle translation keys

### DIFF
--- a/src/components/battle.i18n.yml
+++ b/src/components/battle.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  damageTaken: 'Subit {amount} dégâts'
+  healedFor: 'Soigné de {amount} PV'
+en:
+  damageTaken: 'Took {amount} damage'
+  healedFor: 'Healed for {amount} HP'


### PR DESCRIPTION
## Summary
- add English and French translations for battle damage/heal messages

## Testing
- `pnpm lint` *(fails: Strings must use singlequote, Missing trailing comma, etc.)*
- `pnpm test:unit` *(fails: battle item cooldown assertion, invalid translate arguments, sort item test)*

------
https://chatgpt.com/codex/tasks/task_e_68971ef086cc832aa93900744ca7df25