### PR TITLE
Reset additional stores on save reset

### DIFF
--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -22,6 +22,13 @@ export const useSaveStore = defineStore('save', () => {
   const equipment = useEquipmentStore()
   const eggBox = useEggBoxStore()
   const egg = useEggStore()
+  const playtime = usePlaytimeStore()
+  const deckFilter = useDeckFilterStore()
+  const inventoryFilter = useInventoryFilterStore()
+  const shopFilter = useShopFilterStore()
+  const potionInfo = usePotionInfoStore()
+  const kingPotion = useKingPotionStore()
+  const shortcuts = useShortcutsStore()
 
   function reset() {
     dex.reset()
@@ -44,6 +51,13 @@ export const useSaveStore = defineStore('save', () => {
     equipment.reset()
     eggBox.reset()
     egg.reset()
+    playtime.reset()
+    deckFilter.reset()
+    inventoryFilter.reset()
+    shopFilter.reset()
+    potionInfo.reset()
+    kingPotion.reset()
+    shortcuts.reset()
   }
 
   /**


### PR DESCRIPTION
## Summary
- reset playtime, filter, potion, and shortcut stores when clearing save data

## Testing
- `pnpm exec eslint src/stores/save.ts src/stores/playtime.ts src/stores/deckFilter.ts src/stores/inventoryFilter.ts src/stores/shopFilter.ts src/stores/potionInfo.ts src/stores/kingPotion.ts src/stores/shortcuts.ts`
- `pnpm test` (fails: Cannot call props on an empty VueWrapper; ignores rapid successive clicks to keep the UI responsive; computes cost correctly; sSR locale pages renders / as English page like /en; redirect uses navigator language when available; redirect falls back to default locale for unsupported language; redirect falls back to default locale when navigator missing; displays shlagemons with items first)


------
https://chatgpt.com/codex/tasks/task_e_689cb2387a10832a85a0d165f4adb624