### PR TITLE
fix: avoid async setup in AnimatedNumber

### DIFF
--- a/src/components/ui/AnimatedNumber.vue
+++ b/src/components/ui/AnimatedNumber.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue'
 
 type EasingName = 'linear' | 'easeInOutCubic' | 'easeOutCubic' | 'easeInCubic'
 
@@ -30,12 +30,15 @@ const emit = defineEmits<{ (e: 'finished', finalValue: number): void }>()
  * the client. When rendered on the server a formatted static number is
  * displayed instead of an animation.
  */
-let NumberAnimationComponent:
-  | (typeof import('vue-number-animation')['default'])
-  | null = null
+const NumberAnimationComponent = shallowRef<
+  null | typeof import('vue-number-animation')['default']
+    >(null)
 
-if (!import.meta.env.SSR)
-  NumberAnimationComponent = (await import('vue-number-animation')).default
+if (!import.meta.env.SSR) {
+  import('vue-number-animation').then((mod) => {
+    NumberAnimationComponent.value = mod.default
+  })
+}
 
 // const prefersReduced = usePreferredReducedMotion()
 


### PR DESCRIPTION
## Summary
- avoid async setup in AnimatedNumber by dynamically importing vue-number-animation without top-level await
- store the imported component in a shallowRef to prevent it from becoming reactive

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Type 'Stoppable<[]>' is missing the following properties from type 'Timeout'...)*
- `pnpm test:unit` *(fails: renders /fr/** in French; renders / as English page like /en/; displays shlagemons with items first)*

------
https://chatgpt.com/codex/tasks/task_e_68990e7ad490832a83d133c9f4f0138d