### PR TITLE
feat: add save utilities and checksum validation

### DIFF
--- a/src/utils/save/assertSavePayload.ts
+++ b/src/utils/save/assertSavePayload.ts
@@ -1,0 +1,43 @@
+import type { GameSave } from '../save-code'
+
+/**
+ * Structure of a saved game payload stored in a file.
+ */
+export interface SavePayload {
+  /** Incremented whenever the payload structure changes. */
+  version: number
+  /** Actual saved data. */
+  data: GameSave
+  /** Optional SHA-256 checksum of {@link SavePayload.data}. */
+  checksum?: string
+}
+
+/**
+ * Current supported save payload version.
+ */
+export const SAVE_VERSION = 1 as const
+
+/**
+ * Assert that an unknown value conforms to {@link SavePayload}.
+ *
+ * @param value - The value to validate.
+ * @throws {Error} If the value is not a valid {@link SavePayload} or the
+ *         version is unsupported.
+ */
+export function assertSavePayload(value: unknown): asserts value is SavePayload {
+  if (typeof value !== 'object' || value === null)
+    throw new Error('Invalid save payload: not an object')
+
+  const { version, data, checksum } = value as Record<string, unknown>
+
+  if (!Number.isInteger(version))
+    throw new Error('Invalid save payload: missing version')
+  if (version !== SAVE_VERSION)
+    throw new Error(`Unsupported save version: ${version}`)
+
+  if (typeof data !== 'object' || data === null)
+    throw new Error('Invalid save payload: missing data')
+
+  if (checksum !== undefined && typeof checksum !== 'string')
+    throw new Error('Invalid save payload: checksum must be a string')
+}

--- a/src/utils/save/formatPlaytime.ts
+++ b/src/utils/save/formatPlaytime.ts
@@ -1,0 +1,35 @@
+/**
+ * Convert a duration expressed in milliseconds into a human readable string.
+ *
+ * The output omits zero-value units and always includes seconds. Examples:
+ *   - 65000 => "1m 5s"
+ *   - 3_600_000 => "1h"
+ *   - 86_400_000 + 3_600_000 => "1d 1h"
+ *
+ * @param ms - Duration in milliseconds.
+ * @returns A formatted string such as "1h 2m 3s".
+ */
+export function formatPlaytime(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0)
+    return '0s'
+
+  const totalSeconds = Math.floor(ms / 1_000)
+  const seconds = totalSeconds % 60
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  const minutes = totalMinutes % 60
+  const totalHours = Math.floor(totalMinutes / 60)
+  const hours = totalHours % 24
+  const days = Math.floor(totalHours / 24)
+
+  const parts: string[] = []
+  if (days > 0)
+    parts.push(`${days}d`)
+  if (hours > 0)
+    parts.push(`${hours}h`)
+  if (minutes > 0)
+    parts.push(`${minutes}m`)
+  if (seconds > 0 || parts.length === 0)
+    parts.push(`${seconds}s`)
+
+  return parts.join(' ')
+}

