### PR TITLE
refactor: unify shlagemon selection modal

### DIFF
--- a/src/components/arena/Panel.vue
+++ b/src/components/arena/Panel.vue
@@ -198,15 +198,14 @@ onUnmounted(() => {
             </UiButton>
           </div>
         </div>
-        <UiModal v-model="showDex">
-          <ArenaSelectionModal
-            v-if="selectedEnemy"
-            :mon="selectedEnemy"
-            :selected="arena.selections.filter(Boolean) as string[]"
-            :initial="currentSelection"
-            @select="onMonSelected"
-          />
-        </UiModal>
+        <ArenaSelectionModal
+          v-if="selectedEnemy"
+          v-model="showDex"
+          :mon="selectedEnemy"
+          :selected="arena.selections.filter(Boolean) as string[]"
+          :initial="currentSelection"
+          @select="onMonSelected"
+        />
       </div>
     </div>
     <div v-if="showDuel" class="h-full w-full flex flex-1 flex-col items-center gap-2">

--- a/src/components/arena/SelectionModal.vue
+++ b/src/components/arena/SelectionModal.vue
@@ -2,10 +2,14 @@
 import type { DexShlagemon } from '~/type/shlagemon'
 
 interface Props {
+  /** Whether the modal is visible. */
+  modelValue: boolean
+  /** Opponent currently targeted. */
   mon: DexShlagemon
+  /** IDs already selected for the team. */
   selected: string[]
   /**
-   * Currently selected Shlagemon for the opened slot.
+   * Shlagémon pre-selected when opening the modal.
    */
   initial?: DexShlagemon | null
 }
@@ -13,11 +17,13 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   initial: null,
 })
+
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'select', mon: DexShlagemon): void
 }>()
 
+const open = useVModel(props, 'modelValue', emit)
 const { t } = useI18n()
 
 const candidate = ref<DexShlagemon | null>(props.initial)
@@ -29,10 +35,6 @@ watch(
   },
 )
 
-function close() {
-  emit('update:modelValue', false)
-}
-
 function onSelect(mon: DexShlagemon) {
   candidate.value = mon
 }
@@ -41,20 +43,22 @@ function confirm() {
   if (!candidate.value)
     return
   emit('select', candidate.value)
-  close()
+  open.value = false
 }
 </script>
 
 <template>
-  <div class="h-full flex flex-col gap-2 overflow-hidden">
-    <h3 class="mb-2 text-center text-lg font-bold">
-      {{ t('components.arena.SelectionModal.title', { name: t(props.mon.base.name) }) }}
-    </h3>
+  <ShlagemonSelectModal
+    v-model="open"
+    :title="t('components.arena.SelectionModal.title', { name: t(props.mon.base.name) })"
+    :selected-ids="props.selected"
+    :close-on-select="false"
+    @select="onSelect"
+  >
     <ArenaEnemyStatsCompact :mon="props.mon" enemy />
-    <ShlagemonQuickSelect class="flex-1" :selected="props.selected" @select="onSelect" />
     <ArenaEnemyStatsCompact v-if="candidate" :mon="candidate" />
     <UiButton v-if="candidate" class="mt-2" type="primary" @click="confirm">
       {{ t('components.arena.SelectionModal.confirm') }}
     </UiButton>
-  </div>
+  </ShlagemonSelectModal>
 </template>

--- a/src/components/inventory/OdorElixirModal.vue
+++ b/src/components/inventory/OdorElixirModal.vue
@@ -4,7 +4,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 const store = useOdorElixirStore()
 const { t } = useI18n()
 
