### PR TITLE
Slow floating number animations

### DIFF
--- a/src/components/battle/mon/FloatingNumbers.vue
+++ b/src/components/battle/mon/FloatingNumbers.vue
@@ -42,7 +42,7 @@ function onEnd(id: number) {
   transform: translate(0, 0) scale(var(--scale, 1)) rotate(var(--rot, 0deg));
 }
 .float-enter-active {
-  animation: floatDamage 0.9s cubic-bezier(0.22, 0.8, 0.22, 0.99) both;
+  animation: floatDamage 1.2s cubic-bezier(0.22, 0.8, 0.22, 0.99) both;
 }
 .float-chip.heal.float-enter-active {
   animation-name: floatHeal;
@@ -87,7 +87,7 @@ function onEnd(id: number) {
 }
 @media (prefers-reduced-motion: reduce) {
   .float-enter-active {
-    animation-duration: 0.3s;
+    animation-duration: 0.4s;
   }
   @keyframes floatDamage {
     0% {
@@ -96,7 +96,7 @@ function onEnd(id: number) {
     }
     100% {
       opacity: 1;
-      transform: translate(0, -8px) scale(1) rotate(0deg);
+      transform: translate(0, -4px) scale(1) rotate(0deg);
     }
   }
   @keyframes floatHeal {
@@ -106,7 +106,7 @@ function onEnd(id: number) {
     }
     100% {
       opacity: 1;
-      transform: translate(0, 8px) scale(1);
+      transform: translate(0, 4px) scale(1);
     }
   }
 }

--- a/src/composables/useFloatingNumbers.ts
+++ b/src/composables/useFloatingNumbers.ts
@@ -113,12 +113,12 @@ export function useFloatingNumbers(hp: Ref<number>, visible: Ref<boolean>) {
       if (kind === 'damage') {
         const charCount = String(amount).length + 1
         const w = Math.max(14, charCount * 8)
-        const maxHoriz = w * 3
+        const maxHoriz = w * 1.5
         dx = randomDx(w, maxHoriz)
         const centerFactor = 1 - Math.abs(dx) / maxHoriz
         const baseRise = 46
         const extraRise = 18 * centerFactor
-        dy = -(baseRise + extraRise + Math.random() * 10)
+        dy = -((baseRise + extraRise + Math.random() * 10) * 0.5)
         const magnitude = 4 + Math.random() * 6
         rotation = Math.round(magnitude * Math.sign(dx))
         const average = damageCount > 0 ? totalDamage / damageCount : amount
@@ -128,7 +128,7 @@ export function useFloatingNumbers(hp: Ref<number>, visible: Ref<boolean>) {
         damageCount++
       }
       else {
-        dy = 46 + Math.random() * 10
+        dy = (46 + Math.random() * 10) * 0.5
       }
       results.push({
         id: ++idCounter,


### PR DESCRIPTION
## Summary
- extend floating damage/heal number animation to 1.2s and adjust reduced-motion keyframes
- halve floating number travel distance for less dramatic movement

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Invalid arguments in test/page-locale-ssr.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6899fc93cde0832a8b75ac48526b08d1