### PR TITLE
Fix Multi Exp equip preserving active selection

### DIFF
--- a/src/components/inventory/WearableItemModal.vue
+++ b/src/components/inventory/WearableItemModal.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import { multiExp } from '~/data/items'
 
 const store = useWearableItemStore()
 const dex = useShlagedexStore()
 const { t } = useI18n()
 
-const itemName = computed(() => store.current ? t(store.current.name) : '')
+const itemName = computed(() => (store.current ? t(store.current.name) : ''))
+const selectsActive = computed(() => store.current?.id !== multiExp.id)
 
 function select(mon: DexShlagemon) {
   store.setHolder(mon.id)
@@ -22,6 +24,7 @@ function select(mon: DexShlagemon) {
         v-if="dex.shlagemons.length"
         class="max-h-60vh"
         :selected="store.holderId ? [store.holderId] : []"
+        :selects-active="selectsActive"
         @select="select"
       />
       <p v-else class="text-center text-sm">

--- a/src/components/shlagemon/QuickSelect.vue
+++ b/src/components/shlagemon/QuickSelect.vue
@@ -4,17 +4,24 @@ import type { DexShlagemon } from '~/type/shlagemon'
 interface Props {
   selected?: string[]
   locked?: boolean
+  /**
+   * Whether selecting a Shlagémon should mark it as the active combatant.
+   * Defaults to `true` to preserve existing behaviour.
+   */
+  selectsActive?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   selected: () => [],
   locked: false,
+  selectsActive: true,
 })
 const emit = defineEmits<{ (e: 'select', mon: DexShlagemon): void }>()
 const dex = useShlagedexStore()
 
 function choose(mon: DexShlagemon) {
-  dex.setActiveShlagemon(mon)
+  if (props.selectsActive)
+    dex.setActiveShlagemon(mon)
   emit('select', mon)
 }
 </script>

--- a/test/equipment-multi-exp-active.test.ts
+++ b/test/equipment-multi-exp-active.test.ts
@@ -1,25 +1,43 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it } from 'vitest'
 import { multiExp } from '../src/data/items'
+import { attackRing } from '../src/data/items/wearables/attackRing'
 import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { useEquipmentStore } from '../src/stores/equipment'
 import { useInventoryStore } from '../src/stores/inventory'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 
 describe('equipping multi exp', () => {
-  it('does not change the active shlagemon', () => {
+  it('keeps the current active shlagemon when equipped to another shlagemon', () => {
     setActivePinia(createPinia())
     const dex = useShlagedexStore()
     const inventory = useInventoryStore()
     const equipment = useEquipmentStore()
 
     const active = dex.createShlagemon(pikachiant)
-    const holder = dex.createShlagemon(pikachiant)
+    const holder = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(active)
     inventory.add(multiExp.id)
 
     equipment.equip(holder.id, multiExp.id)
 
     expect(dex.activeShlagemon?.id).toBe(active.id)
+  })
+
+  it('sets the target shlagemon active when equipping other items', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const inventory = useInventoryStore()
+    const equipment = useEquipmentStore()
+
+    const active = dex.createShlagemon(pikachiant)
+    const holder = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(active)
+    inventory.add(attackRing.id)
+
+    equipment.equip(holder.id, attackRing.id)
+
+    expect(dex.activeShlagemon?.id).toBe(holder.id)
   })
 })

--- a/test/quick-select-active.test.ts
+++ b/test/quick-select-active.test.ts
@@ -1,0 +1,42 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import QuickSelect from '../src/components/shlagemon/QuickSelect.vue'
+import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('shlagemonQuickSelect selectsActive', () => {
+  it('does not change active when selectsActive is false', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const active = dex.createShlagemon(pikachiant)
+    const target = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(active)
+
+    const wrapper = mount(QuickSelect, {
+      props: { selectsActive: false },
+      shallow: true,
+    })
+
+    ;(wrapper.vm as any).choose(target)
+
+    expect(dex.activeShlagemon?.id).toBe(active.id)
+  })
+
+  it('changes active when selectsActive is true', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const active = dex.createShlagemon(pikachiant)
+    const target = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(active)
+
+    const wrapper = mount(QuickSelect, {
+      shallow: true,
+    })
+
+    ;(wrapper.vm as any).choose(target)
+
+    expect(dex.activeShlagemon?.id).toBe(target.id)
+  })
+})


### PR DESCRIPTION
## Summary
- prevent Shlagémon quick select from switching active when equipping passive Multi Exp
- add regression tests covering QuickSelect `selectsActive` behavior and Multi Exp equip

## Testing
- `pnpm vitest run test/equipment-multi-exp-active.test.ts test/quick-select-active.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68984acc18e8832a8b21de58910a01bd