### PR TITLE
Handle missing mon in breeding eggs

### DIFF
--- a/src/components/egg/BoxModal.vue
+++ b/src/components/egg/BoxModal.vue
@@ -15,12 +15,23 @@ interface BreedingEntry extends BreedingEggItem {
   readonly mon: typeof baseShlagemons[number]
 }
 
-const breedingEggs = computed<BreedingEntry[]>(() => {
-  return box.breeding.map(egg => ({
-    ...egg,
-    mon: baseShlagemons.find(b => b.id === egg.monId)!,
-  }))
-})
+/**
+ * Breeding eggs that have a matching shlagemon entry.
+ * Entries without a corresponding mon are ignored to avoid runtime errors.
+ */
+const breedingEggs = computed<BreedingEntry[]>(() =>
+  box.breeding
+    .map((egg) => {
+      const mon = baseShlagemons.find(b => b.id === egg.monId)
+      return mon
+        ? {
+            ...egg,
+            mon,
+          }
+        : null
+    })
+    .filter((entry): entry is BreedingEntry => entry !== null),
+)
 
 const hasEggs = computed(() => typeEggs.value.length > 0 || breedingEggs.value.length > 0)
 

--- a/test/egg-box-modal-missing-mon.test.ts
+++ b/test/egg-box-modal-missing-mon.test.ts
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import BoxModal from '../src/components/egg/BoxModal.vue'
+import { useEggBoxStore } from '../src/stores/eggBox'
+
+vi.mock('../src/stores/eggMonsModal', () => ({
+  useEggMonsModalStore: () => ({ open: vi.fn() }),
+}))
+
+describe('egg box modal', () => {
+  it('skips breeding entries with unknown shlagemon', () => {
+    const box = useEggBoxStore()
+    box.isModalOpen = true
+    box.breeding = [
+      {
+        id: 'unknown-egg',
+        monId: 'missing-mon',
+        type: 'feu',
+      },
+    ] as any
+
+    const wrapper = mount(BoxModal)
+
+    expect(wrapper.vm.breedingEggs).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- safeguard `EggBoxModal` by filtering breeding eggs that reference unknown shlagemon data
- test that modal skips invalid breeding entries

## Testing
- `pnpm exec eslint src/components/egg/BoxModal.vue test/egg-box-modal-missing-mon.test.ts`
- `pnpm typecheck` *(fails: Types of property 'isPending' are incompatible in shlagedex store)*
- `pnpm test:unit test/egg-box-modal-missing-mon.test.ts -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689e01bd8700832ab4f649fbba7069ab