### PR TITLE
Handle unknown breeding eggs

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -172,6 +172,7 @@ declare global {
   const useBattleship: typeof import('./composables/useBattleship')['useBattleship']
   const useBluetooth: typeof import('@vueuse/core')['useBluetooth']
   const useBreakpoints: typeof import('@vueuse/core')['useBreakpoints']
+  const useBreedingEggs: typeof import('./composables/useBreedingEggs')['useBreedingEggs']
   const useBreedingStore: typeof import('./stores/breeding')['useBreedingStore']
   const useBroadcastChannel: typeof import('@vueuse/core')['useBroadcastChannel']
   const useBrowserLocation: typeof import('@vueuse/core')['useBrowserLocation']
@@ -430,6 +431,9 @@ declare global {
   export type { Cell } from './composables/useBattleship'
   import('./composables/useBattleship')
   // @ts-ignore
+  export type { BreedingEntry } from './composables/useBreedingEggs'
+  import('./composables/useBreedingEggs')
+  // @ts-ignore
   export type { FaintAutoEmitResult } from './composables/useFaintAutoEmit'
   import('./composables/useFaintAutoEmit')
   // @ts-ignore
@@ -674,6 +678,7 @@ declare module 'vue' {
     readonly useBattleship: UnwrapRef<typeof import('./composables/useBattleship')['useBattleship']>
     readonly useBluetooth: UnwrapRef<typeof import('@vueuse/core')['useBluetooth']>
     readonly useBreakpoints: UnwrapRef<typeof import('@vueuse/core')['useBreakpoints']>
+    readonly useBreedingEggs: UnwrapRef<typeof import('./composables/useBreedingEggs')['useBreedingEggs']>
     readonly useBreedingStore: UnwrapRef<typeof import('./stores/breeding')['useBreedingStore']>
     readonly useBroadcastChannel: UnwrapRef<typeof import('@vueuse/core')['useBroadcastChannel']>
     readonly useBrowserLocation: UnwrapRef<typeof import('@vueuse/core')['useBrowserLocation']>

--- a/src/components/egg/BoxModal.vue
+++ b/src/components/egg/BoxModal.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { EggType } from '~/stores/egg'
-import type { BreedingEggItem, EggItemId } from '~/stores/eggBox'
+import type { EggItemId } from '~/stores/eggBox'
 import { allItems } from '~/data/items'
-import { baseShlagemons } from '~/data/shlagemons'
 
 const eggMonsModal = useEggMonsModalStore()
 
@@ -11,27 +10,7 @@ const { t } = useI18n()
 
 const typeEggs = computed(() => eggIds.filter(id => box.eggs[id]))
 
-interface BreedingEntry extends BreedingEggItem {
-  readonly mon: typeof baseShlagemons[number]
-}
-
-/**
- * Breeding eggs that have a matching shlagemon entry.
- * Entries without a corresponding mon are ignored to avoid runtime errors.
- */
-const breedingEggs = computed<BreedingEntry[]>(() =>
-  box.breeding
-    .map((egg) => {
-      const mon = baseShlagemons.find(b => b.id === egg.monId)
-      return mon
-        ? {
-            ...egg,
-            mon,
-          }
-        : null
-    })
-    .filter((entry): entry is BreedingEntry => entry !== null),
-)
+const breedingEggs = useBreedingEggs()
 
 const hasEggs = computed(() => typeEggs.value.length > 0 || breedingEggs.value.length > 0)
 

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
+import type { BreedingEntry } from '~/composables/useBreedingEggs'
 import type { EggType } from '~/stores/egg'
-import type { BreedingEggItem, EggItemId } from '~/stores/eggBox'
+import type { EggItemId } from '~/stores/eggBox'
 import type { DialogNode } from '~/type/dialog'
 import { eggTypeMap } from '~/constants/egg'
 import { magalieBredouille } from '~/data/characters/magalie-bredouille'
 import { allItems } from '~/data/items'
-import { baseShlagemons } from '~/data/shlagemons'
 
 /** === Stores ============================================================ */
 const eggs = useEggStore()
@@ -59,10 +59,6 @@ interface InventoryEntry {
   }
 }
 
-interface BreedingEntry extends BreedingEggItem {
-  readonly mon: typeof baseShlagemons[number]
-}
-
 const colorMap: Record<EggType, string> = {
   feu: 'text-orange-500 dark:text-orange-400',
   eau: 'text-blue-500 dark:text-blue-400',
@@ -89,12 +85,7 @@ const typeEggs = computed<InventoryEntry[]>(() => {
     .filter(e => e.qty > 0)
 })
 
-const breedingEggs = computed<BreedingEntry[]>(() => {
-  return box.breeding.map(egg => ({
-    ...egg,
-    mon: baseShlagemons.find(b => b.id === egg.monId)!,
-  }))
-})
+const breedingEggs = useBreedingEggs()
 
 const incubatorSlots = computed(() => {
   // always 4 slots; fill with null placeholders

--- a/src/composables/useBreedingEggs.ts
+++ b/src/composables/useBreedingEggs.ts
@@ -1,0 +1,32 @@
+import type { BreedingEggItem } from '~/stores/eggBox'
+import { baseShlagemons } from '~/data/shlagemons'
+
+/**
+ * Enriched breeding egg entry combining the raw egg data with its shlagémon.
+ */
+export interface BreedingEntry extends BreedingEggItem {
+  readonly mon: typeof baseShlagemons[number]
+}
+
+/**
+ * Provides breeding eggs that reference a known shlagémon.
+ *
+ * Eggs with an unknown `monId` are filtered out to avoid runtime errors.
+ */
+export function useBreedingEggs() {
+  const box = useEggBoxStore()
+
+  return computed<BreedingEntry[]>(() =>
+    box.breeding
+      .map((egg) => {
+        const mon = baseShlagemons.find(b => b.id === egg.monId)
+        return mon
+          ? {
+              ...egg,
+              mon,
+            }
+          : null
+      })
+      .filter((entry): entry is BreedingEntry => entry !== null),
+  )
+}

--- a/test/poulailler-dialog-flow.test.ts
+++ b/test/poulailler-dialog-flow.test.ts
@@ -32,8 +32,10 @@ vi.mock('../src/stores/egg', () => ({
   }),
 }))
 
+const mockEggBoxStore = { eggs: {}, breeding: [] as any[] }
+
 vi.mock('../src/stores/eggBox', () => ({
-  useEggBoxStore: () => ({ eggs: {} }),
+  useEggBoxStore: () => mockEggBoxStore,
 }))
 
 vi.mock('../src/stores/eggMonsModal', () => ({
@@ -101,7 +103,9 @@ function mountPoulailler() {
 }
 
 describe('poulailler dialog flow', () => {
-  beforeEach(() => {})
+  beforeEach(() => {
+    mockEggBoxStore.breeding = []
+  })
 
   it('transitions from intro to content to idle outro', async () => {
     const wrapper = mountPoulailler()
@@ -127,5 +131,11 @@ describe('poulailler dialog flow', () => {
     ;(flow.vm as any).finish('hatched')
     await nextTick()
     expect(flow.vm.outroDialog![0].text).toBe('running')
+  })
+
+  it('ignores breeding eggs with unknown mon id', () => {
+    mockEggBoxStore.breeding.push({ id: 'egg1', monId: 'missing-mon', type: 'feu', rarity: 1 })
+    const wrapper = mountPoulailler()
+    expect((wrapper.vm as any).breedingEggs.length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- avoid runtime errors from breeding eggs referencing unknown shlagémon
- centralize breeding egg mapping logic
- test henhouse component ignores invalid breeding eggs

## Testing
- `pnpm lint` *(fails: Missing trailing comma etc. in unrelated files)*
- `npx eslint src/components/panel/Poulailler.vue src/components/egg/BoxModal.vue src/composables/useBreedingEggs.ts test/poulailler-dialog-flow.test.ts`
- `pnpm typecheck` *(fails: incompatible types in src/stores/shlagedex.ts)*
- `pnpm test:unit` *(fails: breeding dialog flow > completes a job and shows running outro message)*

------
https://chatgpt.com/codex/tasks/task_e_689e3c030784832a919f28ac2d098c90