### PR TITLE
chore: guard zone max level access

### DIFF
--- a/src/components/battle/Header.vue
+++ b/src/components/battle/Header.vue
@@ -13,7 +13,7 @@ const zone = useZoneStore()
         <div class="w-full overflow-hidden text-ellipsis whitespace-nowrap text-center" :title="props.zoneName">
           {{ props.zoneName }}
         </div>
-        <div v-if="zone.current.maxLevel" class="whitespace-nowrap text-xs">
+        <div v-if="zone.current.type === 'sauvage'" class="whitespace-nowrap text-xs">
           {{ zone.current.minLevel }} - {{ zone.current.maxLevel }}
         </div>
       </div>

--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -9,6 +9,9 @@ import { pickByAlphabet } from '~/utils/spawn'
 
 const dex = useShlagedexStore()
 const zone = useZoneStore()
+const zoneMaxLevel = computed(() =>
+  zone.current.type === 'sauvage' ? zone.current.maxLevel : undefined,
+)
 const { selectedAt } = storeToRefs(zone)
 const progress = useZoneProgressStore()
 const wearableItemStore = useWearableItemStore()
@@ -35,7 +38,7 @@ function createEnemy(): DexShlagemon | null {
   const base = pickByAlphabet(pool, count)
   progress.registerEncounter(zone.current.id, base.id)
   const min = Number(zone.current.minLevel ?? 1)
-  const zoneMax = Number(zone.current.maxLevel ?? (min + 1))
+  const zoneMax = zoneMaxLevel.value ?? (min + 1)
   const max = Math.max(zoneMax - 1, min)
   const lvl = Math.floor(Math.random() * (max - min + 1)) + min
   const created = createDexShlagemon(base, false, lvl, wildLevel.highestWildLevel)
@@ -110,10 +113,10 @@ async function handleEnd(result: 'win' | 'lose' | 'draw') {
     notifyAchievement({ type: 'battle-win', stronger })
     if (dex.activeShlagemon) {
       const xp = dex.xpGainForLevel(defeated.lvl)
-      await dex.gainXp(dex.activeShlagemon, xp, undefined, undefined, zone.current.maxLevel)
+      await dex.gainXp(dex.activeShlagemon, xp, undefined, undefined, zoneMaxLevel.value)
       const holder = wearableItemStore.getHolder(multiExp.id)
       if (holder)
-        await dex.gainXp(holder, Math.round(xp * 0.5), undefined, undefined, zone.current.maxLevel)
+        await dex.gainXp(holder, Math.round(xp * 0.5), undefined, undefined, zoneMaxLevel.value)
     }
   }
   else if (result === 'lose') {

--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -28,6 +28,9 @@ const { t } = useI18n()
 const dex = useShlagedexStore()
 const disease = useDiseaseStore()
 const zone = useZoneStore()
+const zoneMaxLevel = computed(() =>
+  zone.current.type === 'sauvage' ? zone.current.maxLevel : undefined,
+)
 const wearableItemStore = useWearableItemStore()
 
 const displayedPlayer = ref(props.player)
@@ -103,10 +106,10 @@ async function onCaptureEnd(success: boolean) {
     notifyAchievement({ type: 'capture', shiny: props.enemy.isShiny })
     if (dex.activeShlagemon) {
       const xp = dex.xpGainForLevel(props.enemy.lvl)
-      await dex.gainXp(dex.activeShlagemon, xp, undefined, undefined, zone.current.maxLevel)
+      await dex.gainXp(dex.activeShlagemon, xp, undefined, undefined, zoneMaxLevel.value)
       const holder = wearableItemStore.getHolder(multiExp.id)
       if (holder)
-        await dex.gainXp(holder, Math.round(xp * 0.5), undefined, undefined, zone.current.maxLevel)
+        await dex.gainXp(holder, Math.round(xp * 0.5), undefined, undefined, zoneMaxLevel.value)
     }
     emit('capture')
     showConfetti.value = true

--- a/src/components/battle/Trainer.vue
+++ b/src/components/battle/Trainer.vue
@@ -117,7 +117,7 @@ function createEnemy(): DexShlagemon | null {
     return null
   const max = wildLevel.highestWildLevel
   const min = isZoneKing.value ? Math.max(1, max - 20) : 1
-  const zoneMax = zone.current.maxLevel ?? 1
+  const zoneMax = zone.current.type === 'sauvage' ? zone.current.maxLevel : 1
 
   let level
   if (zoneMax === 99) {

--- a/src/data/kings.ts
+++ b/src/data/kings.ts
@@ -109,6 +109,15 @@ import vieuxBlaireau from './shlagemons/evolutions/vieuxblaireau'
 import sulfusouris from './shlagemons/sulfusouris'
 import { zonesData } from './zones'
 
+/**
+ * Return the maximum level allowed in the specified savage zone.
+ * Falls back to `1` when the zone is not found or not savage.
+ */
+function getZoneMaxLevel(zoneId: SavageZoneId): number {
+  const zone = zonesData.find(z => z.id === zoneId)
+  return zone && zone.type === 'sauvage' ? zone.maxLevel : 1
+}
+
 function _createKing(
   zoneId: SavageZoneId,
   character: Character,
@@ -118,11 +127,11 @@ function _createKing(
   dialogDefeat: I18nKey,
 ): Trainer {
   const zone = zonesData.find(z => z.id === zoneId)
-  if (!zone) {
+  if (!zone || zone.type !== 'sauvage')
     throw new Error(`Zone ${zoneId} not found`)
-  }
+
   // Gather base shlagemons and their first evolution stage
-  const available = zone.shlagemons!
+  const available = (zone.shlagemons ?? [])
     .flatMap(b => b.evolution?.base ? [b, b.evolution.base] : [b])
     // Remove potential duplicates by id
     .reduce<Record<string, BaseShlagemon>>((acc, mon) => {
@@ -149,7 +158,7 @@ function _createKing(
     dialogBefore,
     dialogAfter,
     dialogDefeat,
-    reward: zone.maxLevel || 1,
+    reward: zone.maxLevel,
     shlagemons,
   }
 }
@@ -164,7 +173,7 @@ export const kings: Kings = {
   'plaine-kekette': {
     id: 'king-plaine-kekette',
     character: ondejeune,
-    reward: zonesData.find(z => z.id === 'plaine-kekette')?.maxLevel || 1,
+    reward: getZoneMaxLevel('plaine-kekette'),
     dialogBefore: 'data.kings.plaine-kekette.dialogBefore',
     dialogAfter: 'data.kings.plaine-kekette.dialogAfter',
     dialogDefeat: 'data.kings.plaine-kekette.dialogDefeat',
@@ -179,7 +188,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.bois-de-bouffon.dialogBefore',
     dialogAfter: 'data.kings.bois-de-bouffon.dialogAfter',
     dialogDefeat: 'data.kings.bois-de-bouffon.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'bois-de-bouffon')?.maxLevel || 1,
+    reward: getZoneMaxLevel('bois-de-bouffon'),
     shlagemons: [
       racaillou.id,
       onixtamere.id,
@@ -192,7 +201,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.chemin-du-slip.dialogBefore',
     dialogAfter: 'data.kings.chemin-du-slip.dialogAfter',
     dialogDefeat: 'data.kings.chemin-du-slip.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'chemin-du-slip')?.maxLevel || 1,
+    reward: getZoneMaxLevel('chemin-du-slip'),
     shlagemons: [
       melofoutre.id,
       huithuit.id,
@@ -205,7 +214,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.ravin-fesse-molle.dialogBefore',
     dialogAfter: 'data.kings.ravin-fesse-molle.dialogAfter',
     dialogDefeat: 'data.kings.ravin-fesse-molle.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'ravin-fesse-molle')?.maxLevel || 1,
+    reward: getZoneMaxLevel('ravin-fesse-molle'),
     shlagemons: [
       houlard.id,
       rafflamby.id,
@@ -218,7 +227,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.precipice-nanard.dialogBefore',
     dialogAfter: 'data.kings.precipice-nanard.dialogAfter',
     dialogDefeat: 'data.kings.precipice-nanard.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'precipice-nanard')?.maxLevel || 1,
+    reward: getZoneMaxLevel('precipice-nanard'),
     shlagemons: [
       goubite.id,
       vieuxBlaireau.id,
@@ -232,7 +241,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.marais-moudugenou.dialogBefore',
     dialogAfter: 'data.kings.marais-moudugenou.dialogAfter',
     dialogDefeat: 'data.kings.marais-moudugenou.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'marais-moudugenou')?.maxLevel || 1,
+    reward: getZoneMaxLevel('marais-moudugenou'),
     shlagemons: [
       orchibre.id,
       barbeBizarre.id,
@@ -242,7 +251,7 @@ export const kings: Kings = {
   },
   'forteresse-petmoalfiak': {
     id: 'king-forteresse-petmoalfiak',
-    reward: zonesData.find(z => z.id === 'forteresse-petmoalfiak')?.maxLevel || 1,
+    reward: getZoneMaxLevel('forteresse-petmoalfiak'),
     character: charlesManoir,
     dialogBefore: 'data.kings.forteresse-petmoalfiak.dialogBefore',
     dialogAfter: 'data.kings.forteresse-petmoalfiak.dialogAfter',
@@ -260,7 +269,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.route-du-nawak.dialogBefore',
     dialogAfter: 'data.kings.route-du-nawak.dialogAfter',
     dialogDefeat: 'data.kings.route-du-nawak.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'route-du-nawak')?.maxLevel || 1,
+    reward: getZoneMaxLevel('route-du-nawak'),
     shlagemons: [
       pyrolise.id,
       cacanus.id,
@@ -274,7 +283,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.mont-dracatombe.dialogBefore',
     dialogAfter: 'data.kings.mont-dracatombe.dialogAfter',
     dialogDefeat: 'data.kings.mont-dracatombe.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'mont-dracatombe')?.maxLevel || 1,
+    reward: getZoneMaxLevel('mont-dracatombe'),
     shlagemons: [
       piafsansbec.id,
       hericouille.id,
@@ -289,7 +298,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.catacombes-merdifientes.dialogBefore',
     dialogAfter: 'data.kings.catacombes-merdifientes.dialogAfter',
     dialogDefeat: 'data.kings.catacombes-merdifientes.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'catacombes-merdifientes')?.maxLevel || 1,
+    reward: getZoneMaxLevel('catacombes-merdifientes'),
     shlagemons: [
       amonichiasse.id,
       dentlait.id,
@@ -304,7 +313,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.route-aguicheuse.dialogBefore',
     dialogAfter: 'data.kings.route-aguicheuse.dialogAfter',
     dialogDefeat: 'data.kings.route-aguicheuse.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'route-aguicheuse')?.maxLevel || 1,
+    reward: getZoneMaxLevel('route-aguicheuse'),
     shlagemons: [
       coksale.id,
       aerobite.id,
@@ -319,7 +328,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.vallee-des-chieurs.dialogBefore',
     dialogAfter: 'data.kings.vallee-des-chieurs.dialogAfter',
     dialogDefeat: 'data.kings.vallee-des-chieurs.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'vallee-des-chieurs')?.maxLevel || 1,
+    reward: getZoneMaxLevel('vallee-des-chieurs'),
     shlagemons: [
       nidononbinaireF.id,
       nidononbinaireM.id,
@@ -334,7 +343,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.trou-du-bide.dialogBefore',
     dialogAfter: 'data.kings.trou-du-bide.dialogAfter',
     dialogDefeat: 'data.kings.trou-du-bide.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'trou-du-bide')?.maxLevel || 1,
+    reward: getZoneMaxLevel('trou-du-bide'),
     shlagemons: [
       fantomanus.id,
       qulbudrogue.id,
@@ -349,7 +358,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.zone-giga-zob.dialogBefore',
     dialogAfter: 'data.kings.zone-giga-zob.dialogAfter',
     dialogDefeat: 'data.kings.zone-giga-zob.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'zone-giga-zob')?.maxLevel || 1,
+    reward: getZoneMaxLevel('zone-giga-zob'),
     shlagemons: [
       marginal.id,
       marginal.id,
@@ -364,7 +373,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.route-so-dom.dialogBefore',
     dialogAfter: 'data.kings.route-so-dom.dialogAfter',
     dialogDefeat: 'data.kings.route-so-dom.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'route-so-dom')?.maxLevel || 1,
+    reward: getZoneMaxLevel('route-so-dom'),
     shlagemons: [
       krabbolosse.id,
       grossetarte.id,
@@ -379,7 +388,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.lac-aux-relous.dialogBefore',
     dialogAfter: 'data.kings.lac-aux-relous.dialogAfter',
     dialogDefeat: 'data.kings.lac-aux-relous.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'lac-aux-relous')?.maxLevel || 1,
+    reward: getZoneMaxLevel('lac-aux-relous'),
     shlagemons: [
       metamorve.id,
       ratonton.id,
@@ -395,7 +404,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.canyon-a-la-derp.dialogBefore',
     dialogAfter: 'data.kings.canyon-a-la-derp.dialogAfter',
     dialogDefeat: 'data.kings.canyon-a-la-derp.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'canyon-a-la-derp')?.maxLevel || 1,
+    reward: getZoneMaxLevel('canyon-a-la-derp'),
     shlagemons: [
       pauvreetcon.id,
       kandurex.id,
@@ -411,7 +420,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.cratere-des-legends.dialogBefore',
     dialogAfter: 'data.kings.cratere-des-legends.dialogAfter',
     dialogDefeat: 'data.kings.cratere-des-legends.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'cratere-des-legends')?.maxLevel || 1,
+    reward: getZoneMaxLevel('cratere-des-legends'),
     shlagemons: [
       minidrapcon.id,
       voltamere.id,
@@ -427,7 +436,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.mont-kouillasse.dialogBefore',
     dialogAfter: 'data.kings.mont-kouillasse.dialogAfter',
     dialogDefeat: 'data.kings.mont-kouillasse.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'mont-kouillasse')?.maxLevel || 1,
+    reward: getZoneMaxLevel('mont-kouillasse'),
     shlagemons: [
       lecocu.id,
       meladolphe.id,
@@ -443,7 +452,7 @@ export const kings: Kings = {
     dialogBefore: 'data.kings.paturage-crado.dialogBefore',
     dialogAfter: 'data.kings.paturage-crado.dialogAfter',
     dialogDefeat: 'data.kings.paturage-crado.dialogDefeat',
-    reward: zonesData.find(z => z.id === 'paturage-crado')?.maxLevel || 1,
+    reward: getZoneMaxLevel('paturage-crado'),
     shlagemons: [
       floripute.id,
       dracoCon.id,

--- a/src/stores/wildLevel.ts
+++ b/src/stores/wildLevel.ts
@@ -1,3 +1,4 @@
+import type { SavageZone } from '~/type/zone'
 import { defineStore } from 'pinia'
 
 export const useWildLevelStore = defineStore('wildLevel', () => {
@@ -6,9 +7,9 @@ export const useWildLevelStore = defineStore('wildLevel', () => {
 
   const highestWildLevel = computed(() => {
     const wildZones = accessibleZones.value
-      .filter(z => z.type === 'sauvage')
+      .filter((z): z is SavageZone => z.type === 'sauvage')
     const last = wildZones[wildZones.length - 1]
-    return last?.maxLevel ?? 1
+    return last ? last.maxLevel : 1
   })
 
   return { highestWildLevel }

--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -1,5 +1,5 @@
 import type { Trainer } from '~/type/trainer'
-import type { SavageZoneId, Zone, ZoneId } from '~/type/zone'
+import type { SavageZone, SavageZoneId, Zone, ZoneId } from '~/type/zone'
 import { defineStore } from 'pinia'
 import { kings as kingsData } from '~/data/kings'
 import { zonesData } from '~/data/zones'
@@ -17,7 +17,9 @@ export const useZoneStore = defineStore('zone', () => {
     return zone ?? zones.value[0]
   })
   const xpZones = computed(() =>
-    zones.value.filter(z => (z.maxLevel ?? 0) > 0),
+    zones.value.filter(
+      (z): z is SavageZone => z.type === 'sauvage' && z.maxLevel > 0,
+    ),
   )
 
   const wildCooldownRemaining = computed(() => {
@@ -44,9 +46,9 @@ export const useZoneStore = defineStore('zone', () => {
 
   const rewardMultiplier = computed(() => {
     const zone = current.value
-    const maxLevel = zone.maxLevel ?? 0
-    if (!maxLevel)
+    if (zone.type !== 'sauvage')
       return 1
+    const { maxLevel } = zone
     const rank = maxLevel / 5
     return rank >= 0 ? 2 ** rank : 1
   })

--- a/src/stores/zoneAccess.ts
+++ b/src/stores/zoneAccess.ts
@@ -1,11 +1,11 @@
-import type { Zone } from '~/type/zone'
+import type { SavageZone, Zone } from '~/type/zone'
 import { zonesData } from '~/data/zones'
 
 export function useZoneAccess(highestLevel: Ref<number>) {
   const progress = useZoneProgressStore()
   const zones = zonesData
   const xpZones = computed(() =>
-    zones.filter(z => (z.maxLevel ?? 0) > 0),
+    zones.filter((z): z is SavageZone => z.type === 'sauvage' && z.maxLevel > 0),
   )
 
   function canAccess(z: Zone): boolean {
@@ -23,7 +23,9 @@ export function useZoneAccess(highestLevel: Ref<number>) {
 
   const accessibleZones = computed(() => zones.filter(z => canAccess(z)))
   const accessibleXpZones = computed(() =>
-    accessibleZones.value.filter(z => (z.maxLevel ?? 0) > 0),
+    accessibleZones.value.filter(
+      (z): z is SavageZone => z.type === 'sauvage' && z.maxLevel > 0,
+    ),
   )
 
   return {


### PR DESCRIPTION
## Summary
- guard accesses to zone.maxLevel behind type checks
- add helper to fetch savage zone max level
- ensure stores and components handle non-savage zones

## Testing
- `pnpm exec eslint src/stores/zone.ts src/data/kings.ts src/components/battle/Header.vue src/components/battle/Round.vue src/components/battle/Main.vue src/components/battle/Trainer.vue src/stores/zoneAccess.ts src/stores/wildLevel.ts`
- `pnpm typecheck` *(fails: Property 'stop' does not exist on type...)*
- `pnpm test:unit` *(fails: 8 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68990da0c47c832a8f4dd8c4bfb4bdcb