### PR TITLE
chore: refresh shlagemon locales

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,6 +2,12 @@ App:
   title: Shlagemon - It smells very strong
   description: Catch all the Shlagémons in this hilarious parody game! Collect absurd monsters, engage in wacky battles, and save the planet from a totally crazy invasion. Download now and become the ultimate Shlagitrainer!
   author: Aife
+common:
+  loading: Loading…
+  pleaseWait: Please wait
+  copy: Copy
+  remove: Remove
+  eggOf: Egg of {name}
 components:
   LanguageSelector:
     label: Language
@@ -67,7 +73,7 @@ components:
       captured: You captured {name}!
       fail: Missed!
     DiseaseBadge:
-      tooltip: "Sick: {n} battles remaining"
+      tooltip: 'Sick: {n} battles remaining'
     EffectBadge:
       attack: Your attack is boosted for {remaining} more
       defense: Your defense is boosted for {remaining} more
@@ -99,13 +105,13 @@ components:
       defeat: Defeat...
       queen: queen
       king: king
-      zoneKingChallenge: "{label} zone challenge"
+      zoneKingChallenge: '{label} zone challenge'
       reward: +{amount} Shlagidiamonds
     damageTaken: Took {amount} damage
     healedFor: Healed for {amount} HP
   deck:
     Detail:
-      evolution: "Evolution:"
+      evolution: 'Evolution:'
       level: lvl {n}
     List:
       search: Search
@@ -127,7 +133,7 @@ components:
             retry: Retry
             quit: Quit
     ArenaVictoryDialog:
-      toast: "{name} obtained!"
+      toast: '{name} obtained!'
       steps:
         step1:
           text: Congratulations! You triumphed at the arena.
@@ -232,7 +238,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "Let me tell you about a curious item: the Cuck Ring."
+          text: 'Let me tell you about a curious item: the Cuck Ring.'
           responses:
             back: Back
             next: Continue
@@ -242,7 +248,7 @@ components:
             back: Back
             next: Continue
         step4:
-          text: "It makes each attack unpredictable: double damage or healing the foe instead."
+          text: 'It makes each attack unpredictable: double damage or healing the foe instead.'
           responses:
             back: Back
             next: Continue
@@ -365,7 +371,7 @@ components:
           responses:
             next: Continue
         step2:
-          text: "As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP."
+          text: 'As {name}, I am proud of you. To help you on your adventure, I will give you a very special item: the Multi-EXP.'
           responses:
             back: Back
             next: Continue
@@ -599,7 +605,7 @@ components:
         step1:
           text: Impressive! You've captured at least {count} Shlagemons.
         step2:
-          text: "Here is a unique item: {name}."
+          text: 'Here is a unique item: {name}.'
         step3:
           text: It increases the holder's {stat} by {percent}%.
         step4:
@@ -676,7 +682,7 @@ components:
         - You're one step away from a brain fart.
         - Rarely seen someone so pathetic.
       validate: Validate
-      attemptsLeft: "{n} attempts left"
+      attemptsLeft: '{n} attempts left'
       win: You've cracked a Shlag's mind!
       lose: Even a Grimer would have done it
       legend:
@@ -685,7 +691,7 @@ components:
         absent: Not in the combination
       selectSlot: Select a slot
     Pairs:
-      attempts: "{n} attempt | {n} attempts"
+      attempts: '{n} attempt | {n} attempts'
     masterMind:
       SelectionModal:
         title: Choose a Shlagemon
@@ -703,9 +709,91 @@ components:
       intro1: The Shlagedex bonus increases the final damage of all your Shlagémons! It represents the maximum bonus you could get by capturing all accessible Shlagémons.
       intro2: It is based on the completion rate of this potential Shlagedex as well as your team's average level.
       formula: Bonus = average level × 2 × (completion rate / 100) / 10
-      completion: "Completion:"
-      averageLevel: "Average level:"
-      currentBonus: "Current bonus:"
+      completion: 'Completion:'
+      averageLevel: 'Average level:'
+      currentBonus: 'Current bonus:'
+    Breeding:
+      title: Breeding
+      exit: Leave the breeding center
+      intro: Hello, I can seed your Shlagémons for you—I'm a pro at it, just hand me one!
+      outro:
+        running: I'll take care of the breeding right away, you can come back very soon.
+        idle: Come back very soon, I can't wait to take care of your Shlagémons.
+      during:
+        unselected: Give me one of your Shlagémons, I'll seed it with tenderness and love!
+        selected:
+          - Oh! I love your {shlagemon_name}, I'll seed that one real good!
+          - Oh, this one… I can tell it'll take the seed nicely!
+          - Mmmh… perfect for some deep seeding!
+          - Watch out {shlagemon_name}, it's going to be a heavy seeding here!
+          - Ohoh… {shlagemon_name}, get ready for a masterful seeding!
+        completed:
+          - All done, I put everything in and it popped out an egg!
+          - "Mission accomplished: it's full… and it laid an egg!"
+          - I gave it all it needed… and bam! An egg.
+          - "I didn't do things halfway: here's the egg!"
+          - 'I stuffed it completely… result: a nice warm egg.'
+          - Filled with happiness… and here's an egg as a gift!
+      selectMon: Choose a Shlagémon
+      changeSelected: Change {name}
+      selected: Selected Shlagémon
+      rarity: Rarity
+      eggType: Egg type
+      cost: Cost
+      duration: Duration
+      minutes: minutes
+      progress: Progress
+      remaining: Remaining time
+      cta:
+        payAndStart: Pay & start
+        changeMon: Change Shlagémon
+        collectEgg: Collect egg
+      toast:
+        started: Breeding started!
+        finished: Egg obtained!
+        collected: Egg collected!
+      status:
+        running: Breeding in progress
+      a11y:
+        openSelector: Choose parent
+        startBreeding: Start breeding
+        changeParent: Change parent
+        collectEgg: Collect egg
+        normanCareMessage: Reassuring message from Norman
+    Dojo:
+      title: Dojo
+      exit: Leave the dojo
+      intro: Welcome to the dojo. Here you can train your Shlagémons.
+      outro:
+        running: Your Shlagémon is training. Come back later to see the results.
+        idle: No training in progress. Come back whenever you want to strengthen your Shlagémons.
+      selectMon: Train a Shlagémon
+      selected: Selected Shlagémon
+      controls: Controls
+      rarity:
+        current: Current rarity
+        after: Rarity after
+        points: Training points
+        limitReached: Cannot exceed 100 rarity.
+      cost:
+        label: Cost
+        insufficient: Insufficient funds
+      duration:
+        label: Duration
+        minute: minute
+        minutes: minutes
+        remaining: Remaining time
+        endsAt: Ends at {time}
+      progress: Progress
+      status:
+        running: Training in progress
+      cta:
+        payAndStart: Pay & start
+        changeMon: Change Shlagémon
+        trainingRunning: Training in progress
+      toast:
+        started: Training started!
+        finished: Training finished! Rarity improved.
     Inventory:
       search: Search
       sort:
