### PR TITLE
chore: add crypto-js types

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@iconify-json/mdi": "catalog:dev",
     "@intlify/unplugin-vue-i18n": "catalog:build",
     "@shikijs/markdown-it": "catalog:build",
+    "@types/crypto-js": "catalog:",
     "@types/howler": "catalog:build",
     "@types/leaflet": "catalog:types",
     "@types/markdown-it-link-attributes": "catalog:types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,9 @@ importers:
       '@shikijs/markdown-it':
         specifier: catalog:build
         version: 3.8.1(markdown-it-async@2.2.0)
+      '@types/crypto-js':
+        specifier: ^4.2.2
+        version: 4.2.2
       '@types/howler':
         specifier: catalog:build
         version: 2.2.12
@@ -2087,6 +2090,9 @@ packages:
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/crypto-js@4.2.2':
+    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -8312,6 +8318,8 @@ snapshots:
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
+
+  '@types/crypto-js@4.2.2': {}
 
   '@types/debug@4.1.12':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages: []
 
+catalog:
+  '@types/crypto-js': ^4.2.2
 catalogs:
   build:
     '@intlify/unplugin-vue-i18n': ^6.0.8


### PR DESCRIPTION
## Summary
- add `@types/crypto-js` dev dependency for proper typings

## Testing
- `pnpm typecheck` *(fails: Property 'stop' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_68990f5d9abc832a9d19bc8dcac17df3