### PR TITLE
feat: support unique breeding eggs

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -481,7 +481,7 @@ declare global {
   export type { EggType, Egg } from './stores/egg'
   import('./stores/egg')
   // @ts-ignore
-  export type { EggItemId } from './stores/eggBox'
+  export type { EggItemId, BreedingEggItem } from './stores/eggBox'
   import('./stores/eggBox')
   // @ts-ignore
   export type { EventMap, EventCallback } from './stores/event'

--- a/src/common.i18n.yml
+++ b/src/common.i18n.yml
@@ -3,9 +3,11 @@ fr:
   pleaseWait: Veuillez patienter
   copy: Copier
   remove: Supprimer
+  eggOf: 'Oeuf de {name}'
 
 en:
   loading: Loading…
   pleaseWait: Please wait
   copy: Copy
   remove: Remove
+  eggOf: 'Egg of {name}'

--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -39,7 +39,7 @@ const eggType = computed<EggType | null>(() =>
   selected.value ? selected.value.base.types[0].id as EggType : null,
 )
 const job = computed(() => (eggType.value ? breeding.getJob(eggType.value) : null))
-const isRunning = computed<boolean>(() => (eggType.value ? breeding.isRunning(eggType.value) : false))
+const isRunning = computed<boolean>(() => job.value?.status === 'running')
 const isCompleted = computed<boolean>(() => job.value?.status === 'completed')
 const cost = computed<number>(() => (selected.value ? breedingCost(selected.value.rarity) : 0))
 const durationMin = Math.round(BREEDING_DURATION_MS / 60000)
@@ -73,7 +73,7 @@ function createOutro(_: string | undefined, exit: () => void): DialogNode[] {
 
 /** === Actions =========================================================== */
 function openSelector() {
-  if (isRunning.value)
+  if (job.value)
     return
   selectorOpen.value = true
 }
@@ -82,7 +82,7 @@ function selectMon(mon: DexShlagemon) {
   selectorOpen.value = false
 }
 function changeMon() {
-  if (isRunning.value)
+  if (job.value)
     return
   selected.value = null
   openSelector()
@@ -175,7 +175,7 @@ onBeforeUnmount(pauseTick)
               <!-- Sous-colonne gauche : infos coût/durée/progression + message -->
               <div class="min-w-0 w-full flex flex-col gap-3 md:w-2/3">
                 <!-- Bloc coût/durée seulement si un mon est sélectionné et que ça ne tourne pas -->
-                <div v-if="selected && !isRunning" class="w-full flex flex-col items-center gap-2">
+                <div v-if="selected && !job" class="w-full flex flex-col items-center gap-2">
                   <div class="flex items-center gap-1 text-sm">
                     <span class="text-gray-500 dark:text-gray-400">{{ t('components.panel.Breeding.cost') }}:</span>
                     <UiCurrencyAmount :amount="cost" currency="shlagidolar" />
@@ -257,7 +257,7 @@ onBeforeUnmount(pauseTick)
     <template #footer>
       <div class="w-full flex justify-end gap-2">
         <UiButton
-          v-if="selected && !isRunning"
+          v-if="selected && !job"
           :disabled="cost > game.shlagidolar"
           type="primary"
           class="flex flex-1 flex-wrap items-center gap-1"

--- a/test/breeding-store.test.ts
+++ b/test/breeding-store.test.ts
@@ -1,0 +1,42 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useBreedingStore } from '../src/stores/breeding'
+import { useEggBoxStore } from '../src/stores/eggBox'
+import { useGameStore } from '../src/stores/game'
+import { BREEDING_DURATION_MS } from '../src/utils/breeding'
+
+vi.mock('../src/stores/egg', () => ({
+  useEggStore: () => ({ incubator: [], startIncubation: vi.fn() }),
+}))
+
+describe('breeding store', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('blocks new breeding until egg collected and stores egg in box', () => {
+    const breeding = useBreedingStore()
+    const game = useGameStore()
+    const box = useEggBoxStore()
+    game.shlagidolar = 1_000_000
+
+    expect(breeding.start('feu', 10, 'salamiches')).toBe(true)
+    expect(breeding.start('feu', 10, 'salamiches')).toBe(false)
+
+    vi.advanceTimersByTime(BREEDING_DURATION_MS + 1)
+    expect(breeding.completeIfDue('feu')).toBe(true)
+    expect(breeding.start('feu', 10, 'salamiches')).toBe(false)
+    expect(box.breeding.length).toBe(0)
+
+    expect(breeding.collectEgg('feu')).toBe(true)
+    expect(box.breeding.length).toBe(1)
+    expect(box.breeding[0].monId).toBe('salamiches')
+
+    expect(breeding.start('feu', 10, 'salamiches')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- prevent starting new breeding jobs until existing eggs are collected
- store breeding eggs in egg box with custom color and name
- incubate breeding eggs separately from type-based eggs

## Testing
- `pnpm test` *(fails: multiple vitest suites failing)*
- `pnpm vitest run test/breeding-store.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689def492348832a86d3057579ad4f64