### PR TITLE
refactor: useClipboard for SaveTab copy

### DIFF
--- a/src/components/settings/SaveTab.vue
+++ b/src/components/settings/SaveTab.vue
@@ -8,7 +8,7 @@ const playtime = usePlaytimeStore()
 const exportCode = ref('')
 const importCode = ref('')
 const showImport = ref(false)
-const copied = ref(false)
+const { copy, copied } = useClipboard({ copiedDuring: 1500 })
 const fileInput = ref<HTMLInputElement>()
 const generating = ref(false)
 const loading = ref(false)
@@ -24,12 +24,8 @@ async function generateExport() {
 async function copyExport() {
   if (!exportCode.value)
     await generateExport()
-  navigator.clipboard.writeText(exportCode.value)
-  copied.value = true
+  await copy(exportCode.value)
   toast.success(t('components.settings.SaveTab.copied'))
-  setTimeout(() => {
-    copied.value = false
-  }, 1500)
 }
 
 function downloadExport() {


### PR DESCRIPTION
## Summary
- use `useClipboard` to manage exporting save code and copied state

## Testing
- `npx eslint src/components/settings/SaveTab.vue`
- `pnpm lint src/components/settings/SaveTab.vue` *(fails: 14 problems (12 errors, 2 warnings))*
- `pnpm test:unit` *(fails: Test Files  1 failed | 11 passed | 2 skipped (120))*

------
https://chatgpt.com/codex/tasks/task_e_6898fc5d4cb0832aad33b72c19184bf5