### PR TITLE
feat: allow shiny upgrade at max rarity

### DIFF
--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -575,7 +575,14 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const existing = shlagemons.value.find(mon => mon.base.id === base.id)
     if (existing) {
       if (existing.rarity >= 100) {
-        toast(i18n.global.t('stores.shlagedex.alreadyMax'))
+        if (shiny && !existing.isShiny) {
+          existing.captureCount += 1
+          existing.isShiny = true
+          toast(i18n.global.t('stores.shlagedex.obtained', { name: i18n.global.t(existing.base.name) }))
+        }
+        else {
+          toast(i18n.global.t('stores.shlagedex.alreadyMax'))
+        }
         return existing
       }
       const before = existing.rarity
@@ -630,7 +637,14 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
     const existing = shlagemons.value.find(mon => mon.base.id === enemy.base.id)
     if (existing) {
       if (existing.rarity >= 100) {
-        toast(i18n.global.t('stores.shlagedex.alreadyMax'))
+        if (enemy.isShiny && !existing.isShiny) {
+          existing.captureCount += 1
+          existing.isShiny = true
+          toast(i18n.global.t('stores.shlagedex.obtained', { name: i18n.global.t(existing.base.name) }))
+        }
+        else {
+          toast(i18n.global.t('stores.shlagedex.alreadyMax'))
+        }
         return existing
       }
       const before = existing.rarity

--- a/test/shlagedex.test.ts
+++ b/test/shlagedex.test.ts
@@ -138,6 +138,32 @@ describe('shlagedex capture', () => {
       'Vous avez déjà ce Shlagémon au maximum de sa rareté',
     )
   })
+
+  it('turns rarity 100 mon shiny via captureShlagemon when capturing shiny duplicate', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.rarity = 100
+    mon.isShiny = false
+    const result = dex.captureShlagemon(carapouffe, true)
+    expect(result.id).toBe(mon.id)
+    expect(mon.isShiny).toBe(true)
+  })
+
+  it('turns rarity 100 mon shiny via captureEnemy when capturing shiny enemy', () => {
+    setActivePinia(createPinia())
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    mon.rarity = 100
+    mon.isShiny = false
+    const enemy = createDexShlagemon(carapouffe, true, 20)
+    enemy.rarity = 100
+    applyStats(enemy)
+    applyCurrentStats(enemy)
+    const result = dex.captureEnemy(enemy)
+    expect(result.id).toBe(mon.id)
+    expect(mon.isShiny).toBe(true)
+  })
 })
 
 describe('shlagedex highest level', () => {


### PR DESCRIPTION
## Summary
- allow capturing a shiny duplicate to upgrade a max-rarity Shlagémon to shiny
- test shiny upgrade when capturing via base or enemy instance

## Testing
- `pnpm exec eslint src/stores/shlagedex.ts test/shlagedex.test.ts`
- `pnpm test:unit` *(fails: Cannot call props on an empty VueWrapper, ignores rapid successive clicks to keep the UI responsive, invalid arguments, snapshot mismatched, redirect function issues, expected name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a089b03d8832ab98a05225c7cce87