@@ -722,7 +810,7 @@ components:
     MiniGame:
       exit: Exit
     PlayerInfos:
-      sick: "Sick: {n} battles left"
+      sick: 'Sick: {n} battles left'
       dex: ShlageDex
       averageLevel: Average level
       bonus: Bonus
@@ -731,6 +819,10 @@ components:
     Poulailler:
       title: Henhouse
       exit: Exit
+      intro: Welcome to the henhouse. Keep an eye on your eggs.
+      outro:
+        running: I'll take care of your eggs, don't worry I won't steal a single one, come back soon to see them hatch!
+        idle: Come back whenever you want to hatch Shlagémon eggs
       incubator: Incubator
       noEgg: No egg
       yourEggs: Your eggs
@@ -745,12 +837,10 @@ components:
       a11y:
         showSpecies: Show species for {name}
         incubateEgg: Incubate the {name} egg
-        eggReady: "{type} egg ready"
+        eggReady: '{type} egg ready'
         eggProgress: Egg progress
-      intro: Welcome to the henhouse. Keep an eye on your eggs.
-      outro:
-        running: I'll take care of your eggs, don't worry I won't steal a single one, come back soon to see them hatch!
-        idle: Come back whenever you want to hatch Shlagémon eggs
+    Shlagedex:
+      new: You have {n} new Shlagemon | You have {n} new Shlagemons
     Shop:
       title: Shop
       details: Details
@@ -768,97 +858,15 @@ components:
       exit: Leave the village
     Zone:
       capturedAlt: captured
-    Dojo:
-      title: Dojo
-      exit: Leave the dojo
-      introDialog: Welcome to the dojo. Here you can train your shlaguemons.
-      selectMon: Train a Shlagémon
-      selected: Selected Shlagémon
-      rarity:
-        current: Current rarity
-        after: Rarity after
-        points: Training points
-        limitReached: Cannot exceed 100 rarity.
-      cost:
-        label: Cost
-        insufficient: Insufficient funds
-      duration:
-        label: Duration
-        minute: minute
-        minutes: minutes
-        remaining: Remaining time
-        endsAt: Ends at {time}
-      cta:
-        payAndStart: Pay & start
-        trainingRunning: Training in progress
-        changeMon: Change Shlagémon
-      toast:
-        started: Training started!
-        finished: Training finished! Rarity improved.
-      progress: Progress
-      controls: Controls
-      status:
-        running: Training in progress
-      intro: Welcome to the dojo. Here you can train your Shlagémons.
-      outro:
-        running: Your Shlagémon is training. Come back later to see the results.
-        idle: No training in progress. Come back whenever you want to strengthen your Shlagémons.
-    Breeding:
-      name: Breeding
-      introDialog: Welcome to the breeding center. Pick the parent to breed.
-      introOk: Let's go!
-      selectMon: Choose a Shlagémon
-      selected: Selected Shlagémon
-      partner: Partner
-      rarity: Rarity
-      cost: Cost
-      duration: Duration
-      minutes: minutes
-      progress: Progress
-      remaining: Remaining time
-      endsAt: Ends at {time}
-      cta:
-        payAndStart: Pay & start
-        seeEgg: View egg
-        changeMon: Change Shlagémon
-        collectEgg: Collect egg
-      toast:
-        started: Breeding started!
-        finished: Egg obtained!
-        collected: Egg collected!
-      a11y:
-        openSelector: Choose parent
-        startBreeding: Start breeding
-        goToEgg: Go to egg
-        changeParent: Change parent
-        collectEgg: Collect egg
-        normanCareMessage: Reassuring message from Norman
-      title: Breeding
-      exit: Leave the breeding center
-      eggType: Egg type
-      status:
-        running: Breeding in progress
-      intro: Hello, I can seed your Shlagémons for you—I'm a pro at it, just hand me one!
-      outro:
-        running: I'll take care of the breeding right away, you can come back very soon.
-        idle: Come back very soon, I can't wait to take care of your Shlagémons.
-      during:
-        typing: Don't worry, I'll take good care of it, you can trust me
-        unselected: Give me one of your Shlagémons, I'll seed it with tenderness and love!
-        selected:
-          - Oh! I love your {shlagemon_name}, I'll seed that one real good!
-          - Oh, this one… I can tell it'll take the seed nicely!
-          - Mmmh… perfect for some deep seeding!
-          - Watch out {shlagemon_name}, it's going to be a heavy seeding here!
-          - Ohoh… {shlagemon_name}, get ready for a masterful seeding!
-        completed:
-          - All done, I put everything in and it popped out an egg!
-          - "Mission accomplished: it's full… and it laid an egg!"
-          - I gave it all it needed… and bam! An egg.
-          - "I didn't do things halfway: here's the egg!"
-          - 'I stuffed it completely… result: a nice warm egg.'
-          - Filled with happiness… and here's an egg as a gift!
-      changeSelected: Change {name}
+  pwa:
+    InstallBanner:
+      title: Install the app?
+      chromium_hint: Faster access, offline, fullscreen.
+      ios_hint: 'On iOS: add to Home Screen via the Share menu.'
+      ios_instructions: "On iPhone/iPad: tap the 'Share' button, then 'Add to Home Screen'."
+      later: Later
+      install: Install
+      how: How?
   settings:
     AccessibilityTab:
       autoHide:
@@ -907,7 +915,7 @@ components:
     Detail:
       equipItemTitle: Equip an item
       allowEvolution: Allow this Shlagemon to evolve?
-      firstCatch: "First capture: {date}"
+      firstCatch: 'First capture: {date}'
       obtainedTimes: Obtained {count} times
       release: Release
       main: Main
@@ -930,7 +938,7 @@ components:
       smell: Smell
       title: Shlagemon Info
     EvolutionModal:
-      evolveTitle: "{name} is evolving"
+      evolveTitle: '{name} is evolving'
       question: '"{from}" wants to evolve into "{to}", will you allow it or stop the spread of shlaguitude?'
       alreadyOwned: You already own this evolution
       yes: Yes
@@ -950,8 +958,25 @@ components:
         date: First capture
         evolution: Ready to evolve
       new: You have {n} new Shlagemon | You have {n} new Shlagemons
+    ListGeneric:
+      search: Search
+      sort:
+        level: Level
+        rarity: Rarity
+        shiny: Shiny
+        item: Held item
+        name: Name
+        type: Type
+        attack: Attack
+        defense: Defense
+        count: Catch count
+        date: First capture
+        evolution: Ready to evolve
     RarityInfo:
       tooltip: Rarity
