### PR TITLE
Reset battle type cycle tracker after combat

### DIFF
--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -38,7 +38,7 @@ export function useBattleCore(options: BattleCoreOptions) {
   }
 
   function stopInterval() {
-    battle.stopLoop()
+    battle.stopBattle()
   }
 
   function stopBattle() {


### PR DESCRIPTION
## Summary
- track attack type rotation using a WeakMap keyed by `DexShlagemon`
- reset attack type cycle tracking when a battle stops
- call battle `stopBattle` from battle core to clear attacker type state

## Testing
- `pnpm lint` *(fails: Multiple spaces, parsing errors, import order issues)*
- `pnpm test` *(fails: battle item cooldown test and others)*

------
https://chatgpt.com/codex/tasks/task_e_6898f08db120832abf705f3ad3ad0230