### PR TITLE
fix: add running status translations for dojo panel

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -67,7 +67,7 @@ components:
       captured: You captured {name}!
       fail: Missed!
     DiseaseBadge:
-      tooltip: "Sick: {n} battles remaining"
+      tooltip: 'Sick: {n} battles remaining'
     EffectBadge:
       attack: Your attack is boosted for {remaining} more
       defense: Your defense is boosted for {remaining} more
@@ -99,13 +99,13 @@ components:
       defeat: Defeat...
       queen: queen
       king: king
-      zoneKingChallenge: "{label} zone challenge"
+      zoneKingChallenge: '{label} zone challenge'
       reward: +{amount} Shlagidiamonds
     damageTaken: Took {amount} damage
     healedFor: Healed for {amount} HP
   deck:
     Detail:
-      evolution: "Evolution:"
+      evolution: 'Evolution:'
       level: lvl {n}
     List:
       search: Search
@@ -127,7 +127,7 @@ components:
             retry: Retry
             quit: Quit
     ArenaVictoryDialog:
-      toast: "{name} obtained!"
+      toast: '{name} obtained!'
       steps:
         step1:
           text: Congratulations! You triumphed at the arena.
@@ -232,7 +232,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "Let me tell you about a curious item: the Cuck Ring."
+          text: 'Let me tell you about a curious item: the Cuck Ring.'
           responses:
             back: Back
             next: Continue
@@ -242,7 +242,7 @@ components:
             back: Back
             next: Continue
         step4:
-          text: "It makes each attack unpredictable: double damage or healing the foe instead."
+          text: 'It makes each attack unpredictable: double damage or healing the foe instead.'
           responses:
             back: Back
             next: Continue
@@ -365,7 +365,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP."
+          text: 'As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP.'
           responses:
             back: Back
             next: Continue
@@ -599,7 +599,7 @@ components:
         step1:
           text: Impressive! You've captured at least {count} Shlagemons.
         step2:
-          text: "Here is a unique item: {name}."
+          text: 'Here is a unique item: {name}.'
         step3:
           text: It increases the holder's {stat} by {percent}%.
         step4:
@@ -676,7 +676,7 @@ components:
         - You're one step away from a brain fart.
         - Rarely seen someone so pathetic.
       validate: Validate
-      attemptsLeft: "{n} attempts left"
+      attemptsLeft: '{n} attempts left'
       win: You've cracked a Shlag's mind!
       lose: Even a Grimer would have done it
       legend:
@@ -685,7 +685,7 @@ components:
         absent: Not in the combination
       selectSlot: Select a slot
     Pairs:
-      attempts: "{n} attempt | {n} attempts"
+      attempts: '{n} attempt | {n} attempts'
     masterMind:
       SelectionModal:
         title: Choose a Shlagemon
@@ -703,9 +703,9 @@ components:
       intro1: The Shlagedex bonus increases the final damage of all your Shlagémons! It represents the maximum bonus you could get by capturing all accessible Shlagémons.
       intro2: It is based on the completion rate of this potential Shlagedex as well as your team's average level.
       formula: Bonus = average level × 2 × (completion rate / 100) / 10
-      completion: "Completion:"
-      averageLevel: "Average level:"
-      currentBonus: "Current bonus:"
+      completion: 'Completion:'
+      averageLevel: 'Average level:'
+      currentBonus: 'Current bonus:'
     Inventory:
       search: Search
       sort:
@@ -722,7 +722,7 @@ components:
     MiniGame:
       exit: Exit
     PlayerInfos:
-      sick: "Sick: {n} battles left"
+      sick: 'Sick: {n} battles left'
       dex: ShlageDex
       averageLevel: Average level
       bonus: Bonus
@@ -745,7 +745,7 @@ components:
       a11y:
         showSpecies: Show species for {name}
         incubateEgg: Incubate the {name} egg
-        eggReady: "{type} egg ready"
+        eggReady: '{type} egg ready'
         eggProgress: Egg progress
     Shop:
       title: Shop
@@ -792,6 +792,8 @@ components:
         finished: Training finished! Rarity improved.
       progress: Progress
       controls: Controls
