### PR TITLE
feat(battle): add held item icon component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -28,6 +28,7 @@ declare module 'vue' {
     BattleHeader: typeof import('./components/battle/Header.vue')['default']
     BattleKingPotionButton: typeof import('./components/battle/KingPotionButton.vue')['default']
     BattleMain: typeof import('./components/battle/Main.vue')['default']
+    BattleMonHeldItemIcon: typeof import('./components/battle/mon/HeldItemIcon.vue')['default']
     BattleRound: typeof import('./components/battle/Round.vue')['default']
     BattleShlagemon: typeof import('./components/battle/Shlagemon.vue')['default']
     BattleToast: typeof import('./components/battle/Toast.vue')['default']

--- a/src/components/battle/mon/HeldItemIcon.vue
+++ b/src/components/battle/mon/HeldItemIcon.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { Item } from '~/type/item'
+
+/**
+ * Displays an accessible icon for a held item.
+ * The parent component must provide the item data.
+ */
+const props = defineProps<{
+  /** Item to display. */
+  item: Readonly<Item>
+  /** Optional tooltip label. When omitted, the item name is used. */
+  tooltip?: string
+}>()
+
+const { t } = useI18n()
+
+const tooltip = computed(() => props.tooltip ?? t(props.item.name))
+</script>
+
+<template>
+  <div
+    v-if="props.item.icon"
+    v-tooltip="tooltip"
+    role="img"
+    :aria-label="t(props.item.name)"
+    v-bind="$attrs"
+    :class="[props.item.icon, props.item.iconClass]"
+  />
+  <img
+    v-else-if="props.item.image"
+    v-tooltip="tooltip"
+    v-bind="$attrs"
+    :src="props.item.image"
+    :alt="t(props.item.name)"
+    class="object-contain"
+  >
+</template>

--- a/test/battle-held-item-icon.test.ts
+++ b/test/battle-held-item-icon.test.ts
@@ -1,0 +1,47 @@
+import type { Item } from '../src/type/item'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import HeldItemIcon from '../src/components/battle/mon/HeldItemIcon.vue'
+
+describe('battle held item icon', () => {
+  const messages = { en: { item: { test: 'Test Item' } } }
+  const i18n = createI18n({ legacy: false, locale: 'en', messages })
+
+  it('renders image with alt text', () => {
+    const item: Item = {
+      id: 'test',
+      name: 'item.test',
+      description: 'desc',
+      image: '/test.png',
+    }
+
+    const wrapper = mount(HeldItemIcon, {
+      props: { item },
+      global: { plugins: [i18n], directives: { tooltip: () => {} } },
+    })
+
+    const img = wrapper.get('img')
+    expect(img.attributes('src')).toBe('/test.png')
+    expect(img.attributes('alt')).toBe('Test Item')
+  })
+
+  it('renders icon with aria-label', () => {
+    const item: Item = {
+      id: 'test',
+      name: 'item.test',
+      description: 'desc',
+      icon: 'i-test-icon',
+      iconClass: 'text-red',
+    }
+
+    const wrapper = mount(HeldItemIcon, {
+      props: { item },
+      global: { plugins: [i18n], directives: { tooltip: () => {} } },
+    })
+
+    const div = wrapper.get('div')
+    expect(div.classes()).toContain('i-test-icon')
+    expect(div.attributes('aria-label')).toBe('Test Item')
+  })
+})


### PR DESCRIPTION
## Summary
- add accessible HeldItemIcon to render held item icons or images
- cover rendering behavior with unit tests

## Testing
- `pnpm test:unit` *(fails: battle item cooldown; page locale SSR; shlagedex sort item)*

------
https://chatgpt.com/codex/tasks/task_e_68985b283448832ab47a777267ef2f09