### PR TITLE
feat(detail): show evolution owned icon

### DIFF
--- a/src/components/shlagemon/Detail.vue
+++ b/src/components/shlagemon/Detail.vue
@@ -170,6 +170,11 @@ const captureInfo = computed(() => {
           @click="openOwnedEvolution"
         >
           {{ evolutionInfo }}
+          <img
+            src="/items/shlageball/shlageball.webp"
+            alt=""
+            class="ml-1 inline-block h-4 w-4"
+          >
         </button>
         <div
           v-else

--- a/test/shlagemon-detail-evolution-icon.test.ts
+++ b/test/shlagemon-detail-evolution-icon.test.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+
+import ShlagemonDetail from '../src/components/shlagemon/Detail.vue'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { carabifle } from '../src/data/shlagemons/evolutions/carabifle'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+import { createDexShlagemon } from '../src/utils/dexFactory'
+
+describe('shlagemon detail evolution icon', () => {
+  it('displays shlageball icon when evolution is owned', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    const dex = useShlagedexStore()
+    const mon = createDexShlagemon(carapouffe)
+    const evo = createDexShlagemon(carabifle)
+    dex.shlagemons.push(mon, evo)
+
+    const messages = {
+      en: {
+        components: {
+          shlagemon: {
+            Detail: { evolveByLevel: 'Level {level}' },
+          },
+        },
+      },
+    }
+
+    const i18n = createI18n({ legacy: false, locale: 'en', messages })
+
+    const wrapper = mount(ShlagemonDetail, {
+      props: { mon },
+      global: {
+        plugins: [pinia, i18n],
+        stubs: {
+          ShlagemonImage: true,
+          ShlagemonType: true,
+          WearableItemIcon: true,
+          ShlagemonStats: true,
+          ShlagemonXpBar: true,
+          ShlagemonRarityInfo: true,
+          UiButton: true,
+          UiCheckBox: true,
+        },
+        directives: { tooltip: () => {} },
+      },
+    })
+
+    const button = wrapper.findAll('button').find(b => b.text().includes('Level'))
+    expect(button).toBeTruthy()
+    expect(button!.find('img').attributes('src')).toBe('/items/shlageball/shlageball.webp')
+  })
+})


### PR DESCRIPTION
## Summary
- show shlageball icon beside evolution info when evolved form is owned
- test evolution icon display

## Testing
- `pnpm exec eslint src/components/shlagemon/Detail.vue test/shlagemon-detail-evolution-icon.test.ts`
- `pnpm lint` *(fails: Strings must use singlequote in locales/en.yml)*
- `pnpm test:unit` *(fails: 9 failing tests; sample: animated number duration test)*
- `pnpm test:unit test/shlagemon-detail-evolution-icon.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a0e3d960c832aba770fa318fc60e5