### PR TITLE
feat: detect pwa environment

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -313,6 +313,8 @@ declare global {
   const usePreferredReducedMotion: typeof import('@vueuse/core')['usePreferredReducedMotion']
   const usePreferredReducedTransparency: typeof import('@vueuse/core')['usePreferredReducedTransparency']
   const usePrevious: typeof import('@vueuse/core')['usePrevious']
+  const usePwaEnvironment: typeof import('./composables/usePwaEnvironment')['usePwaEnvironment']
+  const usePwaEnvironmentStore: typeof import('./stores/pwaEnvironment')['usePwaEnvironmentStore']
   const usePwaUpdateStore: typeof import('./stores/pwaUpdate')['usePwaUpdateStore']
   const useRafFn: typeof import('@vueuse/core')['useRafFn']
   const useRefHistory: typeof import('@vueuse/core')['useRefHistory']
@@ -438,6 +440,9 @@ declare global {
   // @ts-ignore
   export type { PageHeadOptions } from './composables/usePageHead'
   import('./composables/usePageHead')
+  // @ts-ignore
+  export type { PwaEnvironment } from './composables/usePwaEnvironment'
+  import('./composables/usePwaEnvironment')
   // @ts-ignore
   export type { SlidingPuzzle, PuzzleDirection } from './composables/useSlidingPuzzle'
   import('./composables/useSlidingPuzzle')
@@ -799,6 +804,8 @@ declare module 'vue' {
     readonly usePreferredReducedMotion: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedMotion']>
     readonly usePreferredReducedTransparency: UnwrapRef<typeof import('@vueuse/core')['usePreferredReducedTransparency']>
     readonly usePrevious: UnwrapRef<typeof import('@vueuse/core')['usePrevious']>
+    readonly usePwaEnvironment: UnwrapRef<typeof import('./composables/usePwaEnvironment')['usePwaEnvironment']>
+    readonly usePwaEnvironmentStore: UnwrapRef<typeof import('./stores/pwaEnvironment')['usePwaEnvironmentStore']>
     readonly usePwaUpdateStore: UnwrapRef<typeof import('./stores/pwaUpdate')['usePwaUpdateStore']>
     readonly useRafFn: UnwrapRef<typeof import('@vueuse/core')['useRafFn']>
     readonly useRefHistory: UnwrapRef<typeof import('@vueuse/core')['useRefHistory']>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -47,6 +47,8 @@ const headerClass = [
   'z-50',
   'relative',
 ]
+
+const pwaEnv = usePwaEnvironmentStore()
 </script>
 
 <template>
@@ -110,7 +112,7 @@ const headerClass = [
       <DeveloperSettingsModal v-if="showDevButton" v-model="showDeveloper" />
 
       <!-- Plein écran : même hauteur/largeur/visuel que les autres ! -->
-      <UiFullscreenToggle />
+      <UiFullscreenToggle v-if="!pwaEnv.isTwa" />
     </nav>
   </header>
 </template>

--- a/src/composables/usePwaEnvironment.spec.ts
+++ b/src/composables/usePwaEnvironment.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+const originalUA = navigator.userAgent
+const originalMatchMedia = window.matchMedia
+
+function mockMatchMedia(standalone: boolean) {
+  window.matchMedia = (query: string) => ({
+    matches: standalone && /display-mode: (?:standalone|fullscreen)/.test(query),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }) as any
+}
+
+afterEach(() => {
+  window.history.replaceState(null, '', '/')
+  Object.defineProperty(window.navigator, 'userAgent', { value: originalUA, configurable: true })
+  window.matchMedia = originalMatchMedia
+})
+
+describe('usePwaEnvironment', () => {
+  it('detects twa via query parameter', () => {
+    window.history.replaceState(null, '', '/?twa=1')
+    const { isTwa } = usePwaEnvironment()
+    expect(isTwa.value).toBe(true)
+  })
+
+  it('detects twa via standalone android chrome', () => {
+    mockMatchMedia(true)
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Linux; Android 10) Chrome/99.0 Mobile',
+      configurable: true,
+    })
+    const { isTwa } = usePwaEnvironment()
+    expect(isTwa.value).toBe(true)
+  })
+
+  it('is not twa by default', () => {
+    mockMatchMedia(false)
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'Mozilla/5.0', configurable: true })
+    const { isTwa } = usePwaEnvironment()
+    expect(isTwa.value).toBe(false)
+  })
+})

