### PR TITLE
feat: persist breeding jobs

### DIFF
--- a/src/stores/save.ts
+++ b/src/stores/save.ts
@@ -1,5 +1,6 @@
 import type { PersistedStoreId } from '~/utils/save-code'
 import { defineStore } from 'pinia'
+import { useBreedingStore } from '~/stores/breeding'
 import { PERSISTED_STORE_KEYS } from '~/utils/save-code'
 
 interface ResettableStore { reset?: () => void }
@@ -16,6 +17,7 @@ const PERSISTED_STORE_GETTERS = {
   achievementsFilter: useAchievementsFilterStore,
   ball: useBallStore,
   battleStats: useBattleStatsStore,
+  breeding: useBreedingStore,
   deckFilter: useDeckFilterStore,
   dexFilter: useDexFilterStore,
   dialog: useDialogStore,

--- a/src/utils/save-code.ts
+++ b/src/utils/save-code.ts
@@ -11,6 +11,7 @@ export const PERSISTED_STORE_KEYS = [
   'achievementsFilter',
   'ball',
   'battleStats',
+  'breeding',
   'deckFilter',
   'dexFilter',
   'dialog',


### PR DESCRIPTION
## Summary
- include breeding store in save reset routine
- persist breeding store key so breeding jobs survive reloads

## Testing
- `pnpm lint` *(fails: 47 problems, 40 errors, 7 warnings)*
- `pnpm typecheck` *(fails: various type errors)*
- `pnpm test:unit` *(fails: 9 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cd75d7d34832aa59d3bda10aa00a0