### PR TITLE
Persist breeding jobs across sessions

### DIFF
--- a/src/modules/breeding.ts
+++ b/src/modules/breeding.ts
@@ -1,0 +1,11 @@
+import type { UserModule } from '~/types'
+
+/**
+ * Instantiate the breeding store on startup so breeding jobs
+ * persist and progress even when the breeding panel is closed.
+ */
+export const install: UserModule = ({ isClient }) => {
+  if (!isClient)
+    return
+  useBreedingStore()
+}

--- a/src/stores/breeding.ts
+++ b/src/stores/breeding.ts
@@ -32,6 +32,14 @@ export interface BreedingState {
   byType: Record<EggType, BreedingJob | undefined>
 }
 
+/**
+ * Minimal shape of the store used during hydration.
+ */
+interface HydratedBreedingStore {
+  byType: BreedingState['byType']
+  completeIfDue: (type: EggType) => boolean
+}
+
 export const useBreedingStore = defineStore('breeding', () => {
   const byType = ref<BreedingState['byType']>({})
   const now = ref(Date.now())
@@ -161,5 +169,12 @@ export const useBreedingStore = defineStore('breeding', () => {
 }, {
   persist: {
     pick: ['byType'],
+    afterHydrate(ctx) {
+      const store = ctx.store as HydratedBreedingStore
+      for (const type of Object.keys(store.byType) as EggType[]) {
+        if (store.completeIfDue(type))
+          toast.success(i18n.global.t('components.panel.Breeding.toast.finished'))
+      }
+    },
   },
 })

--- a/test/breeding-persist.test.ts
+++ b/test/breeding-persist.test.ts
@@ -1,0 +1,46 @@
+import { createPinia, setActivePinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { describe, expect, it, vi } from 'vitest'
+import { createApp } from 'vue'
+import { toast } from '../src/modules/toast'
+import { useBreedingStore } from '../src/stores/breeding'
+import { useEggBoxStore } from '../src/stores/eggBox'
+import { BREEDING_DURATION_MS } from '../src/utils/breeding'
+
+vi.mock('../src/modules/toast', () => ({ toast: { success: vi.fn() } }))
+vi.mock('../src/modules/i18n', () => ({ i18n: { global: { t: (k: string) => k } } }))
+vi.mock('../src/stores/egg', () => ({
+  useEggStore: () => ({ incubator: [], startIncubation: vi.fn() }),
+}))
+
+describe('breeding persistence', () => {
+  it('restores running job and completes it after hydration', () => {
+    const pinia = createPinia()
+    pinia.use(piniaPluginPersistedstate)
+    const app = createApp({})
+    app.use(pinia)
+    setActivePinia(pinia)
+
+    const startedAt = Date.now() - BREEDING_DURATION_MS - 1000
+    const endsAt = startedAt + BREEDING_DURATION_MS
+    window.localStorage.setItem('breeding', JSON.stringify({
+      byType: {
+        feu: {
+          type: 'feu',
+          rarity: 10,
+          parentId: 'salamiches',
+          startedAt,
+          endsAt,
+          status: 'running',
+        },
+      },
+    }))
+
+    const breeding = useBreedingStore()
+    const box = useEggBoxStore()
+    expect(breeding.getJob('feu')?.status).toBe('completed')
+    expect(toast.success).toHaveBeenCalledWith('components.panel.Breeding.toast.finished')
+    expect(breeding.collectEgg('feu')).toBe(true)
+    expect(box.breeding.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure breeding jobs survive app reload and auto-complete once elapsed
- bootstrap breeding store on app start to continue background timing
- test hydration of breeding jobs from persisted state

## Testing
- `pnpm exec eslint src/stores/breeding.ts src/modules/breeding.ts test/breeding-persist.test.ts`
- `pnpm typecheck` *(fails: Type 'Readonly<Ref<boolean, boolean>>' is not assignable to type 'boolean')*
- `pnpm test --run` *(fails: multiple vitest suites failing, e.g., animated-number-duration.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a09b37634c832a8dc6a25e2ccfe311