+    SelectModal:
+      noAvailable: No Shlagemon available.
+      locked: Selection locked.
     TypeChart:
       defense: Defense
       attack: Attack
@@ -960,15 +985,13 @@ components:
     WearableEquipModal:
       title: Choose an item to equip
       noAvailable: No item available.
-    SelectModal:
-      noAvailable: No Shlagemon available.
   ui:
     CurrencyAmount:
       shlagidiamond: Shlagiamond
       shlagidolar: Shlagidollar
     FullscreenToggle:
       label: Fullscreen
-    Info:
+    Infos:
       ok: Ok
     LanguageToggle:
       label: Toggle language
@@ -980,38 +1003,27 @@ components:
     SortControls:
       ascending: Ascending sort
       descending: Descending sort
-    Infos:
-      ok: Ok
   village:
     ZoneActions:
       shop: Shop
       minigame: Minigame
       arena: Arena
+      dojo: Dojo
       henhouse: Henhouse
       breeding: Breeding
       fightKing: Challenge the {label} of the zone
-      kingDefeated: "{label} defeated!"
-      dojo: Dojo
+      kingDefeated: '{label} defeated!'
   zone:
     MonsModal:
-      title: "{zone} Shlagemons"
-  pwa:
-    InstallBanner:
-      title: Install the app?
-      chromium_hint: Faster access, offline, fullscreen.
-      ios_hint: "On iOS: add to Home Screen via the Share menu."
-      ios_instructions: "On iPhone/iPad: tap the 'Share' button, then 'Add to Home Screen'."
-      later: Later
-      install: Install
-      how: How?
+      title: '{zone} Shlagemons'
 composables:
   useFormatDuration:
-    year: "{count} year | {count} years"
-    month: "{count} month | {count} months"
-    day: "{count} day | {count} days"
-    hour: "{count} hour | {count} hours"
-    minute: "{count} minute | {count} minutes"
-    second: "{count} second | {count} seconds"
+    year: '{count} year | {count} years'
+    month: '{count} month | {count} months'
+    day: '{count} day | {count} days'
+    hour: '{count} hour | {count} hours'
+    minute: '{count} minute | {count} minutes'
+    second: '{count} second | {count} seconds'
     and: and
 data:
   Minigame:
@@ -1404,7 +1416,7 @@ data:
         description: Cringeon was once cool. Cringeon spent too much time scratching minor chords at the edge of an extinct volcano. From now on, Cool's not cool wanders with a guitar too big for his wings, freckles crying, and a check shirt that smells wet grass and regrets. His plumage took on a sad rust colour, and his red wick hides a remorseful look, as if he constantly realized that he could have evolved into a legendary raptor, but preferred to release an independent EP. It's always a little cold around him, even in the summer. Its signature capacity, Refrain Getting into trouble, inflicts a deep discomfort on all the arena, reducing the accuracy of enemy attacks as long as they turn their eyes away. He's very good at driving wild Pokémons away… and dating.
         name: Cringeon
       sacdepates:
-        description: "Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Pastafreak undergoes a physical attack, he can wrap around the enemy to trap and immobilize."
+        description: 'Pasta bag is a living ball of entangled spaghetti, whose long strands form a moving labyrinth. With two piercing eyes in the middle of his pasta, he intimidates anyone who crosses his infernal gaze. His red feet, smooth and glossy, allow him to ride at all speed on his opponents, whom he crushes without mercy in an acute and diabolical laughter. He spends his days painting himself thoroughly with a fine comb, hoping one day to unravel the infinite knot that he has become. It is said that the more tangled his spaghetti, the more formidable he becomes. Talent: Fatal Node — When Pastafreak undergoes a physical attack, he can wrap around the enemy to trap and immobilize.'
         name: Pastafreak
     05-10:
       aspigros:
@@ -1429,7 +1441,7 @@ data:
         description: A mass of foul mud that drags slowly. Where he passes, nothing grows because of his toxicity. It is made of a toxic mud. He pollutes everything he touches, even the ground becomes sterile. He stinks so much that people vanish just by crossing him. His body is a concentrate of toxins.
         name: Snotto
       ptitocard:
-        description: "Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure."
+        description: 'Ptitocard is as fragile as a wet and expressive bellboat as an existential crisis in full crisis. His empty, humid and terribly plaintive gaze melts the most hardened hearts - or annoys them deeply, as desired. It flows more than it swim, and its ventral spiral only runs when it has an anxiety attack. He constantly drools, but not in the mouth: it is his whole body that sweats distress. We think it is sad of birth, but some specialists evoke a simple allergy to life. His special capacity, *infinite tear *, causes fatal boredom in the enemy. An opponent who looks at Ptitocard for more than 10 seconds can fall into a coma of deep indifference. Ptitocard dreams of becoming a big champion ... but does nothing for. It is often found floating on the surface of the puddles, wondering if it really deserves to evolve. Spoiler: not sure.'
         name: Lamewag
     10-15:
       abraquemar:
@@ -1717,7 +1729,7 @@ data:
         description: Its endless language is dragging everywhere and is mainly used to slander. He likes to criticize his opponents until they abandon by weariness.
         name: Gossipbitch
       lecocu:
-        description: "Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness."
+        description: 'Lecocu always has a sad look: his wife deceives him with all the local trainers. Despite his unlucky love, he cared for others with a disconcerting kindness.'
         name: Cheated
       rhinofaringite:
         description: This sneezed rhinoceros sneezed from the rocks on its enemies. Its nose runs permanently, which makes it as slippery as it is unpredictable.
@@ -2377,7 +2389,7 @@ layouts:
   NotFound:
     not-found: Page not found
 pages:
-  "404":
+  '404':
     title: Page not found
     description: The page you are looking for does not exist, has been moved, or the URL contains a typo.
     goHome: Back to Home
@@ -2386,14 +2398,15 @@ pages:
     copied: Copied!
     copyTitle: Copy details (URL, browser...)
     report: Report a broken link
-    hint: "Tip: press H to go home, B to go back."
+    hint: 'Tip: press H to go home, B to go back.'
   index:
     title: Shlagemon - It smells very strong
     description: Shlagemons don't smell very good.
     welcome: Welcome to Shlagemon
   privacy-policy:
     title: Privacy Policy – Shlagémon
-    lastUpdated: "Last updated: 06/08/2025"
+    description: Information about data collection and usage in Shlagémon.
+    lastUpdated: 'Last updated: 06/08/2025'
     sections:
       data:
         title: 1. Data collected
@@ -2418,9 +2431,14 @@ pages:
   save:
     ImportPage:
       title: Import Save
+      description: Import a Shlagémon save from a .shlag file.
+      subtitle: Import a .shlag save file to replace your local data.
       drop: Drop your .shlag file here or click to select
       select: Select a file
+      hint: Click or drag-and-drop a {ext} file
+      warningTitle: 'Warning: destructive import'
       warning: Importing will overwrite your current save. Make sure you have a backup.
