### PR TITLE
feat: add breeding dialog flow

### DIFF
--- a/src/components/panel/Breeding.i18n.yml
+++ b/src/components/panel/Breeding.i18n.yml
@@ -1,8 +1,10 @@
 fr:
   title: Élevage
   exit: Quitter l'élevage
-  introDialog: Bienvenue au centre d'élevage. Choisis un Shlagémon à confier.
-  outroDialog: À plus tard !
+  dialog:
+    intro: "Je peux m'occuper de la reproduction pour toi... enfin, si tu veux."
+    outroRunning: "Je m'occupe tout de suite de la reproduction, tu pourras repasser dans très peu de temps."
+    outroIdle: "Reviens très vite, j'ai hâte de m'occuper de tes Shlagémons."
   selectMon: Choisir un Shlagémon
   selected: Shlagémon sélectionné
   rarity: Rareté
@@ -32,8 +34,10 @@ fr:
 en:
   title: Breeding
   exit: Leave the breeding center
-  introDialog: Welcome to the breeding center. Choose a Shlagémon to leave.
-  outroDialog: See you later!
+  dialog:
+    intro: 'I can handle the breeding for you... uh, if you want.'
+    outroRunning: "I'll take care of the breeding right away, you can come back very soon."
+    outroIdle: "Come back very soon, I can't wait to take care of your Shlagémons."
   selectMon: Choose a Shlagémon
   selected: Selected Shlagémon
   rarity: Rarity

--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -21,21 +21,9 @@ function createIntro(next: () => void): DialogNode[] {
   return [
     {
       id: 'intro',
-      text: t('components.panel.Breeding.introDialog'),
+      text: t('components.panel.Breeding.dialog.intro'),
       responses: [
         { label: t('ui.Info.ok'), type: 'primary', action: next },
-      ],
-    },
-  ]
-}
-
-function createOutro(_: string | undefined, exit: () => void): DialogNode[] {
-  return [
-    {
-      id: 'outro',
-      text: t('components.panel.Breeding.outroDialog'),
-      responses: [
-        { label: t('ui.Info.ok'), type: 'valid', action: exit },
       ],
     },
   ]
@@ -69,6 +57,19 @@ const remainingLabel = computed<string>(() => {
   const s = total % 60
   return `${m}:${String(s).padStart(2, '0')}`
 })
+
+function createOutro(_: string | undefined, exit: () => void): DialogNode[] {
+  const key = isRunning.value ? 'outroRunning' : 'outroIdle'
+  return [
+    {
+      id: 'outro',
+      text: t(`components.panel.Breeding.dialog.${key}`),
+      responses: [
+        { label: t('ui.Info.ok'), type: 'valid', action: exit },
+      ],
+    },
+  ]
+}
 
 /** === Actions =========================================================== */
 function openSelector() {


### PR DESCRIPTION
## Summary
- add intro/outro dialog nodes for breeding panel
- compute outro dialog based on job state
- test breeding panel dialog scenarios

## Testing
- `pnpm test:unit test/breeding.test.ts` *(fails: missing translation keys)*

------
https://chatgpt.com/codex/tasks/task_e_689dc9a60028832aa6a3421876be8421