### PR TITLE
refactor: replace setTimeout with useTimeoutFn

### DIFF
--- a/src/components/battle/KingPotionButton.vue
+++ b/src/components/battle/KingPotionButton.vue
@@ -11,12 +11,12 @@ const { power } = storeToRefs(potion)
 const audio = useAudioStore()
 
 const holding = ref(false)
-let timer: ReturnType<typeof setTimeout> | null = null
+let timer: ReturnType<typeof useTimeoutFn> | null = null
 let soundId: number | undefined
 
 function cancelHold() {
   if (timer) {
-    clearTimeout(timer)
+    timer.stop()
     timer = null
   }
   if (soundId !== undefined) {
@@ -31,7 +31,7 @@ function startHold() {
     return
   holding.value = true
   soundId = audio.playSfx('items-KingPotion', { loop: true })
-  timer = setTimeout(() => {
+  timer = useTimeoutFn(() => {
     potion.activate(props.enemy ?? undefined)
     holding.value = false
     if (soundId !== undefined) {

--- a/src/components/settings/SaveTab.vue
+++ b/src/components/settings/SaveTab.vue
@@ -13,10 +13,14 @@ const fileInput = ref<HTMLInputElement>()
 const generating = ref(false)
 const loading = ref(false)
 
+const resetCopyTimer = useTimeoutFn(() => {
+  copied.value = false
+}, 1500, { immediate: false })
+
 async function generateExport() {
   generating.value = true
   await nextTick()
-  await new Promise(resolve => setTimeout(resolve))
+  await new Promise<void>(resolve => useTimeoutFn(resolve, 0))
   exportCode.value = exportSave(collectSave())
   generating.value = false
 }
@@ -27,9 +31,8 @@ async function copyExport() {
   navigator.clipboard.writeText(exportCode.value)
   copied.value = true
   toast.success(t('components.settings.SaveTab.copied'))
-  setTimeout(() => {
-    copied.value = false
-  }, 1500)
+  resetCopyTimer.stop()
+  resetCopyTimer.start()
 }
 
 function downloadExport() {
@@ -47,7 +50,7 @@ function downloadExport() {
 async function loadImport() {
   loading.value = true
   await nextTick()
-  await new Promise(resolve => setTimeout(resolve))
+  await new Promise<void>(resolve => useTimeoutFn(resolve, 0))
   const data = importSave(importCode.value)
   if (!data) {
     toast.error(t('components.settings.SaveTab.invalid'))
@@ -72,6 +75,8 @@ function loadFromFile(event: Event) {
     showImport.value = true
   })
 }
+
+onUnmounted(() => resetCopyTimer.stop())
 </script>
 
 <template>

--- a/src/components/ui/TypingText.vue
+++ b/src/components/ui/TypingText.vue
@@ -10,31 +10,29 @@ const emit = defineEmits<{
 const audio = useAudioStore()
 
 const display = ref('')
-let timer: ReturnType<typeof setTimeout> | undefined
+let timer: ReturnType<typeof useTimeoutFn> | undefined
 
 function start() {
   display.value = ''
-  if (timer)
-    clearTimeout(timer)
+  timer?.stop()
   if (!props.text)
     return emit('finished')
   let i = 0
-  function type() {
+  function typeChar() {
     display.value += props.text[i++]
     audio.playTypingSfx()
     if (i < props.text.length)
-      timer = setTimeout(type, props.speed)
+      timer = useTimeoutFn(typeChar, props.speed)
     else
       emit('finished')
   }
-  type()
+  typeChar()
 }
 
 watch(() => props.text, start, { immediate: true })
 
 onUnmounted(() => {
-  if (timer)
-    clearTimeout(timer)
+  timer?.stop()
 })
 </script>
 

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -104,7 +104,7 @@ export const useAudioStore = defineStore('audio', () => {
       currentMusic.value.play()
   }
 
-  let fadeTimer: ReturnType<typeof setTimeout> | null = null
+  let fadeTimer: ReturnType<typeof useTimeoutFn> | null = null
   let fadingOut: Howl | null = null
 
   function fadeToMusic(track: string) {
@@ -119,7 +119,7 @@ export const useAudioStore = defineStore('audio', () => {
       return
 
     if (fadeTimer) {
-      clearTimeout(fadeTimer)
+      fadeTimer.stop()
       if (fadingOut) {
         fadingOut.stop()
         fadingOut.unload()
@@ -144,7 +144,7 @@ export const useAudioStore = defineStore('audio', () => {
       next.fade(0, musicVolume.value, 1000)
       old.fade(old.volume(), 0, 1000)
       fadingOut = old
-      fadeTimer = setTimeout(() => {
+      fadeTimer = useTimeoutFn(() => {
         fadingOut?.stop()
         fadingOut?.unload()
         fadingOut = null
@@ -178,7 +178,7 @@ export const useAudioStore = defineStore('audio', () => {
     currentMusic.value.unload()
     currentMusic.value = null
     if (fadeTimer) {
-      clearTimeout(fadeTimer)
+      fadeTimer.stop()
       fadeTimer = null
     }
   }


### PR DESCRIPTION
## Summary
- replace setTimeout uses with useTimeoutFn across various components and store
- expose cancel/start controls for timers to handle resets

## Testing
- `pnpm lint` *(fails: Parsing error etc.)*
- `pnpm test:unit` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc6701d0832a8bdb77c080faf96f