### PR TITLE
feat: add save import composable

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -322,6 +322,7 @@ declare global {
   const useRoute: typeof import('vue-router')['useRoute']
   const useRouter: typeof import('vue-router')['useRouter']
   const useSSRWidth: typeof import('@vueuse/core')['useSSRWidth']
+  const useSaveImport: typeof import('./composables/useSaveImport')['useSaveImport']
   const useSaveStore: typeof import('./stores/save')['useSaveStore']
   const useScreenOrientation: typeof import('@vueuse/core')['useScreenOrientation']
   const useScreenSafeArea: typeof import('@vueuse/core')['useScreenSafeArea']
@@ -814,6 +815,7 @@ declare module 'vue' {
     readonly useRoute: UnwrapRef<typeof import('vue-router')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router')['useRouter']>
     readonly useSSRWidth: UnwrapRef<typeof import('@vueuse/core')['useSSRWidth']>
+    readonly useSaveImport: UnwrapRef<typeof import('./composables/useSaveImport')['useSaveImport']>
     readonly useSaveStore: UnwrapRef<typeof import('./stores/save')['useSaveStore']>
     readonly useScreenOrientation: UnwrapRef<typeof import('@vueuse/core')['useScreenOrientation']>
     readonly useScreenSafeArea: UnwrapRef<typeof import('@vueuse/core')['useScreenSafeArea']>

--- a/src/composables/useSaveImport.spec.ts
+++ b/src/composables/useSaveImport.spec.ts
@@ -1,0 +1,60 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSaveStore } from '~/stores/save'
+import { useSaveImport } from './useSaveImport'
+
+const push = vi.fn()
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
+
+vi.mock('~/utils/save-code', () => ({
+  importSave: vi.fn((text: string) => (text === 'valid' ? { player: { name: 'Ash' } } : null)),
+  PERSISTED_STORE_KEYS: ['player'],
+}))
+
+describe('useSaveImport', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    push.mockReset()
+  })
+
+  it('loads and parses a file', async () => {
+    const composable = useSaveImport()
+    const file = new File(['valid'], 'save.shlag')
+    await composable.loadFromFile(file)
+    expect(composable.payload.value).toEqual({ player: { name: 'Ash' } })
+    expect(composable.status.value).toBe('loaded')
+  })
+
+  it('loads from share target', async () => {
+    const composable = useSaveImport()
+    const file = new File(['valid'], 'save.shlag')
+    const form = new FormData()
+    form.append('file', file)
+    await composable.loadFromShareTarget(form)
+    expect(composable.payload.value).toEqual({ player: { name: 'Ash' } })
+  })
+
+  it('validates payload keys', () => {
+    const composable = useSaveImport()
+    composable.payload.value = { player: {} }
+    expect(composable.validate()).toBe(true)
+    expect(composable.status.value).toBe('ready')
+
+    composable.payload.value = { unknown: {} }
+    expect(composable.validate()).toBe(false)
+    expect(composable.status.value).toBe('error')
+  })
+
+  it('confirms import and navigates', async () => {
+    const composable = useSaveImport()
+    const save = useSaveStore() as any
+    save.replaceWith = vi.fn()
+    save.persist = vi.fn().mockResolvedValue(undefined)
+    composable.payload.value = { player: {} }
+    await composable.confirmImport()
+    expect(save.replaceWith).toHaveBeenCalledWith({ player: {} })
+    expect(save.persist).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/')
+  })
+})

