### PR TITLE
feat(select-modal): support selection state

### DIFF
--- a/src/components/shlagemon/SelectModal.i18n.yml
+++ b/src/components/shlagemon/SelectModal.i18n.yml
@@ -1,4 +1,6 @@
 fr:
   noAvailable: Aucun Shlagémon disponible.
+  locked: Sélection verrouillée.
 en:
   noAvailable: No Shlagemon available.
+  locked: Selection locked.

--- a/src/components/shlagemon/SelectModal.vue
+++ b/src/components/shlagemon/SelectModal.vue
@@ -11,7 +11,9 @@ interface Props {
   /** Displayed title of the modal. */
   title: string
   /** IDs of pre-selected Shlagémons. */
-  selected?: string[]
+  selectedIds?: string[]
+  /** IDs of disabled Shlagémons. */
+  disabledIds?: string[]
   /** Disable selection interactions. */
   locked?: boolean
   /** Whether selecting also sets the active combatant. */
@@ -21,7 +23,8 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  selected: () => [],
+  selectedIds: () => [],
+  disabledIds: () => [],
   locked: false,
   selectsActive: true,
 })
@@ -37,9 +40,16 @@ const headingId = computed(() => props.titleId || defaultTitleId)
 const dex = useShlagedexStore()
 const { t } = useI18n()
 
-function onSelect(mon: DexShlagemon) {
+function handleClick(mon: DexShlagemon) {
+  if (props.selectsActive)
+    dex.setActiveShlagemon(mon)
   emit('select', mon)
   open.value = false
+}
+
+function handleActivate(mon: DexShlagemon) {
+  if (props.selectsActive)
+    dex.setActiveShlagemon(mon)
 }
 </script>
 
@@ -49,13 +59,18 @@ function onSelect(mon: DexShlagemon) {
       <h3 :id="headingId" class="text-center text-lg font-bold">
         {{ title }}
       </h3>
-      <ShlagemonQuickSelect
+      <p v-if="locked" class="text-center text-sm">
+        {{ t('components.shlagemon.SelectModal.locked') }}
+      </p>
+      <ShlagemonListGeneric
         v-if="dex.shlagemons.length"
         class="max-h-60vh"
-        :selected="selected"
+        :highlight-ids="selectedIds"
+        :disabled-ids="disabledIds"
         :locked="locked"
-        :selects-active="selectsActive"
-        @select="onSelect"
+        :active-id="dex.activeShlagemon?.id"
+        :on-item-click="handleClick"
+        :on-item-activate="selectsActive ? handleActivate : undefined"
       />
       <p v-else class="text-center text-sm">
         {{ t('components.shlagemon.SelectModal.noAvailable') }}


### PR DESCRIPTION
## Summary
- replace QuickSelect with ListGeneric in selection modal
- allow preselecting and disabling shlagemons
- show lock message and emit select event on click

## Testing
- `pnpm test:unit` *(fails: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a06a5b8018832a8d69d7bd44d79088