### PR TITLE
feat: support breeding metadata for eggs

### DIFF
--- a/src/utils/egg-serialize.ts
+++ b/src/utils/egg-serialize.ts
@@ -10,11 +10,15 @@ interface StoredEgg {
   rarity: number
   startedAt: number
   hatchesAt: number
+  isBreeding?: boolean
+  forcedMonId?: string
+  forcedRarity?: number
 }
 
 /**
  * Eggs are stored as a JSON array of plain objects containing only
- * `id`, `type`, `baseId`, `rarity`, `startedAt`, and `hatchesAt`.
+ * `id`, `type`, `baseId`, `rarity`, `startedAt`, `hatchesAt`, and
+ * optional breeding metadata.
  */
 export const eggSerializer: Serializer = {
   serialize(data: StateTree): string {
@@ -27,6 +31,9 @@ export const eggSerializer: Serializer = {
       rarity: e.rarity,
       startedAt: e.startedAt,
       hatchesAt: e.hatchesAt,
+      ...(e.isBreeding && { isBreeding: true }),
+      ...(e.forcedMonId && { forcedMonId: e.forcedMonId }),
+      ...(e.forcedRarity !== undefined && { forcedRarity: e.forcedRarity }),
     }))
     return JSON.stringify(list)
   },
@@ -35,14 +42,23 @@ export const eggSerializer: Serializer = {
       return { incubator: [] } as StateTree
     const list = JSON.parse(raw) as StoredEgg[]
     const baseMap = Object.fromEntries(allShlagemons.map(b => [b.id, b]))
-    const incubator = list.map(e => ({
-      id: e.id,
-      type: e.type,
-      base: baseMap[e.baseId],
-      rarity: e.rarity,
-      startedAt: e.startedAt,
-      hatchesAt: e.hatchesAt,
-    })).filter(e => e.base)
+    const incubator = list.map((e) => {
+      const egg: Egg = {
+        id: e.id,
+        type: e.type,
+        base: baseMap[e.baseId],
+        rarity: e.rarity,
+        startedAt: e.startedAt,
+        hatchesAt: e.hatchesAt,
+      }
+      if (e.isBreeding)
+        egg.isBreeding = true
+      if (e.forcedMonId)
+        egg.forcedMonId = e.forcedMonId
+      if (typeof e.forcedRarity === 'number')
+        egg.forcedRarity = Math.min(100, Math.max(1, e.forcedRarity))
+      return egg
+    }).filter(e => e.base)
     return { incubator } as StateTree
   },
 } as const

--- a/test/egg-persist.test.ts
+++ b/test/egg-persist.test.ts
@@ -23,6 +23,9 @@ describe('egg persistence', () => {
           rarity: 42,
           startedAt: 1000,
           hatchesAt: 2000,
+          isBreeding: true,
+          forcedMonId: allShlagemons[0].id,
+          forcedRarity: 200,
         },
       ],
     })
@@ -35,5 +38,8 @@ describe('egg persistence', () => {
     expect(egg.hatchesAt).toBe(2000)
     expect(egg.rarity).toBe(42)
     expect(egg.base.id).toBe(allShlagemons[0].id)
+    expect(egg.isBreeding).toBe(true)
+    expect(egg.forcedMonId).toBe(allShlagemons[0].id)
+    expect(egg.forcedRarity).toBe(100)
   })
 })

--- a/test/egg.test.ts
+++ b/test/egg.test.ts
@@ -32,4 +32,26 @@ describe('egg workflow', () => {
     expect(dex.shlagemons.length).toBe(1)
     vi.useRealTimers()
   })
+
+  it('hatches breeding egg with forced parameters', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const eggs = useEggStore()
+    const dex = useShlagedexStore()
+
+    eggs.startIncubation('feu', { isBreeding: true, forcedMonId: 'salamiches', forcedRarity: 150 })
+    expect(eggs.incubator.length).toBe(1)
+    const egg = eggs.incubator[0]
+    expect(egg.isBreeding).toBe(true)
+    expect(egg.forcedMonId).toBe('salamiches')
+    expect(egg.forcedRarity).toBe(100)
+    const duration = egg.hatchesAt - egg.startedAt
+    expect(duration).toBe(hatchDurationForRarity(100))
+    vi.advanceTimersByTime(duration + 1)
+    const mon = eggs.hatchEgg(egg.id)!
+    expect(mon.base.id).toBe('salamiches')
+    expect(mon.rarity).toBe(100)
+    expect(dex.shlagemons.length).toBe(1)
+    vi.useRealTimers()
+  })
 })


### PR DESCRIPTION
## Summary
- allow eggs to record breeding metadata and forced hatch parameters
- persist breeding fields across saves
- cover forced hatch and persistence logic with tests

## Testing
- `pnpm exec eslint src/stores/egg.ts src/utils/egg-serialize.ts test/egg.test.ts test/egg-persist.test.ts`
- `pnpm typecheck` *(fails: Type 'Readonly<Ref<boolean, boolean>>' is not assignable to type 'boolean')*
- `pnpm test:unit test/egg.test.ts test/egg-persist.test.ts`
- `pnpm test:unit` *(fails: Invalid arguments, expected "data.shlagemons.carapouffe.name")*

------
https://chatgpt.com/codex/tasks/task_e_689cb9e27cac832abcc2c60ae8b3289b