### PR TITLE
feat: add dialog flow to poulailler

### DIFF
--- a/src/components/panel/Poulailler.i18n.yml
+++ b/src/components/panel/Poulailler.i18n.yml
@@ -1,6 +1,10 @@
 fr:
   title: Poulailler
   exit: Quitter
+  intro: Bienvenue au poulailler. Ici, tu peux surveiller tes œufs.
+  outro:
+    running: Un œuf a éclos ! Félicitations !
+    idle: Aucun œuf n'a éclos. Reviens bientôt.
   incubator: Incubateur
   noEgg: Aucun œuf
   yourEggs: Vos œufs
@@ -21,6 +25,10 @@ fr:
 en:
   title: Henhouse
   exit: Exit
+  intro: Welcome to the henhouse. Keep an eye on your eggs.
+  outro:
+    running: An egg has hatched! Congratulations!
+    idle: No egg hatched. Come back soon.
   incubator: Incubator
   noEgg: No egg
   yourEggs: Your eggs

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import type { EggType } from '~/stores/egg'
 import type { EggItemId } from '~/stores/eggBox'
+import type { DialogNode } from '~/type/dialog'
 import { eggTypeMap } from '~/constants/egg'
+import { magalieBredouille } from '~/data/characters/magalie-bredouille'
 import { allItems } from '~/data/items'
 
 /** === Stores ============================================================ */
@@ -11,6 +13,35 @@ const eggMonsModal = useEggMonsModalStore()
 const hatchModal = useEggHatchModalStore()
 const panel = useMainPanelStore()
 const { t } = useI18n()
+
+function onExit() {
+  panel.showVillage()
+}
+
+function createIntro(next: () => void): DialogNode[] {
+  return [
+    {
+      id: 'intro',
+      text: t('components.panel.Poulailler.intro'),
+      responses: [
+        { label: t('ui.Info.ok'), type: 'primary', action: next },
+      ],
+    },
+  ]
+}
+
+function createOutro(result: string | undefined, exit: () => void): DialogNode[] {
+  const key = result ? 'running' : 'idle'
+  return [
+    {
+      id: 'outro',
+      text: t(`components.panel.Poulailler.outro.${key}`),
+      responses: [
+        { label: t('ui.Info.ok'), type: 'valid', action: exit },
+      ],
+    },
+  ]
+}
 
 /** === Const / Types ===================================================== */
 const INCUBATOR_SLOTS = 4 as const
