### PR TITLE
chore: cancel floating number timers on unmount

### DIFF
--- a/src/composables/useFloatingNumbers.ts
+++ b/src/composables/useFloatingNumbers.ts
@@ -30,12 +30,20 @@ export function useFloatingNumbers(hp: Ref<number>, visible: Ref<boolean>) {
   let idCounter = 0
   let totalDamage = 0
   let damageCount = 0
+  const removalTimers = new Set<ReturnType<typeof setTimeout>>()
+
+  function clearRemovalTimers(): void {
+    for (const timer of removalTimers)
+      clearTimeout(timer)
+    removalTimers.clear()
+  }
 
   function clear(): void {
     pending.splice(0, pending.length)
     entries.value = []
     totalDamage = 0
     damageCount = 0
+    clearRemovalTimers()
   }
 
   watch(visible, (v) => {
@@ -65,10 +73,12 @@ export function useFloatingNumbers(hp: Ref<number>, visible: Ref<boolean>) {
       for (const e of built)
         entries.value.push(e)
       if (typeof setTimeout !== 'undefined') {
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           for (const e of built)
             remove(e.id)
+          removalTimers.delete(timeoutId)
         }, 1200)
+        removalTimers.add(timeoutId)
       }
     })
   }
@@ -148,6 +158,8 @@ export function useFloatingNumbers(hp: Ref<number>, visible: Ref<boolean>) {
     }
     return results
   }
+
+  onUnmounted(clearRemovalTimers)
 
   return {
     entries: readonly(entries),


### PR DESCRIPTION
## Summary
- prevent floating number removals after component teardown by tracking timeout IDs

## Testing
- `pnpm exec eslint src/composables/useFloatingNumbers.ts`
- `pnpm test --run test/useFloatingNumbers.test.ts`
- `pnpm test` *(fails: battle-item-cooldown.test.ts, capture.test.ts)*
- `pnpm typecheck` *(fails: src/type/ball.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6898f2dc4680832a83dd56048248da69