### PR TITLE
test: improve breeding flow coverage

### DIFF
--- a/test/breeding.test.ts
+++ b/test/breeding.test.ts
@@ -59,6 +59,25 @@ vi.mock('../src/stores/breeding', () => ({
   }),
 }))
 
+const mon = {
+  id: 'm1',
+  base: { id: 'm1', name: 'm1', description: '', types: [{ id: 'feu' }], speciality: 'evolution0' },
+  baseStats: { hp: 1, attack: 1, defense: 1, smelling: 1 },
+  captureDate: '',
+  captureCount: 1,
+  lvl: 1,
+  xp: 0,
+  rarity: 1,
+  sex: 'male',
+  isShiny: false,
+  hpCurrent: 1,
+  allowEvolution: true,
+  hp: 1,
+  attack: 1,
+  defense: 1,
+  smelling: 1,
+}
+
 function createI18nInstance() {
   return createI18n({
     legacy: false,
@@ -132,41 +151,35 @@ describe('breeding dialog flow', () => {
     )
   })
 
+  it('launches breeding and closes intro before showing content', async () => {
+    const wrapper = mountBreeding()
+    await nextTick()
+    const flow = wrapper.findComponent(PoiDialogFlow)
+    expect(wrapper.findComponent(DialogBox).exists()).toBe(true)
+    ;(flow.vm as any).phase = 'content'
+    await nextTick()
+    expect(wrapper.findComponent(DialogBox).exists()).toBe(false)
+    expect(wrapper.text()).toContain(
+      'T\'inquiètes pas j\'en prendrais bien soin, tu peux me faire confiance',
+    )
+  })
+
+  it('completes a job and shows running outro message', async () => {
+    isRunning.mockReturnValue(true)
+    const wrapper = mountBreeding()
+    await nextTick()
+    // Skip intro
+    ;(wrapper.findComponent(PoiDialogFlow).vm as any).phase = 'content'
+    ;(wrapper.vm as any).selected = mon
+    await nextTick()
+    ;(wrapper.findComponent(PoiDialogFlow).vm as any).finish()
+    await nextTick()
+    expect(wrapper.findComponent(DialogBox).text()).toContain(
+      'Je m\'occupe tout de suite de la reproduction, tu pourras repasser dans très peu de temps.',
+    )
+  })
+
   describe('outro dialog', () => {
-    const mon = {
-      id: 'm1',
-      base: { id: 'm1', name: 'm1', description: '', types: [{ id: 'feu' }], speciality: 'evolution0' },
-      baseStats: { hp: 1, attack: 1, defense: 1, smelling: 1 },
-      captureDate: '',
-      captureCount: 1,
-      lvl: 1,
-      xp: 0,
-      rarity: 1,
-      sex: 'male',
-      isShiny: false,
-      hpCurrent: 1,
-      allowEvolution: true,
-      hp: 1,
-      attack: 1,
-      defense: 1,
-      smelling: 1,
-    }
-
-    it('shows running outro when job is running', async () => {
-      isRunning.mockReturnValue(true)
-      const wrapper = mountBreeding()
-      ;(wrapper.vm as any).selected = mon
-      await nextTick()
-      const flow = wrapper.findComponent(PoiDialogFlow)
-      ;(flow.vm as any).phase = 'content'
-      await nextTick()
-      ;(flow.vm as any).finish()
-      await nextTick()
-      expect(wrapper.findComponent(DialogBox).text()).toContain(
-        'Je m\'occupe tout de suite de la reproduction, tu pourras repasser dans très peu de temps.',
-      )
-    })
-
     it('shows idle outro when no job is running', async () => {
       isRunning.mockReturnValue(false)
       const wrapper = mountBreeding()

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -4,6 +4,15 @@ import { carapouffe } from '../src/data/shlagemons/carapouffe'
 import { captureChanceFromHp, getCaptureChance, tryCapture } from '../src/utils/capture'
 import { createDexShlagemon } from '../src/utils/dexFactory'
 
+vi.mock('../src/stores/shlagedex', async () => ({
+  ...(await vi.importActual('../src/stores/shlagedex')),
+}))
+vi.mock('../src/stores/developer', () => ({
+  useDeveloperStore: () => ({ debug: false }),
+}))
+vi.unmock('../src/stores/shlagedex')
+vi.unmock('../src/stores/developer')
+
 describe('capture mechanics', () => {
   beforeEach(() => {
     vi.restoreAllMocks()

--- a/test/main-panel-breeding.test.ts
+++ b/test/main-panel-breeding.test.ts
@@ -1,6 +1,102 @@
+import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import DialogBox from '../src/components/dialog/Box.vue'
+import Breeding from '../src/components/panel/Breeding.vue'
+import PoiDialogFlow from '../src/components/panel/PoiDialogFlow.vue'
 import { useMainPanelStore } from '../src/stores/mainPanel'
+
+vi.mock('../src/components/ui/TypingText.vue', () => ({
+  default: {
+    name: 'UiTypingText',
+    props: ['text'],
+    emits: ['finished'],
+    mounted() {
+      this.$emit('finished')
+    },
+    template: '<p class="typing">{{ text }}</p>',
+  },
+}))
+
+vi.mock('../src/stores/audio', () => ({
+  useAudioStore: () => ({
+    fadeToMusic: vi.fn(),
+    playSfx: vi.fn(),
+    playTypingSfx: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/stores/zone', () => ({
+  useZoneStore: () => ({
+    current: { id: 'zone', type: 'sauvage' },
+  }),
+}))
+
+vi.mock('../src/stores/game', () => ({
+  useGameStore: () => ({
+    shlagidolar: 0,
+    addShlagidolar: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/stores/breeding', () => ({
+  useBreedingStore: () => ({
+    isRunning: vi.fn(() => false),
+    getJob: vi.fn(),
+    remainingMs: vi.fn(),
+    progress: vi.fn(),
+    start: vi.fn(),
+    collectEgg: vi.fn(),
+    completeIfDue: vi.fn(),
+  }),
+}))
+
+function createI18nInstance() {
+  return createI18n({
+    legacy: false,
+    locale: 'fr',
+    messages: {
+      fr: {
+        ui: { Info: { ok: 'Ok' } },
+        components: {
+          panel: {
+            Breeding: {
+              title: 'Élevage',
+              exit: 'Quitter l\'élevage',
+              intro: 'intro',
+              outro: { running: 'running', idle: 'idle' },
+              during: { typing: 'typing' },
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+const globalStubs = {
+  LayoutTitledPanel: { template: '<div><slot /><slot name="footer" /></div>' },
+  UiButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  UiTypingText: { props: ['text'], template: '<p class="typing">{{ text }}</p>' },
+  UiAdaptiveDisplayer: { name: 'UiAdaptiveDisplayer', template: '<div><slot /></div>' },
+  UiCurrencyAmount: { template: '<span />' },
+  UiModal: { template: '<div><slot /></div>' },
+  ShlagemonQuickSelect: { template: '<div />' },
+  UiImageByBackground: { props: ['src'], template: '<img :src="src" />' },
+}
+
+function mountBreeding() {
+  return mount(Breeding, {
+    global: {
+      plugins: [createI18nInstance(), createPinia()],
+      stubs: globalStubs,
+      components: { PoiDialogFlow, DialogBox },
+    },
+  })
+}
 
 /** Ensure the breeding panel can be opened through the main panel store. */
 describe('main panel breeding', () => {
@@ -9,5 +105,16 @@ describe('main panel breeding', () => {
     const panel = useMainPanelStore()
     panel.showBreeding()
     expect(panel.current).toBe('breeding')
+  })
+
+  it('renders two columns with Norman image and typing animation', async () => {
+    const wrapper = mountBreeding()
+    const flow = wrapper.findComponent(PoiDialogFlow)
+    ;(flow.vm as any).phase = 'content'
+    await nextTick()
+    const grids = wrapper.findAll('.area-grid')
+    expect(grids.length).toBeGreaterThan(1)
+    expect(wrapper.html()).toContain('/characters/norman')
+    expect(wrapper.find('.typing').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- expand breeding dialog flow tests for intro, content, and outro transitions
- add DOM checks for main breeding panel layout and animation
- ensure capture tests isolate store mocks

## Testing
- `pnpm test:unit --run --silent`

------
https://chatgpt.com/codex/tasks/task_e_689dde437bc8832a83c0700adef7ee2c