### PR TITLE
feat: add generic shlagemon list

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -152,6 +152,7 @@ declare module 'vue' {
     ShlagemonEvolutionModal: typeof import('./components/shlagemon/EvolutionModal.vue')['default']
     ShlagemonImage: typeof import('./components/shlagemon/Image.vue')['default']
     ShlagemonList: typeof import('./components/shlagemon/List.vue')['default']
+    ShlagemonListGeneric: typeof import('./components/shlagemon/ListGeneric.vue')['default']
     ShlagemonListItem: typeof import('./components/shlagemon/ListItem.vue')['default']
     ShlagemonQuickSelect: typeof import('./components/shlagemon/QuickSelect.vue')['default']
     ShlagemonRarity: typeof import('./components/shlagemon/Rarity.vue')['default']

--- a/src/components/shlagemon/ListGeneric.i18n.yml
+++ b/src/components/shlagemon/ListGeneric.i18n.yml
@@ -1,0 +1,30 @@
+fr:
+  search: Rechercher
+  sort:
+    level: Niveau
+    rarity: Rareté
+    shiny: Shiny
+    item: Objet équipé
+    name: Nom
+    type: Type
+    attack: Attaque
+    defense: Défense
+    count: Nb obtentions
+    date: Première capture
+    evolution: Proche d'évoluer
+  new: 'Vous avez {n} nouveau Shlagémon | Vous avez {n} nouveaux Shlagémons'
+en:
+  search: Search
+  sort:
+    level: Level
+    rarity: Rarity
+    shiny: Shiny
+    item: Held item
+    name: Name
+    type: Type
+    attack: Attack
+    defense: Defense
+    count: Catch count
+    date: First capture
+    evolution: Ready to evolve
+  new: 'You have {n} new Shlagemon | You have {n} new Shlagemons'

--- a/src/components/shlagemon/ListGeneric.spec.ts
+++ b/src/components/shlagemon/ListGeneric.spec.ts
@@ -1,0 +1,71 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import ListGeneric from './ListGeneric.vue'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+const filterStore = { search: ref(''), sortBy: ref('level'), sortAsc: ref(true) }
+vi.mock('~/stores/dexFilter', () => ({ useDexFilterStore: () => filterStore }))
+
+const featureLockStore = { isShlagedexLocked: false }
+vi.mock('~/stores/featureLock', () => ({ useFeatureLockStore: () => featureLockStore }))
+
+const shlagemons = ref<any[]>([])
+const dexStore = { shlagemons, newCount: 0, markAllSeen: vi.fn() }
+vi.mock('~/stores/shlagedex', () => ({ useShlagedexStore: () => dexStore }))
+
+const stubs = {
+  LayoutScrollablePanel: { template: '<div><slot name="header"/><slot name="content"/></div>' },
+  UiSortControls: { template: '<div></div>' },
+  UiSearchInput: { template: '<input />' },
+  UiInfo: { template: '<div><slot /></div>' },
+  ShlagemonListItem: { template: '<div class="item" @click="$emit(\'click\')" @activate="$emit(\'activate\')" />' },
+  TransitionGroup: { template: '<div><slot /></div>' },
+}
+
+const type = { id: 'normal', name: 't', description: 'd', color: '#000', resistance: [], weakness: [], tags: [], passiveEffects: [] }
+function createMon(id = 'm1') {
+  return {
+    id,
+    base: { id: 'b1', name: 'test', description: 'd', types: [type], speciality: 'unique' },
+    baseStats: { hp: 1, attack: 1, defense: 1, smelling: 1 },
+    captureDate: '2024-01-01',
+    captureCount: 1,
+    lvl: 1,
+    xp: 0,
+    rarity: 1,
+    sex: 'male',
+    isShiny: false,
+    hpCurrent: 1,
+    allowEvolution: false,
+    hp: 1,
+    attack: 1,
+    defense: 1,
+    smelling: 1,
+    heldItemId: undefined,
+  }
+}
+
+describe('listGeneric', () => {
+  it('uses store shlagemons and emits callbacks', async () => {
+    const mon = createMon()
+    shlagemons.value = [mon]
+    const click = vi.fn()
+    const activate = vi.fn()
+    const wrapper = mount(ListGeneric, {
+      props: { onItemClick: click, onItemActivate: activate },
+      global: { stubs },
+    })
+
+    const item = wrapper.find('.item')
+    expect(item.exists()).toBe(true)
+
+    await item.trigger('click')
+    expect(click).toHaveBeenCalledWith(mon)
+
+    await item.trigger('activate')
+    expect(activate).toHaveBeenCalledWith(mon)
+  })
+})

--- a/src/components/shlagemon/ListGeneric.vue
+++ b/src/components/shlagemon/ListGeneric.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
+import { allItems } from '~/data/items'
+
+interface Props {
+  /** Display a checkbox next to each item. */
+  showCheckbox?: boolean
+  /** Disable items whose ids are in this list. */
+  disabledIds?: readonly string[]
+  /** Highlight the given ids regardless of search results. */
+  highlightIds?: readonly string[]
+  /** Mark this id as active. */
+  activeId?: string | null
+  /** Force the list into a locked state. */
+  locked?: boolean
+  /** Callback triggered when an item is clicked. */
+  onItemClick?: (mon: DexShlagemon) => void
+  /** Callback triggered when an item is activated. */
+  onItemActivate?: (mon: DexShlagemon) => void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showCheckbox: false,
+  disabledIds: () => [],
+  highlightIds: () => [],
+  activeId: null,
+  locked: undefined,
+})
+
+const { t } = useI18n()
+
+const filter = useDexFilterStore()
+const dex = useShlagedexStore()
+const featureLock = useFeatureLockStore()
+
+const isLocked = computed(() => props.locked ?? featureLock.isShlagedexLocked)
+
+const items = Object.fromEntries(allItems.map(i => [i.id, i])) as Record<string, typeof allItems[number]>
+const panelRef = ref<{ scrollToTop: () => void } | null>(null)
+
+const newCount = computed(() => dex.newCount)
+
+const sortOptions = [
+  { label: t('components.shlagemon.ListGeneric.sort.level'), value: 'level' },
+  { label: t('components.shlagemon.ListGeneric.sort.rarity'), value: 'rarity' },
+  { label: t('components.shlagemon.ListGeneric.sort.shiny'), value: 'shiny' },
+  { label: t('components.shlagemon.ListGeneric.sort.item'), value: 'item' },
+  { label: t('components.shlagemon.ListGeneric.sort.name'), value: 'name' },
+  { label: t('components.shlagemon.ListGeneric.sort.type'), value: 'type' },
+  { label: t('components.shlagemon.ListGeneric.sort.attack'), value: 'attack' },
+  { label: t('components.shlagemon.ListGeneric.sort.defense'), value: 'defense' },
+  { label: t('components.shlagemon.ListGeneric.sort.count'), value: 'count' },
+  { label: t('components.shlagemon.ListGeneric.sort.date'), value: 'date' },
+  { label: t('components.shlagemon.ListGeneric.sort.evolution'), value: 'evolution' },
+] as const
+
+const displayedMons = computed(() => {
+  const query = filter.search.trim().toLowerCase()
+  const filtered: DexShlagemon[] = []
+  for (const mon of dex.shlagemons) {
+    if (query && !t(mon.base.name).toLowerCase().includes(query))
+      continue
+    filtered.push(mon)
+  }
+  switch (filter.sortBy) {
+    case 'level':
+      filtered.sort((a, b) => a.lvl - b.lvl)
+      break
+    case 'rarity':
+      filtered.sort((a, b) => a.rarity - b.rarity)
+      break
+    case 'shiny':
+      filtered.sort((a, b) => Number(a.isShiny) - Number(b.isShiny))
+      break
+    case 'item':
+      filtered.sort((a, b) => Number(Boolean(a.heldItemId)) - Number(Boolean(b.heldItemId)))
+      break
+    case 'attack':
+      filtered.sort((a, b) => a.attack - b.attack)
+      break
+    case 'defense':
+      filtered.sort((a, b) => a.defense - b.defense)
+      break
+    case 'count':
+      filtered.sort((a, b) => a.captureCount - b.captureCount)
+      break
+    case 'date':
+      filtered.sort((a, b) => new Date(a.captureDate).getTime() - new Date(b.captureDate).getTime())
+      break
+    case 'name':
+      filtered.sort((a, b) => t(a.base.name).localeCompare(t(b.base.name)))
+      break
+    case 'type':
+      filtered.sort((a, b) => (a.base.types[0]?.name || '').localeCompare(b.base.types[0]?.name || ''))
+      break
+    case 'evolution':
+      filtered.sort((a, b) => evolutionDistance(a) - evolutionDistance(b))
+      break
+  }
+  if (!filter.sortAsc)
+    filtered.reverse()
+
+  const activeId = props.activeId
+  const highlightSet = new Set(props.highlightIds)
+
+  const active: DexShlagemon[] = []
+  const highlights: DexShlagemon[] = []
+  const others: DexShlagemon[] = []
+
+  for (const mon of filtered) {
+    if (activeId && mon.id === activeId) {
+      active.push(mon)
+    }
+    else if (highlightSet.has(mon.id) || mon.isNew) {
+      highlights.push(mon)
+    }
+    else {
+      others.push(mon)
+    }
+  }
+
+  return [...active, ...highlights, ...others]
+})
+
+function evolutionDistance(mon: DexShlagemon): number {
+  const evo = mon.base.evolution
+  if (!evo)
+    return Number.POSITIVE_INFINITY
+  if (!mon.allowEvolution)
+    return Number.POSITIVE_INFINITY
+  if (evo.condition.type === 'item')
+    return -2000
+  if (evo.condition.type === 'lvl') {
+    const diff = Math.abs(evo.condition.value - mon.lvl)
+    if (mon.lvl >= evo.condition.value)
+      return diff - 1000
+    return diff
+  }
+  return Number.POSITIVE_INFINITY
+}
+
+function handleClick(mon: DexShlagemon) {
+  if (props.disabledIds.includes(mon.id))
+    return
+  props.onItemClick?.(mon)
+}
+
+function handleActivate(mon: DexShlagemon) {
+  if (isLocked.value)
+    return
+  props.onItemActivate?.(mon)
+}
+
+function isActive(mon: DexShlagemon) {
+  return props.activeId === mon.id
+}
+
+function isHighlighted(mon: DexShlagemon) {
+  return props.highlightIds.includes(mon.id) || Boolean(mon.isNew)
+}
+
+watch(
+  () => props.activeId,
+  () => {
+    nextTick(() => panelRef.value?.scrollToTop())
+  },
+)
+</script>
+
+<template>
+  <LayoutScrollablePanel ref="panelRef">
+    <template #header>
+      <div class="sticky top-0 z-40 w-full flex flex-col gap-1 bg-white/70 backdrop-blur-lg dark:bg-gray-900/70">
+        <div class="flex items-center gap-1">
+          <UiSortControls
+            v-model:sort-by="filter.sortBy"
+            v-model:sort-asc="filter.sortAsc"
+            :options="sortOptions"
+          />
+          <span class="ml-auto select-none text-xs font-mono opacity-70">
+            {{ displayedMons.length }} / {{ dex.shlagemons.length }}
+          </span>
+        </div>
+        <div class="flex gap-1">
+          <UiSearchInput
+            v-model="filter.search"
+            :placeholder="t('components.shlagemon.ListGeneric.search')"
+          />
+        </div>
+      </div>
+    </template>
+
+    <template #content>
+      <TransitionGroup name="fade-list" tag="div" class="grid grid-cols-1 gap-1">
+        <div v-if="newCount > 0" class="mb-1">
+          <UiInfo
+            color="info"
+            class="col-span-2 row-start-3"
+            ok-button
+            @ok="dex.markAllSeen"
+          >
+            {{ t('components.shlagemon.ListGeneric.new', newCount) }}
+          </UiInfo>
+        </div>
+        <ShlagemonListItem
+          v-for="mon in displayedMons"
+          :key="mon.id"
+          :mon="mon"
+          :is-active="isActive(mon)"
+          :is-highlighted="isHighlighted(mon)"
+          :disabled="props.disabledIds.includes(mon.id)"
+          :locked="isLocked"
+          :item="mon.heldItemId ? items[mon.heldItemId] : null"
+          :show-checkbox="props.showCheckbox"
+          @click="() => handleClick(mon)"
+          @activate="() => handleActivate(mon)"
+        />
+      </TransitionGroup>
+    </template>
+  </LayoutScrollablePanel>
+</template>
+
+<style scoped>
+.fade-list-move,
+.fade-list-enter-active,
+.fade-list-leave-active {
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.fade-list-enter-from,
+.fade-list-leave-to {
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+}
+.fade-list-leave-active {
+  position: absolute;
+}
+</style>


### PR DESCRIPTION
## Summary
- add `ListGeneric` component fetching Shlagemon list from store
- expose callbacks for item click and activation
- provide translations and basic unit test

## Testing
- `pnpm lint` *(fails: This line has 4 statements. Maximum allowed is 1)*
- `pnpm test:unit` *(fails: ReferenceError: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a062f88768832a8f428d392354939b