+      status:
+        running: Training in progress
     Breeding:
       name: Breeding
       introDialog: Welcome to the breeding center. Pick the parent to breed.
@@ -864,7 +866,7 @@ components:
     Detail:
       equipItemTitle: Equip an item
       allowEvolution: Allow this Shlagemon to evolve?
-      firstCatch: "First capture: {date}"
+      firstCatch: 'First capture: {date}'
       obtainedTimes: Obtained {count} times
       release: Release
       main: Main
@@ -887,7 +889,7 @@ components:
       smell: Smell
       title: Shlagemon Info
     EvolutionModal:
-      evolveTitle: "{name} is evolving"
+      evolveTitle: '{name} is evolving'
       question: '"{from}" wants to evolve into "{to}", will you allow it or stop the spread of shlaguitude?'
       alreadyOwned: You already own this evolution
       yes: Yes
@@ -943,19 +945,19 @@ components:
       henhouse: Henhouse
       breeding: Breeding
       fightKing: Challenge the {label} of the zone
-      kingDefeated: "{label} defeated!"
+      kingDefeated: '{label} defeated!'
       dojo: Dojo
   zone:
     MonsModal:
-      title: "{zone} Shlagemons"
+      title: '{zone} Shlagemons'
 composables:
   useFormatDuration:
-    year: "{count} year | {count} years"
-    month: "{count} month | {count} months"
-    day: "{count} day | {count} days"
-    hour: "{count} hour | {count} hours"
-    minute: "{count} minute | {count} minutes"
-    second: "{count} second | {count} seconds"
+    year: '{count} year | {count} years'
+    month: '{count} month | {count} months'
+    day: '{count} day | {count} days'
+    hour: '{count} hour | {count} hours'
+    minute: '{count} minute | {count} minutes'
+    second: '{count} second | {count} seconds'
     and: and
 data:
   Minigame:
@@ -1348,7 +1350,7 @@ data:
         description: Cringeon was once cool. Cringeon spent too much time scratching minor chords at the edge of an extinct volcano. From now on, Cool's not cool wanders with a guitar too big for his wings, freckles crying, and a check shirt that smells wet grass and regrets. His plumage took on a sad rust colour, and his red wick hides a remorseful look, as if he constantly realized that he could have evolved into a legendary raptor, but preferred to release an independent EP. It's always a little cold around him, even in the summer. Its signature capacity, Refrain Getting into trouble, inflicts a deep discomfort on all the arena, reducing the accuracy of enemy attacks as long as they turn their eyes away. He's very good at driving wild Pokémons away… and dating.
         name: Cringeon
       sacdepates:
-        description: "Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Pastafreak undergoes a physical attack, he can wrap around the enemy to trap and immobilize."
+        description: 'Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Pastafreak undergoes a physical attack, he can wrap around the enemy to trap and immobilize.'
         name: Pastafreak
     05-10:
       aspigros:
@@ -1373,7 +1375,7 @@ data:
         description: A mass of foul mud that drags slowly. Where he passes, nothing grows because of his toxicity. It is made of a toxic mud. He pollutes everything he touches, even the ground becomes sterile. He stinks so much that people vanish just by crossing him. His body is a concentrate of toxins.
         name: Snotto
       ptitocard:
-        description: "Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure."
+        description: 'Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure.'
         name: Lamewag
     10-15:
       abraquemar:
@@ -1661,7 +1663,7 @@ data:
         description: Its endless language is dragging everywhere and is mainly used to slander. He likes to criticize his opponents until they abandon by weariness.
         name: Gossipbitch
       lecocu:
-        description: "Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness."
+        description: 'Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness.'
         name: Cheated
       rhinofaringite:
         description: This sneezed rhinoceros sneezed from the rocks on its enemies. Its nose runs permanently, which makes it as slippery as it is unpredictable.
@@ -2327,7 +2329,7 @@ pages:
     welcome: Welcome to Shlagemon
   privacy-policy:
     title: Privacy Policy – Shlagémon
-    lastUpdated: "Last updated: 06/08/2025"
+    lastUpdated: 'Last updated: 06/08/2025'
     sections:
       data:
         title: 1. Data collected
