### PR TITLE
feat: add panel transition sfx

### DIFF
--- a/test/main-panel-sfx.test.ts
+++ b/test/main-panel-sfx.test.ts
@@ -1,0 +1,29 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useAudioStore } from '../src/stores/audio'
+import { useMainPanelStore } from '../src/stores/mainPanel'
+
+/** Ensure panel transitions play enter/leave sound effects. */
+describe('main panel sound effects', () => {
+  it.each([
+    ['showShop', 'shop-enter', 'shop-leave'],
+    ['showMiniGame', 'mini-game-enter', 'mini-game-leave'],
+    ['showArena', 'arena-enter', 'arena-leave'],
+  ] as const)(
+    'plays %s sounds',
+    async (method, enter, leave) => {
+      setActivePinia(createPinia())
+      const audio = useAudioStore()
+      const panel = useMainPanelStore()
+      const spy = vi.spyOn(audio, 'playSfx')
+      ;(panel[method] as () => void)()
+      await nextTick()
+      expect(spy).toHaveBeenCalledWith(enter)
+      spy.mockClear()
+      panel.showVillage()
+      await nextTick()
+      expect(spy).toHaveBeenCalledWith(leave)
+    },
+  )
+})


### PR DESCRIPTION
## Summary
- play dedicated SFX when entering or leaving shop, mini-game, or arena panels
- add unit tests for panel transition sound effects

## Testing
- `pnpm lint` *(fails: formatting errors in existing files)*
- `pnpm typecheck` *(fails: type errors in existing files)*
- `pnpm test` *(fails: numerous existing test failures)*
- `pnpm test --run test/main-panel-sfx.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689bc2d7cc68832aa6324fc0dd6f4b7f