@@ -106,155 +137,160 @@ function eggReadyLabel(type: EggType) {
 </script>
 
 <template>
-  <LayoutTitledPanel
+  <PanelPoiDialogFlow
     :title="t('components.panel.Poulailler.title')"
     :exit-text="t('components.panel.Poulailler.exit')"
-    @exit="panel.showVillage()"
+    :character="magalieBredouille"
+    :create-intro="createIntro"
+    :create-outro="createOutro"
+    @exit="onExit"
   >
-    <div class="area flex-1 overflow-hidden">
-      <div class="area-grid gap-2 w-full h-full overflow-hidden">
-        <section
-          class="min-h-0 flex flex-col border rounded-lg bg-white/60 dark:bg-gray-900/40"
-          aria-labelledby="eggs-inventory-title"
-        >
-          <header class="sticky top-0 z-1 rounded-t-lg bg-[inherit] p-2">
-            <h4 id="eggs-inventory-title" class="text-base font-semibold">
-              {{ t('components.panel.Poulailler.yourEggs') }}
-            </h4>
-          </header>
-
-          <div
-            v-if="inventoryEggs.length"
-            class="tiny-scrollbar min-h-0 flex-1 overflow-y-auto pr-1"
-            role="list"
-            aria-label="Egg inventory list"
+    <template #default="{ finish }">
+      <div class="area flex-1 overflow-hidden">
+        <div class="area-grid h-full w-full gap-2 overflow-hidden">
+          <section
+            class="min-h-0 flex flex-col border rounded-lg bg-white/60 dark:bg-gray-900/40"
+            aria-labelledby="eggs-inventory-title"
           >
-            <article
-              v-for="entry in inventoryEggs"
-              :key="entry.id"
-              role="listitem"
-              class="group flex items-center justify-between gap-2 border-b p-2 transition-colors last:border-b-0 hover:bg-gray/5"
-            >
-              <button
-                type="button"
-                class="min-w-0 flex flex-1 items-center gap-2 overflow-hidden text-left outline-none"
-                :aria-label="t('components.panel.Poulailler.a11y.showSpecies', { name: t(entry.item.name) })"
-                @click="showEggMons(entry.id)"
-              >
-                <div
-                  v-if="entry.item.icon"
-                  class="h-6 w-6 shrink-0"
-                  :class="[entry.item.icon, entry.item.iconClass]"
-                  aria-hidden="true"
-                />
-                <span class="truncate text-sm font-medium">
-                  {{ t(entry.item.name) }}
-                </span>
-              </button>
+            <header class="sticky top-0 z-1 rounded-t-lg bg-[inherit] p-2">
+              <h4 id="eggs-inventory-title" class="text-base font-semibold">
+                {{ t('components.panel.Poulailler.yourEggs') }}
+              </h4>
+            </header>
 
-              <!-- Qté + CTA incubate -->
-              <div class="flex items-center gap-2">
-                <span class="shrink-0 text-xs text-gray-700 font-semibold dark:text-gray-200">
-                  ×{{ entry.qty }}
-                </span>
-                <UiButton
-                  size="xs"
-                  class="flex items-center gap-1 px-2 py-1 text-xs transition-all hover:translate-y--0.5"
-                  :disabled="eggs.incubator.length >= 4"
-                  :aria-label="incubateLabel(t(entry.item.name) as string)"
-                  @click="startIncubation(entry.id)"
-                >
-                  <div class="i-carbon:chemistry text-base" aria-hidden="true" />
-                  <span class="hidden sm:inline">
-                    {{ t('components.panel.Poulailler.incubate') }}
-                  </span>
-                </UiButton>
-              </div>
-            </article>
-          </div>
-
-          <p v-else class="mt-4 text-center text-sm text-gray-600 dark:text-gray-300">
-            {{ t('components.panel.Poulailler.noEggBox') }}
-          </p>
-        </section>
-
-        <!-- === Colonne droite : Grille 2x2 incubateur ============================= -->
-        <section
-          class="min-h-0 flex flex-col border rounded-lg bg-white/60 p-3 dark:bg-gray-900/40"
-          aria-labelledby="incubator-title"
-        >
-          <header class="sticky top-0 z-1 mb-2 rounded-t-lg bg-[inherit] p-3 -m-3">
-            <h4 id="incubator-title" class="text-base font-semibold">
-              {{ t('components.panel.Poulailler.incubator') }}
-            </h4>
-          </header>
-
-          <div
-            class="grid grid-cols-2 grid-rows-2 flex-1 gap-3 overflow-hidden"
-            role="grid"
-            aria-rowcount="2"
-            aria-colcount="2"
-          >
-            <!-- 4 slots (œufs ou placeholders) -->
             <div
-              v-for="(slot, idx) in incubatorSlots"
-              :key="slot?.id ?? `empty-${idx}`"
-              role="gridcell"
-              class="flex items-center justify-center border rounded-lg bg-white/50 p-2 shadow-sm transition-all dark:bg-gray-950/40 hover:shadow-md"
+              v-if="inventoryEggs.length"
+              class="tiny-scrollbar min-h-0 flex-1 overflow-y-auto pr-1"
+              role="list"
+              aria-label="Egg inventory list"
             >
-              <!-- Slot rempli -->
-              <template v-if="slot">
+              <article
+                v-for="entry in inventoryEggs"
+                :key="entry.id"
+                role="listitem"
+                class="group flex items-center justify-between gap-2 border-b p-2 transition-colors last:border-b-0 hover:bg-gray/5"
+              >
                 <button
                   type="button"
-                  class="group ring-primary w-full flex flex-col items-center gap-1 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-                  :aria-label="eggs.isReady(slot) ? eggReadyLabel(slot.type) : t('components.panel.Poulailler.a11y.eggProgress')"
-                  :title="eggs.isReady(slot) ? (t('components.panel.Poulailler.tapToHatch') as string) : undefined"
-                  @click="eggs.isReady(slot) && hatch(slot.id)"
+                  class="min-w-0 flex flex-1 items-center gap-2 overflow-hidden text-left outline-none"
+                  :aria-label="t('components.panel.Poulailler.a11y.showSpecies', { name: t(entry.item.name) })"
+                  @click="showEggMons(entry.id)"
                 >
                   <div
-                    class="i-game-icons:egg-eye transition-transform duration-300"
-                    :class="[
-                      eggs.isReady(slot)
-                        ? 'h-14 w-14 animate-pulse-alt animate-count-infinite group-hover:scale-110 cursor-pointer'
-                        : 'h-10 w-10 animate-bounce animate-count-infinite',
-                      colorClass(slot.type),
-                    ]"
+                    v-if="entry.item.icon"
+                    class="h-6 w-6 shrink-0"
+                    :class="[entry.item.icon, entry.item.iconClass]"
                     aria-hidden="true"
                   />
