### PR TITLE
feat: allow changing shlagémon before dojo training

### DIFF
--- a/src/components/panel/Dojo.i18n.yml
+++ b/src/components/panel/Dojo.i18n.yml
@@ -24,6 +24,7 @@ fr:
     running: Entraînement en cours
   cta:
     payAndStart: Payer & lancer
+    changeMon: Changer de Shlagémon
     trainingRunning: Entraînement en cours
   toast:
     started: Entraînement lancé !
@@ -54,6 +55,7 @@ en:
     running: Training in progress
   cta:
     payAndStart: Pay & start
+    changeMon: Change Shlagémon
     trainingRunning: Training in progress
   toast:
     started: Training started!

--- a/src/components/panel/Dojo.vue
+++ b/src/components/panel/Dojo.vue
@@ -299,6 +299,16 @@ const ids = {
         </UiButton>
 
         <UiButton
+          v-if="selected && !isRunning"
+          type="default"
+          variant="outline"
+          class="w-full md:w-auto"
+          @click="openSelector"
+        >
+          {{ t('components.panel.Dojo.cta.changeMon') }}
+        </UiButton>
+
+        <UiButton
           type="danger"
           variant="outline"
           class="w-full md:w-auto"


### PR DESCRIPTION
## Summary
- add change shlagémon button to Dojo panel before training starts
- localize CTA label in French and English

## Testing
- `pnpm lint` *(fails: Missing trailing comma ... BonusDetails.i18n.yml)*
- `pnpm typecheck` *(fails: Type 'Readonly<Ref<boolean, boolean>>' is not assignable to type 'boolean')*
- `pnpm test` *(fails: capture mechanics > super ball doubles chance for low level foe)*
- `pnpm exec eslint src/components/panel/Dojo.vue src/components/panel/Dojo.i18n.yml`


------
https://chatgpt.com/codex/tasks/task_e_689d108cca58832aa02a222b602b2f51