### PR TITLE
refactor: use vueuse storage composables

### DIFF
--- a/src/pages/root.vue
+++ b/src/pages/root.vue
@@ -10,6 +10,7 @@ const router = useRouter()
 const store = useLocaleStore()
 const preferredLanguages = usePreferredLanguages()
 const isRedirecting = ref(true) // Pour l'affichage du loader
+const storedLocale = useLocalStorage<Locale | null>('locale', null, { writeDefaults: false })
 
 /**
  * Teste si une chaîne est une locale supportée.
@@ -22,10 +23,9 @@ onMounted(async () => {
   let targetLocale: Locale | undefined
 
   // 1. Locale stockée explicitement par l'utilisateur (préférence forte)
-  const stored = localStorage.getItem('locale')
-  if (isLocale(stored)) {
+  const stored = storedLocale.value
+  if (isLocale(stored))
     targetLocale = stored
-  }
 
   // 2. Store Pinia, utile en SSR/hydratation ou session restaurée
   if (!targetLocale && isLocale(store.locale) && store.locale !== defaultLocale) {

--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -51,7 +51,7 @@ export const useSaveStore = defineStore('save', () => {
    */
   function clearPersisted(): void {
     for (const key of PERSISTED_STORE_KEYS)
-      window.localStorage.removeItem(key)
+      useStorage(key, null, undefined, { flush: 'sync' }).value = null
   }
 
   return { reset, clearPersisted }

--- a/src/utils/save-code.ts
+++ b/src/utils/save-code.ts
@@ -1,3 +1,4 @@
+import { StorageSerializers } from '@vueuse/core'
 import CryptoJS from 'crypto-js'
 import lzString from 'lz-string'
 
@@ -105,7 +106,11 @@ function wordArrayToUint8Array(wordArray: CryptoJS.lib.WordArray): Uint8Array {
 export function collectSave(): GameSave {
   const save: GameSave = {}
   for (const key of PERSISTED_STORE_KEYS) {
-    const raw = localStorage.getItem(key)
+    const stored = useStorage<string | null>(key, null, undefined, {
+      serializer: StorageSerializers.string,
+      writeDefaults: false,
+    })
+    const raw = stored.value
     if (raw !== null) {
       try {
         save[key] = JSON.parse(raw)
@@ -120,7 +125,9 @@ export function collectSave(): GameSave {
 
 export function applySave(save: GameSave): void {
   for (const [key, value] of Object.entries(save) as [PersistedStoreId, unknown][]) {
-    localStorage.setItem(key, JSON.stringify(value))
+    useStorage<string | null>(key, null, undefined, {
+      serializer: StorageSerializers.string,
+    }).value = JSON.stringify(value)
   }
 }
 


### PR DESCRIPTION
## Summary
- replace direct localStorage access with useLocalStorage/useStorage
- keep same persistence logic for saves and locale detection

## Testing
- `pnpm lint` *(fails: parsing error and import order issues in unrelated files)*
- `pnpm test:unit` *(fails: 10 failing tests)*
- `pnpm test:unit test/save-clear.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689902035c80832a8ba3ed63b7813ee2