### PR TITLE
fix: complete breeding and dojo translations

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -856,8 +856,9 @@ components:
           - "Mission accomplished: it's full… and it laid an egg!"
           - I gave it all it needed… and bam! An egg.
           - "I didn't do things halfway: here's the egg!"
-          - "I stuffed it completely… result: a nice warm egg."
+          - 'I stuffed it completely… result: a nice warm egg.'
           - Filled with happiness… and here's an egg as a gift!
+      changeSelected: Change {name}
   settings:
     AccessibilityTab:
       autoHide:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -853,11 +853,12 @@ components:
           - Ohoh… {shlagemon_name}, prépare-toi pour un ensemencement magistral !
         completed:
           - ça y est je lui ai tout mis dedans, il a sorti un oeuf !
-          - "Mission accomplie : il est plein… et il a pondu !"
+          - 'Mission accomplie : il est plein… et il a pondu !'
           - Je lui ai mis tout ce qu’il fallait… et paf ! Un œuf.
-          - "Je n’ai pas fait les choses à moitié : voilà l’œuf !"
-          - "Je lui ai mis tout le paquet… résultat : un œuf bien chaud."
+          - 'Je n’ai pas fait les choses à moitié : voilà l’œuf !'
+          - 'Je lui ai mis tout le paquet… résultat : un œuf bien chaud.'
           - Rempli de bonheur… et voilà un œuf en cadeau !
+      changeSelected: Changer {name}
   settings:
     AccessibilityTab:
       autoHide:

--- a/src/components/dojo/MonPreview.vue
+++ b/src/components/dojo/MonPreview.vue
@@ -27,7 +27,7 @@ const rarityAfter = computed<number>(() => Math.min(100, props.mon.rarity + prop
     <div class="pointer-events-none">
       <span
         class="absolute left-0 right-0 top-0 border border-emerald-100 rounded-full px-2 py-0.5 text-center text-xs text-emerald-800 font-medium dark:border-emerald-900/50 dark:text-emerald-200"
-        aria-label="Rareté actuelle"
+        :aria-label="t('components.panel.Dojo.rarity.current')"
       >
         {{ t('components.panel.Dojo.rarity.current') }}: {{ mon.rarity }}
       </span>
@@ -35,7 +35,7 @@ const rarityAfter = computed<number>(() => Math.min(100, props.mon.rarity + prop
       <span
         class="absolute bottom-0 left-0 right-0 rounded-full bg-emerald-100 px-2 py-0.5 text-center text-xs text-emerald-800 font-medium dark:bg-emerald-900/50 dark:text-emerald-200"
         :class="rarityAfter === 100 ? 'mask-rainbow' : ''"
-        aria-label="Rareté après entraînement"
+        :aria-label="t('components.panel.Dojo.rarity.after')"
       >
         {{ t('components.panel.Dojo.rarity.after') }}: {{ rarityAfter }}
       </span>

--- a/src/components/panel/Breeding.i18n.yml
+++ b/src/components/panel/Breeding.i18n.yml
@@ -21,6 +21,7 @@ fr:
       - 'Je lui ai mis tout le paquet… résultat : un œuf bien chaud.'
       - Rempli de bonheur… et voilà un œuf en cadeau !
   selectMon: Choisir un Shlagémon
+  changeSelected: Changer {name}
   selected: Shlagémon sélectionné
   rarity: Rareté
   eggType: Type d'œuf
@@ -68,6 +69,7 @@ en:
       - 'I stuffed it completely… result: a nice warm egg.'
       - "Filled with happiness… and here's an egg as a gift!"
   selectMon: Choose a Shlagémon
+  changeSelected: Change {name}
   selected: Selected Shlagémon
   rarity: Rarity
   eggType: Egg type


### PR DESCRIPTION
## Summary
- add missing `changeSelected` key for breeding panel
- use i18n for dojo preview rarity aria-labels

## Testing
- `pnpm lint` *(fails: format/prettier and eslint errors)*
- `pnpm test:unit` *(fails: 12 failing tests, missing translations)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe8f9520832aa10c002db08910a2