### PR TITLE
Grey out Multi Exp button when not equipped

### DIFF
--- a/src/components/shlagemon/List.spec.ts
+++ b/src/components/shlagemon/List.spec.ts
@@ -57,7 +57,7 @@ const stubs = {
   LayoutScrollablePanel: { template: '<div><slot name="header"></slot><slot name="content"></slot></div>' },
   UiSortControls: { template: '<div></div>' },
   UiSearchInput: { template: '<input />' },
-  UiButton: { template: '<button><slot /></button>' },
+  UiButton: { template: '<button v-bind="$attrs"><slot /></button>' },
   UiInfo: { template: '<div><slot /></div>' },
   ShlagemonListItem: { template: '<div></div>' },
   TransitionGroup: { template: '<div><slot /></div>' },
@@ -77,7 +77,9 @@ describe('shlagemon List Multi Exp button', () => {
     shlagemons.value.push(mon)
     holders.value[multiExp.id] = mon.id
     const wrapper = mount(List, { props: { mons: [mon], isMainShlagedex: true }, global: { stubs } })
-    expect(wrapper.find('button').exists()).toBe(true)
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.classes()).not.toContain('saturate-0')
   })
 
   it('opens the holder modal on click', async () => {
@@ -94,7 +96,9 @@ describe('shlagemon List Multi Exp button', () => {
     shlagemons.value.push(mon)
     inventoryStore.items[multiExp.id] = 1
     const wrapper = mount(List, { props: { mons: [mon], isMainShlagedex: true }, global: { stubs } })
-    expect(wrapper.find('button').exists()).toBe(true)
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.classes()).toContain('saturate-0')
   })
 
   it('opens the equip modal when not equipped', async () => {

--- a/src/components/shlagemon/List.vue
+++ b/src/components/shlagemon/List.vue
@@ -211,7 +211,13 @@ watch(
           />
           <UiButton
             v-if="isMainShlagedex && ownsMultiExp"
-            v-tooltip="t(multiExp.name)" icon size="xs" variant="outline" type="primary" @click="handleMultiExpClick"
+            v-tooltip="t(multiExp.name)"
+            :class="{ 'saturate-0': !multiExpHolder }"
+            icon
+            size="xs"
+            variant="outline"
+            type="primary"
+            @click="handleMultiExpClick"
           >
             <span :class="[multiExp.icon, multiExp.iconClass]" />
           </UiButton>


### PR DESCRIPTION
## Summary
- desaturate Multi Exp button when owned but not equipped so players know it’s inactive
- cover unequipped state in shlagedex list tests and forward UiButton classes in tests

## Testing
- `pnpm eslint src/components/shlagemon/List.vue src/components/shlagemon/List.spec.ts`
- `pnpm lint` *(fails: Variable 't' already declared, multi spaces, indentation, parsing error in unrelated files, import order issues)*
- `pnpm typecheck` *(fails: Parsing error in `src/type/ball.ts`)*
- `pnpm test:unit` *(fails: 4 failing tests e.g., attack throttle, battle item cooldown)*


------
https://chatgpt.com/codex/tasks/task_e_6898ea41852c832a9d1d2df4aa777048