### PR TITLE
feat: add dojo training system

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -113,6 +113,7 @@ declare module 'vue' {
     PanelArena: typeof import('./components/panel/Arena.vue')['default']
     PanelBonusDetails: typeof import('./components/panel/BonusDetails.vue')['default']
     PanelDialog: typeof import('./components/panel/Dialog.vue')['default']
+    PanelDojo: typeof import('./components/panel/Dojo.vue')['default']
     PanelInventory: typeof import('./components/panel/Inventory.vue')['default']
     PanelMain: typeof import('./components/panel/Main.vue')['default']
     PanelMap: typeof import('./components/panel/Map.vue')['default']

--- a/src/components/panel/Dojo.i18n.yml
+++ b/src/components/panel/Dojo.i18n.yml
@@ -1,0 +1,54 @@
+fr:
+  title: Dojo
+  exit: Quitter le dojo
+  introDialog: Bienvenue dans le dojo. C’est ici que tu vas pouvoir faire progresser tes schlages.
+  selectMon: Entraîner un Schlagémon
+  selected: Schlagémon sélectionné
+  rarity:
+    current: Rareté actuelle
+    after: Rareté après
+    points: Points d’entraînement
+    limitReached: Impossible de dépasser 100 de rareté.
+  cost:
+    label: Coût
+    insufficient: Fonds insuffisants
+  duration:
+    label: Durée
+    minute: minute
+    minutes: minutes
+    remaining: Temps restant
+    endsAt: Se termine à {{time}}
+  cta:
+    payAndStart: Payer & lancer
+    selectFirst: Sélectionne un Schlagémon
+    trainingRunning: Entraînement en cours
+  toast:
+    started: Entraînement lancé !
+    finished: Entraînement terminé ! Rareté améliorée.
+en:
+  title: Dojo
+  exit: Leave the dojo
+  introDialog: Welcome to the dojo. Here you can train your schlages.
+  selectMon: Train a Schlagémon
+  selected: Selected Schlagémon
+  rarity:
+    current: Current rarity
+    after: Rarity after
+    points: Training points
+    limitReached: Cannot exceed 100 rarity.
+  cost:
+    label: Cost
+    insufficient: Insufficient funds
+  duration:
+    label: Duration
+    minute: minute
+    minutes: minutes
+    remaining: Remaining time
+    endsAt: Ends at {{time}}
+  cta:
+    payAndStart: Pay & start
+    selectFirst: Select a Schlagémon
+    trainingRunning: Training in progress
+  toast:
+    started: Training started!
+    finished: Training finished! Rarity improved.

--- a/src/components/panel/Dojo.vue
+++ b/src/components/panel/Dojo.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+import { toast } from '~/modules/toast'
+import { dojoTrainingCost, useDojoStore } from '~/stores/dojo'
+
+const panel = useMainPanelStore()
+const dojo = useDojoStore()
+const game = useGameStore()
+const { t } = useI18n()
+
+const selected = ref<DexShlagemon | null>(null)
+const selectorOpen = ref(false)
+const points = ref(1)
+const now = ref(Date.now())
+useIntervalFn(() => {
+  now.value = Date.now()
+}, 1000)
+
+const job = computed(() => selected.value ? dojo.getJob(selected.value.id) : null)
+const maxPoints = computed(() => selected.value ? Math.max(0, 100 - selected.value.rarity) : 0)
+watch(selected, () => {
+  points.value = 1
+})
+const cost = computed(() => selected.value ? dojoTrainingCost(selected.value.rarity, points.value) : 0)
+const durationMin = computed(() => points.value)
+const remaining = computed(() => job.value ? Math.max(0, Math.ceil(dojo.remainingMs(job.value.monId) / 1000)) : 0)
+const progress = computed(() => job.value ? dojo.progressRatio(job.value.monId) * 100 : 0)
+
+watch(now, () => {
+  if (selected.value) {
+    if (dojo.completeIfDue(selected.value.id))
+      toast.success(t('components.panel.Dojo.toast.finished'))
+  }
+})
+
+function openSelector() {
+  selectorOpen.value = true
+}
+function selectMon(mon: DexShlagemon) {
+  selected.value = mon
+  selectorOpen.value = false
+}
+function start() {
+  if (!selected.value)
+    return
+  const res = dojo.startTraining(selected.value.id, selected.value.rarity, points.value)
+  if (res.ok) {
+    toast.success(t('components.panel.Dojo.toast.started'))
+  }
+}
+</script>
+
+<template>
+  <LayoutTitledPanel
+    :title="t('components.panel.Dojo.title')"
+    :exit-text="t('components.panel.Dojo.cta.selectFirst')"
+    @exit="panel.showVillage()"
+  >
+    <div class="flex flex-1 flex-col gap-4">
+      <UiButton v-if="!selected" type="primary" @click="openSelector">
+        {{ t('components.panel.Dojo.selectMon') }}
+      </UiButton>
+      <div v-else class="flex flex-col items-center gap-4">
+        <ShlagemonImage
+          :id="selected.base.id"
+          :alt="t(selected.base.name)"
+          class="h-32 w-32"
+        />
+        <div class="text-sm">
+          {{ t('components.panel.Dojo.rarity.current') }}:
+          {{ selected.rarity }} → {{ Math.min(100, selected.rarity + points) }}
+        </div>
+        <div class="w-24">
+          <UiNumberInput v-model="points" :min="1" :max="maxPoints" />
+        </div>
+        <div class="text-sm">
+          {{ t('components.panel.Dojo.cost.label') }}:
+          <UiCurrencyAmount :amount="cost" currency="shlagidolar" />
+        </div>
+        <div class="text-sm">
+          {{ t('components.panel.Dojo.duration.label') }}:
+          {{ durationMin }}
+          {{ durationMin === 1 ? t('components.panel.Dojo.duration.minute') : t('components.panel.Dojo.duration.minutes') }}
+        </div>
+        <UiButton
+          v-if="!job"
+          :disabled="cost > game.shlagidolar || points < 1"
+          type="primary"
+          @click="start"
+        >
+          {{ t('components.panel.Dojo.cta.payAndStart') }}
+        </UiButton>
+        <div v-else class="w-full flex flex-col gap-2">
+          <div class="h-2 w-full rounded bg-gray-300">
+            <div class="h-full rounded bg-green-500" :style="{ width: `${progress}%` }" />
+          </div>
+          <p class="text-center text-sm">
+            {{ t('components.panel.Dojo.duration.remaining') }}:
+            {{ Math.ceil(remaining / 60) }}
+            {{ t('components.panel.Dojo.duration.minutes') }}
+          </p>
+        </div>
+      </div>
+    </div>
+    <UiModal v-model="selectorOpen" role="dialog" aria-labelledby="dojo-select-title">
+      <div class="flex flex-col gap-2">
+        <h3 id="dojo-select-title" class="text-center text-lg font-bold">
+          {{ t('components.panel.Dojo.selectMon') }}
+        </h3>
+        <ShlagemonQuickSelect class="max-h-60vh" @select="selectMon" />
+      </div>
+    </UiModal>
+  </LayoutTitledPanel>
+</template>

--- a/src/components/panel/Main.vue
+++ b/src/components/panel/Main.vue
@@ -2,6 +2,7 @@
 import BattleMain from '../battle/Main.vue'
 import BattleTrainer from '../battle/Trainer.vue'
 import ArenaPanel from './Arena.vue'
+import DojoPanel from './Dojo.vue'
 import MiniGamePanel from './MiniGame.vue'
 import PoulaillerPanel from './Poulailler.vue'
 import ShopPanel from './Shop.vue'
@@ -26,6 +27,8 @@ const currentComponent = computed(() => {
       return ArenaPanel
     case 'poulailler':
       return PoulaillerPanel
+    case 'dojo':
+      return DojoPanel
     case 'village':
       return VillagePanel
     default:

--- a/src/components/village/ZoneActions.i18n.yml
+++ b/src/components/village/ZoneActions.i18n.yml
@@ -2,6 +2,7 @@ fr:
   shop: Magasin
   minigame: Mini-jeu
   arena: Arène
+  dojo: Dojo
   henhouse: Poulailler
   fightKing: 'Défier la {label} de la zone'
   kingDefeated: '{label} vaincu{suffix} !'
@@ -9,6 +10,7 @@ en:
   shop: Shop
   minigame: Minigame
   arena: Arena
+  dojo: Dojo
   henhouse: Henhouse
   fightKing: 'Challenge the {label} of the zone'
   kingDefeated: '{label} defeated!'

--- a/src/components/village/ZoneActions.vue
+++ b/src/components/village/ZoneActions.vue
@@ -33,6 +33,13 @@ const miniGamePoi = computed(() =>
     ? zone.current.pois.minigame
     : undefined,
 )
+const dojoPoi = computed(() =>
+  zone.current.type === 'village'
+    ? zone.current.pois.dojo
+    : undefined,
+)
+const hasDojo = computed(() => !!dojoPoi.value)
+
 const poulaillerPoi = computed(() =>
   zone.current.type === 'village'
     ? zone.current.pois.poulailler
@@ -91,6 +98,12 @@ function openPoulailler() {
     return
   panel.showPoulailler()
 }
+
+function openDojo() {
+  if (arena.inBattle)
+    return
+  panel.showDojo()
+}
 </script>
 
 <template>
@@ -121,6 +134,13 @@ function openPoulailler() {
       hover="bg-red-700 dark:bg-red-800"
       :disabled="arena.inBattle"
       @click="openArena"
+    />
+    <UiNavigationButton
+      v-if="hasDojo"
+      icon="i-mdi:school"
+      :label="t('components.village.ZoneActions.dojo')"
+      :disabled="arena.inBattle"
+      @click="openDojo"
     />
     <UiNavigationButton
       v-if="hasPoulailler"

--- a/src/data/zones/villages/village80.ts
+++ b/src/data/zones/villages/village80.ts
@@ -88,5 +88,11 @@ export const village80: Zone = {
       position: { lat: -199.50125361005428, lng: 142.2667046594498 },
       miniGame: 'shlagmind',
     },
+    dojo: {
+      id: 'dojo',
+      type: 'dojo',
+      label: 'Dojo',
+      position: { lat: -170, lng: 160 },
+    },
   },
 }

--- a/src/stores/dojo.ts
+++ b/src/stores/dojo.ts
@@ -1,0 +1,121 @@
+import { defineStore } from 'pinia'
+
+/**
+ * Parameters for a dojo training job.
+ */
+export interface DojoTrainingJob {
+  readonly monId: string
+  readonly startedAt: number
+  readonly endsAt: number
+  readonly fromRarity: number
+  readonly points: number
+  readonly targetRarity: number
+  readonly paid: number
+  readonly status: 'running'
+}
+
+const COST_A = 1000
+const COST_B = 100000 ** (1 / 98)
+
+/**
+ * Compute the total training cost for increasing rarity.
+ *
+ * @param rarity Current rarity before training.
+ * @param points Desired rarity points.
+ */
+export function dojoTrainingCost(rarity: number, points: number): number {
+  const r = Math.max(1, rarity)
+  const k = Math.max(0, points)
+  const cost = COST_A * COST_B ** (r - 1) * (COST_B ** k - 1) / (COST_B - 1)
+  return Math.ceil(cost)
+}
+
+export const useDojoStore = defineStore('dojo', () => {
+  const byMonId = ref<Record<string, DojoTrainingJob | undefined>>({})
+  const game = useGameStore()
+  const dex = useShlagedexStore()
+
+  function getJob(monId: string): DojoTrainingJob | null {
+    return byMonId.value[monId] ?? null
+  }
+
+  function isTraining(monId: string): boolean {
+    return Boolean(byMonId.value[monId])
+  }
+
+  function remainingMs(monId: string): number {
+    const job = byMonId.value[monId]
+    if (!job)
+      return 0
+    return Math.max(0, job.endsAt - Date.now())
+  }
+
+  function progressRatio(monId: string): number {
+    const job = byMonId.value[monId]
+    if (!job)
+      return 0
+    const total = job.endsAt - job.startedAt
+    return total > 0 ? 1 - remainingMs(monId) / total : 1
+  }
+
+  function startTraining(monId: string, fromRarity: number, points: number) {
+    if (points < 1 || fromRarity >= 100)
+      return { ok: false as const, reason: 'invalid_points' as const }
+    if (isTraining(monId))
+      return { ok: false as const, reason: 'already_training' as const }
+    const capped = Math.min(points, 100 - fromRarity)
+    if (capped < 1)
+      return { ok: false as const, reason: 'invalid_points' as const }
+    const cost = dojoTrainingCost(fromRarity, capped)
+    if (game.shlagidolar < cost)
+      return { ok: false as const, reason: 'insufficient_funds' as const }
+    game.addShlagidolar(-cost)
+    const startedAt = Date.now()
+    byMonId.value[monId] = {
+      monId,
+      startedAt,
+      endsAt: startedAt + capped * 60_000,
+      fromRarity,
+      points: capped,
+      targetRarity: Math.min(100, fromRarity + capped),
+      paid: cost,
+      status: 'running',
+    }
+    return { ok: true as const }
+  }
+
+  function completeIfDue(monId: string): boolean {
+    const job = byMonId.value[monId]
+    if (!job)
+      return false
+    if (Date.now() < job.endsAt)
+      return false
+    const mon = dex.shlagemons.find(m => m.id === monId)
+    if (mon)
+      mon.rarity = Math.min(100, job.targetRarity)
+    delete byMonId.value[monId]
+    return true
+  }
+
+  function clearFinished(): void {
+    for (const [id, job] of Object.entries(byMonId.value)) {
+      if (job && Date.now() >= job.endsAt)
+        delete byMonId.value[id]
+    }
+  }
+
+  return {
+    byMonId,
+    getJob,
+    isTraining,
+    remainingMs,
+    progressRatio,
+    startTraining,
+    completeIfDue,
+    clearFinished,
+  }
+}, {
+  persist: {
+    pick: ['byMonId'],
+  },
+})

--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -1,7 +1,7 @@
 import type { SfxId } from '~/data/sfx'
 import { defineStore } from 'pinia'
 
-export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop' | 'miniGame' | 'arena' | 'poulailler'
+export type MainPanel = 'village' | 'battle' | 'trainerBattle' | 'shop' | 'miniGame' | 'arena' | 'poulailler' | 'dojo'
 
 export const useMainPanelStore = defineStore('mainPanel', () => {
   const zone = useZoneStore()
@@ -83,6 +83,12 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     current.value = 'poulailler'
   }
 
+  function showDojo() {
+    if (arena.inBattle)
+      return
+    current.value = 'dojo'
+  }
+
   function showArena() {
     if (arena.inBattle)
       return
@@ -108,6 +114,7 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
     showTrainerBattle,
     showMiniGame,
     showPoulailler,
+    showDojo,
     showArena,
     showVillage,
     reset,
@@ -122,7 +129,7 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
       const miniGameStore = useMiniGameStore()
       if (store.current === 'arena' && !arenaStore.inBattle)
         store.reset()
-      if (store.current === 'trainerBattle' || store.current === 'poulailler')
+      if (store.current === 'trainerBattle' || store.current === 'poulailler' || store.current === 'dojo')
         store.reset()
       if (store.current === 'miniGame' && !miniGameStore.currentId)
         store.reset()

--- a/src/type/zone.ts
+++ b/src/type/zone.ts
@@ -22,7 +22,7 @@ export interface Position {
 
 export interface VillagePOI {
   readonly id: string
-  readonly type: 'shop' | 'arena' | 'minigame' | 'poulailler' | string
+  readonly type: 'shop' | 'arena' | 'minigame' | 'poulailler' | 'dojo' | string
   readonly label: string
   readonly position: Position
   /** Items available in the shop when the POI type is `shop`. */

--- a/test/dojo-store.test.ts
+++ b/test/dojo-store.test.ts
@@ -1,0 +1,35 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
+import { dojoTrainingCost, useDojoStore } from '../src/stores/dojo'
+import { useGameStore } from '../src/stores/game'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('dojo store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('computes cost correctly', () => {
+    expect(dojoTrainingCost(1, 1)).toBe(1000)
+    expect(dojoTrainingCost(99, 1)).toBe(100000000)
+  })
+
+  it('starts and completes a training job', () => {
+    const game = useGameStore()
+    game.addShlagidolar(200000000)
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(pikachiant)
+    const dojo = useDojoStore()
+    const result = dojo.startTraining(mon.id, mon.rarity, 1)
+    expect(result.ok).toBe(true)
+    const job = dojo.getJob(mon.id)
+    expect(job).not.toBeNull()
+    if (job)
+      job.endsAt = Date.now() - 1
+    const before = mon.rarity
+    const completed = dojo.completeIfDue(mon.id)
+    expect(completed).toBe(true)
+    expect(mon.rarity).toBe(before + 1)
+  })
+})


### PR DESCRIPTION
## Summary
- add persistent dojo training store with exponential cost formula
- introduce Dojo panel with rarity training controls and modal selection
- expose dojo in village actions and unlock for village80

## Testing
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_689ca46ebda0832a9063aff0adf2120c