-                  <span
-                    v-if="!eggs.isReady(slot)"
-                    class="text-xs text-gray-700 tabular-nums dark:text-gray-200"
-                    aria-live="polite"
-                  >
-                    {{ fmtSec(remaining(slot)) }}
-                  </span>
-                  <span
-                    v-else
-                    class="text-primary-600 dark:text-primary-400 rounded px-2 py-0.5 text-xs font-semibold"
-                  >
-                    {{ t('components.panel.Poulailler.ready') }}
+                  <span class="truncate text-sm font-medium">
+                    {{ t(entry.item.name) }}
                   </span>
                 </button>
-              </template>
 
-              <template v-else>
-                <div class="flex flex-col items-center gap-2 opacity-70">
-                  <div class="i-ph:egg-light h-10 w-10" aria-hidden="true" />
-                  <span class="text-center text-[11px] text-gray-500 dark:text-gray-400">
-                    {{ t('components.panel.Poulailler.emptySlot') }}
+                <!-- Qté + CTA incubate -->
+                <div class="flex items-center gap-2">
+                  <span class="shrink-0 text-xs text-gray-700 font-semibold dark:text-gray-200">
+                    ×{{ entry.qty }}
                   </span>
+                  <UiButton
+                    size="xs"
+                    class="flex items-center gap-1 px-2 py-1 text-xs transition-all hover:translate-y--0.5"
+                    :disabled="eggs.incubator.length >= 4"
+                    :aria-label="incubateLabel(t(entry.item.name) as string)"
+                    @click="startIncubation(entry.id)"
+                  >
+                    <div class="i-carbon:chemistry text-base" aria-hidden="true" />
+                    <span class="hidden sm:inline">
+                      {{ t('components.panel.Poulailler.incubate') }}
+                    </span>
+                  </UiButton>
                 </div>
-              </template>
+              </article>
             </div>
-          </div>
-        </section>
-      </div>
-    </div>
 
