### PR TITLE
feat: play music for breeding, poulailler and dojo POIs

### DIFF
--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -42,6 +42,13 @@ export const useUIStore = defineStore('ui', () => {
     return classes.join(' ')
   })
 
+  const panelMusics = {
+    shop: '/audio/musics/shop.ogg',
+    poulailler: '/audio/musics/poulailler.ogg',
+    dojo: '/audio/musics/dojo.ogg',
+    breeding: '/audio/musics/breeding.ogg',
+  } as const satisfies Partial<Record<MainPanel, string>>
+
   // Explicit tuple typing keeps arguments in sync when adding new sources
   watch<[MainPanel, ZoneId, string | undefined, ZoneType, boolean], true>(
     () => [
@@ -52,8 +59,9 @@ export const useUIStore = defineStore('ui', () => {
       arena.inBattle,
     ],
     ([panel, zoneId, trainerCharId, zoneType, inArenaBattle]) => {
-      if (panel === 'shop') {
-        audio.fadeToMusic('/audio/musics/shop.ogg')
+      const directTrack = panelMusics[panel]
+      if (directTrack) {
+        audio.fadeToMusic(directTrack)
         return
       }
 

--- a/test/main-panel-music.test.ts
+++ b/test/main-panel-music.test.ts
@@ -1,0 +1,25 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useAudioStore } from '../src/stores/audio'
+import { useMainPanelStore } from '../src/stores/mainPanel'
+import { useUIStore } from '../src/stores/ui'
+
+/** Ensure POI panels trigger their dedicated background music. */
+describe('main panel music', () => {
+  it.each([
+    ['showShop', '/audio/musics/shop.ogg'],
+    ['showPoulailler', '/audio/musics/poulailler.ogg'],
+    ['showDojo', '/audio/musics/dojo.ogg'],
+    ['showBreeding', '/audio/musics/breeding.ogg'],
+  ] as const)('plays %s track', async (method, track) => {
+    setActivePinia(createPinia())
+    const panel = useMainPanelStore()
+    useUIStore()
+    const audio = useAudioStore()
+    const spy = vi.spyOn(audio, 'fadeToMusic')
+    ;(panel[method] as () => void)()
+    await nextTick()
+    expect(spy).toHaveBeenCalledWith(track)
+  })
+})


### PR DESCRIPTION
## Summary
- play dedicated tracks when entering breeding, poulailler or dojo panels
- cover POI music switching with unit tests

## Testing
- `pnpm eslint src/stores/ui.ts test/main-panel-music.test.ts`
- `CI=1 pnpm test:unit` *(fails: Invalid arguments in page-locale-ssr.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d104909bc832ab9e18765b2bf2aff