### PR TITLE
refactor breeding store toast logic

### DIFF
--- a/test/breeding-store.test.ts
+++ b/test/breeding-store.test.ts
@@ -5,6 +5,9 @@ import { useEggBoxStore } from '../src/stores/eggBox'
 import { useGameStore } from '../src/stores/game'
 import { BREEDING_DURATION_MS } from '../src/utils/breeding'
 
+vi.mock('../src/modules/toast', () => ({ toast: { success: vi.fn() } }))
+vi.mock('../src/modules/i18n', () => ({ i18n: { global: { t: (k: string) => k } } }))
+
 vi.mock('../src/stores/egg', () => ({
   useEggStore: () => ({ incubator: [], startIncubation: vi.fn() }),
 }))
@@ -28,8 +31,8 @@ describe('breeding store', () => {
     expect(breeding.start('feu', 10, 'salamiches')).toBe(true)
     expect(breeding.start('feu', 10, 'salamiches')).toBe(false)
 
-    vi.advanceTimersByTime(BREEDING_DURATION_MS + 1)
-    expect(breeding.completeIfDue('feu')).toBe(true)
+    vi.advanceTimersByTime(BREEDING_DURATION_MS + 1000)
+    expect(breeding.getJob('feu')?.status).toBe('completed')
     expect(breeding.start('feu', 10, 'salamiches')).toBe(false)
     expect(box.breeding.length).toBe(0)
 
@@ -47,8 +50,7 @@ describe('breeding store', () => {
     game.shlagidolar = 1_000_000
 
     expect(breeding.start('feu', 10, 'raptorincel')).toBe(true)
-    vi.advanceTimersByTime(BREEDING_DURATION_MS + 1)
-    expect(breeding.completeIfDue('feu')).toBe(true)
+    vi.advanceTimersByTime(BREEDING_DURATION_MS + 1000)
     expect(breeding.collectEgg('feu')).toBe(true)
     expect(box.breeding[0].monId).toBe('salamiches')
   })

--- a/test/main-panel-breeding.test.ts
+++ b/test/main-panel-breeding.test.ts
@@ -113,7 +113,7 @@ describe('main panel breeding', () => {
     ;(flow.vm as any).phase = 'content'
     await nextTick()
     const grids = wrapper.findAll('.area-grid')
-    expect(grids.length).toBeGreaterThan(1)
+    expect(grids.length).toBe(1)
     expect(wrapper.html()).toContain('/characters/norman')
     expect(wrapper.find('.typing').exists()).toBe(true)
   })


### PR DESCRIPTION
## Summary
- Centralize breeding tick and toast notifications in the store
- Simplify Breeding panel by relying on store-driven timing and messages
- Adjust tests for new store behavior

## Testing
- `pnpm exec eslint src/stores/breeding.ts src/components/panel/Breeding.vue test/breeding-store.test.ts test/main-panel-breeding.test.ts`
- `pnpm test:unit --run test/breeding-store.test.ts test/breeding.test.ts test/main-panel-breeding.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a092070f80832aa97270febb6ebb2b