### PR TITLE
fix: guard AnimatedNumber for SSR

### DIFF
--- a/test/animated-number-ssr.test.ts
+++ b/test/animated-number-ssr.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+
+/** Ensure the AnimatedNumber component can render during SSR without DOM globals. */
+describe('animated number ssr', () => {
+  it('renders static number when SSR is true', async () => {
+    vi.stubEnv('SSR', true)
+    try {
+      const { default: AnimatedNumber } = await import('../src/components/ui/AnimatedNumber.vue')
+      const app = createSSRApp({
+        render: () => h(AnimatedNumber, { value: 42 }),
+      })
+      const html = await renderToString(app)
+      expect(html).toContain('42')
+    }
+    finally {
+      vi.unstubAllEnvs()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- load vue-number-animation only on client and render formatted number during SSR
- add SSR regression test for AnimatedNumber component

## Testing
- `npx eslint src/components/ui/AnimatedNumber.vue test/animated-number-ssr.test.ts`
- `pnpm test test/animated-number-ssr.test.ts --run`
- `pnpm typecheck` *(fails: src/type/ball.ts(8,3): error TS1005: '>' expected)*

------
https://chatgpt.com/codex/tasks/task_e_6899036b9924832a8b6cf41f5b0f2528