### PR TITLE
feat: add poulailler transition sounds

### DIFF
--- a/src/stores/mainPanel.ts
+++ b/src/stores/mainPanel.ts
@@ -27,6 +27,7 @@ export const useMainPanelStore = defineStore('mainPanel', () => {
   const transitionSfx = {
     shop: { enter: 'shop-enter', leave: 'shop-leave' },
     miniGame: { enter: 'mini-game-enter', leave: 'mini-game-leave' },
+    poulailler: { enter: 'mini-game-enter', leave: 'mini-game-leave' },
     arena: { enter: 'arena-enter', leave: 'arena-leave' },
     dojo: { enter: 'mini-game-enter', leave: 'mini-game-leave' },
   } as const satisfies Partial<Record<MainPanel, { enter: SfxId, leave: SfxId }>>

--- a/test/main-panel-sfx.test.ts
+++ b/test/main-panel-sfx.test.ts
@@ -9,6 +9,7 @@ describe('main panel sound effects', () => {
   it.each([
     ['showShop', 'shop-enter', 'shop-leave'],
     ['showMiniGame', 'mini-game-enter', 'mini-game-leave'],
+    ['showPoulailler', 'mini-game-enter', 'mini-game-leave'],
     ['showArena', 'arena-enter', 'arena-leave'],
   ] as const)(
     'plays %s sounds',


### PR DESCRIPTION
## Summary
- play mini-game enter/leave sfx when entering or exiting the poulailler
- cover poulailler panel transition sounds with unit tests

## Testing
- `pnpm lint src/stores/mainPanel.ts test/main-panel-sfx.test.ts` (fails: lint errors in unrelated files)
- `pnpm test` (fails: multiple failing tests)


------
https://chatgpt.com/codex/tasks/task_e_689cc281616c832a939d2981e46f9467