### PR TITLE
feat: add share target to web manifest

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "share_target": {
+    "action": "/save/import",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "files": [
+        {
+          "name": "file",
+          "accept": [
+            "application/x-shlag",
+            "application/octet-stream",
+            ".shlag"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow the PWA to receive `.shlag` save files via the Web Share Target API

## Testing
- `pnpm lint` *(fails: 122 problems across existing files)*
- `pnpm test` *(fails: 7 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689afd6d6d3c832aa7275046abdd964e