### PR TITLE
refactor: centralize SEO link utilities

### DIFF
--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,0 +1,5 @@
+/**
+ * Absolute base URL of the deployed application.
+ * Must not include a trailing slash.
+ */
+export const SITE_URL = 'https://shlagemon.aife.io'

--- a/src/utils/seo-links.ts
+++ b/src/utils/seo-links.ts
@@ -1,0 +1,79 @@
+import type { Locale } from '~/constants/locales'
+
+/**
+ * Selects the best available localized path.
+ *
+ * @param paths - Mapping of locale to path.
+ * @param preferred - Desired locale to retrieve.
+ * @returns The path for the preferred locale or the first available fallback.
+ */
+export function pickBest(paths: Partial<Record<Locale, string>>, preferred: Locale): string {
+  return paths[preferred]
+    ?? paths.en
+    ?? paths.fr
+    ?? '/'
+}
+
+export interface AlternateLink {
+  hreflang: string
+  href: string
+}
+
+export interface BuildLocalizedLinksOptions {
+  /** Localized paths for the route. */
+  paths: Partial<Record<Locale, string>>
+  /** Absolute base URL without trailing slash. */
+  siteUrl: string
+  /** Locale of the current page. */
+  currentLocale: Locale
+  /** List of supported locales. */
+  locales: readonly Locale[]
+  /** Default locale used for x-default. */
+  defaultLocale: Locale
+  /** Indicates the entry is the home page. */
+  isHome?: boolean
+  /**
+   * x-default behavior:
+   * - 'root'   => home x-default points to '/'
+   * - 'locale' => x-default always points to the default locale
+   */
+  xDefaultMode?: 'root' | 'locale'
+  /** Explicit canonical path overriding the computed one. */
+  canonicalPath?: string
+}
+
+export interface LocalizedLinks {
+  canonical: string
+  alternates: AlternateLink[]
+}
+
+/**
+ * Builds canonical and alternate links for a localized route.
+ */
+export function buildLocalizedLinks(options: BuildLocalizedLinksOptions): LocalizedLinks {
+  const {
+    paths,
+    siteUrl,
+    currentLocale,
+    locales,
+    defaultLocale,
+    isHome = false,
+    xDefaultMode = 'root',
+    canonicalPath,
+  } = options
+
+  const resolvedCanonicalPath = canonicalPath ?? pickBest(paths, currentLocale)
+  const canonical = `${siteUrl}${resolvedCanonicalPath}`
+
+  const alternates: AlternateLink[] = locales.map(locale => ({
+    hreflang: locale,
+    href: `${siteUrl}${pickBest(paths, locale)}`,
+  }))
+
+  const xDefaultPath = (xDefaultMode === 'root' && isHome)
+    ? '/'
+    : pickBest(paths, defaultLocale)
+  alternates.push({ hreflang: 'x-default', href: `${siteUrl}${xDefaultPath}` })
+
+  return { canonical, alternates }
+}

--- a/test/seo-links.test.ts
+++ b/test/seo-links.test.ts
@@ -1,0 +1,48 @@
+import type { Locale } from '../src/constants/locales'
+import { describe, expect, it } from 'vitest'
+import { buildLocalizedLinks, pickBest } from '../src/utils/seo-links'
+
+const locales: readonly Locale[] = ['fr', 'en']
+const siteUrl = 'https://example.com'
+
+describe('seo-links utilities', () => {
+  it('builds canonical and alternates for home', () => {
+    const { canonical, alternates } = buildLocalizedLinks({
+      paths: { fr: '/fr', en: '/en' },
+      siteUrl,
+      currentLocale: 'fr',
+      locales,
+      defaultLocale: 'en',
+      isHome: true,
+    })
+
+    expect(canonical).toBe(`${siteUrl}/fr`)
+    expect(alternates).toEqual([
+      { hreflang: 'fr', href: `${siteUrl}/fr` },
+      { hreflang: 'en', href: `${siteUrl}/en` },
+      { hreflang: 'x-default', href: `${siteUrl}/` },
+    ])
+  })
+
+  it('falls back when a translation is missing', () => {
+    const { canonical, alternates } = buildLocalizedLinks({
+      paths: { en: '/en/partial' },
+      siteUrl,
+      currentLocale: 'fr',
+      locales,
+      defaultLocale: 'en',
+    })
+
+    expect(canonical).toBe(`${siteUrl}/en/partial`)
+    expect(alternates).toEqual([
+      { hreflang: 'fr', href: `${siteUrl}/en/partial` },
+      { hreflang: 'en', href: `${siteUrl}/en/partial` },
+      { hreflang: 'x-default', href: `${siteUrl}/en/partial` },
+    ])
+  })
+
+  it('pickBest returns best available path', () => {
+    const paths: Partial<Record<Locale, string>> = { en: '/en/only' }
+    expect(pickBest(paths, 'fr')).toBe('/en/only')
+  })
+})


### PR DESCRIPTION
## Summary
- factor shared SEO helpers into `src/utils/seo-links.ts`
- use shared helpers and unified `SITE_URL` constant in sitemap generator and `useSeoHead`
- add unit tests for `pickBest` and `buildLocalizedLinks`

## Testing
- `pnpm test --run test/seo-links.test.ts test/seo-head.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a04785e9bc832ab128da21ef3b7584