### PR TITLE
feat: add breeding cost utilities

### DIFF
--- a/src/utils/breeding.ts
+++ b/src/utils/breeding.ts
@@ -1,0 +1,33 @@
+/**
+ * Utilities for Shlagémon breeding mechanics.
+ */
+
+/**
+ * Fixed duration for a breeding attempt in milliseconds.
+ */
+export const BREEDING_DURATION_MS = 300_000
+
+/**
+ * Base cost applied to a rarity 1 breeding attempt.
+ */
+export const COST_BASE_A = 1_000
+
+/**
+ * Exponential growth factor used in the breeding cost formula.
+ */
+export const COST_GROWTH_C = 1.1
+
+/**
+ * Compute the currency cost for breeding based on rarity.
+ *
+ * Cost follows an exponential curve: \(A \times C^{r-1}\) where `A`
+ * is {@link COST_BASE_A}, `C` is {@link COST_GROWTH_C} and `r` is the
+ * rarity clamped to the [1, 100] range.
+ *
+ * @param rarity - Rarity value of the resulting egg.
+ * @returns Rounded cost for the breeding attempt.
+ */
+export function breedingCost(rarity: number): number {
+  const r = Math.min(100, Math.max(1, Math.round(rarity)))
+  return Math.round(COST_BASE_A * COST_GROWTH_C ** (r - 1))
+}

--- a/test/breeding.test.ts
+++ b/test/breeding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { breedingCost, COST_BASE_A, COST_GROWTH_C } from '~/utils/breeding'
+
+describe('breedingCost', () => {
+  it('returns base cost for rarity 1', () => {
+    expect(breedingCost(1)).toBe(Math.round(COST_BASE_A))
+  })
+
+  it('clamps rarity below 1', () => {
+    expect(breedingCost(-5)).toBe(breedingCost(1))
+  })
+
+  it('clamps rarity above 100', () => {
+    expect(breedingCost(999)).toBe(breedingCost(100))
+  })
+
+  it('applies exponential growth', () => {
+    const rarity = 10
+    const expected = Math.round(COST_BASE_A * COST_GROWTH_C ** (rarity - 1))
+    expect(breedingCost(rarity)).toBe(expected)
+  })
+})


### PR DESCRIPTION
## Summary
- add breeding cost helper with exponential scaling
- cover breeding cost logic with unit tests

## Testing
- `pnpm exec eslint src/utils/breeding.ts test/breeding.test.ts`
- `pnpm lint` *(fails: format/prettier in unrelated files)*
- `pnpm test test/breeding.test.ts`
- `pnpm test` *(fails: 9 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1cb8fcc832ab02f3a291c282238