### PR TITLE
refactor: define Ball as Item intersection type

### DIFF
--- a/src/type/ball.ts
+++ b/src/type/ball.ts
@@ -1,7 +1,14 @@
 import type { Item } from './item'
 
-export interface Ball extends Item {
+/**
+ * A capture device item used to catch Shlagémon.
+ * Combines base item properties with capture-specific attributes.
+ */
+export type Ball = Item & {
+  /** Bonus applied to the capture probability. */
   catchBonus: number
+  /** Image or animation displayed when the ball is thrown. */
   animation: string
+  /** Number of remaining balls of this type in the player's inventory. */
   quantity?: number
 }


### PR DESCRIPTION
## Summary
- replace Ball interface with Item-based type alias
- document capture bonus, animation, and quantity attributes

## Testing
- `pnpm lint` *(fails: Catalog item "@bubblewrap/cli:default" is not used in any package.json)*
- `pnpm typecheck` *(fails: Type 'Stoppable<[]>' is missing the following properties from type 'Timeout': ref, unref, hasRef, refresh, [Symbol.toPrimitive])*
- `pnpm test:unit` *(fails: SyntaxError: Invalid arguments in sSR locale pages)*

------
https://chatgpt.com/codex/tasks/task_e_68990a30e120832aa73637054683dfef