### PR TITLE
feat: toggle zone info visibility

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -396,6 +396,7 @@ declare global {
   const useWindowSize: typeof import('@vueuse/core')['useWindowSize']
   const useZoneAccess: typeof import('./stores/zoneAccess')['useZoneAccess']
   const useZoneCompletion: typeof import('./composables/useZoneCompletion')['useZoneCompletion']
+  const useZoneInfoStore: typeof import('./stores/zoneInfo')['useZoneInfoStore']
   const useZoneMonsModalStore: typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']
   const useZoneProgressStore: typeof import('./stores/zoneProgress')['useZoneProgressStore']
   const useZoneStore: typeof import('./stores/zone')['useZoneStore']
@@ -886,6 +887,7 @@ declare module 'vue' {
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
     readonly useZoneAccess: UnwrapRef<typeof import('./stores/zoneAccess')['useZoneAccess']>
     readonly useZoneCompletion: UnwrapRef<typeof import('./composables/useZoneCompletion')['useZoneCompletion']>
+    readonly useZoneInfoStore: UnwrapRef<typeof import('./stores/zoneInfo')['useZoneInfoStore']>
     readonly useZoneMonsModalStore: UnwrapRef<typeof import('./stores/zoneMonsModal')['useZoneMonsModalStore']>
     readonly useZoneProgressStore: UnwrapRef<typeof import('./stores/zoneProgress')['useZoneProgressStore']>
     readonly useZoneStore: UnwrapRef<typeof import('./stores/zone')['useZoneStore']>

--- a/src/components/battle/Header.vue
+++ b/src/components/battle/Header.vue
@@ -4,16 +4,17 @@ import type { Trainer } from '~/type'
 const props = defineProps<{ zoneName?: string, trainer?: Trainer, defeated?: number }>()
 const defeated = computed(() => props.defeated ?? 0)
 const zone = useZoneStore()
+const info = useZoneInfoStore()
 </script>
 
 <template>
   <div class="w-full flex items-center gap-2 overflow-hidden font-bold" :class="props.trainer ? 'justify-end' : 'justify-center'">
-    <template v-if="props.zoneName">
+    <template v-if="props.zoneName && info.hasMultipleZones">
       <div class="flex flex-col items-center justify-center p-x-20">
         <div class="w-full overflow-hidden text-ellipsis whitespace-nowrap text-center" :title="props.zoneName">
           {{ props.zoneName }}
         </div>
-        <div v-if="zone.current.type === 'sauvage'" class="whitespace-nowrap text-xs">
+        <div v-if="zone.current.type === 'sauvage' && info.showZoneLevels" class="whitespace-nowrap text-xs">
           {{ zone.current.minLevel }} - {{ zone.current.maxLevel }}
         </div>
       </div>

--- a/src/components/battle/Main.vue
+++ b/src/components/battle/Main.vue
@@ -24,6 +24,8 @@ const wildLevel = useWildLevelStore()
 
 const enemy = ref(null as DexShlagemon | null)
 const { t } = useI18n()
+const info = useZoneInfoStore()
+const zoneName = computed(() => info.hasMultipleZones ? t(zone.current.name) : undefined)
 
 function createEnemy(): DexShlagemon | null {
   const available = zone.current.shlagemons?.length ? zone.current.shlagemons : allShlagemons
@@ -161,7 +163,7 @@ function onCapture() {
       @capture="onCapture"
     >
       <template #header>
-        <BattleHeader :zone-name="t(zone.current.name)" />
+        <BattleHeader :zone-name="zoneName" />
       </template>
     </BattleRound>
     <ZoneMonsModal />

--- a/src/components/panel/Village.vue
+++ b/src/components/panel/Village.vue
@@ -18,6 +18,7 @@ const player = usePlayerStore()
 const interfaceStore = useInterfaceStore()
 const { t } = useI18n()
 const { showVillagesOnMap } = storeToRefs(interfaceStore)
+const info = useZoneInfoStore()
 
 const mapRef = ref<InstanceType<typeof VillageMap> | null>(null)
 const activePoiId = ref<string | null>(null)
@@ -116,7 +117,7 @@ function leaveVillage() {
 
 <template>
   <LayoutTitledPanel
-    :title="t(zone.current.name)"
+    :title="info.hasMultipleZones ? t(zone.current.name) : ''"
     :exit-text="t('components.panel.Village.exit')"
     @exit="leaveVillage"
   >

--- a/src/components/zone/ButtonWild.vue
+++ b/src/components/zone/ButtonWild.vue
@@ -13,6 +13,7 @@ const featureLock = useFeatureLockStore()
 const visit = useZoneVisitStore()
 const { t } = useI18n()
 const { canAccess } = useZoneAccess(toRef(dex, 'highestLevel'))
+const info = useZoneInfoStore()
 
 const zoneButtonsDisabled = computed(
   () =>
@@ -77,8 +78,8 @@ const highlightClasses = 'animate-pulse-alt  animate-count-infinite'
     :disabled="buttonDisabled()"
     @click="selectZone"
   >
-    <span class="text-2xs absolute left-1 top-0.5">{{ props.zone.minLevel }}</span>
-    <span class="text-2xs absolute right-1 top-0.5">{{ props.zone.maxLevel }}</span>
+    <span v-if="info.showZoneLevels" class="text-2xs absolute left-1 top-0.5">{{ props.zone.minLevel }}</span>
+    <span v-if="info.showZoneLevels" class="text-2xs absolute right-1 top-0.5">{{ props.zone.maxLevel }}</span>
     <div class="flex-center">
       <div class="i-game-icons:forest h-6 w-6" />
     </div>

--- a/src/stores/zoneInfo.ts
+++ b/src/stores/zoneInfo.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+
+/**
+ * Global zone-related flags used to control UI visibility.
+ *
+ * Flags persist once unlocked because they only evolve forward.
+ */
+export const useZoneInfoStore = defineStore('zoneInfo', () => {
+  const hasMultipleZones = ref(false)
+  const showZoneLevels = ref(false)
+
+  const dex = useShlagedexStore()
+  const { accessibleZones } = useZoneAccess(toRef(dex, 'highestLevel'))
+
+  watchEffect(() => {
+    if (!hasMultipleZones.value && accessibleZones.value.length > 1)
+      hasMultipleZones.value = true
+  })
+
+  watchEffect(() => {
+    if (!showZoneLevels.value && dex.highestLevel >= 5)
+      showZoneLevels.value = true
+  })
+
+  function reset() {
+    hasMultipleZones.value = false
+    showZoneLevels.value = false
+  }
+
+  return {
+    hasMultipleZones,
+    showZoneLevels,
+    reset,
+  }
+}, {
+  persist: true,
+})

--- a/test/zone-info-display.test.ts
+++ b/test/zone-info-display.test.ts
@@ -1,0 +1,75 @@
+import type { SavageZone } from '../src/type/zone'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import BattleHeader from '../src/components/battle/Header.vue'
+import ZoneButtonWild from '../src/components/zone/ButtonWild.vue'
+import { useZoneInfoStore } from '../src/stores/zoneInfo'
+
+function setupPinia() {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  return pinia
+}
+
+describe('zone info visibility flags', () => {
+  it('hides zone name and levels when not unlocked', () => {
+    const pinia = setupPinia()
+    const info = useZoneInfoStore()
+    info.hasMultipleZones = false
+    info.showZoneLevels = false
+
+    const wrapper = mount(BattleHeader, {
+      props: { zoneName: 'Test Zone' },
+      global: { plugins: [pinia] },
+    })
+
+    expect(wrapper.text()).not.toContain('Test Zone')
+    expect(wrapper.text()).not.toMatch(/\d+ - \d+/)
+  })
+
+  it('shows zone name and levels when unlocked', () => {
+    const pinia = setupPinia()
+    const info = useZoneInfoStore()
+    info.hasMultipleZones = true
+    info.showZoneLevels = true
+
+    const wrapper = mount(BattleHeader, {
+      props: { zoneName: 'Test Zone' },
+      global: { plugins: [pinia] },
+    })
+
+    expect(wrapper.text()).toContain('Test Zone')
+    expect(wrapper.text()).toContain('1 - 5')
+  })
+
+  it('renders zone levels on buttons only when unlocked', () => {
+    const pinia = setupPinia()
+    const info = useZoneInfoStore()
+    info.showZoneLevels = false
+
+    const zone: SavageZone = {
+      id: 'plaine-kekette',
+      name: 'zone.test',
+      type: 'sauvage',
+      position: { lat: 0, lng: 0 },
+      minLevel: 1,
+      maxLevel: 5,
+      shlagemons: [],
+    }
+
+    const wrapper = mount(ZoneButtonWild, {
+      props: { zone },
+      global: { plugins: [pinia], directives: { tooltip: () => {} } },
+    })
+
+    expect(wrapper.text()).not.toContain('1')
+    expect(wrapper.text()).not.toContain('5')
+
+    info.showZoneLevels = true
+    return wrapper.vm.$nextTick().then(() => {
+      expect(wrapper.text()).toContain('1')
+      expect(wrapper.text()).toContain('5')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- persist whether multiple zones are unlocked and if zone levels should display
- hide zone name when only one zone is available and show level range only after lvl5
- cover zone info visibility with unit tests

## Testing
- `npx vitest run test/zone-info-display.test.ts --reporter=verbose`


------
https://chatgpt.com/codex/tasks/task_e_6899daa8c61c832a896924f5ce482e1e