### PR TITLE
refactor: use VueUse event listener

### DIFF
--- a/src/components/minigame/Taquin.vue
+++ b/src/components/minigame/Taquin.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { PuzzleDirection } from '~/composables/useSlidingPuzzle'
-import { useElementSize, useEventListener, useSwipe, useTimeoutFn } from '@vueuse/core'
 import { useSlidingPuzzle } from '~/composables/useSlidingPuzzle'
 
 const props = withDefaults(defineProps<{ difficulty?: 'easy' | 'hard' }>(), {
@@ -30,19 +29,8 @@ useSwipe(wrapper, {
       puzzle.move(dir)
   },
 })
-
-onMounted(() => {
-  const el = wrapper.value
-  if (!el)
-    return
-
-  const preventScroll = (e: TouchEvent) => e.preventDefault()
-  el.addEventListener('touchmove', preventScroll, { passive: false })
-
-  onUnmounted(() => {
-    el.removeEventListener('touchmove', preventScroll)
-  })
-})
+const preventScroll = (e: TouchEvent) => e.preventDefault()
+useEventListener(wrapper, 'touchmove', preventScroll, { passive: false })
 
 useEventListener('keydown', (e: KeyboardEvent) => {
   if (puzzle.solved.value || puzzle.shuffling.value)

--- a/src/components/shlagemon/TypeChart.vue
+++ b/src/components/shlagemon/TypeChart.vue
@@ -29,12 +29,7 @@ function onWheel(e: WheelEvent) {
     tableContainer.value.scrollLeft += e.deltaY
   }
 }
-onMounted(() => {
-  tableContainer.value?.addEventListener('wheel', onWheel, { passive: true })
-})
-onBeforeUnmount(() => {
-  tableContainer.value?.removeEventListener('wheel', onWheel)
-})
+useEventListener(tableContainer, 'wheel', onWheel, { passive: true })
 
 // --- Table logique
 function getMultiplier(att: TypeName, def: TypeName) {

--- a/src/components/ui/KeyCapture.vue
+++ b/src/components/ui/KeyCapture.vue
@@ -29,10 +29,8 @@ function onKeydown(e: KeyboardEvent) {
   stopCapture()
   emit('update:modelValue', e.key)
 }
-
-onMounted(() => window.addEventListener('keydown', onKeydown))
+useEventListener(window, 'keydown', onKeydown)
 onBeforeUnmount(() => {
-  window.removeEventListener('keydown', onKeydown)
   stopCapture()
 })
 onMounted(() => {

--- a/src/components/ui/Modal.vue
+++ b/src/components/ui/Modal.vue
@@ -52,7 +52,7 @@ function close() {
   if (!dialog || dialog.classList.contains('closing'))
     return
   dialog.classList.add('closing')
-  dialog.addEventListener('animationend', () => {
+  useEventListener(dialog, 'animationend', () => {
     dialog.classList.remove('closing')
     dialog.close()
   }, { once: true })

--- a/src/modules/keyboard.ts
+++ b/src/modules/keyboard.ts
@@ -5,7 +5,7 @@ export const install: UserModule = ({ isClient }) => {
     return
   const store = useShortcutsStore()
   const capture = useKeyboardCaptureStore()
-  window.addEventListener('keydown', (event) => {
+  useEventListener(window, 'keydown', (event) => {
     const target = event.target as HTMLElement | null
     if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable))
       return


### PR DESCRIPTION
## Summary
- replace manual addEventListener/removeEventListener with useEventListener
- preserve existing listener options

## Testing
- `pnpm eslint src/components/ui/KeyCapture.vue src/components/shlagemon/TypeChart.vue src/components/minigame/Taquin.vue src/components/ui/Modal.vue src/modules/keyboard.ts`
- `pnpm test:unit` *(fails: Snapshots 1 failed, Tests 10 failed | 203 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc755ca4832a875303b7666337f9