-    <!-- Modals -->
-    <EggHatchModal />
-    <EggMonsModal />
-  </LayoutTitledPanel>
+            <p v-else class="mt-4 text-center text-sm text-gray-600 dark:text-gray-300">
+              {{ t('components.panel.Poulailler.noEggBox') }}
+            </p>
+          </section>
+
+          <!-- === Colonne droite : Grille 2x2 incubateur ============================= -->
+          <section
+            class="min-h-0 flex flex-col border rounded-lg bg-white/60 p-3 dark:bg-gray-900/40"
+            aria-labelledby="incubator-title"
+          >
+            <header class="sticky top-0 z-1 mb-2 rounded-t-lg bg-[inherit] p-3 -m-3">
+              <h4 id="incubator-title" class="text-base font-semibold">
+                {{ t('components.panel.Poulailler.incubator') }}
+              </h4>
+            </header>
+
+            <div
+              class="grid grid-cols-2 grid-rows-2 flex-1 gap-3 overflow-hidden"
+              role="grid"
+              aria-rowcount="2"
+              aria-colcount="2"
+            >
+              <!-- 4 slots (œufs ou placeholders) -->
+              <div
+                v-for="(slot, idx) in incubatorSlots"
+                :key="slot?.id ?? `empty-${idx}`"
+                role="gridcell"
+                class="flex items-center justify-center border rounded-lg bg-white/50 p-2 shadow-sm transition-all dark:bg-gray-950/40 hover:shadow-md"
+              >
+                <!-- Slot rempli -->
+                <template v-if="slot">
+                  <button
+                    type="button"
+                    class="group ring-primary w-full flex flex-col items-center gap-1 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                    :aria-label="eggs.isReady(slot) ? eggReadyLabel(slot.type) : t('components.panel.Poulailler.a11y.eggProgress')"
+                    :title="eggs.isReady(slot) ? (t('components.panel.Poulailler.tapToHatch') as string) : undefined"
+                    @click="eggs.isReady(slot) && (hatch(slot.id), finish('hatched'))"
+                  >
+                    <div
+                      class="i-game-icons:egg-eye transition-transform duration-300"
+                      :class="[
+                        eggs.isReady(slot)
+                          ? 'h-14 w-14 animate-pulse-alt animate-count-infinite group-hover:scale-110 cursor-pointer'
+                          : 'h-10 w-10 animate-bounce animate-count-infinite',
+                        colorClass(slot.type),
+                      ]"
+                      aria-hidden="true"
+                    />
+                    <span
+                      v-if="!eggs.isReady(slot)"
+                      class="text-xs text-gray-700 tabular-nums dark:text-gray-200"
+                      aria-live="polite"
+                    >
+                      {{ fmtSec(remaining(slot)) }}
+                    </span>
+                    <span
+                      v-else
+                      class="text-primary-600 dark:text-primary-400 rounded px-2 py-0.5 text-xs font-semibold"
+                    >
+                      {{ t('components.panel.Poulailler.ready') }}
+                    </span>
+                  </button>
+                </template>
+
+                <template v-else>
+                  <div class="flex flex-col items-center gap-2 opacity-70">
+                    <div class="i-ph:egg-light h-10 w-10" aria-hidden="true" />
+                    <span class="text-center text-[11px] text-gray-500 dark:text-gray-400">
+                      {{ t('components.panel.Poulailler.emptySlot') }}
+                    </span>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <!-- Modals -->
+      <EggHatchModal />
+      <EggMonsModal />
+    </template>
+  </PanelPoiDialogFlow>
 </template>
 
 <style scoped>