+      fileReady: File ready. Review details below.
       import: Import
       confirmTitle: Confirm Import
       confirmMessage: This will replace your current progress. Continue?
@@ -2428,63 +2446,35 @@ pages:
       cancel: Cancel
       summary:
         title: Summary
-        mons: "Shlagemons: {count}"
-        shlagidolar: "Shlagidollars: {amount}"
-        shlagidiamond: "Shlagidiamonds: {amount}"
-        playtime: "Playtime: {time}"
+        mons: 'Shlagemons: {count}'
+        shlagidolar: 'Shlagidollars: {amount}'
+        shlagidiamond: 'Shlagidiamonds: {amount}'
+        playtime: 'Playtime: {time}'
         monsLabel: Shlagemons
         shlagidolarLabel: Shlagidollars
         shlagidiamondLabel: Shlagidiamonds
         playtimeLabel: Playtime
+      acknowledge: I understand this action replaces ALL my local data.
       errorInvalid: Invalid save file.
       errorApply: Import failed.
-      subtitle: Import a .shlag save file to replace your local data.
-      hint: Click or drag-and-drop a {ext} file
-      warningTitle: "Warning: destructive import"
-      fileReady: File ready. Review details below.
-      acknowledge: I understand this action replaces ALL my local data.
   shlagedex:
     title: Shlagedex
-  breeding:
-    title: Breeding
-    name: Breeding
-    introDialog: Welcome to the breeding center. Pick the parent to breed.
-    introOk: Let's go!
-    selectMon: Choose a Shlagémon
-    selected: Selected Shlagémon
-    partner: Partner
-    rarity: Rarity
-    cost: Cost
-    duration: Duration
-    minutes: minutes
-    progress: Progress
-    remaining: Remaining time
-    endsAt: Ends at {time}
-    cta:
-      payAndStart: Pay & start
-      seeEgg: View egg
-    toast:
-      started: Breeding started!
-      finished: Egg obtained!
-    a11y:
-      openSelector: Choose parent
-      startBreeding: Start breeding
-      goToEgg: Go to egg
+    description: Browse the full compendium of Shlagemons.
 stores:
   achievements:
-    unlocked: "Achievement unlocked: {title}"
-    zoneShinyTitle: "{zone}: Rainbow Hunter"
+    unlocked: 'Achievement unlocked: {title}'
+    zoneShinyTitle: '{zone}: Rainbow Hunter'
     zoneShinyDescription: Capture every Shlagémon in {zone} in shiny form.
-    zoneRarityTitle: "{zone}: Perfectionist"
+    zoneRarityTitle: '{zone}: Perfectionist'
     zoneRarityDescription: Raise every Shlagémon in {zone} to rarity 100.
     zoneCompleteDescription: Capture every Shlagémon in {zone}.
-    zoneWinTitle: "{n} victories - {zone}"
+    zoneWinTitle: '{n} victories - {zone}'
     zoneWinDescription: Defeat {n} Shlagémon in {zone}.
     shinyTitles:
-      "1": Shiny!
-      "10": 10 shinies
-      "100": 100 shinies
-      "1000": Living Legend
+      '1': Shiny!
+      '10': 10 shinies
+      '100': 100 shinies
+      '1000': Living Legend
     shinyDescription: Capture {n} extremely rare shiny Shlagémon.
     itemTitles:
       firstPurchase: First Purchase
@@ -2504,19 +2494,11 @@ stores:
     toast:
       item: You obtained {qty} {item} ({category})!
   shlagedex:
-    rarityReached: "{name} reached rarity {rarity}!"
-    evolved: "{name} evolved!"
+    rarityReached: '{name} reached rarity {rarity}!'
+    evolved: '{name} evolved!'
     obtained: You obtained {name}!
     alreadyMax: You already have this Shlagemon at max rarity
     point: point | points
     level: level | levels
-    rarityChanged: "{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!"
-    released: "{name} was released!"
-common:
-  loading: Loading…
-  pleaseWait: Please wait
-  copy: Copy
-  remove: Remove
-  min: Min
-  max: Max
-  eggOf: Egg of {name}
+    rarityChanged: '{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!'
+    released: '{name} was released!'

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -2,6 +2,12 @@ App:
   title: Shlagémon - Ça sent très fort
   description: Attrape tous les Shlagémons dans ce jeu parodique hilarant ! Collectionne des monstres absurdes, mène des combats délirants et sauve la planète d’une invasion complètement folle. Télécharge maintenant et deviens le meilleur shlagidresseur !
   author: Aife
+common:
+  loading: Chargement…
+  pleaseWait: Veuillez patienter
+  copy: Copier
+  remove: Supprimer
+  eggOf: Œuf de {name}
 components:
   LanguageSelector:
     label: Langue
@@ -67,7 +73,7 @@ components:
       captured: Vous avez capturé {name} !
       fail: Raté !
     DiseaseBadge:
-      tooltip: "Malade : {n} combats restants"
+      tooltip: 'Malade : {n} combats restants'
     EffectBadge:
       attack: Votre attaque est boostée pour encore {remaining}
       defense: Votre défense est boostée pour encore {remaining}
@@ -105,7 +111,7 @@ components:
     healedFor: Soigné de {amount} PV
   deck:
     Detail:
-      evolution: "Évolution :"
+      evolution: 'Évolution :'
       level: lvl {n}
     List:
       search: Rechercher
@@ -127,7 +133,7 @@ components:
             retry: Réessayer
             quit: Quitter
     ArenaVictoryDialog:
-      toast: "{name} obtenu !"
+      toast: '{name} obtenu !'
       steps:
         step1:
           text: Félicitations ! Tu as triomphé de l'arène.
@@ -599,7 +605,7 @@ components:
         step1:
           text: Impressionnant ! Tu as capturé au moins {count} Shlagémons.
         step2:
-          text: "Voici un objet unique : {name}."
+          text: 'Voici un objet unique : {name}.'
         step3:
           text: Il augmente {stat} du porteur de {percent}%.
         step4:
@@ -676,7 +682,7 @@ components:
         - T'es à deux doigts de faire un pet cérébral.
         - Rarement vu quelqu'un aussi merdique.
       validate: Valider
-      attemptsLeft: "{n} tentatives restantes"
+      attemptsLeft: '{n} tentatives restantes'
       win: T'as percé le cerveau d'un Shlag !
       lose: Même un Petmorv y serait arrivé
       legend:
@@ -685,7 +691,7 @@ components:
         absent: Absent de la combinaison
       selectSlot: Sélectionne une case
     Pairs:
-      attempts: "{n} tentative | {n} tentatives"
+      attempts: '{n} tentative | {n} tentatives'
     masterMind:
       SelectionModal:
         title: Choisis un Shlagémon
