### PR TITLE
fix: use supported button styles

### DIFF
--- a/src/components/UpdateSnackbar.vue
+++ b/src/components/UpdateSnackbar.vue
@@ -114,8 +114,8 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
           <div class="flex items-center gap-2">
             <UiButton
               v-if="hasError"
-              type="secondary"
-              variant="soft"
+              type="default"
+              variant="outline"
               data-state="error"
               @click="handleRetry"
             >

--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -100,7 +100,7 @@ onMounted(() => {
 
     <section class="flex flex-col gap-3">
       <UiButton
-        type="secondary"
+        type="default"
         class="flex items-center self-start gap-1"
         :aria-label="t('components.panel.Breeding.a11y.openSelector')"
         @click="openSelector"


### PR DESCRIPTION
## Summary
- replace unsupported `secondary` button variant in update snackbar
- standardize breeding panel selector button style

## Testing
- `pnpm test:unit` *(fails: `Cannot call props on an empty VueWrapper`, `Invalid arguments`, `(0 , redirect) is not a function`, and others)*

------
https://chatgpt.com/codex/tasks/task_e_689d015e6ee4832a9329c0a88960f5c9