--- a/test/poulailler-dialog-flow.test.ts
+++ b/test/poulailler-dialog-flow.test.ts
@@ -1,0 +1,131 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import DialogBox from '../src/components/dialog/Box.vue'
+import PoiDialogFlow from '../src/components/panel/PoiDialogFlow.vue'
+import Poulailler from '../src/components/panel/Poulailler.vue'
+
+vi.mock('../src/stores/audio', () => ({
+  useAudioStore: () => ({
+    fadeToMusic: vi.fn(),
+    playSfx: vi.fn(),
+    playTypingSfx: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/stores/zone', () => ({
+  useZoneStore: () => ({ current: { id: 'zone', type: 'sauvage' } }),
+}))
+
+vi.mock('../src/stores/mainPanel', () => ({
+  useMainPanelStore: () => ({ showVillage: vi.fn() }),
+}))
+
+vi.mock('../src/stores/egg', () => ({
+  useEggStore: () => ({
+    incubator: [],
+    startIncubation: vi.fn(),
+    hatchEgg: vi.fn(),
+    isReady: vi.fn(() => false),
+  }),
+}))
+
+vi.mock('../src/stores/eggBox', () => ({
+  useEggBoxStore: () => ({ eggs: {} }),
+}))
+
+vi.mock('../src/stores/eggMonsModal', () => ({
+  useEggMonsModalStore: () => ({ open: vi.fn() }),
+}))
+
+vi.mock('../src/stores/eggHatchModal', () => ({
+  useEggHatchModalStore: () => ({ open: vi.fn() }),
+}))
+
+function createI18nInstance() {
+  return createI18n({
+    legacy: false,
+    locale: 'fr',
+    messages: {
+      fr: {
+        ui: { Info: { ok: 'Ok' } },
+        components: {
+          panel: {
+            Poulailler: {
+              title: 'Poulailler',
+              exit: 'Quitter',
+              intro: 'intro',
+              outro: { running: 'running', idle: 'idle' },
+              yourEggs: 'Vos œufs',
+              incubator: 'Incubateur',
+              noEggBox: 'Aucun',
+              emptySlot: 'Vide',
+              tapToHatch: 'Tap',
+              ready: 'Prêt',
+              a11y: { showSpecies: 'spec', incubateEgg: 'incubate', eggReady: 'ready', eggProgress: 'progress' },
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+const globalStubs = {
+  LayoutTitledPanel: { template: '<div><slot /><slot name="footer" /></div>' },
+  UiButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  UiModal: { template: '<div><slot /></div>' },
+  EggHatchModal: { template: '<div />' },
+  EggMonsModal: { template: '<div />' },
+  CharacterImage: { template: '<div />' },
+  UiTypingText: {
+    props: ['text'],
+    emits: ['finished'],
+    mounted() {
+      this.$emit('finished')
+    },
+    template: '<p>{{ text }}</p>',
+  },
+}
+
+function mountPoulailler() {
+  return mount(Poulailler, {
+    global: {
+      plugins: [createI18nInstance()],
+      stubs: globalStubs,
+      components: { PoiDialogFlow, DialogBox },
+    },
+  })
+}
+
+describe('poulailler dialog flow', () => {
+  beforeEach(() => {})
+
+  it('transitions from intro to content to idle outro', async () => {
+    const wrapper = mountPoulailler()
+    await nextTick()
+    const flow = wrapper.findComponent(PoiDialogFlow)
+    expect(flow.vm.phase).toBe('intro')
+    expect(flow.vm.introDialog[0].text).toBe('intro')
+    flow.vm.phase = 'content'
+    await nextTick()
+    expect(flow.vm.phase).toBe('content')
+    ;(flow.vm as any).finish()
+    await nextTick()
+    expect(flow.vm.phase).toBe('outro')
+    expect(flow.vm.outroDialog![0].text).toBe('idle')
+  })
+
+  it('uses running outro when result is provided', async () => {
+    const wrapper = mountPoulailler()
+    await nextTick()
+    const flow = wrapper.findComponent(PoiDialogFlow)
+    await wrapper.findComponent(DialogBox).find('button').trigger('click')
+    await nextTick()
+    ;(flow.vm as any).finish('hatched')
+    await nextTick()
+    expect(flow.vm.outroDialog![0].text).toBe('running')
+  })
+})


### PR DESCRIPTION
## Summary
- wrap Poulailler panel in PanelPoiDialogFlow with intro/outro dialogs
- add translations for intro and outro states
- cover dialog flow with unit tests

## Testing
- `pnpm test` *(fails: capture.test.ts, page-locale-ssr.test.ts, sort-item.test.ts)*
- `pnpm test poulailler-dialog-flow.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689df473b598832a88b6122243b7b459