@@ -703,9 +709,91 @@ components:
       intro1: Le bonus du Shlagedex augmente les dégâts finaux de tous vos Shlagémons ! Il représente le bonus maximal que vous pouvez obtenir en capturant tous les Shlagémons accessibles.
       intro2: Il se base sur le pourcentage de complétion de ce Shlagédex potentiel ainsi que sur le niveau moyen de votre équipe.
       formula: Bonus = niveau moyen × 2 × (taux de complétion / 100) / 10
-      completion: "Complétion :"
-      averageLevel: "Niveau moyen :"
-      currentBonus: "Bonus actuel :"
+      completion: 'Complétion :'
+      averageLevel: 'Niveau moyen :'
+      currentBonus: 'Bonus actuel :'
+    Breeding:
+      title: Élevage
+      exit: Quitter l'élevage
+      intro: Bonjour, je peux m'occuper d'ensemencer tes Shlagémons, je suis un pro pour faire ça, tu n'as qu'à m'en confier un !
+      outro:
+        running: Je m'occupe tout de suite de la reproduction, tu pourras repasser dans très peu de temps.
+        idle: Reviens très vite, j'ai hâte de m'occuper de tes Shlagémons.
+      during:
+        unselected: Confie moi un de tes Shlagémons, je vais l'ensemencer avec tendresse et amour !
+        selected:
+          - Ho ! J'adore ton {shlagemon_name}, je vais pouvoir l'ensemencer bien fort celui là !
+          - Oh, celui-là… je sens qu’il va bien prendre la graine !
+          - Mmmh… parfait pour un ensemencement en profondeur !
+          - Attention {shlagemon_name}, ça va semer sec ici !
+          - Ohoh… {shlagemon_name}, prépare-toi pour un ensemencement magistral !
+        completed:
+          - ça y est je lui ai tout mis dedans, il a sorti un oeuf !
+          - 'Mission accomplie : il est plein… et il a pondu !'
+          - Je lui ai mis tout ce qu’il fallait… et paf ! Un œuf.
+          - 'Je n’ai pas fait les choses à moitié : voilà l’œuf !'
+          - 'Je lui ai mis tout le paquet… résultat : un œuf bien chaud.'
+          - Rempli de bonheur… et voilà un œuf en cadeau !
+      selectMon: Choisir un Shlagémon
+      changeSelected: Changer {name}
+      selected: Shlagémon sélectionné
+      rarity: Rareté
+      eggType: Type d'œuf
+      cost: Coût
+      duration: Durée
+      minutes: minutes
+      progress: Progression
+      remaining: Temps restant
+      cta:
+        payAndStart: Payer & lancer
+        changeMon: Changer de Shlagémon
+        collectEgg: Récupérer l'œuf
+      toast:
+        started: Élevage lancé !
+        finished: Œuf obtenu !
+        collected: Œuf récupéré !
+      status:
+        running: Élevage en cours
+      a11y:
+        openSelector: Choisir le parent
+        startBreeding: Lancer l'élevage
+        changeParent: Changer de parent
+        collectEgg: Récupérer l'œuf
+        normanCareMessage: Message rassurant de Norman
+    Dojo:
+      title: Dojo
+      exit: Quitter le dojo
+      intro: Bienvenue dans le dojo. C’est ici que tu vas pouvoir faire progresser tes Shlagémons.
+      outro:
+        running: Ton Shlagémon s'entraîne. Reviens plus tard pour voir les résultats.
+        idle: Aucun entraînement en cours. Reviens quand tu veux renforcer tes Shlagémons.
+      selectMon: Entraîner un Shlagémon
+      selected: Shlagémon sélectionné
+      controls: Contrôles
+      rarity:
+        current: Rareté actuelle
+        after: Rareté après
+        points: Points d’entraînement
+        limitReached: Impossible de dépasser 100 de rareté.
+      cost:
+        label: Coût
+        insufficient: Fonds insuffisants
+      duration:
+        label: Durée
+        minute: minute
+        minutes: minutes
+        remaining: Temps restant
+        endsAt: Se termine à {time}
+      progress: Progression
+      status:
+        running: Entraînement en cours
+      cta:
+        payAndStart: Payer & lancer
+        changeMon: Changer de Shlagémon
+        trainingRunning: Entraînement en cours
+      toast:
+        started: Entraînement lancé !
+        finished: Entraînement terminé ! Rareté améliorée.
     Inventory:
       search: Rechercher
       sort:
@@ -722,7 +810,7 @@ components:
     MiniGame:
       exit: Quitter
     PlayerInfos:
-      sick: "Malade : {n} combats restants"
+      sick: 'Malade : {n} combats restants'
       dex: ShlagéDex
       averageLevel: Niveau moyen
       bonus: Bonus
@@ -731,6 +819,10 @@ components:
     Poulailler:
       title: Poulailler
       exit: Quitter
+      intro: Bienvenue au poulailler. Ici, tu peux surveiller tes œufs.
+      outro:
+        running: Je m'occupe de tes œufs, t'inquiètes j'en volerai pas un seul, reviens vite pour les voir éclore !
+        idle: Reviens me voir quand tu voudras faire éclore des œufs de Shlagémons
       incubator: Incubateur
       noEgg: Aucun œuf
       yourEggs: Vos œufs
@@ -747,10 +839,8 @@ components:
         incubateEgg: Incuber l’œuf {name}
         eggReady: Œuf {type} prêt
         eggProgress: Progression de l’œuf
-      intro: Bienvenue au poulailler. Ici, tu peux surveiller tes œufs.
-      outro:
-        running: Je m'occupe de tes œufs, t'inquiètes j'en volerai pas un seul, reviens vite pour les voir éclore !
-        idle: Reviens me voir quand tu voudras faire éclore des œufs de Shlagémons
+    Shlagedex:
+      new: Vous avez {n} nouveau Shlagémon | Vous avez {n} nouveaux Shlagémons
     Shop:
       title: Boutique
       details: Détails
@@ -768,97 +858,15 @@ components:
       exit: Quitter le Village
     Zone:
       capturedAlt: capturé