-const itemName = computed(() => store.current ? t(store.current.name) : '')
+const itemName = computed(() => (store.current ? t(store.current.name) : ''))
 
 function select(mon: DexShlagemon) {
   store.useOn(mon)
@@ -12,19 +12,9 @@ function select(mon: DexShlagemon) {
 </script>
 
 <template>
-  <UiModal v-model="store.isVisible" footer-close>
-    <div class="flex flex-col gap-2">
-      <h3 class="text-center text-lg font-bold">
-        {{ store.current ? t('components.inventory.OdorElixirModal.title', { name: itemName }) : '' }}
-      </h3>
-      <ShlagemonQuickSelect
-        v-if="store.availableMons.length"
-        class="max-h-60vh"
-        @select="select"
-      />
-      <p v-else class="text-center text-sm">
-        {{ t('components.inventory.OdorElixirModal.noAvailable') }}
-      </p>
-    </div>
-  </UiModal>
+  <ShlagemonSelectModal
+    v-model="store.isVisible"
+    :title="store.current ? t('components.inventory.OdorElixirModal.title', { name: itemName }) : ''"
+    @select="select"
+  />
 </template>

--- a/src/components/inventory/WearableItemModal.vue
+++ b/src/components/inventory/WearableItemModal.vue
@@ -3,7 +3,6 @@ import type { DexShlagemon } from '~/type/shlagemon'
 import { multiExp } from '~/data/items'
 
 const store = useWearableItemStore()
-const dex = useShlagedexStore()
 const { t } = useI18n()
 
 const itemName = computed(() => (store.current ? t(store.current.name) : ''))
@@ -15,21 +14,11 @@ function select(mon: DexShlagemon) {
 </script>
 
 <template>
-  <UiModal v-model="store.isVisible" footer-close>
-    <div class="flex flex-col gap-2">
-      <h3 class="text-center text-lg font-bold">
-        {{ store.current ? t('components.inventory.WearableItemModal.title', { name: itemName }) : '' }}
-      </h3>
-      <ShlagemonQuickSelect
-        v-if="dex.shlagemons.length"
-        class="max-h-60vh"
-        :selected="store.holderId ? [store.holderId] : []"
-        :selects-active="selectsActive"
-        @select="select"
-      />
-      <p v-else class="text-center text-sm">
-        {{ t('components.inventory.WearableItemModal.noAvailable') }}
-      </p>
-    </div>
-  </UiModal>
+  <ShlagemonSelectModal
+    v-model="store.isVisible"
+    :title="store.current ? t('components.inventory.WearableItemModal.title', { name: itemName }) : ''"
+    :selected-ids="store.holderId ? [store.holderId] : []"
+    :selects-active="selectsActive"
+    @select="select"
+  />
 </template>

--- a/src/components/panel/Dojo.vue
+++ b/src/components/panel/Dojo.vue
@@ -231,18 +231,6 @@ const ids = {
         title-id="dojo-select-title"
         @select="selectMon"
       />
-
-      <!-- Sélecteur -->
-      <UiModal v-model="selectorOpen" role="dialog" aria-modal="true" aria-labelledby="dojo-select-title">
-        <div class="max-w-160 flex flex-col gap-2">
-          <h3 id="dojo-select-title" class="text-center text-lg font-bold">
-            {{ t('components.panel.Dojo.selectMon') }}
-          </h3>
-          <div class="max-h-80 min-h-0 overflow-y-auto">
-            <ShlagemonQuickSelect @select="selectMon" />
-          </div>
-        </div>
-      </UiModal>
     </template>
     <template #footer>
       <div class="w-full flex justify-end gap-1 md:flex-nowrap md:justify-end">

--- a/src/components/shlagemon/SelectModal.vue
+++ b/src/components/shlagemon/SelectModal.vue
@@ -18,6 +18,11 @@ interface Props {
   locked?: boolean
   /** Whether selecting also sets the active combatant. */
   selectsActive?: boolean
+  /**
+   * Close the modal automatically when a Shlagémon is selected.
+   * Defaults to `true` to preserve current behaviour.
+   */
+  closeOnSelect?: boolean
   /** Optional ID for the title element (used for aria-labelledby). */
   titleId?: string
 }
@@ -27,6 +32,7 @@ const props = withDefaults(defineProps<Props>(), {
   disabledIds: () => [],
   locked: false,
   selectsActive: true,
+  closeOnSelect: true,
 })
 
 const emit = defineEmits<{
@@ -44,7 +50,8 @@ function handleClick(mon: DexShlagemon) {
   if (props.selectsActive)
     dex.setActiveShlagemon(mon)
   emit('select', mon)
-  open.value = false
+  if (props.closeOnSelect)
+    open.value = false
 }
 
 function handleActivate(mon: DexShlagemon) {
@@ -75,6 +82,7 @@ function handleActivate(mon: DexShlagemon) {
       <p v-else class="text-center text-sm">
         {{ t('components.shlagemon.SelectModal.noAvailable') }}
       </p>
+      <slot />
     </div>
   </UiModal>
 </template>

--- a/test/arena-selection-modal.test.ts
+++ b/test/arena-selection-modal.test.ts
@@ -62,7 +62,7 @@ function createI18nInstance() {
 }
 
 const globalStubs = {
-  ShlagemonQuickSelect: { name: 'ShlagemonQuickSelect', template: '<div />' },
+  ShlagemonSelectModal: { name: 'ShlagemonSelectModal', template: '<div><slot /></div>' },
   ShlagemonImage: true,
   ShlagemonRarityInfo: { name: 'ShlagemonRarityInfo', template: '<div />' },
   RarityInfo: { name: 'RarityInfo', template: '<div />' },
@@ -88,7 +88,7 @@ describe('arena selection modal', () => {
     const enemy = createMon('enemy', 5)
     const candidate = createMon('candidate', 7)
 
-    const wrapper = mountModal({ mon: enemy, selected: [] })
+    const wrapper = mountModal({ mon: enemy, selected: [], modelValue: true })
     ;(wrapper.vm as unknown as { candidate: DexShlagemon | null }).candidate = candidate
     await nextTick()
 
@@ -104,7 +104,7 @@ describe('arena selection modal', () => {
     const first = createMon('first', 6)
     const second = createMon('second', 8)
 
-    const wrapper = mountModal({ mon: enemy, selected: [], initial: first })
+    const wrapper = mountModal({ mon: enemy, selected: [], initial: first, modelValue: true })
     expect(wrapper.text()).toContain('lvl 6')
 
     await wrapper.setProps({ initial: second })

--- a/test/breeding.test.ts
+++ b/test/breeding.test.ts
@@ -115,7 +115,6 @@ const globalStubs = {
   UiAdaptiveDisplayer: { template: '<div><slot /></div>' },
   UiCurrencyAmount: { template: '<span />' },
   UiModal: { template: '<div><slot /></div>' },
-  ShlagemonQuickSelect: { template: '<div />' },
   ShlagemonSelectModal: { template: '<div />' },
   UiImageByBackground: { props: ['src'], template: '<img :src="src" />' },
 }

--- a/test/dojo-dialog-flow.test.ts
+++ b/test/dojo-dialog-flow.test.ts
@@ -7,6 +7,13 @@ import DialogBox from '../src/components/dialog/Box.vue'
 import Dojo from '../src/components/panel/Dojo.vue'
 import PoiDialogFlow from '../src/components/panel/PoiDialogFlow.vue'
 
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', ResizeObserver)
+
 vi.mock('../src/modules/toast', () => ({
   toast: { success: vi.fn() },
 }))
@@ -76,7 +83,7 @@ const globalStubs = {
   UiAdaptiveDisplayer: { template: '<div><slot /></div>' },
   UiCurrencyAmount: { template: '<span />' },
   UiModal: { template: '<div><slot /></div>' },
-  ShlagemonQuickSelect: { template: '<div />' },
+  ShlagemonSelectModal: { template: '<div />' },
   UiNumberInput: { props: ['modelValue'], emits: ['update:modelValue', 'input'], template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value); $emit(\'input\', $event.target.value)" />' },
   ShlagemonImage: { template: '<div />' },
   CharacterImage: { template: '<div />' },

--- a/test/main-panel-breeding.test.ts
+++ b/test/main-panel-breeding.test.ts
@@ -84,7 +84,6 @@ const globalStubs = {
   UiAdaptiveDisplayer: { name: 'UiAdaptiveDisplayer', template: '<div><slot /></div>' },
   UiCurrencyAmount: { template: '<span />' },
   UiModal: { template: '<div><slot /></div>' },
-  ShlagemonQuickSelect: { template: '<div />' },
   ShlagemonSelectModal: { template: '<div />' },
   UiImageByBackground: { props: ['src'], template: '<img :src="src" />' },
 }


### PR DESCRIPTION
## Summary
- replace bespoke quick selectors with `ShlagemonSelectModal`
- expose optional auto-close behaviour and slot in `ShlagemonSelectModal`
- adapt arena, inventory and dojo flows to the new modal

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: tests failed – watching for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_68a06d98d1ac832aaf4252cc4e7ccd5e