--- a/src/composables/usePwaEnvironment.ts
+++ b/src/composables/usePwaEnvironment.ts
@@ -1,0 +1,81 @@
+/**
+ * Reactive helpers to detect PWA or Trusted Web Activity contexts.
+ *
+ * Exposes installability state and a conservative heuristic to detect
+ * Trusted Web Activity (TWA) sessions.
+ */
+const TWA_PARAM_KEYS = ['twa', 'source', 'app'] as const
+
+type TwaParamKey = (typeof TWA_PARAM_KEYS)[number]
+
+export interface PwaEnvironment {
+  /** True when the app runs without browser UI (PWA/TWA/fullscreen). */
+  readonly isStandalone: Readonly<Ref<boolean>>
+  /** True when the browser considers the app installable. */
+  readonly isInstallable: Readonly<Ref<boolean>>
+  /** True immediately after installation. */
+  readonly isInstalledNow: Readonly<Ref<boolean>>
+  /** Heuristic signal to detect a Trusted Web Activity. */
+  readonly isTwa: ComputedRef<boolean>
+}
+
+/**
+ * Detects PWA and TWA execution environments.
+ */
+export function usePwaEnvironment(): PwaEnvironment {
+  // 1) Standalone (Chrome/Edge) + iOS Safari
+  const matchesStandalone = useMediaQuery('(display-mode: standalone)')
+  const matchesFullscreen = useMediaQuery('(display-mode: fullscreen)')
+  const isIosStandalone = ref<boolean>(
+    typeof navigator !== 'undefined'
+    && (navigator as unknown as { standalone?: boolean }).standalone === true,
+  )
+  const isStandalone = computed(() =>
+    matchesStandalone.value || matchesFullscreen.value || isIosStandalone.value,
+  )
+
+  // 2) Installable / Installed
+  const isInstallable = ref(false)
+  const isInstalledNow = ref(false)
+  if (typeof window !== 'undefined') {
+    useEventListener(window, 'beforeinstallprompt', () => {
+      isInstallable.value = true
+    })
+    useEventListener(window, 'appinstalled', () => {
+      isInstalledNow.value = true
+      isInstallable.value = false
+    })
+  }
+
+  // 3) TWA: signal via query param or heuristics
+  const params: Record<string, unknown> = typeof window === 'undefined'
+    ? reactive({})
+    : useUrlSearchParams<'history' | 'hash' | 'hash-params'>(
+        'history',
+        { removeNullishValues: true },
+      )
+  const ua = useUserAgent()
+
+  // Explicit signal ?twa=1 or ?source=twa etc.
+  const twaSignalParam = computed(() =>
+    TWA_PARAM_KEYS.some((k: TwaParamKey) => {
+      const value = String(params[k] ?? '').toLowerCase()
+      return value === 'twa' || value === '1'
+    }),
+  )
+
+  // Conservative heuristic: standalone Android Chrome
+  const uaLooksAndroidChrome = computed(() =>
+    /Android/i.test(ua.value) && /Chrome\/\d+/i.test(ua.value),
+  )
+  const isTwa = computed(() =>
+    twaSignalParam.value || (isStandalone.value && uaLooksAndroidChrome.value),
+  )
+
+  return {
+    isStandalone: readonly(isStandalone),
+    isInstallable: readonly(isInstallable),
+    isInstalledNow: readonly(isInstalledNow),
+    isTwa,
+  }
+}

--- a/src/stores/pwaEnvironment.ts
+++ b/src/stores/pwaEnvironment.ts
@@ -1,0 +1,9 @@
+import { defineStore } from 'pinia'
+
+/**
+ * Store exposing the current PWA environment state.
+ */
+export const usePwaEnvironmentStore = defineStore('pwaEnvironment', () => {
+  const env = usePwaEnvironment()
+  return env
+})


### PR DESCRIPTION
## Summary
- add composable to track PWA/TWA environment details
- expose environment via new Pinia store
- hide fullscreen toggle when running inside a TWA

## Testing
- `pnpm exec eslint src/composables/usePwaEnvironment.ts src/stores/pwaEnvironment.ts src/components/layout/Header.vue src/composables/usePwaEnvironment.spec.ts`
- `pnpm test:unit` *(failed: AssertionError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6899c4156f88832ab65c1c8980998b6c