### PR TITLE
Refactor breeding panel to mirror dojo

### DIFF
--- a/src/components/panel/Breeding.i18n.yml
+++ b/src/components/panel/Breeding.i18n.yml
@@ -1,47 +1,47 @@
 fr:
-  name: Élevage
-  introDialog: Bienvenue au centre d'élevage. Choisis le Shlagémon à reproduire.
-  introOk: C'est parti !
+  title: Élevage
+  exit: Quitter l'élevage
   selectMon: Choisir un Shlagémon
   selected: Shlagémon sélectionné
-  partner: Partenaire
   rarity: Rareté
+  eggType: Type d'œuf
   cost: Coût
   duration: Durée
   minutes: minutes
   progress: Progression
   remaining: Temps restant
-  endsAt: Se termine à {time}
   cta:
     payAndStart: Payer & lancer
     seeEgg: Voir l'œuf
   toast:
     started: Élevage lancé !
     finished: Œuf obtenu !
+  status:
+    running: Élevage en cours
   a11y:
     openSelector: Choisir le parent
     startBreeding: Lancer l'élevage
     goToEgg: Aller à l'œuf
 en:
-  name: Breeding
-  introDialog: Welcome to the breeding center. Pick the parent to breed.
-  introOk: Let's go!
+  title: Breeding
+  exit: Leave the breeding center
   selectMon: Choose a Shlagémon
   selected: Selected Shlagémon
-  partner: Partner
   rarity: Rarity
+  eggType: Egg type
   cost: Cost
   duration: Duration
   minutes: minutes
   progress: Progress
   remaining: Remaining time
-  endsAt: Ends at {time}
   cta:
     payAndStart: Pay & start
     seeEgg: View egg
   toast:
     started: Breeding started!
     finished: Egg obtained!
+  status:
+    running: Breeding in progress
   a11y:
     openSelector: Choose parent
     startBreeding: Start breeding

--- a/src/components/panel/Dojo.i18n.yml
+++ b/src/components/panel/Dojo.i18n.yml
@@ -20,6 +20,8 @@ fr:
     remaining: Temps restant
     endsAt: Se termine à {time}
   progress: Progression
+  status:
+    running: Entraînement en cours
   cta:
     payAndStart: Payer & lancer
     trainingRunning: Entraînement en cours
@@ -48,6 +50,8 @@ en:
     remaining: Remaining time
     endsAt: Ends at {time}
   progress: Progress
+  status:
+    running: Training in progress
   cta:
     payAndStart: Pay & start
     trainingRunning: Training in progress


### PR DESCRIPTION
## Summary
- Rebuild breeding panel without character dialog, mirroring dojo layout
- Add dedicated breeding translations and running status for both panels

## Testing
- `npx eslint src/components/panel/Breeding.vue src/components/panel/Breeding.i18n.yml src/components/panel/Dojo.i18n.yml`
- `pnpm test run test/breeding.test.ts`
- `pnpm test run` *(fails: shlagedex sort item, animated number duration)*

------
https://chatgpt.com/codex/tasks/task_e_689d0d5d8618832aaef8aa49ba2c0c65