### PR TITLE
fix: show battle toasts only on normal attacks

### DIFF
--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -66,8 +66,8 @@ export function useBattleCore(options: BattleCoreOptions) {
   function attack() {
     if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
       return false
-    const { effect, crit } = battle.clickAttack(dex.activeShlagemon, enemy.value)
-    showEffect('enemy', effect, crit)
+    // Manual click attacks intentionally bypass effectiveness toasts.
+    battle.clickAttack(dex.activeShlagemon, enemy.value)
     enemyHp.value = enemy.value.hpCurrent
     flashEnemy.value = true
     hideFlashEnemy()

--- a/test/battle-toast.test.ts
+++ b/test/battle-toast.test.ts
@@ -1,0 +1,51 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useBattleCore } from '../src/composables/useBattleCore'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useBattleStore } from '../src/stores/battle'
+
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+// Spy on battle effect notifications
+const showEffect = vi.fn()
+vi.mock('~/composables/battleEngine', () => ({
+  useBattleEffects: () => ({
+    playerEffect: ref(''),
+    enemyEffect: ref(''),
+    playerVariant: ref('normal'),
+    enemyVariant: ref('normal'),
+    showEffect,
+  }),
+}))
+
+describe('battle toast visibility', () => {
+  it('triggers on normal attacks but not on click attacks', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const battle = useBattleStore()
+    const player = dex.createShlagemon(carapouffe)
+    const enemy = dex.createShlagemon(carapouffe)
+    dex.setActiveShlagemon(player)
+
+    // Prevent the interval loop from running automatically
+    vi.spyOn(battle, 'startLoop').mockImplementation(() => {})
+
+    const core = useBattleCore({ createEnemy: () => enemy })
+    core.startBattle()
+
+    // Manual click attack should not emit toasts
+    showEffect.mockClear()
+    core.attack()
+    expect(showEffect).not.toHaveBeenCalled()
+
+    // Normal tick attack should emit a toast
+    showEffect.mockClear()
+    vi.spyOn(battle, 'duel').mockReturnValue({
+      player: { damage: 1, effect: 'super', crit: 'normal' },
+      enemy: null,
+    })
+    core.tick()
+    expect(showEffect).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- avoid triggering battle effectiveness toast during manual click attacks
- add regression test covering toast visibility

## Testing
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6899e0b2e8cc832aa667355b87a4f5bb