### PR TITLE
fix(map): show golden aura on perfect zone ball

### DIFF
--- a/src/composables/leaflet/useMapMarkers.ts
+++ b/src/composables/leaflet/useMapMarkers.ts
@@ -86,13 +86,13 @@ export function useMapMarkers(map: LeafletMap) {
 
       // --- Icône principale (zone) ---
       const zoneIconStyle
-    = zone.type !== 'village'
-      ? (captureState.value === 'missing'
-          ? GREY_FILTER
-          : captureState.value === 'perfect'
-            ? GOLD_FILTER
-            : '')
-      : ''
+        = zone.type !== 'village'
+          ? (!allCaptured.value
+              ? GREY_FILTER
+              : perfectZone.value
+                ? GOLD_FILTER
+                : '')
+          : ''
       const baseIcon = `<img src="${iconPath(zone)}" class="w-${iconClassSize} h-${iconClassSize} block ${highlight}" style="${zoneIconStyle}" />`
 
       // --- Badges / chip sous l'icône ---
@@ -107,15 +107,14 @@ export function useMapMarkers(map: LeafletMap) {
         badges = arena
       }
       else {
-        const ballStyle = {
-          missing: GREY_FILTER,
-          complete: '',
-          perfect: GOLD_FILTER,
-          shiny: '',
-        }[captureState.value]
+        const ballStyle = captureState.value === 'missing'
+          ? GREY_FILTER
+          : perfectZone.value
+            ? GOLD_FILTER
+            : ''
         const ball = `<img src="/items/shlageball/shlageball.webp" class="h-3 w-3" style="${ballStyle}" />`
 
-        const shinyBadge = captureState.value === 'shiny'
+        const shinyBadge = allShiny.value
           ? '<div class="i-mdi:star h-2 w-2 mask-rainbow absolute -top-1 -right-1"></div>'
           : ''
         const ballWithBadge = shinyBadge
@@ -153,7 +152,7 @@ export function useMapMarkers(map: LeafletMap) {
       title: i18n.global.t(zone.name),
     })
 
-    watch([captureState, kingState, arenaCompleted, visited], () => {
+    watch([captureState, perfectZone, allShiny, kingState, arenaCompleted, visited], () => {
       marker.setIcon(new DivIcon({
         html: buildHtml(),
         iconSize: [markerSize, markerSize],

--- a/test/map-marker-tooltip.test.ts
+++ b/test/map-marker-tooltip.test.ts
@@ -131,7 +131,7 @@ describe('useMapMarkers', () => {
     addMarker(zone)
     const html = useLeafletMarkerMock.mock.calls[0][0].html as string
     expect(html).toContain('mask-rainbow')
-    expect(html).not.toContain('drop-shadow(0 0 2px #facc15)')
+    expect(html).toContain('drop-shadow(0 0 2px #facc15)')
   })
 
   it('hides crown when zone has no king', () => {


### PR DESCRIPTION
## Summary
- highlight zone markers with golden shlageball when all monsters have 100 rarity
- extend tests for golden aura on perfect zones

## Testing
- `pnpm test` *(fails: SyntaxError: Invalid arguments in page-locale-ssr.test.ts; AssertionError in sort-item.test.ts)*
- `pnpm lint` *(fails: Expected object keys to be in ascending order in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899145d9614832a965b9cdf591d1b26