### PR TITLE
feat: add cosmic egg icon for breeding

### DIFF
--- a/src/components/egg/BoxModal.vue
+++ b/src/components/egg/BoxModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { EggType } from '~/stores/egg'
 import type { EggItemId } from '~/stores/eggBox'
+import { eggColorClass } from '~/constants/egg'
 import { allItems } from '~/data/items'
 
 const eggMonsModal = useEggMonsModalStore()
@@ -13,18 +13,6 @@ const typeEggs = computed(() => eggIds.filter(id => box.eggs[id]))
 const breedingEggs = useBreedingEggs()
 
 const hasEggs = computed(() => typeEggs.value.length > 0 || breedingEggs.value.length > 0)
-
-const colorMap: Record<EggType, string> = {
-  feu: 'text-orange-500 dark:text-orange-400',
-  eau: 'text-blue-500 dark:text-blue-400',
-  plante: 'text-green-500 dark:text-green-400',
-  electrique: 'text-yellow-500 dark:text-yellow-400',
-  psy: 'text-pink-500 dark:text-pink-400',
-}
-
-function colorClass(type: EggType): string {
-  return colorMap[type] ?? ''
-}
 
 function getItem(id: string) {
   return allItems.find(i => i.id === id)!
@@ -67,8 +55,10 @@ function openEgg(id: EggItemId) {
         >
           <template #left>
             <div class="flex items-center gap-1">
-              <div class="i-ph:egg-fill h-6 w-6" :class="colorClass(entry.type)" />
-              <span class="text-sm">{{ t('common.eggOf', { name: t(entry.mon.name) }) }}</span>
+              <div class="i-game-icons:cosmic-egg h-6 w-6" :class="eggColorClass(entry.type)" />
+              <span class="text-sm" :class="eggColorClass(entry.type)">
+                {{ t('common.eggOf', { name: t(entry.mon.name) }) }}
+              </span>
             </div>
           </template>
         </UiListItem>

--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -3,6 +3,7 @@ import type { EggType } from '~/stores/egg'
 import type { DialogNode } from '~/type/dialog'
 
 import type { DexShlagemon } from '~/type/shlagemon'
+import { eggColorClass } from '~/constants/egg'
 import { norman } from '~/data/characters/norman'
 import { toast } from '~/modules/toast'
 import { BREEDING_DURATION_MS, breedingCost } from '~/utils/breeding'
@@ -173,7 +174,8 @@ watch([selected, isCompleted], () => {
                       {{ t('components.panel.Breeding.rarity') }}: {{ selected.rarity }}
                     </span>
                     <span
-                      class="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-900 font-medium dark:bg-amber-900/50 dark:text-amber-100"
+                      class="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium dark:bg-amber-900/50"
+                      :class="eggType ? eggColorClass(eggType) : ''"
                       :aria-label="t('components.panel.Breeding.eggType')"
                     >
                       {{ t('components.panel.Breeding.eggType') }}: {{ eggType }}
@@ -291,9 +293,13 @@ watch([selected, isCompleted], () => {
           v-if="isCompleted"
           type="primary"
           variant="outline"
+          class="flex items-center gap-1"
           @click="collect"
         >
-          {{ t('components.panel.Breeding.cta.collectEgg') }}
+          <div class="i-game-icons:cosmic-egg" :class="eggType ? eggColorClass(eggType) : ''" aria-hidden="true" />
+          <span :class="eggType ? eggColorClass(eggType) : ''">
+            {{ t('components.panel.Breeding.cta.collectEgg') }}
+          </span>
         </UiButton>
       </div>
     </template>

--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -3,7 +3,7 @@ import type { BreedingEntry } from '~/composables/useBreedingEggs'
 import type { EggType } from '~/stores/egg'
 import type { EggItemId } from '~/stores/eggBox'
 import type { DialogNode } from '~/type/dialog'
-import { eggTypeMap } from '~/constants/egg'
+import { eggColorClass, eggTypeMap } from '~/constants/egg'
 import { magalieBredouille } from '~/data/characters/magalie-bredouille'
 import { allItems } from '~/data/items'
 
@@ -59,14 +59,6 @@ interface InventoryEntry {
   }
 }
 
-const colorMap: Record<EggType, string> = {
-  feu: 'text-orange-500 dark:text-orange-400',
-  eau: 'text-blue-500 dark:text-blue-400',
-  plante: 'text-green-500 dark:text-green-400',
-  electrique: 'text-yellow-500 dark:text-yellow-400',
-  psy: 'text-pink-500 dark:text-pink-400',
-}
-
 /** === Time tick (1s) ==================================================== */
 const now = ref<number>(Date.now())
 useIntervalFn(
@@ -94,10 +86,6 @@ const incubatorSlots = computed(() => {
 })
 
 /** === Helpers =========================================================== */
-function colorClass(type: EggType): string {
-  return colorMap[type] ?? ''
-}
-
 function remaining(egg: { hatchesAt: number }): number {
   return Math.max(0, Math.ceil((egg.hatchesAt - now.value) / 1000))
 }
@@ -188,8 +176,8 @@ function eggReadyLabel(type: EggType) {
                 class="group flex items-center justify-between gap-2 border-b p-2 transition-colors last:border-b-0 hover:bg-gray/5"
               >
                 <div class="min-w-0 flex flex-1 items-center gap-2 overflow-hidden text-left">
-                  <div class="i-ph:egg-fill h-6 w-6 shrink-0" :class="colorClass(entry.type)" aria-hidden="true" />
-                  <span class="truncate text-sm font-medium">
+                  <div class="i-game-icons:cosmic-egg h-6 w-6 shrink-0" :class="eggColorClass(entry.type)" aria-hidden="true" />
+                  <span class="truncate text-sm font-medium" :class="eggColorClass(entry.type)">
                     {{ breedingLabel(entry) }}
                   </span>
                 </div>
@@ -294,7 +282,7 @@ function eggReadyLabel(type: EggType) {
                         eggs.isReady(slot)
                           ? 'h-14 w-14 animate-pulse-alt animate-count-infinite group-hover:scale-110 cursor-pointer'
                           : 'h-10 w-10 animate-bounce animate-count-infinite',
-                        colorClass(slot.type),
+                        eggColorClass(slot.type),
                       ]"
                       aria-hidden="true"
                     />

--- a/src/constants/egg.ts
+++ b/src/constants/egg.ts
@@ -8,3 +8,19 @@ export const eggTypeMap: Record<EggItemId, EggType> = {
   'oeuf-psy': 'psy',
   'oeuf-foudre': 'electrique',
 }
+
+/** Maps each egg type to the corresponding text color classes. */
+export const eggColorMap: Record<EggType, string> = {
+  feu: 'text-orange-500 dark:text-orange-400',
+  eau: 'text-blue-500 dark:text-blue-400',
+  plante: 'text-green-500 dark:text-green-400',
+  electrique: 'text-yellow-500 dark:text-yellow-400',
+  psy: 'text-pink-500 dark:text-pink-400',
+}
+
+/**
+ * Returns the text color classes associated with an egg type.
+ */
+export function eggColorClass(type: EggType): string {
+  return eggColorMap[type] ?? ''
+}

--- a/test/egg-color-class.test.ts
+++ b/test/egg-color-class.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { eggColorClass } from '../src/constants/egg'
+
+describe('eggColorClass', () => {
+  it('returns color classes for known egg types', () => {
+    expect(eggColorClass('feu')).toBe('text-orange-500 dark:text-orange-400')
+    expect(eggColorClass('eau')).toBe('text-blue-500 dark:text-blue-400')
+    expect(eggColorClass('plante')).toBe('text-green-500 dark:text-green-400')
+    expect(eggColorClass('electrique')).toBe('text-yellow-500 dark:text-yellow-400')
+    expect(eggColorClass('psy')).toBe('text-pink-500 dark:text-pink-400')
+  })
+
+  it('returns an empty string for unknown types', () => {
+    expect(eggColorClass('unknown' as any)).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- centralize egg color classes
- show cosmic egg icons and color-coded labels for breeding eggs
- style breeding panel collect button with egg type color

## Testing
- `pnpm exec eslint src/constants/egg.ts src/components/egg/BoxModal.vue src/components/panel/Poulailler.vue src/components/panel/Breeding.vue test/egg-color-class.test.ts`
- `pnpm test:unit` *(fails: animated-number-duration, capture mechanics, SSR locale pages, shlagedex sort item)*

------
https://chatgpt.com/codex/tasks/task_e_689e6eec97a0832aa78acc46815d1e29