### PR TITLE
fix: ensure disease store refs after hydration

### DIFF
--- a/src/stores/disease.ts
+++ b/src/stores/disease.ts
@@ -49,9 +49,9 @@ export const useDiseaseStore = defineStore('disease', () => {
   persist: {
     afterHydrate(ctx) {
       const store = ctx.store as ReturnType<typeof useDiseaseStore>
-      if (typeof store.active !== 'object')
+      if (!isRef(store.active))
         store.active = ref(Boolean(store.active))
-      if (typeof store.remaining !== 'object')
+      if (!isRef(store.remaining))
         store.remaining = ref(Number(store.remaining) || 0)
     },
   },


### PR DESCRIPTION
## Summary
- use `isRef` to wrap disease store state in refs when hydrating

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Property 'maxLevel' does not exist on type 'Zone')*
- `pnpm test:unit --run`
- `pnpm build` *(warning: failed to fetch web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68990faf4718832ab1330f63e19bc0fe