### PR TITLE
refactor: integrate ShlagemonListGeneric in Shlagedex

### DIFF
--- a/src/components/panel/Shlagedex.i18n.yml
+++ b/src/components/panel/Shlagedex.i18n.yml
@@ -1,0 +1,4 @@
+fr:
+  new: 'Vous avez {n} nouveau Shlagémon | Vous avez {n} nouveaux Shlagémons'
+en:
+  new: 'You have {n} new Shlagemon | You have {n} new Shlagemons'

--- a/src/components/panel/Shlagedex.vue
+++ b/src/components/panel/Shlagedex.vue
@@ -1,10 +1,39 @@
 <script setup lang="ts">
 import type { DexShlagemon } from '~/type/shlagemon'
+import { multiExp } from '~/data/items'
 
+const { t } = useI18n()
 const dex = useShlagedexStore()
+const equipment = useEquipmentStore()
+const inventory = useInventoryStore()
+const wearableItem = useWearableItemStore()
+const dexDetailModal = useDexDetailModalStore()
+
 const showDetail = ref(false)
 const detailMon = ref<DexShlagemon | null>(dex.activeShlagemon)
 
+/** Number of newly obtained Shlagémons not yet acknowledged. */
+const newCount = computed(() => dex.newCount)
+/** Shlagémon currently holding the Multi Exp, if any. */
+const multiExpHolder = computed(() => {
+  const holderId = equipment.getHolder(multiExp.id)
+  return holderId ? dex.shlagemons.find(m => m.id === holderId) || null : null
+})
+
+/** Whether the player owns the Multi Exp, either equipped or in inventory. */
+const ownsMultiExp = computed(() => {
+  return (inventory.items[multiExp.id] || 0) > 0 || Boolean(multiExpHolder.value)
+})
+
+/** Handle click on the Multi Exp button. */
+function handleMultiExpClick() {
+  if (multiExpHolder.value)
+    dexDetailModal.open(multiExpHolder.value)
+  else
+    wearableItem.open(multiExp)
+}
+
+/** Open the detail modal for a given Shlagémon. */
 function open(mon: DexShlagemon | null) {
   if (mon) {
     dex.markSeen(mon)
@@ -13,18 +42,46 @@ function open(mon: DexShlagemon | null) {
   }
 }
 
+/** Forwarded click handler from the list component. */
 function onItemClick(mon: DexShlagemon) {
   open(mon)
 }
 </script>
 
 <template>
-  <ShlagemonList
-    :mons="dex.shlagemons"
+  <ShlagemonListGeneric
     show-checkbox
-    is-main-shlagedex
+    :active-id="dex.activeShlagemon?.id"
     :on-item-click="onItemClick"
-  />
+    :on-item-activate="dex.setActiveShlagemon"
+  >
+    <template #header-extra>
+      <UiButton
+        v-if="ownsMultiExp"
+        v-tooltip="t(multiExp.name)"
+        :class="{ 'saturate-0': !multiExpHolder }"
+        icon
+        size="xs"
+        variant="outline"
+        type="primary"
+        @click="handleMultiExpClick"
+      >
+        <span :class="[multiExp.icon, multiExp.iconClass]" />
+      </UiButton>
+    </template>
+    <template #content-top>
+      <div v-if="newCount > 0" class="mb-1">
+        <UiInfo
+          color="info"
+          class="col-span-2 row-start-3"
+          ok-button
+          @ok="dex.markAllSeen"
+        >
+          {{ t('components.panel.Shlagedex.new', newCount) }}
+        </UiInfo>
+      </div>
+    </template>
+  </ShlagemonListGeneric>
   <UiModal
     v-model="showDetail"
     footer-close

--- a/src/components/shlagemon/ListGeneric.i18n.yml
+++ b/src/components/shlagemon/ListGeneric.i18n.yml
@@ -12,7 +12,6 @@ fr:
     count: Nb obtentions
     date: Première capture
     evolution: Proche d'évoluer
-  new: 'Vous avez {n} nouveau Shlagémon | Vous avez {n} nouveaux Shlagémons'
 en:
   search: Search
   sort:
@@ -27,4 +26,3 @@ en:
     count: Catch count
     date: First capture
     evolution: Ready to evolve
-  new: 'You have {n} new Shlagemon | You have {n} new Shlagemons'

--- a/src/components/shlagemon/ListGeneric.vue
+++ b/src/components/shlagemon/ListGeneric.vue
@@ -38,8 +38,6 @@ const isLocked = computed(() => props.locked ?? featureLock.isShlagedexLocked)
 const items = Object.fromEntries(allItems.map(i => [i.id, i])) as Record<string, typeof allItems[number]>
 const panelRef = ref<{ scrollToTop: () => void } | null>(null)
 
-const newCount = computed(() => dex.newCount)
-
 const sortOptions = [
   { label: t('components.shlagemon.ListGeneric.sort.level'), value: 'level' },
   { label: t('components.shlagemon.ListGeneric.sort.rarity'), value: 'rarity' },
@@ -186,22 +184,14 @@ watch(
             v-model="filter.search"
             :placeholder="t('components.shlagemon.ListGeneric.search')"
           />
+          <slot name="header-extra" />
         </div>
       </div>
     </template>
 
     <template #content>
       <TransitionGroup name="fade-list" tag="div" class="grid grid-cols-1 gap-1">
-        <div v-if="newCount > 0" class="mb-1">
-          <UiInfo
-            color="info"
-            class="col-span-2 row-start-3"
-            ok-button
-            @ok="dex.markAllSeen"
-          >
-            {{ t('components.shlagemon.ListGeneric.new', newCount) }}
-          </UiInfo>
-        </div>
+        <slot name="content-top" />
         <ShlagemonListItem
           v-for="mon in displayedMons"
           :key="mon.id"

--- a/src/components/shlagemon/QuickSelect.vue
+++ b/src/components/shlagemon/QuickSelect.vue
@@ -27,10 +27,11 @@ function choose(mon: DexShlagemon) {
 </script>
 
 <template>
-  <ShlagemonList
-    :mons="dex.shlagemons"
+  <ShlagemonListGeneric
     :highlight-ids="props.selected"
     :on-item-click="choose"
+    :on-item-activate="choose"
     :locked="props.locked"
+    :active-id="dex.activeShlagemon?.id"
   />
 </template>

--- a/test/feature-lock.test.ts
+++ b/test/feature-lock.test.ts
@@ -3,7 +3,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { describe, expect, it, vi } from 'vitest'
 import InventoryPanel from '../src/components/panel/Inventory.vue'
 import ZonePanel from '../src/components/panel/Zone.vue'
-import ShlagemonList from '../src/components/shlagemon/List.vue'
+import ShlagemonListGeneric from '../src/components/shlagemon/ListGeneric.vue'
 // Zone button components must be registered explicitly in tests because
 // automatic component registration is not available in the unit test environment.
 import ZoneButtonVillage from '../src/components/zone/ButtonVillage.vue'
@@ -45,8 +45,8 @@ describe('feature lock flags', () => {
     dex.createShlagemon(carapouffe)
     const featureLock = useFeatureLockStore()
     featureLock.lockShlagedex()
-    const wrapper = mount(ShlagemonList, {
-      props: { mons: dex.shlagemons, showCheckbox: true },
+    const wrapper = mount(ShlagemonListGeneric, {
+      props: { showCheckbox: true },
       global: { plugins: [pinia], directives: { tooltip: () => {} } },
     })
     await wrapper.vm.$nextTick()
@@ -61,8 +61,8 @@ describe('feature lock flags', () => {
     dex.createShlagemon(carapouffe)
     const featureLock = useFeatureLockStore()
     featureLock.lockShlagedex()
-    const wrapper = mount(ShlagemonList, {
-      props: { mons: dex.shlagemons, showCheckbox: true, locked: false },
+    const wrapper = mount(ShlagemonListGeneric, {
+      props: { showCheckbox: true, locked: false },
       global: { plugins: [pinia], directives: { tooltip: () => {} } },
     })
     await wrapper.vm.$nextTick()


### PR DESCRIPTION
## Summary
- replace ShlagemonList with ShlagemonListGeneric
- expose header and content slots for custom buttons and info
- handle Multi Exp button and new Shlagémon counter in Shlagedex

## Testing
- `pnpm test` *(fails: 14 failed, 273 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a064d6e1a8832aac6087f533fcbaa3