-    Dojo:
-      title: Dojo
-      exit: Quitter le dojo
-      introDialog: Bienvenue dans le dojo. C’est ici que tu vas pouvoir faire progresser tes Shlagémons.
-      selectMon: Entraîner un Shlagémon
-      selected: Shlagémon sélectionné
-      rarity:
-        current: Rareté actuelle
-        after: Rareté après
-        points: Points d’entraînement
-        limitReached: Impossible de dépasser 100 de rareté.
-      cost:
-        label: Coût
-        insufficient: Fonds insuffisants
-      duration:
-        label: Durée
-        minute: minute
-        minutes: minutes
-        remaining: Temps restant
-        endsAt: Se termine à {time}
-      cta:
-        payAndStart: Payer & lancer
-        trainingRunning: Entraînement en cours
-        changeMon: Changer de Shlagémon
-      toast:
-        started: Entraînement lancé !
-        finished: Entraînement terminé ! Rareté améliorée.
-      progress: Progression
-      controls: Contrôles
-      status:
-        running: Entraînement en cours
-      intro: Bienvenue dans le dojo. C’est ici que tu vas pouvoir faire progresser tes Shlagémons.
-      outro:
-        running: Ton Shlagémon s'entraîne. Reviens plus tard pour voir les résultats.
-        idle: Aucun entraînement en cours. Reviens quand tu veux renforcer tes Shlagémons.
-    Breeding:
-      name: Élevage
-      introDialog: Bienvenue au centre d'élevage. Choisis le Shlagémon à reproduire.
-      introOk: C'est parti !
-      selectMon: Choisir un Shlagémon
-      selected: Shlagémon sélectionné
-      partner: Partenaire
-      rarity: Rareté
-      cost: Coût
-      duration: Durée
-      minutes: minutes
-      progress: Progression
-      remaining: Temps restant
-      endsAt: Se termine à {time}
-      cta:
-        payAndStart: Payer & lancer
-        seeEgg: Voir l'œuf
-        changeMon: Changer de Shlagémon
-        collectEgg: Récupérer l'œuf
-      toast:
-        started: Élevage lancé !
-        finished: Œuf obtenu !
-        collected: Œuf récupéré !
-      a11y:
-        openSelector: Choisir le parent
-        startBreeding: Lancer l'élevage
-        goToEgg: Aller à l'œuf
-        changeParent: Changer de parent
-        collectEgg: Récupérer l'œuf
-        normanCareMessage: Message rassurant de Norman
-      title: Élevage
-      exit: Quitter l'élevage
-      eggType: Type d'œuf
-      status:
-        running: Élevage en cours
-      intro: Bonjour, je peux m'occuper d'ensemencer tes Shlagémons, je suis un pro pour faire ça, tu n'as qu'à m'en confier un !
-      outro:
-        running: Je m'occupe tout de suite de la reproduction, tu pourras repasser dans très peu de temps.
-        idle: Reviens très vite, j'ai hâte de m'occuper de tes Shlagémons.
-      during:
-        typing: T'inquiètes pas j'en prendrais bien soin, tu peux me faire confiance
-        unselected: Confie moi un de tes Shlagémons, je vais l'ensemencer avec tendresse et amour !
-        selected:
-          - Ho ! J'adore ton {shlagemon_name}, je vais pouvoir l'ensemencer bien fort celui là !
-          - Oh, celui-là… je sens qu’il va bien prendre la graine !
-          - Mmmh… parfait pour un ensemencement en profondeur !
-          - Attention {shlagemon_name}, ça va semer sec ici !
-          - Ohoh… {shlagemon_name}, prépare-toi pour un ensemencement magistral !
-        completed:
-          - ça y est je lui ai tout mis dedans, il a sorti un oeuf !
-          - 'Mission accomplie : il est plein… et il a pondu !'
-          - Je lui ai mis tout ce qu’il fallait… et paf ! Un œuf.
-          - 'Je n’ai pas fait les choses à moitié : voilà l’œuf !'
-          - 'Je lui ai mis tout le paquet… résultat : un œuf bien chaud.'
-          - Rempli de bonheur… et voilà un œuf en cadeau !
-      changeSelected: Changer {name}
+  pwa:
+    InstallBanner:
+      title: Installer l’application ?
+      chromium_hint: Accès rapide, hors-ligne, plein écran.
+      ios_hint: 'Sur iOS : ajouter à l’écran d’accueil via le menu Partager.'
+      ios_instructions: "Sur iPhone/iPad : touchez le bouton 'Partager', puis 'Sur l’écran d’accueil'."
+      later: Plus tard
+      install: Installer
+      how: Comment ?
   settings:
     AccessibilityTab:
       autoHide:
@@ -907,7 +915,7 @@ components:
     Detail:
       equipItemTitle: Équiper un objet
       allowEvolution: Autoriser ce Shlagémon à évoluer ?
-      firstCatch: "Première capture : {date}"
+      firstCatch: 'Première capture : {date}'
       obtainedTimes: Obtenu {count} fois
       release: Relâcher
       main: Principal
@@ -930,7 +938,7 @@ components:
       smell: Puanteur
       title: Informations Shlagémon
     EvolutionModal:
-      evolveTitle: "{name} évolue"
+      evolveTitle: '{name} évolue'
       question: « {from} » veut évoluer en « {to} », voulez-vous le laisser faire ou l'empêcher de répandre sa shlaguitude ?
       alreadyOwned: Vous possédez déjà l'évolution de ce Shlagémon
       yes: Oui
@@ -950,8 +958,25 @@ components:
         date: Première capture
         evolution: Proche d'évoluer
       new: Vous avez {n} nouveau Shlagémon | Vous avez {n} nouveaux Shlagémons
+    ListGeneric:
+      search: Rechercher
+      sort:
+        level: Niveau
+        rarity: Rareté
+        shiny: Shiny
+        item: Objet équipé
+        name: Nom
+        type: Type
+        attack: Attaque
+        defense: Défense
+        count: Nb obtentions
+        date: Première capture
+        evolution: Proche d'évoluer
     RarityInfo:
       tooltip: Rareté
+    SelectModal:
+      noAvailable: Aucun Shlagémon disponible.
+      locked: Sélection verrouillée.
     TypeChart:
       defense: Défense
       attack: Attaque
@@ -960,15 +985,13 @@ components:
     WearableEquipModal:
       title: Choisir un objet à équiper
       noAvailable: Aucun objet disponible.
-    SelectModal:
-      noAvailable: Aucun Shlagémon disponible.
   ui:
     CurrencyAmount:
       shlagidiamond: Shlagédiamant
       shlagidolar: Shlagédollar
     FullscreenToggle:
       label: Plein écran
-    Info:
+    Infos:
       ok: Ok
     LanguageToggle:
       label: Changer de langue
@@ -980,38 +1003,27 @@ components:
     SortControls:
       ascending: Tri ascendant
       descending: Tri descendant
-    Infos:
-      ok: Ok
   village:
     ZoneActions:
       shop: Magasin
       minigame: Mini-jeu
       arena: Arène
+      dojo: Dojo
       henhouse: Poulailler
       breeding: Élevage
       fightKing: Défier la {label} de la zone
-      kingDefeated: "{label} vaincu{suffix} !"
-      dojo: Dojo
+      kingDefeated: '{label} vaincu{suffix} !'
   zone:
     MonsModal:
       title: Shlagémons de {zone}