@@ -2362,10 +2364,10 @@ pages:
       cancel: Cancel
       summary:
         title: Summary
-        mons: "Shlagemons: {count}"
-        shlagidolar: "Shlagidollars: {amount}"
-        shlagidiamond: "Shlagidiamonds: {amount}"
-        playtime: "Playtime: {time}"
+        mons: 'Shlagemons: {count}'
+        shlagidolar: 'Shlagidollars: {amount}'
+        shlagidiamond: 'Shlagidiamonds: {amount}'
+        playtime: 'Playtime: {time}'
         monsLabel: Shlagemons
         shlagidolarLabel: Shlagidollars
         shlagidiamondLabel: Shlagidiamonds
@@ -2374,7 +2376,7 @@ pages:
       errorApply: Import failed.
       subtitle: Import a .shlag save file to replace your local data.
       hint: Click or drag-and-drop a {ext} file
-      warningTitle: "Warning: destructive import"
+      warningTitle: 'Warning: destructive import'
       fileReady: File ready. Review details below.
       acknowledge: I understand this action replaces ALL my local data.
   shlagedex:
@@ -2406,19 +2408,19 @@ pages:
       goToEgg: Go to egg
 stores:
   achievements:
-    unlocked: "Achievement unlocked: {title}"
-    zoneShinyTitle: "{zone}: Rainbow Hunter"
+    unlocked: 'Achievement unlocked: {title}'
+    zoneShinyTitle: '{zone}: Rainbow Hunter'
     zoneShinyDescription: Capture every Shlagémon in {zone} in shiny form.
-    zoneRarityTitle: "{zone}: Perfectionist"
+    zoneRarityTitle: '{zone}: Perfectionist'
     zoneRarityDescription: Raise every Shlagémon in {zone} to rarity 100.
     zoneCompleteDescription: Capture every Shlagémon in {zone}.
-    zoneWinTitle: "{n} victories - {zone}"
+    zoneWinTitle: '{n} victories - {zone}'
     zoneWinDescription: Defeat {n} Shlagémon in {zone}.
     shinyTitles:
-      "1": Shiny!
-      "10": 10 shinies
-      "100": 100 shinies
-      "1000": Living Legend
+      '1': Shiny!
+      '10': 10 shinies
+      '100': 100 shinies
+      '1000': Living Legend
     shinyDescription: Capture {n} extremely rare shiny Shlagémon.
     itemTitles:
       firstPurchase: First Purchase
@@ -2438,14 +2440,14 @@ stores:
     toast:
       item: You obtained {qty} {item} ({category})!
   shlagedex:
-    rarityReached: "{name} reached rarity {rarity}!"
-    evolved: "{name} evolved!"
+    rarityReached: '{name} reached rarity {rarity}!'
+    evolved: '{name} evolved!'
     obtained: You obtained {name}!
     alreadyMax: You already have this Shlagemon at max rarity
     point: point | points
     level: level | levels
-    rarityChanged: "{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!"
-    released: "{name} was released!"
+    rarityChanged: '{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!'
+    released: '{name} was released!'
 common:
   loading: Loading…
   pleaseWait: Please wait

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -67,7 +67,7 @@ components:
       captured: Vous avez capturé {name} !
       fail: Raté !
     DiseaseBadge:
-      tooltip: "Malade : {n} combats restants"
+      tooltip: 'Malade : {n} combats restants'
     EffectBadge:
       attack: Votre attaque est boostée pour encore {remaining}
       defense: Votre défense est boostée pour encore {remaining}
@@ -105,7 +105,7 @@ components:
     healedFor: Soigné de {amount} PV
   deck:
     Detail:
-      evolution: "Évolution :"
+      evolution: 'Évolution :'
       level: lvl {n}
     List:
       search: Rechercher
@@ -127,7 +127,7 @@ components:
             retry: Réessayer
             quit: Quitter
     ArenaVictoryDialog:
-      toast: "{name} obtenu !"
+      toast: '{name} obtenu !'
       steps:
         step1:
           text: Félicitations ! Tu as triomphé de l'arène.
