### PR TITLE
Prevent hidden tab HP deltas from queuing animations

### DIFF
--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -217,6 +217,10 @@ function removeFloat(id: number) {
 /** Observe hp et pousse des deltas dans la batch courante */
 let lastHp = props.hp
 watch(() => props.hp, (next) => {
+  if (isHidden.value) { // pas d’anim hors écran
+    lastHp = next
+    return
+  }
   const delta = next - lastHp
   lastHp = next
   if (delta === 0)


### PR DESCRIPTION
## Summary
- ignore HP changes while the battle component is off-screen to avoid burst animations when returning to the tab

## Testing
- `pnpm test:unit` *(fails: battle-item-cooldown.test.ts, page-locale-ssr.test.ts, sort-item.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68984fdbb8ec832aaee42b2c868952b4