### PR TITLE
Fix HP display delay on rapid manual attacks

### DIFF
--- a/src/components/battle/mon/HPPanel.vue
+++ b/src/components/battle/mon/HPPanel.vue
@@ -21,7 +21,7 @@ const props = withDefaults(defineProps<Props>(), {
       :class="{ flash: props.flash }"
     />
     <div class="w-full text-right text-sm">
-      <UiAnimatedNumber :value="props.value" /> / {{ props.max.toLocaleString() }}
+      <UiAnimatedNumber :value="props.value" :duration="0" /> / {{ props.max.toLocaleString() }}
     </div>
   </div>
 </template>

--- a/test/hp-panel-update.test.ts
+++ b/test/hp-panel-update.test.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import BattleMonHPPanel from '../src/components/battle/mon/HPPanel.vue'
+
+// Verify that HP values update immediately even under rapid successive changes.
+describe('battleMonHPPanel', () => {
+  it('displays the latest HP without lag', async () => {
+    const wrapper = mount(BattleMonHPPanel, {
+      props: { value: 100, max: 200 },
+      global: {
+        stubs: {
+          UiProgressBar: true,
+        },
+      },
+    })
+
+    // Simulate rapid HP drops before the DOM flushes.
+    wrapper.setProps({ value: 90 })
+    wrapper.setProps({ value: 80 })
+    await nextTick()
+    expect(wrapper.text()).toContain('80')
+  })
+})


### PR DESCRIPTION
## Summary
- ensure battle HP numbers update instantly on each hit
- add regression test for rapid HP changes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: battle-item-cooldown > prevents using multiple battle items during cooldown; capture > super ball doubles chance for low level foe; page-locale-ssr > renders / as English page like /en/; router-redirect tests; sort-item > displays shlagemons with items first)*

------
https://chatgpt.com/codex/tasks/task_e_6898901f300c832a802b884d71533ced