@@ -599,7 +599,7 @@ components:
         step1:
           text: Impressionnant ! Tu as capturé au moins {count} Shlagémons.
         step2:
-          text: "Voici un objet unique : {name}."
+          text: 'Voici un objet unique : {name}.'
         step3:
           text: Il augmente {stat} du porteur de {percent}%.
         step4:
@@ -676,7 +676,7 @@ components:
         - T'es à deux doigts de faire un pet cérébral.
         - Rarement vu quelqu'un aussi merdique.
       validate: Valider
-      attemptsLeft: "{n} tentatives restantes"
+      attemptsLeft: '{n} tentatives restantes'
       win: T'as percé le cerveau d'un Shlag !
       lose: Même un Petmorv y serait arrivé
       legend:
@@ -685,7 +685,7 @@ components:
         absent: Absent de la combinaison
       selectSlot: Sélectionne une case
     Pairs:
-      attempts: "{n} tentative | {n} tentatives"
+      attempts: '{n} tentative | {n} tentatives'
     masterMind:
       SelectionModal:
         title: Choisis un Shlagémon
@@ -703,9 +703,9 @@ components:
       intro1: Le bonus du Shlagedex augmente les dégâts finaux de tous vos Shlagémons ! Il représente le bonus maximal que vous pouvez obtenir en capturant tous les Shlagémons accessibles.
       intro2: Il se base sur le pourcentage de complétion de ce Shlagédex potentiel ainsi que sur le niveau moyen de votre équipe.
       formula: Bonus = niveau moyen × 2 × (taux de complétion / 100) / 10
-      completion: "Complétion :"
-      averageLevel: "Niveau moyen :"
-      currentBonus: "Bonus actuel :"
+      completion: 'Complétion :'
+      averageLevel: 'Niveau moyen :'
+      currentBonus: 'Bonus actuel :'
     Inventory:
       search: Rechercher
       sort:
@@ -722,7 +722,7 @@ components:
     MiniGame:
       exit: Quitter
     PlayerInfos:
-      sick: "Malade : {n} combats restants"
+      sick: 'Malade : {n} combats restants'
       dex: ShlagéDex
       averageLevel: Niveau moyen
       bonus: Bonus
@@ -792,6 +792,8 @@ components:
         finished: Entraînement terminé ! Rareté améliorée.
       progress: Progression
       controls: Contrôles
+      status:
+        running: Entraînement en cours
     Breeding:
       name: Élevage
       introDialog: Bienvenue au centre d'élevage. Choisis le Shlagémon à reproduire.
@@ -864,7 +866,7 @@ components:
     Detail:
       equipItemTitle: Équiper un objet
       allowEvolution: Autoriser ce Shlagémon à évoluer ?
-      firstCatch: "Première capture : {date}"
+      firstCatch: 'Première capture : {date}'
       obtainedTimes: Obtenu {count} fois
       release: Relâcher
       main: Principal
@@ -887,7 +889,7 @@ components:
       smell: Puanteur
       title: Informations Shlagémon
     EvolutionModal:
-      evolveTitle: "{name} évolue"
+      evolveTitle: '{name} évolue'
       question: « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
       yes: Oui
@@ -943,19 +945,19 @@ components:
       henhouse: Poulailler
       breeding: Élevage
       fightKing: Défier la {label} de la zone
-      kingDefeated: "{label} vaincu{suffix} !"
+      kingDefeated: '{label} vaincu{suffix} !'
       dojo: Dojo
   zone:
     MonsModal:
       title: Shlagémons de {zone}
 composables:
   useFormatDuration:
-    year: "{count} an | {count} ans"
-    month: "{count} mois"
-    day: "{count} jour | {count} jours"
-    hour: "{count} heure | {count} heures"
-    minute: "{count} minute | {count} minutes"
-    second: "{count} seconde | {count} secondes"
+    year: '{count} an | {count} ans'
+    month: '{count} mois'
+    day: '{count} jour | {count} jours'
+    hour: '{count} heure | {count} heures'
+    minute: '{count} minute | {count} minutes'
+    second: '{count} seconde | {count} secondes'
     and: et
 data:
   Minigame:
