### PR TITLE
feat: add OG locale metadata

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -449,6 +449,9 @@ declare global {
   export type { PwaEnvironment } from './composables/usePwaEnvironment'
   import('./composables/usePwaEnvironment')
   // @ts-ignore
+  export type { SeoHead } from './composables/useSeoHead'
+  import('./composables/useSeoHead')
+  // @ts-ignore
   export type { SlidingPuzzle, PuzzleDirection } from './composables/useSlidingPuzzle'
   import('./composables/useSlidingPuzzle')
   // @ts-ignore

--- a/src/composables/usePageHead.ts
+++ b/src/composables/usePageHead.ts
@@ -35,6 +35,12 @@ export function usePageHead(options: PageHeadOptions = {}) {
     const keywords
       = unref(options.keywords)
         ?? 'shlagemon, jeu, pokemon, parodie, capture, combat'
+    const currentLocale = seoHead.currentLocale.value
+    const alternateLocales = seoHead.alternateLocales.value
+    const ogLocaleMeta = [
+      { property: 'og:locale', content: currentLocale },
+      ...alternateLocales.map(locale => ({ property: 'og:locale:alternate', content: locale })),
+    ]
 
     return {
       title,
@@ -50,6 +56,7 @@ export function usePageHead(options: PageHeadOptions = {}) {
         { property: 'og:url', content: seoHead.canonicalUrl.value },
         { property: 'og:image', content: image },
         { property: 'og:site_name', content: 'Shlagémon' },
+        ...ogLocaleMeta,
         { name: 'twitter:card', content: 'summary_large_image' },
         { name: 'twitter:title', content: title },
         { name: 'twitter:description', content: description },

--- a/src/composables/useSeoHead.ts
+++ b/src/composables/useSeoHead.ts
@@ -1,3 +1,4 @@
+import type { Ref } from 'vue'
 import type { Locale } from '~/constants/locales'
 import type { AlternateLink } from '~/utils/seo-links'
 import { availableLocales, defaultLocale } from '~/constants/locales'
@@ -9,11 +10,27 @@ import { buildLocalizedLinks } from '~/utils/seo-links'
  * Manage canonical and alternate link tags based on the current route and locale.
  * Must be invoked from a component setup function.
  */
-export function useSeoHead() {
+export interface SeoHead {
+  /** Canonical URL for the current route. */
+  readonly canonicalUrl: Readonly<Ref<string>>
+  /** Locale resolved from the active route. */
+  readonly currentLocale: Readonly<Ref<Locale>>
+  /** Supported locales excluding the current one. */
+  readonly alternateLocales: Readonly<Ref<Locale[]>>
+}
+
+/**
+ * Manage canonical and alternate link tags based on the current route and locale.
+ * Must be invoked from a component setup function.
+ */
+export function useSeoHead(): SeoHead {
   const route = useRoute()
 
-  const locale = computed(() => String(route.meta.locale) as Locale)
-  const baseName = computed(() => String(route.name).replace(`${locale.value}-`, ''))
+  const currentLocale = computed<Locale>(() => {
+    const candidate = route.meta.locale as Locale | undefined
+    return availableLocales.includes(candidate as Locale) ? candidate as Locale : defaultLocale
+  })
+  const baseName = computed(() => String(route.name).replace(`${currentLocale.value}-`, ''))
   const entry = computed(() => localizedRoutes.find(r => r.name === baseName.value))
 
   const seoLinks = computed(() => {
@@ -24,7 +41,7 @@ export function useSeoHead() {
     return buildLocalizedLinks({
       paths,
       siteUrl: SITE_URL,
-      currentLocale: locale.value,
+      currentLocale: currentLocale.value,
       locales: availableLocales,
       defaultLocale,
       isHome: baseName.value === 'home',
@@ -38,8 +55,12 @@ export function useSeoHead() {
     ],
   }))
 
+  const alternateLocales = computed(() => availableLocales.filter(l => l !== currentLocale.value))
+
   return {
     canonicalUrl: computed(() => seoLinks.value.canonical),
+    currentLocale,
+    alternateLocales,
   }
 }
 

--- a/test/page-head-og-locale.test.ts
+++ b/test/page-head-og-locale.test.ts
@@ -1,0 +1,52 @@
+import type { RouteRecordRaw } from 'vue-router'
+import { createHead, renderSSRHead } from '@unhead/vue/server'
+import { describe, expect, it } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { renderToString } from 'vue/server-renderer'
+import usePageHead from '../src/composables/usePageHead'
+import { availableLocales } from '../src/constants/locales'
+import { i18n } from '../src/modules/i18n'
+import { localizedRoutes } from '../src/router/localizedRoutes'
+
+async function renderHead(path: string, routes: RouteRecordRaw[]) {
+  const head = createHead()
+  const router = createRouter({ history: createMemoryHistory(), routes })
+  router.push(path)
+  await router.isReady()
+
+  const app = createSSRApp({
+    setup() {
+      usePageHead()
+      return () => h('div')
+    },
+  })
+
+  app.use(router)
+  app.use(head)
+  app.use(i18n)
+
+  await renderToString(app)
+  const { headTags } = await renderSSRHead(head)
+  return headTags
+}
+
+describe('OG locale metadata', () => {
+  const routes: RouteRecordRaw[] = []
+  for (const locale of availableLocales) {
+    for (const entry of localizedRoutes) {
+      const path = entry.paths[locale]
+      routes.push({ path, name: `${locale}-${entry.name}`, component: { template: '<div />' }, meta: { locale } })
+    }
+  }
+
+  it('renders correct OG locale tags for every route', async () => {
+    for (const route of routes) {
+      const head = await renderHead(route.path, routes)
+      const current = route.meta?.locale as string
+      expect(head).toContain(`<meta property="og:locale" content="${current}"`)
+      for (const alt of availableLocales.filter(l => l !== current))
+        expect(head).toContain(`<meta property="og:locale:alternate" content="${alt}"`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- expose current and alternate locales via `useSeoHead`
- emit `og:locale` and `og:locale:alternate` meta tags in `usePageHead`
- test OG locale metadata for all localized routes

## Testing
- `pnpm test:unit` *(fails: Cannot call props on an empty VueWrapper, attack-throttle.test.ts failure, capture mechanics failure, dojo-dialog-flow.test.ts missing ResizeObserver, main-panel-breeding.test.ts assertion, page-head-og-locale.test.ts initially failing, page-locale-ssr.test.ts parse error, pwa-manifest.test.ts function missing, router-redirect.test.ts function missing, sort-item.test.ts assertion, and more)*
- `pnpm test:unit test/page-head-og-locale.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a04a72fdcc832a850470868cc53963