### PR TITLE
test: improve VillageMap spec typing

### DIFF
--- a/src/components/village/VillageMap.spec.ts
+++ b/src/components/village/VillageMap.spec.ts
@@ -1,10 +1,10 @@
-import type { VillageZone } from '~/type'
+import type { VillagePOI, VillageZone, VillageZoneId } from '~/type'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import VillageMap from './VillageMap.vue'
+import VillageMap from './Map.vue'
 
 const baseVillage: VillageZone = {
-  id: 'test-village',
+  id: 'village-paume' as VillageZoneId,
   name: 'Test',
   type: 'village',
   villageType: 'basic',
@@ -37,15 +37,15 @@ describe('village map', () => {
     const wrapper = mount(VillageMap, { props: { village: baseVillage } })
     const marker = wrapper.element.querySelector('.leaflet-marker-icon') as HTMLElement
     marker.dispatchEvent(new Event('click'))
-    const events = wrapper.emitted('select')
+    const events = wrapper.emitted('select') as Array<[VillagePOI]> | undefined
     expect(events).toBeTruthy()
     expect(events![0][0].id).toBe('shop')
   })
 
   it('updates markers when village changes', async () => {
     const wrapper = mount(VillageMap, { props: { village: baseVillage } })
-    const newVillage: VillageZone = { ...baseVillage, id: 'v2', pois: {} }
-    await wrapper.setProps({ village: newVillage })
+    const newVillage: VillageZone = { ...baseVillage, id: 'village-boule' as VillageZoneId, pois: {} }
+    await wrapper.setProps({ village: newVillage } as Partial<InstanceType<typeof VillageMap>['$props']>)
     const markers = wrapper.element.querySelectorAll('.leaflet-marker-icon')
     expect(markers.length).toBe(0)
   })


### PR DESCRIPTION
## Summary
- use valid `VillageZoneId` identifiers in village map tests
- type emitted select events as `VillagePOI`
- cast `setProps` to component props for better type safety

## Testing
- `pnpm test:unit` *(fails: Attack throttle spec, HP panel update, page locale SSR, rarity info snapshot, router redirect, shlagedex sort item)*

------
https://chatgpt.com/codex/tasks/task_e_68990a2fbd14832a89aa1925d4f11975