### PR TITLE
fix: define layout for import save page

### DIFF
--- a/src/pages/save/ImportPage.vue
+++ b/src/pages/save/ImportPage.vue
@@ -1,8 +1,3 @@
-<route lang="yaml">
-meta:
-  layout: empty
-</route>
-
 <script setup lang="ts">
 /**
  * Page allowing the user to import a saved game from a `.shlag` file.

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -44,6 +44,9 @@ export const routes: RouteRecordRaw[] = [
     path: '/save/import',
     name: 'save-import',
     component: () => import('~/pages/save/ImportPage.vue'),
+    meta: {
+      layout: 'empty',
+    },
   },
   { path: '/:all(.*)', name: 'not-found', component: () => import('~/pages/404.vue') },
 ]


### PR DESCRIPTION
## Summary
- remove unsupported `<route>` block from `ImportPage.vue`
- declare `/save/import` route layout via meta

## Testing
- `pnpm lint` *(fails: formatting issues in unrelated files)*
- `pnpm typecheck` *(fails: type errors in `src/stores/shlagedex.ts`)*
- `pnpm test` *(fails: 8 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b06531a8c832a8ac72c4ae8d08585