--- a/src/composables/useSaveImport.ts
+++ b/src/composables/useSaveImport.ts
@@ -1,0 +1,131 @@
+import type { GameSave, PersistedStoreId } from '~/utils/save-code'
+import { importSave, PERSISTED_STORE_KEYS } from '~/utils/save-code'
+
+/**
+ * Handle importing a game save from a file or a share target.
+ *
+ * Exposes reactive state describing the loaded file and parsed payload
+ * alongside helper methods to validate and apply the imported data.
+ */
+export function useSaveImport() {
+  /** Currently selected save file. */
+  const file = ref<File | null>(null)
+
+  /** Parsed save payload extracted from the file. */
+  const payload = ref<GameSave | null>(null)
+
+  /**
+   * Tracks the current operation stage.
+   * - `idle`: no file loaded
+   * - `loading`: reading a file
+   * - `loaded`: file parsed, awaiting validation
+   * - `ready`: payload validated and ready for import
+   * - `error`: an error occurred
+   * - `importing`: applying the payload
+   */
+  type ImportStatus = 'idle' | 'loading' | 'loaded' | 'ready' | 'error' | 'importing'
+  const status = ref<ImportStatus>('idle')
+
+  /** Optional error message when status is `error`. */
+  const error = ref<string | null>(null)
+
+  /** Save store with extra helpers provided by the persistence plugin. */
+  const saveStore = useSaveStore() as ReturnType<typeof useSaveStore> & {
+    replaceWith: (data: GameSave) => void
+    persist: () => Promise<void>
+  }
+
+  const router = useRouter()
+
+  /**
+   * Load and parse a save file selected by the user.
+   *
+   * @param f The file containing the exported save data.
+   */
+  async function loadFromFile(f: File): Promise<void> {
+    file.value = f
+    status.value = 'loading'
+    error.value = null
+    try {
+      const text = (await f.text()).trim()
+      const data = importSave(text)
+      if (!data) {
+        payload.value = null
+        status.value = 'error'
+        error.value = 'Invalid save file'
+        return
+      }
+      payload.value = data
+      status.value = 'loaded'
+    }
+    catch (e) {
+      payload.value = null
+      status.value = 'error'
+      error.value = (e as Error).message
+    }
+  }
+
+  /**
+   * Retrieve the first file from share target form data and parse it.
+   *
+   * @param formData `FormData` received from the share target.
+   */
+  async function loadFromShareTarget(formData: FormData): Promise<void> {
+    for (const value of formData.values()) {
+      if (value instanceof File) {
+        await loadFromFile(value)
+        return
+      }
+    }
+    error.value = 'No file provided'
+  }
+
+  /**
+   * Validate the parsed payload against the list of persisted store keys.
+   *
+   * @returns `true` if the payload is valid and ready to be imported.
+   */
+  function validate(): boolean {
+    if (!payload.value) {
+      status.value = 'error'
+      error.value = 'No payload loaded'
+      return false
+    }
+
+    for (const key of Object.keys(payload.value)) {
+      if (!PERSISTED_STORE_KEYS.includes(key as PersistedStoreId)) {
+        status.value = 'error'
+        error.value = `Unknown key: ${key}`
+        return false
+      }
+    }
+
+    status.value = 'ready'
+    error.value = null
+    return true
+  }
+
+  /**
+   * Replace the current save with the validated payload and persist it.
+   * Navigates back to the root page upon success.
+   */
+  async function confirmImport(): Promise<void> {
+    if (!payload.value)
+      throw new Error('Cannot import without payload')
+    status.value = 'importing'
+    saveStore.replaceWith(payload.value)
+    await saveStore.persist()
+    await router.push('/')
+  }
+
+  return {
+    file,
+    payload,
+    status,
+    error,
+    loadFromFile,
+    loadFromShareTarget,
+    validate,
+    confirmImport,
+  }
+}


### PR DESCRIPTION
## Summary
- add `useSaveImport` composable to parse and apply save files
- test save import workflows

## Testing
- `pnpm exec eslint src/composables/useSaveImport.ts src/composables/useSaveImport.spec.ts`
- `pnpm exec vitest run src/composables/useSaveImport.spec.ts` *(no test files found)*
- `pnpm test:unit test/app-store.test.ts` *(fails: Cannot call props on an empty VueWrapper / expected 240 to be 230)*

------
https://chatgpt.com/codex/tasks/task_e_689a6cc21744832aadb45001bdf6b803