### PR TITLE
feat: disable character music in specific panels

### DIFF
--- a/src/components/dialog/Box.vue
+++ b/src/components/dialog/Box.vue
@@ -6,7 +6,7 @@ import { getCharacterTrack, getZoneTrack } from '~/data/music'
 /**
  * Props for {@link DialogBox}. Handles dialog tree and music behavior.
  */
-const { dialogTree, character, orientation, exitTrack, keepMusicOnExit }
+const { dialogTree, character, orientation, exitTrack, keepMusicOnExit, playCharacterTrack }
   = withDefaults(defineProps<{
     dialogTree: DialogNode[]
     character: Character
@@ -18,9 +18,15 @@ const { dialogTree, character, orientation, exitTrack, keepMusicOnExit }
      * Useful when a following scene should keep the character track.
      */
     keepMusicOnExit?: boolean
+    /**
+     * Whether the character's music should play when the dialog opens.
+     * Defaults to true to preserve existing behavior.
+     */
+    playCharacterTrack?: boolean
   }>(), {
     orientation: 'row',
     keepMusicOnExit: false,
+    playCharacterTrack: true,
   })
 
 const buttonClass = computed(() =>
@@ -35,11 +41,13 @@ const zone = useZoneStore()
 
 onMounted(() => {
   currentNode.value = dialogTree[0]
-  const track = getCharacterTrack(character.id)
-  if (track)
-    audio.fadeToMusic(track)
-  else
-    console.warn(`Missing music for character ${character.id}`)
+  if (playCharacterTrack) {
+    const track = getCharacterTrack(character.id)
+    if (track)
+      audio.fadeToMusic(track)
+    else
+      console.warn(`Missing music for character ${character.id}`)
+  }
 })
 
 watch(currentNode, () => {

--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -119,6 +119,7 @@ onBeforeUnmount(pauseTick)
     :character="norman"
     :create-intro="createIntro"
     :create-outro="createOutro"
+    :play-character-track="false"
     @exit="onExit"
   >
     <template #default>

--- a/src/components/panel/Dojo.vue
+++ b/src/components/panel/Dojo.vue
@@ -161,6 +161,7 @@ const ids = {
     :character="siphanus"
     :create-intro="createIntro"
     :create-outro="createOutro"
+    :play-character-track="false"
     @exit="onExit"
   >
     <template #default>
@@ -171,9 +172,8 @@ const ids = {
           <UiButton v-if="!selected" type="primary" class="aspect-square w-24" @click="openSelector">
             {{ t('components.panel.Dojo.selectMon') }}
           </UiButton>
-
-          <!-- Contenu principal -->
           <UiAdaptiveDisplayer v-else class="area-grid h-full w-full gap-3 md:gap-4">
+            <!-- Contenu principal -->
             <div
               class="min-h-0 min-w-0 flex-1 cursor-pointer overflow-hidden rounded-xl bg-gray-50 p-3 dark:bg-gray-800"
               @click="openSelector"
@@ -297,18 +297,17 @@ const ids = {
                 </span>
               </div>
             </div>
-          </div>
-        </UiAdaptiveDisplayer>
+          </UiAdaptiveDisplayer>
+        </div>
       </div>
-    </div>
 
-    <!-- Sélecteur -->
-    <ShlagemonSelectModal
-      v-model="selectorOpen"
-      :title="t('components.panel.Dojo.selectMon')"
-      title-id="dojo-select-title"
-      @select="selectMon"
-    />
+      <!-- Sélecteur -->
+      <ShlagemonSelectModal
+        v-model="selectorOpen"
+        :title="t('components.panel.Dojo.selectMon')"
+        title-id="dojo-select-title"
+        @select="selectMon"
+      />
 
       <!-- Sélecteur -->
       <UiModal v-model="selectorOpen" role="dialog" aria-modal="true" aria-labelledby="dojo-select-title">

--- a/src/components/panel/PoiDialogFlow.vue
+++ b/src/components/panel/PoiDialogFlow.vue
@@ -21,9 +21,15 @@ interface Props {
    * Optional music track to play once the flow exits. Defaults to the zone track.
    */
   exitTrack?: string
+  /**
+   * If false, the character track is never played. Defaults to true.
+   */
+  playCharacterTrack?: boolean
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  playCharacterTrack: true,
+})
 const emit = defineEmits<{ (e: 'exit'): void }>()
 
 const phase = ref<'intro' | 'content' | 'outro'>(props.createIntro ? 'intro' : 'content')
@@ -55,7 +61,7 @@ function onExit() {
 }
 
 onMounted(() => {
-  if (!props.createIntro) {
+  if (!props.createIntro && props.playCharacterTrack) {
     const track = getCharacterTrack(props.character.id)
     if (track)
       audio.fadeToMusic(track)
@@ -76,6 +82,7 @@ onMounted(() => {
         :dialog-tree="introDialog"
         keep-music-on-exit
         orientation="col"
+        :play-character-track="props.playCharacterTrack"
       />
       <slot v-else-if="phase === 'content'" :finish="finish" />
       <DialogBox
@@ -84,6 +91,7 @@ onMounted(() => {
         :dialog-tree="outroDialog!"
         :exit-track="props.exitTrack"
         orientation="col"
+        :play-character-track="props.playCharacterTrack"
       />
     </div>
     <template #footer>

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { EggType } from '~/stores/egg'
-import type { EggItemId } from '~/stores/eggBox'
-import type { DialogNode } from '~/type/dialog'
 import type { BreedingEggItem, EggItemId } from '~/stores/eggBox'
+import type { DialogNode } from '~/type/dialog'
 import { eggTypeMap } from '~/constants/egg'
 import { magalieBredouille } from '~/data/characters/magalie-bredouille'
 import { allItems } from '~/data/items'
@@ -167,6 +166,7 @@ function eggReadyLabel(type: EggType) {
     :character="magalieBredouille"
     :create-intro="createIntro"
     :create-outro="createOutro"
+    :play-character-track="false"
     @exit="onExit"
   >
     <template #default="{ finish }">
@@ -342,7 +342,6 @@ function eggReadyLabel(type: EggType) {
     </template>
   </PanelPoiDialogFlow>
 </template>
-
 
 <style scoped>
 /* micro-ajustements focus visibles sur fond translucide */

--- a/test/panel-dialog-music.test.ts
+++ b/test/panel-dialog-music.test.ts
@@ -1,0 +1,177 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+
+import DialogBox from '../src/components/dialog/Box.vue'
+import Breeding from '../src/components/panel/Breeding.vue'
+import Dojo from '../src/components/panel/Dojo.vue'
+import PoiDialogFlow from '../src/components/panel/PoiDialogFlow.vue'
+import Poulailler from '../src/components/panel/Poulailler.vue'
+import { norman } from '../src/data/characters/norman'
+
+const fadeToMusic = vi.fn()
+vi.mock('../src/stores/audio', () => ({
+  useAudioStore: () => ({
+    fadeToMusic,
+    playSfx: vi.fn(),
+    playTypingSfx: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/stores/zone', () => ({
+  useZoneStore: () => ({ current: { id: 'zone', type: 'sauvage' } }),
+}))
+
+vi.mock('../src/stores/mainPanel', () => ({
+  useMainPanelStore: () => ({ showVillage: vi.fn() }),
+}))
+
+vi.mock('../src/modules/toast', () => ({
+  toast: { success: vi.fn() },
+}))
+
+// Panel specific store mocks
+vi.mock('../src/stores/breeding', () => ({
+  useBreedingStore: () => ({
+    getJob: vi.fn(),
+    remainingMs: vi.fn(),
+    progress: vi.fn(),
+    start: vi.fn(),
+    collectEgg: vi.fn(),
+    completeIfDue: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/stores/game', () => ({
+  useGameStore: () => ({ shlagidolar: 0 }),
+}))
+
+vi.mock('../src/stores/dojo', () => ({
+  dojoTrainingCost: vi.fn(() => 0),
+  useDojoStore: () => ({
+    getJob: vi.fn(),
+    remainingMs: vi.fn(),
+    progressRatio: vi.fn(),
+    startTraining: vi.fn(),
+    completeIfDue: vi.fn(),
+    byMonId: {},
+  }),
+}))
+
+vi.mock('../src/stores/shlagedex', () => ({
+  useShlagedexStore: () => ({ shlagemons: [] }),
+}))
+
+vi.mock('../src/stores/egg', () => ({
+  useEggStore: () => ({
+    incubator: [],
+    startIncubation: vi.fn(),
+    hatchEgg: vi.fn(),
+    isReady: vi.fn(() => false),
+  }),
+}))
+
+vi.mock('../src/stores/eggBox', () => ({
+  useEggBoxStore: () => ({ eggs: {}, breeding: [] }),
+}))
+
+vi.mock('../src/stores/eggMonsModal', () => ({
+  useEggMonsModalStore: () => ({ open: vi.fn() }),
+}))
+
+vi.mock('../src/stores/eggHatchModal', () => ({
+  useEggHatchModalStore: () => ({ open: vi.fn() }),
+}))
+
+function createI18nInstance() {
+  return createI18n({
+    legacy: false,
+    locale: 'fr',
+    messages: {
+      fr: {
+        ui: { Info: { ok: 'Ok' } },
+        components: {
+          panel: {
+            Breeding: {
+              title: 'Breeding',
+              exit: 'Exit',
+              intro: 'intro',
+              outro: { running: 'running', idle: 'idle' },
+              during: { typing: '' },
+            },
+            Dojo: {
+              title: 'Dojo',
+              exit: 'Exit',
+              intro: 'intro',
+              outro: { running: 'running', idle: 'idle' },
+            },
+            Poulailler: {
+              title: 'Poulailler',
+              exit: 'Exit',
+              intro: 'intro',
+              outro: { running: 'running', idle: 'idle' },
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+const globalStubs = {
+  LayoutTitledPanel: { template: '<div><slot /><slot name="footer" /></div>' },
+  UiButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  CharacterImage: { template: '<div />' },
+  UiTypingText: {
+    props: ['text'],
+    emits: ['finished'],
+    mounted() { this.$emit('finished') },
+    template: '<p>{{ text }}</p>',
+  },
+}
+
+beforeEach(() => {
+  fadeToMusic.mockReset()
+})
+
+describe('panel dialog music', () => {
+  it.each([
+    ['Breeding', Breeding],
+    ['Dojo', Dojo],
+    ['Poulailler', Poulailler],
+  ])('does not play character track in %s panel', async (_, Comp) => {
+    mount(Comp, {
+      global: {
+        plugins: [createI18nInstance()],
+        stubs: globalStubs,
+        components: { PoiDialogFlow, DialogBox },
+      },
+    })
+    await nextTick()
+    expect(fadeToMusic).not.toHaveBeenCalled()
+  })
+
+  it('plays character track by default in dialog flow', async () => {
+    mount(PoiDialogFlow, {
+      props: {
+        title: 'Mini',
+        exitText: 'Exit',
+        character: norman,
+        createIntro: (start: () => void) => [{
+          id: 'intro',
+          text: 'hi',
+          responses: [{ label: 'ok', type: 'primary', action: start }],
+        }],
+      },
+      global: {
+        plugins: [createI18nInstance()],
+        stubs: globalStubs,
+        components: { DialogBox },
+      },
+    })
+    await nextTick()
+    expect(fadeToMusic).toHaveBeenCalled()
+    expect(fadeToMusic.mock.calls[0][0]).toContain('/audio/musics/character/')
+  })
+})


### PR DESCRIPTION
## Summary
- add optional `playCharacterTrack` flag to `DialogBox` and `PoiDialogFlow`
- prevent breeding, dojo, and poulailler panels from switching to character music
- cover dialog music routing with focused tests

## Testing
- `CI=1 npx vitest run test/panel-dialog-music.test.ts --reporter=basic` *(fails: warning about deprecated reporter but tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_689df75701a0832a86e950e661ab542a