### PR TITLE
Ensure breeding eggs use base ancestor

### DIFF
--- a/src/stores/breeding.ts
+++ b/src/stores/breeding.ts
@@ -1,6 +1,7 @@
 import type { EggType } from './egg'
 import { defineStore } from 'pinia'
 import { BREEDING_DURATION_MS, breedingCost } from '~/utils/breeding'
+import { findRootAncestorId } from '~/utils/shlagemon-ancestor'
 import { useEggBoxStore } from './eggBox'
 
 /**
@@ -108,12 +109,17 @@ export const useBreedingStore = defineStore('breeding', () => {
 
   /**
    * Collect the egg from a completed job and move it to the egg box.
+   *
+   * The resulting egg always references the earliest known ancestor of the
+   * selected parent so that breeding an evolved Shlagémon yields the base
+   * form's egg.
    */
   function collectEgg(type: EggType): boolean {
     const job = byType.value[type]
     if (!job || job.status !== 'completed')
       return false
-    eggBox.addBreedingEgg(job.parentId, job.type, job.rarity)
+    const ancestorId = findRootAncestorId(job.parentId)
+    eggBox.addBreedingEgg(ancestorId, job.type, job.rarity)
     delete byType.value[type]
     return true
   }

--- a/src/utils/shlagemon-ancestor.ts
+++ b/src/utils/shlagemon-ancestor.ts
@@ -1,0 +1,29 @@
+import type { BaseShlagemon } from '~/type'
+import { allShlagemons } from '~/data/shlagemons'
+
+/**
+ * Determine the identifier of the earliest ancestor for the provided Shlagémon.
+ *
+ * The search walks backward through the evolution chain by locating any
+ * Shlagémon that evolves into the current one. When no previous form is
+ * found, the current identifier is returned.
+ *
+ * @param id - Identifier of the Shlagémon to trace.
+ * @returns Identifier of the root ancestor.
+ */
+export function findRootAncestorId(id: string): string {
+  let current: BaseShlagemon | undefined = allShlagemons.find(m => m.id === id)
+  if (!current)
+    return id
+
+  // Walk backward until no previous evolution is found.
+  while (true) {
+    const previous = allShlagemons.find((candidate) => {
+      const evolutions = candidate.evolutions ?? (candidate.evolution ? [candidate.evolution] : [])
+      return evolutions.some(e => e.base.id === current!.id)
+    })
+    if (!previous)
+      return current.id
+    current = previous
+  }
+}

--- a/test/breeding-store.test.ts
+++ b/test/breeding-store.test.ts
@@ -39,4 +39,17 @@ describe('breeding store', () => {
 
     expect(breeding.start('feu', 10, 'salamiches')).toBe(true)
   })
+
+  it('breeds evolved shlagemon and returns base ancestor egg', () => {
+    const breeding = useBreedingStore()
+    const game = useGameStore()
+    const box = useEggBoxStore()
+    game.shlagidolar = 1_000_000
+
+    expect(breeding.start('feu', 10, 'raptorincel')).toBe(true)
+    vi.advanceTimersByTime(BREEDING_DURATION_MS + 1)
+    expect(breeding.completeIfDue('feu')).toBe(true)
+    expect(breeding.collectEgg('feu')).toBe(true)
+    expect(box.breeding[0].monId).toBe('salamiches')
+  })
 })


### PR DESCRIPTION
## Summary
- add utility to find earliest shlagémon ancestor
- breed store uses ancestor to generate eggs
- test breeding of evolved shlagémon

## Testing
- `pnpm test --run` *(fails: page-locale-ssr.test.ts - Invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_689e7047c468832a92703a8d85d63503