### PR TITLE
feat: add PNG favicon and dedupe head links

### DIFF
--- a/src/composables/usePageHead.ts
+++ b/src/composables/usePageHead.ts
@@ -62,8 +62,16 @@ export function usePageHead(options: PageHeadOptions = {}) {
           rel: 'icon',
           type: 'image/svg+xml',
           href: preferredDark.value ? '/favicon-dark.svg' : '/favicon.svg',
+          key: 'favicon-svg',
         },
-        { rel: 'image_src', href: image },
+        {
+          rel: 'icon',
+          type: 'image/png',
+          sizes: '48x48',
+          href: '/favicon.png',
+          key: 'favicon-png',
+        },
+        { rel: 'image_src', href: image, key: 'image-src' },
       ],
     }
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,7 +99,7 @@ export default defineConfig({
     // https://github.com/antfu/vite-plugin-pwa
     ...(['fr', 'en'] as const).map(locale => VitePWA({
       registerType: 'prompt',
-      includeAssets: ['favicon.svg', 'safari-pinned-tab.svg'],
+      includeAssets: ['favicon.svg', 'favicon.png', 'safari-pinned-tab.svg'],
       manifest: getPwaManifest(locale),
       manifestFilename: `${locale}/manifest.webmanifest`,
       workbox: {


### PR DESCRIPTION
## Summary
- add missing 48x48 PNG favicon and prevent duplicate head links
- include PNG favicon in PWA asset list

## Testing
- `pnpm test` *(fails: AssertionError: expected false to be true, plus unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c4ef20cd4832aa37f6b3c51bfbfe4