### PR TITLE
feat: add save import translations

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,45 @@
+{
+  "saveImport": {
+    "title": "Import Save",
+    "subtitle": "Load a saved game file to continue your adventure.",
+    "dropzone": {
+      "title": "Drop file here",
+      "hint": "Drag and drop a .shlag save file or browse to select one."
+    },
+    "button": {
+      "chooseFile": "Choose File"
+    },
+    "summary": {
+      "title": "Summary",
+      "version": "Version: {version}",
+      "playtime": "Playtime: {time}",
+      "createdAt": "Created: {date}",
+      "player": "Player: {name}",
+      "progress": "Progress: {progress}%"
+    },
+    "warning": {
+      "overwrite": "Importing will overwrite the current save."
+    },
+    "confirm": {
+      "title": "Confirm Import",
+      "description": "This action will replace your existing save. Do you want to continue?"
+    },
+    "action": {
+      "cancel": "Cancel",
+      "import": "Import"
+    },
+    "state": {
+      "parsing": "Parsing file...",
+      "validating": "Validating data...",
+      "importing": "Importing save...",
+      "done": "Import complete."
+    },
+    "error": {
+      "invalidFile": "Invalid save file.",
+      "incompatibleVersion": "Save file version is incompatible.",
+      "parseFailed": "Failed to parse the save file.",
+      "checksum": "Checksum verification failed.",
+      "storage": "Unable to write save to storage."
+    }
+  }
+}

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,0 +1,45 @@
+{
+  "saveImport": {
+    "title": "Importer une sauvegarde",
+    "subtitle": "Chargez un fichier de sauvegarde pour poursuivre votre aventure.",
+    "dropzone": {
+      "title": "Déposez le fichier ici",
+      "hint": "Glissez-déposez un fichier de sauvegarde .shlag ou parcourez pour en sélectionner un."
+    },
+    "button": {
+      "chooseFile": "Choisir un fichier"
+    },
+    "summary": {
+      "title": "Récapitulatif",
+      "version": "Version : {version}",
+      "playtime": "Temps de jeu : {time}",
+      "createdAt": "Créée le : {date}",
+      "player": "Joueur : {name}",
+      "progress": "Progression : {progress} %"
+    },
+    "warning": {
+      "overwrite": "L'import écrasera la sauvegarde actuelle."
+    },
+    "confirm": {
+      "title": "Confirmer l'import",
+      "description": "Cette action remplacera votre sauvegarde existante. Souhaitez-vous continuer ?"
+    },
+    "action": {
+      "cancel": "Annuler",
+      "import": "Importer"
+    },
+    "state": {
+      "parsing": "Analyse du fichier…",
+      "validating": "Validation des données…",
+      "importing": "Import de la sauvegarde…",
+      "done": "Import terminé."
+    },
+    "error": {
+      "invalidFile": "Fichier de sauvegarde invalide.",
+      "incompatibleVersion": "Version de sauvegarde incompatible.",
+      "parseFailed": "Échec de l'analyse du fichier de sauvegarde.",
+      "checksum": "La vérification de l'empreinte a échoué.",
+      "storage": "Impossible d'enregistrer la sauvegarde."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add save import translations (English & French)

## Testing
- `pnpm test` *(fails: Animated number, attack throttle, capture mechanics, disease listener, page locale SSR, rarity info, router redirect, sort item and others)*

------
https://chatgpt.com/codex/tasks/task_e_689afff26304832a831e18fca89bd44b