### PR TITLE
Handle Dojo training notifications in store

### DIFF
--- a/src/stores/dojo.ts
+++ b/src/stores/dojo.ts
@@ -1,4 +1,6 @@
 import { defineStore } from 'pinia'
+import { i18n } from '~/modules/i18n'
+import { toast } from '~/modules/toast'
 
 /**
  * Parameters for a dojo training job.
@@ -34,6 +36,13 @@ export const useDojoStore = defineStore('dojo', () => {
   const byMonId = ref<Record<string, DojoTrainingJob | undefined>>({})
   const game = useGameStore()
   const dex = useShlagedexStore()
+  const now = ref<number>(Date.now())
+
+  useIntervalFn(() => {
+    now.value = Date.now()
+    for (const id of Object.keys(byMonId.value))
+      completeIfDue(id)
+  }, 1000)
 
   function getJob(monId: string): DojoTrainingJob | null {
     return byMonId.value[monId] ?? null
@@ -47,7 +56,7 @@ export const useDojoStore = defineStore('dojo', () => {
     const job = byMonId.value[monId]
     if (!job)
       return 0
-    return Math.max(0, job.endsAt - Date.now())
+    return Math.max(0, job.endsAt - now.value)
   }
 
   function progressRatio(monId: string): number {
@@ -55,7 +64,7 @@ export const useDojoStore = defineStore('dojo', () => {
     if (!job)
       return 0
     const total = job.endsAt - job.startedAt
-    return total > 0 ? 1 - remainingMs(monId) / total : 1
+    return total > 0 ? 1 - Math.max(0, job.endsAt - now.value) / total : 1
   }
 
   function startTraining(monId: string, fromRarity: number, points: number) {
@@ -71,6 +80,7 @@ export const useDojoStore = defineStore('dojo', () => {
       return { ok: false as const, reason: 'insufficient_funds' as const }
     game.addShlagidolar(-cost)
     const startedAt = Date.now()
+    now.value = startedAt
     byMonId.value[monId] = {
       monId,
       startedAt,
@@ -81,6 +91,7 @@ export const useDojoStore = defineStore('dojo', () => {
       paid: cost,
       status: 'running',
     }
+    toast.success(i18n.global.t('components.panel.Dojo.toast.started'))
     return { ok: true as const }
   }
 
@@ -88,18 +99,19 @@ export const useDojoStore = defineStore('dojo', () => {
     const job = byMonId.value[monId]
     if (!job)
       return false
-    if (Date.now() < job.endsAt)
+    if (now.value < job.endsAt)
       return false
     const mon = dex.shlagemons.find(m => m.id === monId)
     if (mon)
       mon.rarity = Math.min(100, job.targetRarity)
     delete byMonId.value[monId]
+    toast.success(i18n.global.t('components.panel.Dojo.toast.finished'))
     return true
   }
 
   function clearFinished(): void {
     for (const [id, job] of Object.entries(byMonId.value)) {
-      if (job && Date.now() >= job.endsAt)
+      if (job && now.value >= job.endsAt)
         delete byMonId.value[id]
     }
   }


### PR DESCRIPTION
## Summary
- notify start/finish of Dojo training from store using toast and i18n
- poll training completion in store with useIntervalFn
- simplify Dojo panel to display state only

## Testing
- `pnpm test:unit --reporter=basic` *(fails: getPwaManifest is not a function, shlagedex sort item test, router redirect test)*

------
https://chatgpt.com/codex/tasks/task_e_68a0920710c0832ab6072d16339b0e56