-  pwa:
-    InstallBanner:
-      title: Installer l’application ?
-      chromium_hint: Accès rapide, hors-ligne, plein écran.
-      ios_hint: "Sur iOS : ajouter à l’écran d’accueil via le menu Partager."
-      ios_instructions: "Sur iPhone/iPad : touchez le bouton 'Partager', puis 'Sur l’écran d’accueil'."
-      later: Plus tard
-      install: Installer
-      how: Comment ?
 composables:
   useFormatDuration:
-    year: "{count} an | {count} ans"
-    month: "{count} mois"
-    day: "{count} jour | {count} jours"
-    hour: "{count} heure | {count} heures"
-    minute: "{count} minute | {count} minutes"
-    second: "{count} seconde | {count} secondes"
+    year: '{count} an | {count} ans'
+    month: '{count} mois'
+    day: '{count} jour | {count} jours'
+    hour: '{count} heure | {count} heures'
+    minute: '{count} minute | {count} minutes'
+    second: '{count} seconde | {count} secondes'
     and: et
 data:
   Minigame:
@@ -1404,7 +1416,7 @@ data:
         description: Roux pas Cool était anciennement cool. Roux pas Cool a passé trop de temps à gratter des accords mineurs au bord d’un volcan éteint. Désormais, Roux pas Cool erre avec une guitare trop grande pour ses ailes, des taches de rousseur qui pleurent, et une chemise à carreaux qui sent l’herbe humide et les regrets. Son plumage a pris une teinte rouille triste, et sa mèche rousse cache un regard empli de remords, comme s’il réalisait constamment qu’il aurait pu évoluer en rapace légendaire, mais a préféré sortir un EP en indépendant. Il fait toujours un peu froid autour de lui, même en plein été. Sa capacité signature, Refrain Gênant, inflige un malaise profond à toute l’arène, réduisant la précision des attaques ennemies tant qu’ils détournent le regard. Il est très doué pour faire fuir les Pokémon sauvages… et les rendez-vous galants.
         name: Roux pas Cool
       sacdepates:
-        description: "Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser."
+        description: 'Sac de Pâtes est une boule vivante de spaghettis emmêlés, dont les longs brins forment un labyrinthe mouvant. Doté de deux yeux perçants incrustés au milieu de ses pâtes, il intimide quiconque croise son regard infernal. Ses pieds rouges, lisses et luisants, lui permettent de rouler à toute vitesse sur ses adversaires, qu’il écrase sans pitié dans un rire aigu et diabolique. Il passe ses journées à se peigner minutieusement avec un peigne fin, espérant un jour démêler le nœud infini qu’il est devenu. On raconte que plus ses spaghettis sont emmêlés, plus il devient redoutable. Talent : Nœud Fatal — Quand Sacdepâtes subit une attaque physique, il peut s’enrouler autour de l’ennemi pour le piéger et l’immobiliser.'
         name: Sac de Pâtes
     05-10:
       aspigros:
@@ -1429,7 +1441,7 @@ data:
         description: Une masse de boue nauséabonde qui se traîne lentement. Là où il passe, plus rien ne pousse à cause de sa toxicité. Il est fait d'une boue toxique. Il pollue tout ce qu’il touche, même le sol devient stérile. Il pue tellement que des gens s’évanouissent rien qu’en le croisant. Son corps est un concentré de toxines.
         name: Metamorve
       ptitocard:
-        description: "Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr."
+        description: 'Ptitocard est aussi fragile qu’une biscotte mouillée et aussi expressif qu’un poisson-panique en pleine crise existentielle. Son regard vide, humide et terriblement plaintif fait fondre les cœurs les plus endurcis — ou les agace profondément, au choix. Il coule plus qu’il ne nage, et sa spirale ventrale ne tourne que lorsqu’il fait une crise d’angoisse. Il bave en permanence, mais pas de la bouche : c’est tout son corps qui transpire la détresse. On pense qu’il est triste de naissance, mais certains spécialistes évoquent une simple allergie à la vie. Sa capacité spéciale, *Larme Infinie*, provoque l’ennui mortel chez l’ennemi. Un adversaire qui regarde Ptitocard pendant plus de 10 secondes peut tomber dans un coma d’indifférence profonde. Ptitocard rêve de devenir un grand champion… mais ne fait rien pour. On le trouve souvent flottant à la surface des flaques, en train de se demander s’il mérite vraiment d’évoluer. Spoiler : pas sûr.'
         name: Ptitocard
     10-15:
       abraquemar:
@@ -1717,7 +1729,7 @@ data:
         description: Sa langue interminable traîne partout et sert principalement à médire. Il aime critiquer ses adversaires jusqu'à ce qu'ils abandonnent par lassitude.
         name: Languedepute
       lecocu:
-        description: "Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante."
+        description: 'Lecocu porte toujours un air triste : sa femme le trompe avec tous les dresseurs du coin. Malgré sa malchance amoureuse, il soigne les autres avec une gentillesse déconcertante.'
         name: Lecocu
       rhinofaringite:
         description: Ce rhinocéros enrhumé éternue des rochers sur ses ennemis. Son nez coule en permanence, ce qui le rend aussi glissant qu'imprévisible.
@@ -1772,7 +1784,7 @@ data:
         Aujourd’hui, Artichaud veille sur les zones de non-droit climatiques, où il impose son règne moite et frigorifié, entre deux éternuements fumants et des engelures de l’aisselle.
       name: Artichaud
     bulgrosboule:
-      description: "Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller."
+      description: 'Bulgrosboule est connu pour ses fesses titanesques capables d’éclipser le soleil couchant. Il avance à reculons, plus par fierté que par stratégie, laissant échapper des bulles parfumées d’une zone que les dresseurs préfèrent ne pas mentionner. Son cri ressemble à un bain moussant sous pression, et sa capacité signature, *Éruption Fessale*, propulse ses ennemis dans une brume tiède et collante. Doté d’une peau rebondie comme une piscine gonflable de brocante, il adore rebondir sur place en gloussant, ce qui désoriente la plupart des adversaires. Bulgrosboule est très affectueux, surtout avec ceux qui le massent. Attention toutefois : s’il se met à trembler des miches, c’est trop tard. Il va buller.'
       name: Bulgrosboule
     carapouffe:
       description: Carapouffe s'est enfoncée dans sa propre carapace moelleuse, elle ne se déplace qu’en roulant lentement, laissant derrière elle une traînée de paillettes et de gloss fondu. Son maquillage dégouline en permanence, formant une couche protectrice impénétrable — les scientifiques appellent ça le « fard d’armure ». Dotée d’un regard mi-séduisant, mi-comateux, elle hypnotise ses adversaires en leur lançant des œillades flasques, accompagnées d’un soupir de lassitude cosmique. Elle passe ses journées à se recoiffer sans bouger la tête, grâce à un système complexe de brosses dissimulées dans son chignon. Sa voix est rauque, son parfum est toxique, et sa principale attaque, "Écrasement Moussant", consiste à s’écrouler violemment sur son ennemi en faisant claquer ses faux ongles.