@@ -1348,7 +1350,7 @@ data:
         description: Roux pas Cool était anciennement cool. Roux pas Cool a passé trop de temps à gratter des accords mineurs au bord d’un volcan éteint. Désormais, Roux pas Cool erre avec une guitare trop grande pour ses ailes, des taches de rousseur qui pleurent, et une chemise à carreaux qui sent l’herbe humide et les regrets. Son plumage a pris une teinte rouille triste, et sa mèche rousse cache un regard empli de remords, comme s’il réalisait constamment qu’il aurait pu évoluer en rapace légendaire, mais a préféré sortir un EP en indépendant. Il fait toujours un peu froid autour de lui, même en plein été. Sa capacité signature, Refrain Gênant, inflige un malaise profond à toute l’arène, réduisant la précision des attaques ennemies tant qu’ils détournent le regard. Il est très doué pour faire fuir les Pokémon sauvages… et les rendez-vous galants.
         name: Roux pas Cool
       sacdepates:
-        description: "Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser."
+        description: 'Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser.'
         name: Sac de Pâtes
     05-10:
       aspigros:
@@ -1373,7 +1375,7 @@ data:
         description: Une masse de boue nauséabonde qui se traîne lentement. Là où il passe, plus rien ne pousse à cause de sa toxicité. Il est fait d'une boue toxique. Il pollue tout ce qu’il touche, même le sol devient stérile. Il pue tellement que des gens s’évanouissent rien qu’en le croisant. Son corps est un concentré de toxines.
         name: Metamorve
       ptitocard:
-        description: "Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr."
+        description: 'Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr.'
         name: Ptitocard
     10-15:
       abraquemar:
@@ -1661,7 +1663,7 @@ data:
         description: Sa langue interminable traîne partout et sert principalement à médire. Il aime critiquer ses adversaires jusqu'à ce qu'ils abandonnent par lassitude.
         name: Languedepute
       lecocu:
-        description: "Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante."
+        description: 'Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.'
         name: Lecocu
       rhinofaringite:
         description: Ce rhinocéros enrhumé éternue des rochers sur ses ennemis. Son nez coule en permanence, ce qui le rend aussi glissant qu'imprévisible.
@@ -1716,7 +1718,7 @@ data:
         Aujourd’hui, Artichaud veille sur les zones de non-droit climatiques, où il impose son règne moite et frigorifié, entre deux éternuements fumants et des engelures de l’aisselle.
       name: Artichaud
     bulgrosboule:
-      description: "Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller."
+      description: 'Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller.'
       name: Bulgrosboule
     carapouffe:
       description: Carapouffe s'est enfoncée dans sa propre carapace moelleuse, elle ne se déplace qu’en roulant lentement, laissant derrière elle une traînée de paillettes et de gloss fondu. Son maquillage dégouline en permanence, formant une couche protectrice impénétrable — les scientifiques appellent ça le « fard d’armure ». Dotée d’un regard mi-séduisant, mi-comateux, elle hypnotise ses adversaires en leur lançant des œillades flasques, accompagnées d’un soupir de lassitude cosmique. Elle passe ses journées à se recoiffer sans bouger la tête, grâce à un système complexe de brosses dissimulées dans son chignon. Sa voix est rauque, son parfum est toxique, et sa principale attaque, "Écrasement Moussant", consiste à s’écrouler violemment sur son ennemi en faisant claquer ses faux ongles.
@@ -2320,7 +2322,7 @@ pages:
     welcome: Bienvenue dans Shlagémon
   privacy-policy:
     title: Politique de Confidentialité – Shlagémon
-    lastUpdated: "Dernière mise à jour : 06/08/2025"
+    lastUpdated: 'Dernière mise à jour : 06/08/2025'
     sections:
       data:
         title: 1. Données collectées
@@ -2355,10 +2357,10 @@ pages:
       cancel: Annuler
       summary:
         title: Récapitulatif
