### PR TITLE
Use battle core for click attacks and test reactive HP sync

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -58,11 +58,14 @@ const {
   enemyVariant,
   startBattle: coreStartBattle,
   stopBattle,
-  attack: coreAttack,
+  attack,
 } = useBattleCore({
   createEnemy: () => props.enemy,
   tickDelay: props.tickDelay,
 })
+
+// Throttle manual click attacks to prevent UI freeze during rapid input
+const throttledAttack = useThrottleFn(attack, 50, false, true)
 
 const showConfetti = ref(false)
 
@@ -139,10 +142,6 @@ watch(
   { immediate: true },
 )
 
-function attack() {
-  coreAttack()
-}
-
 const { start: startEnemyFaintFallback, stop: stopEnemyFaintFallback } = useTimeoutFn(onEnemyFaintEnd, 600, { immediate: false })
 const { start: startPlayerFaintFallback, stop: stopPlayerFaintFallback } = useTimeoutFn(onPlayerFaintEnd, 600, { immediate: false })
 
@@ -201,7 +200,7 @@ function onClick(_e: MouseEvent) {
   cursorClicked.value = true
   useTimeoutFn(() => (cursorClicked.value = false), 150)
   if (props.clickAttack)
-    attack()
+    throttledAttack()
 }
 </script>
 

--- a/test/attack-throttle.test.ts
+++ b/test/attack-throttle.test.ts
@@ -1,0 +1,38 @@
+import { useThrottleFn } from '@vueuse/core'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { useBattleCore } from '../src/composables/useBattleCore'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+vi.mock('../src/stores/audio', () => ({
+  useAudioStore: () => ({
+    playSfx: vi.fn(),
+    isMusicEnabled: false,
+  }),
+}))
+
+describe('throttled click attacks', () => {
+  it('ignores rapid successive clicks to keep the UI responsive', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const player = dex.createShlagemon(carapouffe)
+    const enemy = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(player)
+    const core = useBattleCore({ createEnemy: () => enemy })
+    core.startBattle(enemy)
+    const initialHp = enemy.hpCurrent
+    const throttled = useThrottleFn(core.attack, 50, false, true)
+
+    throttled()
+    throttled()
+    expect(enemy.hpCurrent).toBe(initialHp - 10)
+
+    vi.advanceTimersByTime(50)
+    throttled()
+    expect(enemy.hpCurrent).toBe(initialHp - 20)
+
+    vi.useRealTimers()
+  })
+})

--- a/test/use-battle-core-attack.test.ts
+++ b/test/use-battle-core-attack.test.ts
@@ -1,0 +1,34 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/stores/audio', () => ({
+  useAudioStore: () => ({
+    playSfx: vi.fn(),
+    isMusicEnabled: false,
+  }),
+}))
+
+import { useBattleCore } from '../src/composables/useBattleCore'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('useBattleCore.attack', () => {
+  it('synchronizes reactive hp values after a manual attack', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const player = dex.createShlagemon(carapouffe)
+    const enemy = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(player)
+
+    const core = useBattleCore({
+      createEnemy: () => enemy,
+    })
+    core.startBattle(enemy)
+
+    const initialHp = core.enemyHp.value
+    core.attack()
+
+    expect(enemy.hpCurrent).toBe(initialHp - 10)
+    expect(core.enemyHp.value).toBe(enemy.hpCurrent)
+  })
+})


### PR DESCRIPTION
## Summary
- Call `useBattleCore`'s `attack` in battle round component to keep reactive HP in sync during manual clicks
- Add regression test ensuring manual attacks update `enemyHp` references
- Throttle manual click attacks to stay responsive during rapid input

## Testing
- `pnpm test:unit` *(fails: battle-item-cooldown.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6898b49fcdfc832abdd89f855593f6e1