### PR TITLE
feat: centralize locale-based redirection

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -268,6 +268,7 @@ declare global {
   const useLevelUpAnimation: typeof import('./composables/useLevelUpAnimation')['useLevelUpAnimation']
   const useLink: typeof import('vue-router')['useLink']
   const useLocalStorage: typeof import('@vueuse/core')['useLocalStorage']
+  const useLocaleRedirect: typeof import('./composables/useLocaleRedirect')['useLocaleRedirect']
   const useLocaleStore: typeof import('./stores/locale')['useLocaleStore']
   const useMagicKeys: typeof import('@vueuse/core')['useMagicKeys']
   const useMainPanelStore: typeof import('./stores/mainPanel')['useMainPanelStore']
@@ -763,6 +764,7 @@ declare module 'vue' {
     readonly useLevelUpAnimation: UnwrapRef<typeof import('./composables/useLevelUpAnimation')['useLevelUpAnimation']>
     readonly useLink: UnwrapRef<typeof import('vue-router')['useLink']>
     readonly useLocalStorage: UnwrapRef<typeof import('@vueuse/core')['useLocalStorage']>
+    readonly useLocaleRedirect: UnwrapRef<typeof import('./composables/useLocaleRedirect')['useLocaleRedirect']>
     readonly useLocaleStore: UnwrapRef<typeof import('./stores/locale')['useLocaleStore']>
     readonly useMagicKeys: UnwrapRef<typeof import('@vueuse/core')['useMagicKeys']>
     readonly useMainPanelStore: UnwrapRef<typeof import('./stores/mainPanel')['useMainPanelStore']>
@@ -815,6 +817,7 @@ declare module 'vue' {
     readonly useRoute: UnwrapRef<typeof import('vue-router')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router')['useRouter']>
     readonly useSSRWidth: UnwrapRef<typeof import('@vueuse/core')['useSSRWidth']>
+    readonly useSaveImport: UnwrapRef<typeof import('./composables/useSaveImport')['useSaveImport']>
     readonly useSaveStore: UnwrapRef<typeof import('./stores/save')['useSaveStore']>
     readonly useScreenOrientation: UnwrapRef<typeof import('@vueuse/core')['useScreenOrientation']>
     readonly useScreenSafeArea: UnwrapRef<typeof import('@vueuse/core')['useScreenSafeArea']>

--- a/src/composables/useLocaleRedirect.ts
+++ b/src/composables/useLocaleRedirect.ts
@@ -1,0 +1,58 @@
+import type { Locale } from '~/constants/locales'
+import { availableLocales, defaultLocale } from '~/constants/locales'
+
+/**
+ * Redirects the user to a locale-specific version of a target path.
+ *
+ * Locale detection priority:
+ * 1. Explicit preference stored in localStorage under the `locale` key.
+ * 2. Locale already present in the Pinia store.
+ * 3. Browser preferred languages.
+ *
+ * The resolved locale is written back to the store for global consistency
+ * before performing a client-side redirect to `/${locale}${targetPath}`.
+ *
+ * @param targetPath - Path to append after the locale prefix (must start with '/').
+ * @returns Object containing a `isRedirecting` flag for optional UI feedback.
+ */
+export function useLocaleRedirect(targetPath: string) {
+  if (!targetPath.startsWith('/'))
+    throw new Error('targetPath must start with "/"')
+
+  const router = useRouter()
+  const store = useLocaleStore()
+  const preferredLanguages = usePreferredLanguages()
+  const isRedirecting = ref(true)
+  const storedLocale = useLocalStorage<Locale | null>('locale', null, { writeDefaults: false })
+
+  function isLocale(value: string | null): value is Locale {
+    return value !== null && availableLocales.includes(value as Locale)
+  }
+
+  onMounted(async () => {
+    let targetLocale: Locale | undefined
+
+    const stored = storedLocale.value
+    if (isLocale(stored))
+      targetLocale = stored
+
+    if (!targetLocale && isLocale(store.locale) && store.locale !== defaultLocale)
+      targetLocale = store.locale
+
+    if (!targetLocale) {
+      const navLanguages = preferredLanguages.value.map(language => language.toLowerCase())
+      targetLocale = navLanguages.some(language => language.startsWith('fr')) ? 'fr' : defaultLocale
+    }
+
+    if (targetLocale !== store.locale)
+      store.setLocale(targetLocale)
+
+    setTimeout(async () => {
+      const path = targetPath === '/' ? '' : targetPath
+      await router.replace({ path: `/${targetLocale}${path}` })
+      isRedirecting.value = false
+    }, 200)
+  })
+
+  return { isRedirecting }
+}

--- a/src/pages/root.vue
+++ b/src/pages/root.vue
@@ -1,53 +1,7 @@
 <script setup lang="ts">
-import type { Locale } from '~/constants/locales'
 import { useHead } from '@unhead/vue'
-import { usePreferredLanguages } from '@vueuse/core'
-import { useRouter } from 'vue-router'
-import { availableLocales, defaultLocale } from '~/constants/locales'
-import { useLocaleStore } from '~/stores/locale'
 
-const router = useRouter()
-const store = useLocaleStore()
-const preferredLanguages = usePreferredLanguages()
-const isRedirecting = ref(true) // Pour l'affichage du loader
-const storedLocale = useLocalStorage<Locale | null>('locale', null, { writeDefaults: false })
-
-/**
- * Teste si une chaîne est une locale supportée.
- */
-function isLocale(value: string | null): value is Locale {
-  return value !== null && availableLocales.includes(value as Locale)
-}
-
-onMounted(async () => {
-  let targetLocale: Locale | undefined
-
-  // 1. Locale stockée explicitement par l'utilisateur (préférence forte)
-  const stored = storedLocale.value
-  if (isLocale(stored))
-    targetLocale = stored
-
-  // 2. Store Pinia, utile en SSR/hydratation ou session restaurée
-  if (!targetLocale && isLocale(store.locale) && store.locale !== defaultLocale) {
-    targetLocale = store.locale
-  }
-
-  // 3. Détection navigateur (au premier accès)
-  if (!targetLocale) {
-    const navLanguages = preferredLanguages.value.map(language => language.toLowerCase())
-    targetLocale = navLanguages.some(language => language.startsWith('fr')) ? 'fr' : defaultLocale
-  }
-
-  // On enregistre la locale dans le store pour consistance globale
-  if (targetLocale !== store.locale)
-    store.setLocale(targetLocale)
-
-  // On redirige (petit délai pour l’UX, au cas où)
-  setTimeout(async () => {
-    await router.replace({ path: `/${targetLocale}` })
-    isRedirecting.value = false
-  }, 200) // 200ms pour que le loader s’affiche même sur les réseaux rapides
-})
+useLocaleRedirect('/')
 
 useHead({
   link: [

--- a/src/pages/save/ImportRoot.vue
+++ b/src/pages/save/ImportRoot.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+useLocaleRedirect('/save/import')
+</script>
+
+<template>
+  <Loader />
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -39,15 +39,15 @@ export const routes: RouteRecordRaw[] = [
       ? () => import('~/pages/index.vue') // SSG/SSR : contenu réel de l'index
       : () => import('~/pages/root.vue'), // Client only : redirection pour i18n paths
   },
-  ...buildLocalizedRoutes(),
   {
     path: '/save/import',
-    name: 'save-import',
-    component: () => import('~/pages/save/ImportPage.vue'),
-    meta: {
-      layout: 'empty',
-    },
+    name: 'save-import-root',
+    component: isSSR
+      ? () => import('~/pages/save/ImportPage.vue')
+      : () => import('~/pages/save/ImportRoot.vue'),
+    meta: { layout: 'empty' },
   },
+  ...buildLocalizedRoutes(),
   { path: '/:all(.*)', name: 'not-found', component: () => import('~/pages/404.vue') },
 ]
 

--- a/src/router/localizedRoutes.ts
+++ b/src/router/localizedRoutes.ts
@@ -62,5 +62,14 @@ export const localizedRoutes: LocalizedRoute[] = [
     i18nKey: 'pages.privacy-policy.title',
     layout: 'default',
   },
+  {
+    name: 'save-import',
+    component: () => import('~/pages/save/ImportPage.vue'),
+    paths: {
+      fr: '/fr/sauvegarde/importer',
+      en: '/en/save/import',
+    },
+    layout: 'empty',
+  },
 ]
 export default localizedRoutes

--- a/test/save-import-routes.test.ts
+++ b/test/save-import-routes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter, createWebHistory } from 'vue-router'
+import { buildLocalizedRoutes } from '../src/router'
+
+function createTestRouter(history: ReturnType<typeof createWebHistory> | ReturnType<typeof createMemoryHistory>) {
+  return createRouter({
+    history,
+    routes: [
+      { path: '/', name: 'root', component: { template: '<div></div>' } },
+      {
+        path: '/save/import',
+        name: 'save-import-root',
+        component: { template: '<div></div>' },
+        meta: { layout: 'empty' },
+      },
+      ...buildLocalizedRoutes(),
+    ],
+  })
+}
+
+async function assertNavigation(router: ReturnType<typeof createRouter>) {
+  await router.push('/save/import')
+  await router.isReady()
+  expect(router.currentRoute.value.name).toBe('save-import-root')
+
+  await router.push('/en/save/import')
+  expect(router.currentRoute.value.name).toBe('en-save-import')
+
+  await router.push('/fr/sauvegarde/importer')
+  expect(router.currentRoute.value.name).toBe('fr-save-import')
+}
+
+describe('save import routes', () => {
+  it('resolve correctly with web history', async () => {
+    const router = createTestRouter(createWebHistory())
+    await assertNavigation(router)
+  }, 10000)
+
+  it('resolve correctly with memory history', async () => {
+    const router = createTestRouter(createMemoryHistory())
+    await assertNavigation(router)
+  }, 10000)
+})

--- a/test/useLocaleRedirect.test.ts
+++ b/test/useLocaleRedirect.test.ts
@@ -1,0 +1,94 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRouter, createWebHistory } from 'vue-router'
+import { defaultLocale } from '../src/constants/locales'
+
+const originalNavigator = globalThis.navigator
+
+interface SetupOptions {
+  storedLocale?: string | null
+  storeLocale?: string
+  navigatorLanguages?: string[]
+  targetPath?: string
+}
+
+async function setup(options: SetupOptions = {}) {
+  const {
+    storedLocale = null,
+    storeLocale,
+    navigatorLanguages,
+    targetPath = '/foo',
+  } = options
+
+  localStorage.clear()
+  if (storedLocale)
+    localStorage.setItem('locale', storedLocale)
+
+  if (navigatorLanguages) {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { languages: navigatorLanguages },
+      configurable: true,
+    })
+  }
+
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  if (storeLocale)
+    useLocaleStore().setLocale(storeLocale as any)
+
+  const router = createRouter({ history: createWebHistory(), routes: [{ path: '/', component: { template: '<div></div>' } }] })
+  const replaceSpy = vi.spyOn(router, 'replace').mockResolvedValue(undefined as any)
+
+  mount({
+    template: '<div></div>',
+    setup: () => useLocaleRedirect(targetPath),
+  }, {
+    global: { plugins: [router, pinia] },
+  })
+
+  await vi.advanceTimersByTimeAsync(250)
+
+  return { replaceSpy }
+}
+
+describe('useLocaleRedirect', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        configurable: true,
+      })
+    }
+    else {
+      delete (globalThis as any).navigator
+    }
+  })
+
+  it('redirects using stored locale', async () => {
+    const { replaceSpy } = await setup({ storedLocale: 'fr' })
+    expect(replaceSpy).toHaveBeenCalledWith({ path: '/fr/foo' })
+    expect(useLocaleStore().locale).toBe('fr')
+  })
+
+  it('redirects using store locale', async () => {
+    const { replaceSpy } = await setup({ storeLocale: 'fr' })
+    expect(replaceSpy).toHaveBeenCalledWith({ path: '/fr/foo' })
+  })
+
+  it('uses navigator languages when no preference', async () => {
+    const { replaceSpy } = await setup({ navigatorLanguages: ['fr-FR'] })
+    expect(replaceSpy).toHaveBeenCalledWith({ path: '/fr/foo' })
+    expect(useLocaleStore().locale).toBe('fr')
+  })
+
+  it('falls back to default locale', async () => {
+    const { replaceSpy } = await setup({ navigatorLanguages: ['es-ES'] })
+    expect(replaceSpy).toHaveBeenCalledWith({ path: `/${defaultLocale}/foo` })
+  })
+})


### PR DESCRIPTION
## Summary
- factor locale detection into new `useLocaleRedirect` composable
- replace inline logic in `root.vue` and add `/save/import` entry point
- localize save-import route and cover with unit tests

## Testing
- `pnpm vitest run test/useLocaleRedirect.test.ts test/save-import-routes.test.ts`
- `pnpm test:unit` *(fails: capture.test.ts › capture mechanics › super ball doubles chance for low level foe)*

------
https://chatgpt.com/codex/tasks/task_e_689b183d52ac832a8e3204ef63c2c5d6