### PR TITLE
feat: enhance breeding flow with collectible eggs

### DIFF
--- a/src/components/panel/Breeding.i18n.yml
+++ b/src/components/panel/Breeding.i18n.yml
@@ -12,16 +12,19 @@ fr:
   remaining: Temps restant
   cta:
     payAndStart: Payer & lancer
-    seeEgg: Voir l'œuf
+    changeMon: Changer de Shlagémon
+    collectEgg: Récupérer l'œuf
   toast:
     started: Élevage lancé !
     finished: Œuf obtenu !
+    collected: Œuf récupéré !
   status:
     running: Élevage en cours
   a11y:
     openSelector: Choisir le parent
     startBreeding: Lancer l'élevage
-    goToEgg: Aller à l'œuf
+    changeParent: Changer de parent
+    collectEgg: Récupérer l'œuf
 en:
   title: Breeding
   exit: Leave the breeding center
@@ -36,13 +39,16 @@ en:
   remaining: Remaining time
   cta:
     payAndStart: Pay & start
-    seeEgg: View egg
+    changeMon: Change Shlagémon
+    collectEgg: Collect egg
   toast:
     started: Breeding started!
     finished: Egg obtained!
+    collected: Egg collected!
   status:
     running: Breeding in progress
   a11y:
     openSelector: Choose parent
     startBreeding: Start breeding
-    goToEgg: Go to egg
+    changeParent: Change parent
+    collectEgg: Collect egg

--- a/test/breeding.test.ts
+++ b/test/breeding.test.ts
@@ -40,17 +40,19 @@ describe('breeding store', () => {
 
     const rarity = 10
     const cost = breedingCost(rarity)
-    expect(breeding.start('feu', rarity)).toBe(true)
+    expect(breeding.start('feu', rarity, 'salamiches')).toBe(true)
     expect(game.shlagidolar).toBe(10_000 - cost)
 
     vi.advanceTimersByTime(BREEDING_DURATION_MS - 1)
     expect(breeding.completeIfDue('feu')).toBe(false)
     vi.advanceTimersByTime(1)
     expect(breeding.completeIfDue('feu')).toBe(true)
+    expect(breeding.collectEgg('feu')).toBe(true)
 
     const egg = eggs.incubator[0]
     expect(egg.isBreeding).toBe(true)
     expect(egg.forcedRarity).toBe(rarity)
+    expect(egg.forcedMonId).toBe('salamiches')
     vi.useRealTimers()
   })
 
@@ -67,7 +69,7 @@ describe('breeding store', () => {
     const game = useGameStore()
     game.addShlagidolar(10_000)
     const rarity = 5
-    breeding.start('eau', rarity)
+    breeding.start('eau', rarity, 'salamiches')
     await nextTick()
 
     const stored = window.localStorage.getItem('breeding')
@@ -77,6 +79,7 @@ describe('breeding store', () => {
           eau: {
             type: 'eau',
             rarity,
+            parentId: 'salamiches',
             startedAt: 1000,
             endsAt: 1000 + BREEDING_DURATION_MS,
             status: 'running',
@@ -97,6 +100,7 @@ describe('breeding store', () => {
     expect(job).toEqual({
       type: 'eau',
       rarity,
+      parentId: 'salamiches',
       startedAt: 1000,
       endsAt: 1000 + BREEDING_DURATION_MS,
       status: 'running',


### PR DESCRIPTION
## Summary
- show type name instead of raw object for selected breeder
- allow changing the selected Shlagémon before breeding starts
- collect parent-specific eggs after breeding completion

## Testing
- `pnpm exec eslint src/stores/breeding.ts src/components/panel/Breeding.vue test/breeding.test.ts`
- `CI=1 pnpm test:unit test/breeding.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d11c1d408832ab6927483822dac7d