-        mons: "Shlagémons : {count}"
-        shlagidolar: "Shlagidolars : {amount}"
-        shlagidiamond: "Shlagidiamonds : {amount}"
-        playtime: "Temps de jeu : {time}"
+        mons: 'Shlagémons : {count}'
+        shlagidolar: 'Shlagidolars : {amount}'
+        shlagidiamond: 'Shlagidiamonds : {amount}'
+        playtime: 'Temps de jeu : {time}'
         monsLabel: Shlagémons
         shlagidolarLabel: Shlagidolars
         shlagidiamondLabel: Shlagidiamonds
@@ -2367,7 +2369,7 @@ pages:
       errorApply: L'import a échoué.
       subtitle: Importez une sauvegarde .shlag pour remplacer vos données locales.
       hint: Cliquez ou glissez-déposez un fichier {ext}
-      warningTitle: "Attention : import destructif"
+      warningTitle: 'Attention : import destructif'
       fileReady: Fichier prêt. Vérifiez les détails ci-dessous.
       acknowledge: Je comprends que cette action remplace TOUTES mes données locales.
   shlagedex:
@@ -2399,19 +2401,19 @@ pages:
       goToEgg: Aller à l'œuf
 stores:
   achievements:
-    unlocked: "Succès déverrouillé : {title}"
+    unlocked: 'Succès déverrouillé : {title}'
     zoneShinyTitle: "{zone} : Chasseur d'arc-en-ciel"
     zoneShinyDescription: Capturer tous les Shlagémon de {zone} en version shiny.
-    zoneRarityTitle: "{zone} : Perfectionniste"
+    zoneRarityTitle: '{zone} : Perfectionniste'
     zoneRarityDescription: Amener tous les Shlagémon de {zone} à la rareté 100.
     zoneCompleteDescription: Capturer tous les Shlagémon de {zone}.
-    zoneWinTitle: "{n} victoires - {zone}"
+    zoneWinTitle: '{n} victoires - {zone}'
     zoneWinDescription: Vaincre {n} Shlagémon dans {zone}.
     shinyTitles:
-      "1": Shiny!
-      "10": 10 shinies
-      "100": 100 shinies
-      "1000": Légende vivante
+      '1': Shiny!
+      '10': 10 shinies
+      '100': 100 shinies
+      '1000': Légende vivante
     shinyDescription: Capturer {n} Shlagémon shiny extrêmement rares.
     itemTitles:
       firstPurchase: Premier craquage
@@ -2431,14 +2433,14 @@ stores:
     toast:
       item: Tu obtiens {qty} {item} ({category}) !
   shlagedex:
-    rarityReached: "{name} atteint la rareté {rarity} !"
-    evolved: "{name} a évolué !"
+    rarityReached: '{name} atteint la rareté {rarity} !'
+    evolved: '{name} a évolué !'
     obtained: Tu as obtenu {name} !
     alreadyMax: Vous avez déjà ce Shlagémon au maximum de sa rareté
     point: point | points
     level: niveau | niveaux
-    rarityChanged: "{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !"
-    released: "{name} a été relâché !"
+    rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
+    released: '{name} a été relâché !'
 common:
   loading: Chargement…
   pleaseWait: Veuillez patienter

--- a/src/components/panel/Dojo.i18n.yml
+++ b/src/components/panel/Dojo.i18n.yml
@@ -20,6 +20,8 @@ fr:
     remaining: Temps restant
     endsAt: Se termine à {time}
   progress: Progression
+  status:
+    running: Entraînement en cours
   cta:
     payAndStart: Payer & lancer
     trainingRunning: Entraînement en cours
@@ -48,6 +50,8 @@ en:
     remaining: Remaining time
     endsAt: Ends at {time}
   progress: Progress
+  status:
+    running: Training in progress
   cta:
     payAndStart: Pay & start
     trainingRunning: Training in progress


### PR DESCRIPTION
## Summary
- add missing `status.running` translation for the Dojo panel in French and English
- regenerate merged locale files

## Testing
- `pnpm test` *(fails: Cannot call props on an empty VueWrapper, SyntaxError: Invalid arguments, TypeError: (0 , redirect) is not a function, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_689d0d5f1c60832aadf114d9d79128e1