### PR TITLE
Add ImportPage translations and support ghost button

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2312,8 +2312,17 @@ pages:
         shlagidolar: 'Shlagidollars: {amount}'
         shlagidiamond: 'Shlagidiamonds: {amount}'
         playtime: 'Playtime: {time}'
+        monsLabel: Shlagemons
+        shlagidolarLabel: Shlagidollars
+        shlagidiamondLabel: Shlagidiamonds
+        playtimeLabel: Playtime
       errorInvalid: Invalid save file.
       errorApply: Import failed.
+      subtitle: Import a .shlag save file to replace your local data.
+      hint: Click or drag-and-drop a {ext} file
+      warningTitle: 'Warning: destructive import'
+      fileReady: File ready. Review details below.
+      acknowledge: I understand this action replaces ALL my local data.
   shlagedex:
     title: Shlagedex
 stores:
@@ -2358,3 +2367,8 @@ stores:
     level: level | levels
     rarityChanged: '{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!'
     released: '{name} was released!'
+common:
+  loading: Loading…
+  pleaseWait: Please wait
+  copy: Copy
+  remove: Remove

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2305,8 +2305,17 @@ pages:
         shlagidolar: 'Shlagidolars : {amount}'
         shlagidiamond: 'Shlagidiamonds : {amount}'
         playtime: 'Temps de jeu : {time}'
+        monsLabel: Shlagémons
+        shlagidolarLabel: Shlagidolars
+        shlagidiamondLabel: Shlagidiamonds
+        playtimeLabel: Temps de jeu
       errorInvalid: Fichier de sauvegarde invalide.
       errorApply: L'import a échoué.
+      subtitle: Importez une sauvegarde .shlag pour remplacer vos données locales.
+      hint: Cliquez ou glissez-déposez un fichier {ext}
+      warningTitle: 'Attention : import destructif'
+      fileReady: Fichier prêt. Vérifiez les détails ci-dessous.
+      acknowledge: Je comprends que cette action remplace TOUTES mes données locales.
   shlagedex:
     title: Shlagédex
 stores:
@@ -2351,3 +2360,8 @@ stores:
     level: niveau | niveaux
     rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
     released: '{name} a été relâché !'
+common:
+  loading: Chargement…
+  pleaseWait: Veuillez patienter
+  copy: Copier
+  remove: Supprimer

--- a/src/common.i18n.yml
+++ b/src/common.i18n.yml
@@ -1,0 +1,11 @@
+fr:
+  loading: Chargement…
+  pleaseWait: Veuillez patienter
+  copy: Copier
+  remove: Supprimer
+
+en:
+  loading: Loading…
+  pleaseWait: Please wait
+  copy: Copy
+  remove: Remove

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -5,6 +5,7 @@ export type ButtonType
     | 'valid'
     | 'danger'
     | 'default'
+    | 'ghost'
     | 'icon'
     | 'menu'
 
@@ -94,6 +95,12 @@ const typeVariantClass = computed(() => {
         'bg-cyan-600 dark:bg-cyan-700 text-white hover:bg-cyan-700 dark:hover:bg-cyan-800',
       outline:
         'border border-cyan-600 dark:border-cyan-700 text-cyan-700 dark:text-cyan-200 bg-transparent hover:bg-cyan-50 dark:hover:bg-cyan-800/30',
+    },
+    ghost: {
+      solid:
+        'bg-transparent text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700',
+      outline:
+        'border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-transparent hover:bg-gray-100 dark:hover:bg-gray-700/40',
     },
   }
   return `${sizeClass.value} ${map[props.type][props.variant]}`

--- a/src/pages/save/ImportPage.i18n.yml
+++ b/src/pages/save/ImportPage.i18n.yml
@@ -1,8 +1,12 @@
 fr:
   title: Importer une sauvegarde
+  subtitle: Importez une sauvegarde .shlag pour remplacer vos données locales.
   drop: Déposez votre fichier .shlag ici ou cliquez pour sélectionner
   select: Sélectionner un fichier
+  hint: Cliquez ou glissez-déposez un fichier {ext}
+  warningTitle: 'Attention : import destructif'
   warning: L'import remplacera votre sauvegarde actuelle. Assurez-vous d'avoir une copie.
+  fileReady: Fichier prêt. Vérifiez les détails ci-dessous.
   import: Importer
   confirmTitle: "Confirmer l'import"
   confirmMessage: Cette action écrasera votre progression actuelle. Continuer ?
@@ -14,14 +18,23 @@ fr:
     shlagidolar: 'Shlagidolars : {amount}'
     shlagidiamond: 'Shlagidiamonds : {amount}'
     playtime: 'Temps de jeu : {time}'
+    monsLabel: Shlagémons
+    shlagidolarLabel: Shlagidolars
+    shlagidiamondLabel: Shlagidiamonds
+    playtimeLabel: Temps de jeu
+  acknowledge: Je comprends que cette action remplace TOUTES mes données locales.
   errorInvalid: Fichier de sauvegarde invalide.
   errorApply: "L'import a échoué."
 
 en:
   title: Import Save
+  subtitle: Import a .shlag save file to replace your local data.
   drop: Drop your .shlag file here or click to select
   select: Select a file
+  hint: Click or drag-and-drop a {ext} file
+  warningTitle: 'Warning: destructive import'
   warning: Importing will overwrite your current save. Make sure you have a backup.
+  fileReady: File ready. Review details below.
   import: Import
   confirmTitle: Confirm Import
   confirmMessage: This will replace your current progress. Continue?
@@ -33,5 +46,10 @@ en:
     shlagidolar: 'Shlagidollars: {amount}'
     shlagidiamond: 'Shlagidiamonds: {amount}'
     playtime: 'Playtime: {time}'
+    monsLabel: Shlagemons
+    shlagidolarLabel: Shlagidollars
+    shlagidiamondLabel: Shlagidiamonds
+    playtimeLabel: Playtime
+  acknowledge: I understand this action replaces ALL my local data.
   errorInvalid: Invalid save file.
   errorApply: Import failed.


### PR DESCRIPTION
## Summary
- add missing i18n strings for ImportPage and common messages
- support `ghost` button type in UiButton
- include common translation file

## Testing
- `pnpm lint` *(fails: UnoCSS ordering, quoting in locales)*
- `pnpm test:unit` *(fails: 9 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b25dfdeb8832ab2e5ca4632965cab