### PR TITLE
feat: improve type chart highlighting

### DIFF
--- a/src/components/shlagemon/TypeChart.vue
+++ b/src/components/shlagemon/TypeChart.vue
@@ -43,12 +43,28 @@ function getMultiplier(att: TypeName, def: TypeName) {
 }
 
 /**
- * Toggles the highlighted type. Clicking again clears the selection.
+ * Sets the highlighted type.
  *
- * @param typeId - Type identifier to toggle.
+ * @param typeId - Type identifier to highlight.
  */
-function toggleHighlight(typeId: TypeName) {
-  highlight.value = highlight.value === typeId ? null : typeId
+function setHighlight(typeId: TypeName) {
+  highlight.value = typeId
+}
+
+/**
+ * Returns CSS classes for a multiplier cell.
+ *
+ * @param att - Attacking type identifier.
+ * @param def - Defending type identifier.
+ */
+function getCellClasses(att: TypeName, def: TypeName) {
+  const multiplier = getMultiplier(att, def)
+  return {
+    'bg-blue-200 dark:bg-blue-800': highlight.value === att || highlight.value === def,
+    'font-bold': highlight.value === att && highlight.value === def,
+    'text-blue-600': multiplier === 1.5,
+    'text-red-600': multiplier === 0.5,
+  }
 }
 </script>
 
@@ -81,7 +97,7 @@ function toggleHighlight(typeId: TypeName) {
             <button
               type="button"
               class="w-full"
-              @click="toggleHighlight(typeId)"
+              @click="setHighlight(typeId)"
             >
               <ShlagemonType :value="shlagemonTypes[typeId]" />
             </button>
@@ -98,7 +114,7 @@ function toggleHighlight(typeId: TypeName) {
             <button
               type="button"
               class="w-full text-right"
-              @click="toggleHighlight(atk)"
+              @click="setHighlight(atk)"
             >
               <ShlagemonType :value="shlagemonTypes[atk]" />
             </button>
@@ -107,10 +123,7 @@ function toggleHighlight(typeId: TypeName) {
             v-for="def in typeIds"
             :key="def"
             class="border border-gray-200 p-1 dark:border-gray-700"
-            :class="{
-              'bg-blue-200 dark:bg-blue-800': highlight === atk || highlight === def,
-              'font-bold': highlight === atk && highlight === def,
-            }"
+            :class="getCellClasses(atk, def)"
           >
             {{ getMultiplier(atk, def) }}
           </td>

--- a/test/typechart.test.ts
+++ b/test/typechart.test.ts
@@ -5,7 +5,7 @@ import TypeChart from '../src/components/shlagemon/TypeChart.vue'
 import { shlagemonTypes } from '../src/data/shlagemons-type'
 
 describe('type chart', () => {
-  it('renders correct multipliers using type identifiers', () => {
+  it('renders correct multipliers using type identifiers with color coding', () => {
     const wrapper = mount(TypeChart, {
       props: { highlight: null },
       global: {
@@ -19,11 +19,13 @@ describe('type chart', () => {
     const feeColIndex = ids.indexOf('fee')
     const poisonCells = poisonRow.findAll('td')
     expect(poisonCells[feeColIndex].text()).toBe('1.5')
+    expect(poisonCells[feeColIndex].classes()).toContain('text-blue-600')
 
     const electricRow = wrapper.findAll('tbody tr')[ids.indexOf('electrique')]
     const solColIndex = ids.indexOf('sol')
     const electricCells = electricRow.findAll('td')
     expect(electricCells[solColIndex].text()).toBe('0.5')
+    expect(electricCells[solColIndex].classes()).toContain('text-red-600')
   })
 
   it('highlights row and column on header click', async () => {
@@ -56,5 +58,25 @@ describe('type chart', () => {
       const cell = row.findAll('td')[feeIndex]
       expect(cell.classes()).toContain('bg-blue-200')
     })
+  })
+
+  it('keeps highlight when clicking the same header again', async () => {
+    const wrapper = mount(TypeChart, {
+      props: { highlight: null },
+      global: {
+        stubs: {
+          ShlagemonType: { template: '<div />' },
+        },
+      },
+    })
+    const ids = Object.keys(shlagemonTypes)
+    const poisonIndex = ids.indexOf('poison')
+    const button = wrapper.findAll('tbody tr')[poisonIndex].find('th button')
+    await button.trigger('click')
+    let highlight = wrapper.emitted('update:highlight')?.at(-1)?.[0] as TypeName
+    await wrapper.setProps({ highlight })
+    await button.trigger('click')
+    highlight = wrapper.emitted('update:highlight')?.at(-1)?.[0] as TypeName
+    expect(highlight).toBe('poison')
   })
 })


### PR DESCRIPTION
## Summary
- color 1.5 multipliers blue and 0.5 multipliers red in type chart
- replace previous highlight when selecting a new type
- test: verify color coding and non-toggling highlight behavior

## Testing
- `pnpm lint` *(fails: UnoCSS order, missing trailing commas, etc.)*
- `pnpm exec eslint src/components/shlagemon/TypeChart.vue test/typechart.test.ts`
- `pnpm test:unit` *(fails: 11 failing tests, e.g., animated number duration, attack throttle)*

------
https://chatgpt.com/codex/tasks/task_e_689e3c757e00832aa07d7e2c0f032128