### PR TITLE
fix: handle missing slot props in mini game

### DIFF
--- a/src/components/panel/MiniGame.vue
+++ b/src/components/panel/MiniGame.vue
@@ -56,12 +56,12 @@ function createOutro(result: string | undefined, exit: () => void): DialogNode[]
     :exit-track="zoneTrack"
     @exit="leaveGame"
   >
-    <template #default="{ finish }">
+    <template #default="slot">
       <component
         :is="GameComp"
-        @win="() => { mini.finish('win'); finish('win') }"
-        @lose="() => { mini.finish('lose'); finish('lose') }"
-        @draw="() => { mini.finish('draw'); finish('draw') }"
+        @win="() => { mini.finish('win'); slot.finish?.('win') }"
+        @lose="() => { mini.finish('lose'); slot.finish?.('lose') }"
+        @draw="() => { mini.finish('draw'); slot.finish?.('draw') }"
       />
     </template>
   </PoiDialogFlow>


### PR DESCRIPTION
## Summary
- avoid destructuring undefined slot props in mini games

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Cannot call props on an empty VueWrapper, expected true but got false, SyntaxError: Invalid arguments, (0 , redirect) is not a function, expected to contain 'data.shlagemons.carapouffe.name')*

------
https://chatgpt.com/codex/tasks/task_e_689de7748ec4832a829bf25617b0f09d