### PR TITLE
fix: maintain update snackbar loading state until refresh

### DIFF
--- a/src/components/UpdateSnackbar.vue
+++ b/src/components/UpdateSnackbar.vue
@@ -47,11 +47,6 @@ async function handleReload() {
   hasError.value = null
   try {
     await store.reload()
-    // Si le reload n’est pas immédiat (rare), on évite un flash d’état.
-    setTimeout(() => {
-      if (isUpdating.value)
-        isUpdating.value = false
-    }, 1200)
   }
   catch (e) {
     hasError.value = e instanceof Error ? e : new Error('Update failed')


### PR DESCRIPTION
## Summary
- remove automatic reset of update snackbar loading flag so the toast remains in loading state until the page refreshes

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_6899fa330cb4832aabc4cbbf414af194