### PR TITLE
feat: add breeding store

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -173,6 +173,7 @@ declare global {
   const useBattleship: typeof import('./composables/useBattleship')['useBattleship']
   const useBluetooth: typeof import('@vueuse/core')['useBluetooth']
   const useBreakpoints: typeof import('@vueuse/core')['useBreakpoints']
+  const useBreedingStore: typeof import('./stores/breeding')['useBreedingStore']
   const useBroadcastChannel: typeof import('@vueuse/core')['useBroadcastChannel']
   const useBrowserLocation: typeof import('@vueuse/core')['useBrowserLocation']
   const useCached: typeof import('@vueuse/core')['useCached']
@@ -467,6 +468,9 @@ declare global {
   export type { AttackResult } from './stores/battle'
   import('./stores/battle')
   // @ts-ignore
+  export type { BreedingJob, BreedingState } from './stores/breeding'
+  import('./stores/breeding')
+  // @ts-ignore
   export type { DeckSort } from './stores/deckFilter'
   import('./stores/deckFilter')
   // @ts-ignore
@@ -675,6 +679,7 @@ declare module 'vue' {
     readonly useBattleship: UnwrapRef<typeof import('./composables/useBattleship')['useBattleship']>
     readonly useBluetooth: UnwrapRef<typeof import('@vueuse/core')['useBluetooth']>
     readonly useBreakpoints: UnwrapRef<typeof import('@vueuse/core')['useBreakpoints']>
+    readonly useBreedingStore: UnwrapRef<typeof import('./stores/breeding')['useBreedingStore']>
     readonly useBroadcastChannel: UnwrapRef<typeof import('@vueuse/core')['useBroadcastChannel']>
     readonly useBrowserLocation: UnwrapRef<typeof import('@vueuse/core')['useBrowserLocation']>
     readonly useCached: UnwrapRef<typeof import('@vueuse/core')['useCached']>

--- a/src/stores/breeding.ts
+++ b/src/stores/breeding.ts
@@ -1,0 +1,130 @@
+import type { EggType } from './egg'
+import { defineStore } from 'pinia'
+import { BREEDING_DURATION_MS, breedingCost } from '~/utils/breeding'
+
+/**
+ * Describes a single breeding job.
+ */
+export interface BreedingJob {
+  /** Type of egg that will be produced. */
+  readonly type: EggType
+  /** Target rarity applied to the resulting egg. */
+  readonly rarity: number
+  /** Timestamp when the job started in milliseconds. */
+  readonly startedAt: number
+  /** Timestamp when the job ends in milliseconds. */
+  readonly endsAt: number
+  /** Current status of the job. */
+  status: 'running' | 'completed'
+}
+
+/**
+ * Shape of the breeding store state.
+ */
+export interface BreedingState {
+  /** Mapping of breeding jobs by egg type. */
+  byType: Record<EggType, BreedingJob | undefined>
+}
+
+export const useBreedingStore = defineStore('breeding', () => {
+  const byType = ref<BreedingState['byType']>({})
+  const game = useGameStore()
+  const eggs = useEggStore()
+
+  /**
+   * Retrieve the job associated with the given type.
+   */
+  function getJob(type: EggType): BreedingJob | null {
+    return byType.value[type] ?? null
+  }
+
+  /**
+   * Determine if a breeding job is currently running for the type.
+   */
+  function isRunning(type: EggType): boolean {
+    return byType.value[type]?.status === 'running'
+  }
+
+  /**
+   * Milliseconds remaining before job completion.
+   */
+  function remainingMs(type: EggType): number {
+    const job = byType.value[type]
+    if (!job || job.status !== 'running')
+      return 0
+    return Math.max(0, job.endsAt - Date.now())
+  }
+
+  /**
+   * Progress ratio of the job in the [0,1] range.
+   */
+  function progress(type: EggType): number {
+    const job = byType.value[type]
+    if (!job)
+      return 0
+    const total = job.endsAt - job.startedAt
+    return total > 0 ? 1 - remainingMs(type) / total : 1
+  }
+
+  /**
+   * Start a breeding job if enough currency is available.
+   *
+   * @returns `true` when the job started successfully.
+   */
+  function start(type: EggType, rarity: number): boolean {
+    if (isRunning(type))
+      return false
+    const cost = breedingCost(rarity)
+    if (game.shlagidolar < cost)
+      return false
+    game.addShlagidolar(-cost)
+    const startedAt = Date.now()
+    byType.value[type] = {
+      type,
+      rarity,
+      startedAt,
+      endsAt: startedAt + BREEDING_DURATION_MS,
+      status: 'running',
+    }
+    return true
+  }
+
+  /**
+   * Hatch the breeding egg when the job has completed.
+   */
+  function completeIfDue(type: EggType): boolean {
+    const job = byType.value[type]
+    if (!job || job.status !== 'running')
+      return false
+    if (Date.now() < job.endsAt)
+      return false
+    eggs.startIncubation(type, { isBreeding: true, forcedRarity: job.rarity })
+    job.status = 'completed'
+    return true
+  }
+
+  /**
+   * Remove finished jobs from state.
+   */
+  function clearFinished(): void {
+    for (const [key, job] of Object.entries(byType.value)) {
+      if (job?.status === 'completed')
+        delete byType.value[key as EggType]
+    }
+  }
+
+  return {
+    byType,
+    getJob,
+    isRunning,
+    remainingMs,
+    progress,
+    start,
+    completeIfDue,
+    clearFinished,
+  }
+}, {
+  persist: {
+    pick: ['byType'],
+  },
+})

--- a/test/breeding-store.test.ts
+++ b/test/breeding-store.test.ts
@@ -1,0 +1,42 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { useBreedingStore } from '../src/stores/breeding'
+import { useEggStore } from '../src/stores/egg'
+import { useGameStore } from '../src/stores/game'
+import { BREEDING_DURATION_MS, breedingCost } from '../src/utils/breeding'
+
+describe('breeding store', () => {
+  it('fails to start without funds', () => {
+    setActivePinia(createPinia())
+    const breeding = useBreedingStore()
+    expect(breeding.start('feu', 5)).toBe(false)
+  })
+
+  it('starts and completes a breeding job', () => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const breeding = useBreedingStore()
+    const eggs = useEggStore()
+    const game = useGameStore()
+    game.addShlagidolar(10_000)
+
+    const rarity = 10
+    const cost = breedingCost(rarity)
+    expect(breeding.start('feu', rarity)).toBe(true)
+    expect(game.shlagidolar).toBe(10_000 - cost)
+
+    vi.advanceTimersByTime(BREEDING_DURATION_MS - 1)
+    expect(breeding.completeIfDue('feu')).toBe(false)
+    vi.advanceTimersByTime(2)
+    expect(breeding.completeIfDue('feu')).toBe(true)
+
+    expect(eggs.incubator.length).toBe(1)
+    const egg = eggs.incubator[0]
+    expect(egg.isBreeding).toBe(true)
+    expect(egg.forcedRarity).toBe(rarity)
+
+    breeding.clearFinished()
+    expect(breeding.getJob('feu')).toBeNull()
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary
- add persistent breeding store to manage egg jobs
- cover breeding workflow with unit tests

## Testing
- `pnpm lint` *(fails: Missing trailing comma etc. in src/components/panel/BonusDetails.i18n.yml)*
- `pnpm exec eslint src/stores/breeding.ts test/breeding-store.test.ts`
- `pnpm typecheck` *(fails: Type 'Readonly<Ref<boolean, boolean>>' is not assignable to type 'boolean'. in src/stores/shlagedex.ts)*
- `pnpm test:unit` *(fails: expected false to be true in test/capture.test.ts and SyntaxError in test/page-locale-ssr.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cc6926fc4832aa5e51ab51c055b67