### PR TITLE
feat(i18n): add breeding translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2353,6 +2353,30 @@ pages:
       acknowledge: I understand this action replaces ALL my local data.
   shlagedex:
     title: Shlagedex
+  breeding:
+    name: Breeding
+    introDialog: Welcome to the breeding center. Pick the parent to breed.
+    introOk: Let's go!
+    selectMon: Choose a Shlagémon
+    selected: Selected Shlagémon
+    partner: Partner
+    rarity: Rarity
+    cost: Cost
+    duration: Duration
+    minutes: minutes
+    progress: Progress
+    remaining: Remaining time
+    endsAt: Ends at {time}
+    cta:
+      payAndStart: Pay & start
+      seeEgg: View egg
+    toast:
+      started: Breeding started!
+      finished: Egg obtained!
+    a11y:
+      openSelector: Choose parent
+      startBreeding: Start breeding
+      goToEgg: Go to egg
 stores:
   achievements:
     unlocked: 'Achievement unlocked: {title}'

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2346,6 +2346,30 @@ pages:
       acknowledge: Je comprends que cette action remplace TOUTES mes données locales.
   shlagedex:
     title: Shlagédex
+  breeding:
+    name: Élevage
+    introDialog: Bienvenue au centre d'élevage. Choisis le Shlagémon à reproduire.
+    introOk: C'est parti !
+    selectMon: Choisir un Shlagémon
+    selected: Shlagémon sélectionné
+    partner: Partenaire
+    rarity: Rareté
+    cost: Coût
+    duration: Durée
+    minutes: minutes
+    progress: Progression
+    remaining: Temps restant
+    endsAt: Se termine à {time}
+    cta:
+      payAndStart: Payer & lancer
+      seeEgg: Voir l'œuf
+    toast:
+      started: Élevage lancé !
+      finished: Œuf obtenu !
+    a11y:
+      openSelector: Choisir le parent
+      startBreeding: Lancer l'élevage
+      goToEgg: Aller à l'œuf
 stores:
   achievements:
     unlocked: 'Succès déverrouillé : {title}'

--- a/src/pages/breeding.i18n.yml
+++ b/src/pages/breeding.i18n.yml
@@ -1,5 +1,5 @@
 fr:
-  title: Élevage
+  name: Élevage
   introDialog: Bienvenue au centre d'élevage. Choisis le Shlagémon à reproduire.
   introOk: C'est parti !
   selectMon: Choisir un Shlagémon
@@ -23,7 +23,7 @@ fr:
     startBreeding: Lancer l'élevage
     goToEgg: Aller à l'œuf
 en:
-  title: Breeding
+  name: Breeding
   introDialog: Welcome to the breeding center. Pick the parent to breed.
   introOk: Let's go!
   selectMon: Choose a Shlagémon

--- a/src/pages/breeding.vue
+++ b/src/pages/breeding.vue
@@ -93,7 +93,7 @@ onMounted(() => {
   <div class="mx-auto max-w-160 w-full flex flex-col gap-4 p-4">
     <header class="flex items-center gap-2">
       <h1 class="flex-1 text-xl font-bold">
-        {{ t('pages.breeding.title') }}
+        {{ t('pages.breeding.name') }}
       </h1>
       <CharacterImage :id="currentPartner.id" :alt="currentPartner.name" class="h-12 w-12" />
     </header>


### PR DESCRIPTION
## Summary
- add `pages.breeding` translations in French and English
- use `$t('pages.breeding.name')` in breeding page

## Testing
- `pnpm test:unit` *(fails: Cannot call props on an empty VueWrapper, expected 240 to be 230, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ce1d9a3d4832aaf2b75568912bcae