@@ -2370,7 +2382,7 @@ layouts:
   NotFound:
     not-found: Page introuvable
 pages:
-  "404":
+  '404':
     title: Page introuvable
     description: La page que vous cherchez n'existe pas, a été déplacée ou l'URL contient une erreur.
     goHome: Retour à l’accueil
@@ -2379,14 +2391,15 @@ pages:
     copied: Copié !
     copyTitle: Copier les détails (URL, navigateur...)
     report: Signaler un lien cassé
-    hint: "Astuce : appuyez sur H pour aller à l’accueil, B pour revenir en arrière."
+    hint: 'Astuce : appuyez sur H pour aller à l’accueil, B pour revenir en arrière.'
   index:
     title: Shlagémon - Ça sent très fort
     description: Les Shlagémons ne sentent pas très bon.
     welcome: Bienvenue dans Shlagémon
   privacy-policy:
     title: Politique de Confidentialité – Shlagémon
-    lastUpdated: "Dernière mise à jour : 06/08/2025"
+    description: Informations sur la collecte et l'utilisation des données dans Shlagémon.
+    lastUpdated: 'Dernière mise à jour : 06/08/2025'
     sections:
       data:
         title: 1. Données collectées
@@ -2411,9 +2424,14 @@ pages:
   save:
     ImportPage:
       title: Importer une sauvegarde
+      description: Importez une sauvegarde Shlagémon depuis un fichier .shlag.
+      subtitle: Importez une sauvegarde .shlag pour remplacer vos données locales.
       drop: Déposez votre fichier .shlag ici ou cliquez pour sélectionner
       select: Sélectionner un fichier
+      hint: Cliquez ou glissez-déposez un fichier {ext}
+      warningTitle: 'Attention : import destructif'
       warning: L'import remplacera votre sauvegarde actuelle. Assurez-vous d'avoir une copie.
+      fileReady: Fichier prêt. Vérifiez les détails ci-dessous.
       import: Importer
       confirmTitle: Confirmer l'import
       confirmMessage: Cette action écrasera votre progression actuelle. Continuer ?
@@ -2421,63 +2439,35 @@ pages:
       cancel: Annuler
       summary:
         title: Récapitulatif
-        mons: "Shlagémons : {count}"
-        shlagidolar: "Shlagidolars : {amount}"
-        shlagidiamond: "Shlagidiamonds : {amount}"
-        playtime: "Temps de jeu : {time}"
+        mons: 'Shlagémons : {count}'
+        shlagidolar: 'Shlagidolars : {amount}'
+        shlagidiamond: 'Shlagidiamonds : {amount}'
+        playtime: 'Temps de jeu : {time}'
         monsLabel: Shlagémons
         shlagidolarLabel: Shlagidolars
         shlagidiamondLabel: Shlagidiamonds
         playtimeLabel: Temps de jeu
+      acknowledge: Je comprends que cette action remplace TOUTES mes données locales.
       errorInvalid: Fichier de sauvegarde invalide.
       errorApply: L'import a échoué.
-      subtitle: Importez une sauvegarde .shlag pour remplacer vos données locales.
-      hint: Cliquez ou glissez-déposez un fichier {ext}
-      warningTitle: "Attention : import destructif"
-      fileReady: Fichier prêt. Vérifiez les détails ci-dessous.
-      acknowledge: Je comprends que cette action remplace TOUTES mes données locales.
   shlagedex:
     title: Shlagédex
-  breeding:
-    title: Élevage
-    name: Élevage
-    introDialog: Bienvenue au centre d'élevage. Choisis le Shlagémon à reproduire.
-    introOk: C'est parti !
-    selectMon: Choisir un Shlagémon
-    selected: Shlagémon sélectionné
-    partner: Partenaire
-    rarity: Rareté
-    cost: Coût
-    duration: Durée
-    minutes: minutes
-    progress: Progression
-    remaining: Temps restant
-    endsAt: Se termine à {time}
-    cta:
-      payAndStart: Payer & lancer
-      seeEgg: Voir l'œuf
-    toast:
-      started: Élevage lancé !
-      finished: Œuf obtenu !
-    a11y:
-      openSelector: Choisir le parent
-      startBreeding: Lancer l'élevage
-      goToEgg: Aller à l'œuf
+    description: Le répertoire complet des Shlagémons capturables.
 stores:
   achievements:
-    unlocked: "Succès déverrouillé : {title}"
+    unlocked: 'Succès déverrouillé : {title}'
     zoneShinyTitle: "{zone} : Chasseur d'arc-en-ciel"
     zoneShinyDescription: Capturer tous les Shlagémon de {zone} en version shiny.
-    zoneRarityTitle: "{zone} : Perfectionniste"
+    zoneRarityTitle: '{zone} : Perfectionniste'
     zoneRarityDescription: Amener tous les Shlagémon de {zone} à la rareté 100.
     zoneCompleteDescription: Capturer tous les Shlagémon de {zone}.
-    zoneWinTitle: "{n} victoires - {zone}"
+    zoneWinTitle: '{n} victoires - {zone}'
     zoneWinDescription: Vaincre {n} Shlagémon dans {zone}.
     shinyTitles:
-      "1": Shiny!
-      "10": 10 shinies
-      "100": 100 shinies
-      "1000": Légende vivante
+      '1': Shiny!
+      '10': 10 shinies
+      '100': 100 shinies
+      '1000': Légende vivante
     shinyDescription: Capturer {n} Shlagémon shiny extrêmement rares.
     itemTitles:
       firstPurchase: Premier craquage
@@ -2497,19 +2487,11 @@ stores:
     toast:
       item: Tu obtiens {qty} {item} ({category}) !
   shlagedex:
-    rarityReached: "{name} atteint la rareté {rarity} !"
-    evolved: "{name} a évolué !"
+    rarityReached: '{name} atteint la rareté {rarity} !'
+    evolved: '{name} a évolué !'
     obtained: Tu as obtenu {name} !
     alreadyMax: Vous avez déjà ce Shlagémon au maximum de sa rareté
     point: point | points
     level: niveau | niveaux
-    rarityChanged: "{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !"
-    released: "{name} a été relâché !"
-common:
-  loading: Chargement…
-  pleaseWait: Veuillez patienter
-  copy: Copier
-  remove: Supprimer
-  min: Min
-  max: Max
-  eggOf: Œuf de {name}
+    rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
+    released: '{name} a été relâché !'


### PR DESCRIPTION
## Summary
- regenerate locales from component i18n files
- include ListGeneric sorting strings and SelectModal status messages

## Testing
- `pnpm lint` *(fails: style/max-statements-per-line, unused-imports, etc.)*
- `pnpm test:unit` *(fails: 14 tests, missing translations and assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68a0753acc18832a9086112818259fc2