--- a/src/utils/save/safeJsonParse.ts
+++ b/src/utils/save/safeJsonParse.ts
@@ -1,0 +1,17 @@
+/**
+ * Read a {@link File} and safely parse its JSON content.
+ *
+ * @param file - The file to read.
+ * @throws {Error} If the file cannot be read or the content is not valid JSON.
+ * @returns The parsed JSON value.
+ */
+export async function safeJsonParse(file: File): Promise<unknown> {
+  try {
+    const text = await file.text()
+    return JSON.parse(text)
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid JSON: ${message}`)
+  }
+}

--- a/src/utils/save/verifyChecksum.ts
+++ b/src/utils/save/verifyChecksum.ts
@@ -1,0 +1,43 @@
+import type { SavePayload } from './assertSavePayload'
+import { createHash } from 'node:crypto'
+
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Verify the optional checksum of a {@link SavePayload}.
+ *
+ * The checksum is a SHA-256 hash of the JSON stringified `data` field. If the
+ * payload does not contain a checksum, `true` is returned.
+ *
+ * Depending on the environment, this function may perform the verification
+ * synchronously (Node.js) or asynchronously (Web Crypto API).
+ *
+ * @param payload - Payload to verify.
+ * @returns `true` when the checksum matches or is absent, otherwise `false`.
+ */
+export function verifyChecksum(payload: SavePayload): boolean | Promise<boolean> {
+  if (!payload.checksum)
+    return true
+
+  const json = JSON.stringify(payload.data)
+
+  // Browser / Web Crypto path
+  if (globalThis.crypto?.subtle) {
+    return globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(json))
+      .then(hash => bufferToHex(hash) === payload.checksum)
+      .catch(() => false)
+  }
+
+  // Node.js fallback
+  try {
+    const hash = createHash('sha256').update(json).digest('hex')
+    return hash === payload.checksum
+  }
+  catch {
+    return false
+  }
+}

--- a/test/save-utils.test.ts
+++ b/test/save-utils.test.ts
@@ -1,0 +1,61 @@
+import type { SavePayload } from '~/utils/save/assertSavePayload'
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { assertSavePayload, SAVE_VERSION } from '~/utils/save/assertSavePayload'
+import { formatPlaytime } from '~/utils/save/formatPlaytime'
+import { safeJsonParse } from '~/utils/save/safeJsonParse'
+import { verifyChecksum } from '~/utils/save/verifyChecksum'
+
+describe('formatPlaytime', () => {
+  it('formats durations into human readable strings', () => {
+    expect(formatPlaytime(0)).toBe('0s')
+    expect(formatPlaytime(5_000)).toBe('5s')
+    expect(formatPlaytime(65_000)).toBe('1m 5s')
+    expect(formatPlaytime(3_600_000)).toBe('1h')
+    expect(formatPlaytime(86_400_000 + 3_600_000 + 120_000 + 7_000)).toBe('1d 1h 2m 7s')
+  })
+})
+
+describe('safeJsonParse', () => {
+  it('parses valid JSON files', async () => {
+    const file = { text: () => Promise.resolve(JSON.stringify({ foo: 'bar' })) } as unknown as File
+    await expect(safeJsonParse(file)).resolves.toEqual({ foo: 'bar' })
+  })
+
+  it('rejects invalid JSON files', async () => {
+    const file = { text: () => Promise.resolve('{ invalid json') } as unknown as File
+    await expect(safeJsonParse(file)).rejects.toThrow('Invalid JSON')
+  })
+})
+
+describe('assertSavePayload', () => {
+  it('validates proper payloads', () => {
+    const payload: unknown = { version: SAVE_VERSION, data: {} }
+    expect(() => assertSavePayload(payload)).not.toThrow()
+  })
+
+  it('throws on unsupported version', () => {
+    const payload: unknown = { version: 999, data: {} }
+    expect(() => assertSavePayload(payload)).toThrow('Unsupported save version')
+  })
+})
+
+describe('verifyChecksum', () => {
+  it('returns true when checksum matches', async () => {
+    const data = { foo: 'bar' }
+    const checksum = createHash('sha256').update(JSON.stringify(data)).digest('hex')
+    const payload: SavePayload = { version: SAVE_VERSION, data, checksum }
+    await expect(verifyChecksum(payload)).resolves.toBe(true)
+  })
+
+  it('returns false when checksum does not match', async () => {
+    const data = { foo: 'bar' }
+    const payload: SavePayload = { version: SAVE_VERSION, data, checksum: 'deadbeef' }
+    await expect(verifyChecksum(payload)).resolves.toBe(false)
+  })
+
+  it('returns true when checksum is missing', async () => {
+    const payload: SavePayload = { version: SAVE_VERSION, data: { foo: 'bar' } }
+    await expect(Promise.resolve(verifyChecksum(payload))).resolves.toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add formatPlaytime for human-readable durations
- provide safeJsonParse with robust error handling
- validate save payload structure and checksum support

## Testing
- `pnpm test:unit` *(fails: test suite has 6 failing files)*
- `pnpm test:unit --run test/save-utils.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689af58f0bf4832ab2c38e6dba6a4067