### PR TITLE
fix sitemap hreflang and canonical links

### DIFF
--- a/scripts/generate-sitemap/generate-sitemap.ts
+++ b/scripts/generate-sitemap/generate-sitemap.ts
@@ -1,0 +1,68 @@
+import { writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { localizedRoutes } from '../../src/router/localizedRoutes'
+
+/** Locale codes supported by the application. */
+const locales = ['fr', 'en'] as const
+
+/**
+ * Configuration options for sitemap generation.
+ */
+export interface SitemapOptions {
+  /** Output directory for the sitemap. */
+  outDir: string
+  /** Base URL of the website without trailing slash. */
+  hostname: string
+}
+
+/**
+ * Generate a `sitemap.xml` file with correct `hreflang` links.
+ *
+ * The sitemap includes one entry per localized page and ensures that:
+ * - each page references its language alternatives,
+ * - `x-default` points to the site root,
+ * - unused XML namespaces are omitted.
+ */
+export function generateSitemap(options: SitemapOptions): void {
+  const { outDir, hostname } = options
+  const rootUrl = `${hostname}/`
+  const today = new Date().toISOString().split('T')[0]
+
+  type Locale = typeof locales[number]
+  type LocalizedPaths = Record<Locale, string>
+
+  // Map every path to its group of localized alternatives.
+  const pathGroups = new Map<string, LocalizedPaths>()
+  const homeGroup = localizedRoutes.find(route => route.name === 'home')!.paths as LocalizedPaths
+
+  // Root path uses the home group's localized links.
+  pathGroups.set('/', homeGroup)
+
+  for (const route of localizedRoutes) {
+    const group = route.paths as LocalizedPaths
+    for (const locale of locales)
+      pathGroups.set(group[locale], group)
+  }
+
+  const urlEntries = Array.from(pathGroups.keys()).sort().map((path) => {
+    const group = pathGroups.get(path)!
+    const loc = `${hostname}${path}`
+    const links = [
+      ...locales.map(locale => `<xhtml:link rel="alternate" hreflang="${locale}" href="${hostname}${group[locale]}" />`),
+      `<xhtml:link rel="alternate" hreflang="x-default" href="${rootUrl}" />`,
+    ]
+      .join('\n    ')
+
+    return `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${today}</lastmod>\n    ${links}\n  </url>`
+  }).join('\n')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n`
+    + `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" `
+    + `xmlns:xhtml="http://www.w3.org/1999/xhtml">\n`
+    + `${urlEntries}\n`
+    + `</urlset>\n`
+
+  writeFileSync(resolve(outDir, 'sitemap.xml'), xml)
+}
+
+export default generateSitemap

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import VueDevTools from 'vite-plugin-vue-devtools'
 import Layouts from 'vite-plugin-vue-layouts'
-import generateSitemap from 'vite-ssg-sitemap'
+import generateSitemap from './scripts/generate-sitemap/generate-sitemap'
 import { getPwaManifest } from './src/pwa/manifest'
 import { localizedRoutes } from './src/router/localizedRoutes'
 import 'vitest/config'
@@ -177,15 +177,8 @@ export default defineConfig({
     includedRoutes: getAllLocalizedPaths,
     onFinished() {
       generateSitemap({
+        outDir: 'dist',
         hostname: 'https://shlagemon.aife.io',
-        dynamicRoutes: getAllLocalizedPaths(),
-        i18n: {
-          languages: ['fr', 'en'],
-          // The root path `/` must always reflect the English locale.
-          // Default sitemap language is therefore set to English
-          // to match the SSG output and avoid cross-locale content.
-          defaultLanguage: 'en',
-        },
       })
     },
   },


### PR DESCRIPTION
## Summary
- generate sitemap manually with correct hreflang mappings and x-default root
- remove unused namespaces and duplicate URLs during sitemap generation

## Testing
- `pnpm lint`
- `pnpm test:unit --run` *(partial: 13 test files passed)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689c4f2d8328832aa230e6f0f508b8de