### PR TITLE
feat: add battle item category colors

### DIFF
--- a/src/constants/itemCategory.ts
+++ b/src/constants/itemCategory.ts
@@ -5,6 +5,7 @@ export const itemCategoryTabColors: Record<ItemCategory, string> = {
   passif: 'text-green-700 border-white/50',
   utilitaire: 'text-orange-700 border-white/50',
   activable: 'text-fuchsia-700 border-white/50',
+  battle: 'text-blue-700 border-white/50',
 }
 
 export const itemCategoryTabBaseColors: Record<ItemCategory, string> = {
@@ -12,6 +13,7 @@ export const itemCategoryTabBaseColors: Record<ItemCategory, string> = {
   passif: '',
   utilitaire: '',
   activable: '',
+  battle: '',
 }
 
 export const itemCategoryTabHoverColors: Record<ItemCategory, string> = {
@@ -19,6 +21,7 @@ export const itemCategoryTabHoverColors: Record<ItemCategory, string> = {
   passif: 'hover:bg-green-200 dark:hover:bg-green-700',
   utilitaire: 'hover:bg-yellow-200 dark:hover:bg-yellow-700',
   activable: 'hover:bg-fuchsia-200 dark:hover:bg-fuchsia-700',
+  battle: 'hover:bg-blue-200 dark:hover:bg-blue-700',
 }
 
 export const itemCategoryPanelColors: Record<ItemCategory, string> = {
@@ -26,4 +29,5 @@ export const itemCategoryPanelColors: Record<ItemCategory, string> = {
   passif: 'bg-green-50 dark:bg-green-900/20',
   utilitaire: 'bg-yellow-50 dark:bg-yellow-900/20',
   activable: 'bg-fuchsia-50 dark:bg-fuchsia-900/20',
+  battle: 'bg-blue-50 dark:bg-blue-900/20',
 }


### PR DESCRIPTION
## Summary
- add battle category colors across item category color maps

## Testing
- `pnpm exec eslint src/constants/itemCategory.ts`
- `pnpm typecheck` *(fails: Cannot find type definition file for 'unplugin-vue-macros/macros-global', plus many others)*
- `pnpm test` *(fails: 9 failing tests, e.g., attack throttling and capture mechanics)*

------
https://chatgpt.com/codex/tasks/task_e_68990d8e782c832a99b6ad15c897c917