### PR TITLE
feat: show owned rarity and shiny badges

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -146,6 +146,8 @@ components:
     Shlagemon:
       ownedTooltip: You already own this Shlagemon
       infoTooltip: View details
+      ownedRarity100Tooltip: You own this Shlagemon at rarity 100
+      ownedShinyLabel: Owned shiny
     DiseaseBadge:
       tooltip: 'Sick: {n} battles remaining'
     EffectBadge:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -146,6 +146,8 @@ components:
     Shlagemon:
       ownedTooltip: Vous possédez déjà ce Shlagémon
       infoTooltip: Voir les détails
+      ownedRarity100Tooltip: Vous possédez ce Shlagémon en rareté 100
+      ownedShinyLabel: Shiny possédé
     DiseaseBadge:
       tooltip: 'Malade : {n} combats restants'
     EffectBadge:

--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -41,6 +41,16 @@ const enemyCaptured = computed<boolean>(() =>
   displayedEnemy.value ? dex.capturedBaseIds.has(displayedEnemy.value.base.id) : false,
 )
 
+const enemyRarity100Owned = computed<boolean>(() => {
+  const enemy = displayedEnemy.value
+  return enemy ? dex.shlagemons.some(m => m.base.id === enemy.base.id && m.rarity >= 100) : false
+})
+
+const enemyShinyOwned = computed<boolean>(() => {
+  const enemy = displayedEnemy.value
+  return enemy ? dex.shlagemons.some(m => m.base.id === enemy.base.id && m.isShiny) : false
+})
+
 const {
   playerHp,
   enemyHp,
@@ -264,6 +274,8 @@ function onClick(_e: MouseEvent) {
             :flash="flashEnemy"
             :show-ball="showOwnedBall"
             :owned="enemyCaptured"
+            :owns-rarity-100="enemyRarity100Owned"
+            :owns-shiny="enemyShinyOwned"
             @faint-end="onEnemyFaintEnd"
           >
             <BattleToast v-if="enemyEffect" :message="enemyEffect" :variant="enemyVariant" />

--- a/src/components/battle/Shlagemon.i18n.yml
+++ b/src/components/battle/Shlagemon.i18n.yml
@@ -1,6 +1,10 @@
 fr:
   ownedTooltip: Vous possédez déjà ce Shlagémon
+  ownedRarity100Tooltip: Vous possédez ce Shlagémon en rareté 100
+  ownedShinyLabel: Shiny possédé
   infoTooltip: Voir les détails
 en:
   ownedTooltip: You already own this Shlagemon
+  ownedRarity100Tooltip: You own this Shlagemon at rarity 100
+  ownedShinyLabel: Owned shiny
   infoTooltip: View details

--- a/src/components/battle/Shlagemon.vue
+++ b/src/components/battle/Shlagemon.vue
@@ -12,6 +12,8 @@ interface Props {
   levelPosition?: 'top' | 'bottom'
   showBall?: boolean
   owned?: boolean
+  ownsRarity100?: boolean
+  ownsShiny?: boolean
   belongsToPlayer?: boolean
   effects?: ActiveEffect[]
   disease?: boolean

--- a/src/components/battle/mon/Container.vue
+++ b/src/components/battle/mon/Container.vue
@@ -13,6 +13,10 @@ interface Props {
   levelPosition?: 'top' | 'bottom'
   showBall?: boolean
   owned?: boolean
+  /** Player owns this Shlagemon with rarity 100 or more. */
+  ownsRarity100?: boolean
+  /** Player owns a shiny variant of this Shlagemon. */
+  ownsShiny?: boolean
   belongsToPlayer?: boolean
   effects?: ActiveEffect[]
   disease?: boolean
@@ -27,6 +31,8 @@ const props = withDefaults(defineProps<Props>(), {
   levelPosition: 'bottom',
   showBall: false,
   owned: false,
+  ownsRarity100: false,
+  ownsShiny: false,
   belongsToPlayer: false,
   effects: () => [],
   disease: false,
@@ -106,7 +112,12 @@ const maxHp = computed(() => dex.maxHp(props.mon))
       :owned="props.owned"
       :show-ball="props.showBall"
       :shiny="props.mon.isShiny"
-      :tooltip-owned="t('components.battle.Shlagemon.ownedTooltip')"
+      :owns-rarity-100="props.ownsRarity100"
+      :owns-shiny="props.ownsShiny"
+      :tooltip-owned="props.ownsRarity100
+        ? t('components.battle.Shlagemon.ownedRarity100Tooltip')
+        : t('components.battle.Shlagemon.ownedTooltip')"
+      :shiny-label="t('components.battle.Shlagemon.ownedShinyLabel')"
     >
       <template #anchor>
         <BattleMonFloatingNumbers :entries="entries" @end="remove" />

--- a/src/components/battle/mon/NameRow.vue
+++ b/src/components/battle/mon/NameRow.vue
@@ -1,10 +1,23 @@
 <script setup lang="ts">
+import { GOLD_FILTER } from '~/utils/iconStyles'
+
 interface Props {
+  /** Display name of the Shlagemon. */
   name: string
+  /** Whether the current enemy is already owned. */
   owned?: boolean
+  /** Show the ownership Shlageball icon. */
   showBall?: boolean
+  /** Whether the current Shlagemon is shiny. */
   shiny?: boolean
+  /** Tooltip to display when the ball icon is shown. */
   tooltipOwned?: string
+  /** Player owns this Shlagemon with rarity 100 or more. */
+  ownsRarity100?: boolean
+  /** Player owns a shiny variant of this Shlagemon. */
+  ownsShiny?: boolean
+  /** Accessible label for the shiny badge. */
+  shinyLabel?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -12,18 +25,29 @@ const props = withDefaults(defineProps<Props>(), {
   showBall: false,
   shiny: false,
   tooltipOwned: '',
+  ownsRarity100: false,
+  ownsShiny: false,
+  shinyLabel: '',
 })
 </script>
 
 <template>
   <div class="relative mt-1 flex items-center gap-1">
-    <img
-      v-if="props.showBall && props.owned"
-      v-tooltip="props.tooltipOwned"
-      src="/items/shlageball/shlageball.webp"
-      alt="ball"
-      class="h-4 w-4"
-    >
+    <div v-if="props.showBall && props.owned" class="relative">
+      <img
+        v-tooltip="props.tooltipOwned"
+        src="/items/shlageball/shlageball.webp"
+        alt="ball"
+        class="h-4 w-4"
+        :style="props.ownsRarity100 ? GOLD_FILTER : ''"
+        draggable="false"
+      >
+      <div
+        v-if="props.ownsShiny"
+        class="mask-rainbow i-mdi:star absolute h-2 w-2 -right-1 -top-1"
+        :aria-label="props.shinyLabel"
+      />
+    </div>
     <span class="font-bold" :class="{ 'shiny-text': props.shiny }">{{ props.name }}</span>
     <div class="pointer-events-none absolute left-1/2 z-160 h-0 w-0 -top-4 -translate-x-1/2">
       <slot name="anchor" />

--- a/test/owned-ball.test.ts
+++ b/test/owned-ball.test.ts
@@ -21,6 +21,8 @@ describe('battle round enemy owned indicator', () => {
     await nextTick()
     panel.current = 'trainerBattle'
     const captured = dex.createShlagemon(carapouffe)
+    captured.rarity = 100
+    captured.isShiny = true
     dex.addShlagemon(captured)
     const player = dex.createShlagemon(carapouffe)
     dex.setActiveShlagemon(player)
@@ -47,6 +49,8 @@ describe('battle round enemy owned indicator', () => {
     const enemyComp = shlagemons.at(1)!
     expect(enemyComp.props('owned')).toBe(true)
     expect(enemyComp.props('showBall')).toBe(true)
+    expect(enemyComp.props('ownsRarity100')).toBe(true)
+    expect(enemyComp.props('ownsShiny')).toBe(true)
     wrapper.unmount()
     vi.useRealTimers()
   })


### PR DESCRIPTION
## Summary
- show aura and shiny badge for owned wild shlagemon icons
- detect owned rarity 100 and shiny variants
- add translations and tests for owned badges

## Testing
- `pnpm i18n`
- `pnpm test:unit` *(fails: throttled click attacks, hp panel update, page locale SSR, rarity info, router redirect, sort item and others)*


------
https://chatgpt.com/codex/tasks/task_e_68990ccf7378832ab15167ecc8a81190