### PR TITLE
feat: persist sort order across filters

### DIFF
--- a/src/stores/achievementsFilter.ts
+++ b/src/stores/achievementsFilter.ts
@@ -10,11 +10,18 @@ export const useAchievementsFilterStore = defineStore('achievementsFilter', () =
   const sortBy = ref<AchievementSort>('name')
   const sortAsc = ref(true)
 
-  watch(sortBy, (val) => {
-    if (val === 'name')
-      sortAsc.value = true
-    else
-      sortAsc.value = false
+  const ascendingSorts: AchievementSort[] = ['name']
+  let suppressNextSortAscUpdate = true
+
+  /**
+   * Align orientation with current sort key while preserving stored preference on load.
+   */
+  watch(sortBy, (value) => {
+    if (suppressNextSortAscUpdate) {
+      suppressNextSortAscUpdate = false
+      return
+    }
+    sortAsc.value = ascendingSorts.includes(value)
   })
 
   function reset() {
@@ -26,5 +33,9 @@ export const useAchievementsFilterStore = defineStore('achievementsFilter', () =
 
   return { search, status, sortBy, sortAsc, reset }
 }, {
-  persist: true,
+  persist: {
+    afterRestore: () => {
+      suppressNextSortAscUpdate = false
+    },
+  },
 })

--- a/src/stores/dexFilter.ts
+++ b/src/stores/dexFilter.ts
@@ -18,11 +18,18 @@ export const useDexFilterStore = defineStore('dexFilter', () => {
   const sortBy = ref<DexSort>('level')
   const sortAsc = ref(false)
 
-  watch(sortBy, (val) => {
-    if (val === 'name' || val === 'type' || val === 'date' || val === 'evolution')
-      sortAsc.value = true
-    else
-      sortAsc.value = false
+  const ascendingSorts: DexSort[] = ['name', 'type', 'date', 'evolution']
+  let suppressNextSortAscUpdate = true
+
+  /**
+   * Ensure default orientation per sort key while preserving persisted order on hydration.
+   */
+  watch(sortBy, (value) => {
+    if (suppressNextSortAscUpdate) {
+      suppressNextSortAscUpdate = false
+      return
+    }
+    sortAsc.value = ascendingSorts.includes(value)
   })
 
   function reset() {
@@ -33,5 +40,9 @@ export const useDexFilterStore = defineStore('dexFilter', () => {
 
   return { search, sortBy, sortAsc, reset }
 }, {
-  persist: true,
+  persist: {
+    afterRestore: () => {
+      suppressNextSortAscUpdate = false
+    },
+  },
 })

--- a/src/stores/inventoryFilter.ts
+++ b/src/stores/inventoryFilter.ts
@@ -9,11 +9,18 @@ export const useInventoryFilterStore = defineStore('inventoryFilter', () => {
   const sortAsc = ref(true)
   const category = ref<ItemCategory | 'all'>('all')
 
-  watch(sortBy, (val) => {
-    if (val === 'price')
-      sortAsc.value = false
-    else
-      sortAsc.value = true
+  const ascendingSorts: InventorySort[] = ['name', 'type']
+  let suppressNextSortAscUpdate = true
+
+  /**
+   * Adjust default orientation when sort key changes, preserving persisted order on hydration.
+   */
+  watch(sortBy, (value) => {
+    if (suppressNextSortAscUpdate) {
+      suppressNextSortAscUpdate = false
+      return
+    }
+    sortAsc.value = ascendingSorts.includes(value)
   })
 
   function reset() {
@@ -25,5 +32,9 @@ export const useInventoryFilterStore = defineStore('inventoryFilter', () => {
 
   return { search, sortBy, sortAsc, category, reset }
 }, {
-  persist: true,
+  persist: {
+    afterRestore: () => {
+      suppressNextSortAscUpdate = false
+    },
+  },
 })

--- a/test/filter-order-persist.test.ts
+++ b/test/filter-order-persist.test.ts
@@ -1,0 +1,45 @@
+import { createPinia, setActivePinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
+import { useAchievementsFilterStore } from '../src/stores/achievementsFilter'
+import { useDexFilterStore } from '../src/stores/dexFilter'
+import { useInventoryFilterStore } from '../src/stores/inventoryFilter'
+
+function initPinia() {
+  const pinia = createPinia()
+  pinia.use(piniaPluginPersistedstate)
+  const app = createApp({})
+  app.use(pinia)
+  setActivePinia(pinia)
+}
+
+describe('filter sort order persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('restores dex filter sort order', () => {
+    window.localStorage.setItem('dexFilter', JSON.stringify({ search: '', sortBy: 'name', sortAsc: false }))
+    initPinia()
+    const filter = useDexFilterStore()
+    expect(filter.sortBy).toBe('name')
+    expect(filter.sortAsc).toBe(false)
+  })
+
+  it('restores inventory filter sort order', () => {
+    window.localStorage.setItem('inventoryFilter', JSON.stringify({ search: '', sortBy: 'price', sortAsc: true, category: 'all' }))
+    initPinia()
+    const filter = useInventoryFilterStore()
+    expect(filter.sortBy).toBe('price')
+    expect(filter.sortAsc).toBe(true)
+  })
+
+  it('restores achievements filter sort order', () => {
+    window.localStorage.setItem('achievementsFilter', JSON.stringify({ search: '', status: 'all', sortBy: 'date', sortAsc: true }))
+    initPinia()
+    const filter = useAchievementsFilterStore()
+    expect(filter.sortBy).toBe('date')
+    expect(filter.sortAsc).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- remove manual localStorage reads in filter stores
- rely on Pinia `persist.afterRestore` to skip hydration sort updates

## Testing
- `pnpm test` *(fails: animated number duration, attack throttle, capture mechanics, dojo store cost, SSR locale pages, rarity info snapshot, router redirect, sort item, and others)*

------
https://chatgpt.com/codex/tasks/task_e_689decc772c0832aa2cf6f0341f16e7d