### PR TITLE
fix flipped battle mon and smooth hp updates

### DIFF
--- a/src/components/battle/mon/Container.vue
+++ b/src/components/battle/mon/Container.vue
@@ -41,6 +41,11 @@ const documentVisibility = useDocumentVisibility()
 const visible = computed(() => documentVisibility.value === 'visible')
 
 const { entries, remove } = useFloatingNumbers(toRef(props, 'hp'), visible)
+const animatedHp = useTransition(toRef(props, 'hp'), { duration: 100 })
+watch(visible, (v) => {
+  if (!v)
+    animatedHp.value = props.hp
+})
 const { pulsing } = useLevelUpAnimation(computed(() => props.mon.lvl))
 const { onAnimationEnd, onFaintEnd } = useFaintAutoEmit(toRef(props, 'fainted'))
 onFaintEnd(() => emit('faintEnd'))
@@ -119,7 +124,7 @@ const maxHp = computed(() => dex.maxHp(props.mon))
     </BattleMonNameRow>
 
     <BattleMonHPPanel
-      :value="props.hp"
+      :value="animatedHp"
       :max="maxHp"
       :color="props.color"
       :flash="props.flash"

--- a/src/components/battle/mon/ImageWithFaint.vue
+++ b/src/components/battle/mon/ImageWithFaint.vue
@@ -20,13 +20,13 @@ function onAnimationEnd() {
 </script>
 
 <template>
-  <div class="relative h-full w-full overflow-hidden">
+  <div class="relative h-full w-full overflow-hidden" :class="props.flipped ? '-scale-x-100' : ''">
     <ShlagemonImage
       :id="props.id"
       :alt="props.alt"
       :shiny="props.shiny"
       class="min-h-25"
-      :class="[props.flipped ? '-scale-x-100' : '', { faint: props.fainted }]"
+      :class="{ faint: props.fainted }"
       @animationend="onAnimationEnd"
     />
     <div class="dust" :class="{ active: props.fainted }" />

--- a/test/battle-image-with-faint.test.ts
+++ b/test/battle-image-with-faint.test.ts
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import BattleMonImageWithFaint from '../src/components/battle/mon/ImageWithFaint.vue'
+
+describe('battleMonImageWithFaint', () => {
+  it('applies flip class on wrapper', () => {
+    const wrapper = mount(BattleMonImageWithFaint, {
+      props: { id: 'a', alt: 'a', flipped: true },
+      global: {
+        stubs: { ShlagemonImage: { template: '<div />' } },
+      },
+    })
+    expect(wrapper.classes()).toContain('-scale-x-100')
+  })
+
+  it('retains flip when fainted', () => {
+    const wrapper = mount(BattleMonImageWithFaint, {
+      props: { id: 'a', alt: 'a', flipped: true, fainted: true },
+      global: {
+        stubs: { ShlagemonImage: { template: '<div />', name: 'ShlagemonImage' } },
+      },
+    })
+    expect(wrapper.classes()).toContain('-scale-x-100')
+    expect(wrapper.find('.faint').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- preserve flipped orientation during faint animation
- animate battle mon HP bar for smoother real-time updates
- add regression test for flipped fainted mon

## Testing
- `pnpm test:unit` *(fails: Cannot call props on an empty VueWrapper, and others)*
- `pnpm test:unit --run test/battle-image-with-faint.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6898775a636c832a9f9679db71d49251