### PR TITLE
fix: ensure animated numbers update continuously

### DIFF
--- a/src/components/ui/AnimatedNumber.vue
+++ b/src/components/ui/AnimatedNumber.vue
@@ -5,64 +5,34 @@ const props = withDefaults(defineProps<{ value: number, duration?: number, preci
 })
 
 const MAX_DURATION = 660
-const MIN_STEP_TIME = 20
 
 const factor = computed(() => 10 ** props.precision)
-const displayValue = ref(Math.round(props.value * factor.value))
-const formatted = computed(() => {
-  return (displayValue.value / factor.value).toLocaleString(undefined, {
-    minimumFractionDigits: props.precision,
-    maximumFractionDigits: props.precision,
-  })
+const target = computed(() => Math.round(props.value * factor.value))
+const source = ref(target.value)
+
+watch(target, (val) => {
+  source.value = val
 })
+
 const pulsing = ref(false)
 const { start: stopPulse } = useTimeoutFn(() => (pulsing.value = false), 300, {
   immediate: false,
 })
-let interval: ReturnType<typeof useIntervalFn> | undefined
 
-watch(
-  () => props.value,
-  (val, old) => {
-    if (old === undefined) {
-      displayValue.value = Math.round(val * factor.value)
-      return
-    }
-    if (interval)
-      interval.pause()
-    const target = Math.round(val * factor.value)
-    const diff = target - displayValue.value
-    const sign = Math.sign(diff)
-    let steps = Math.abs(diff)
-    if (!steps)
-      return
-
-    const desiredDuration = Math.min(props.duration, MAX_DURATION)
-
-    let stepValue = sign
-    if (steps * MIN_STEP_TIME > desiredDuration) {
-      steps = Math.floor(desiredDuration / MIN_STEP_TIME)
-      steps = Math.max(1, steps)
-      stepValue = Math.ceil(Math.abs(diff) / steps) * sign
-    }
-
-    const stepTime = Math.max(desiredDuration / steps, MIN_STEP_TIME)
-
-    interval = useIntervalFn(() => {
-      displayValue.value += stepValue
-      if ((sign > 0 && displayValue.value >= target) || (sign < 0 && displayValue.value <= target)) {
-        displayValue.value = target
-        interval!.pause()
-        pulsing.value = true
-        stopPulse()
-      }
-    }, stepTime, { immediate: true })
+const displayValue = useTransition(source, {
+  duration: () => Math.min(props.duration, MAX_DURATION),
+  onFinished: () => {
+    pulsing.value = true
+    stopPulse()
   },
-  { immediate: true },
-)
+})
 
-onUnmounted(() => {
-  interval?.pause()
+const formatted = computed(() => {
+  const value = Math.round(displayValue.value) / factor.value
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: props.precision,
+    maximumFractionDigits: props.precision,
+  })
 })
 </script>
 


### PR DESCRIPTION
## Summary
- animate numbers with `useTransition` so health decreases immediately during rapid updates

## Testing
- `pnpm test:unit` *(fails: battle-item-cooldown, page-locale-ssr, rarity-info, router-redirect, sort-item, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68987ffe923c832abd23c6c65c5e8091