### PR TITLE
fix: make dojo timer reactive

### DIFF
--- a/src/components/panel/Dojo.vue
+++ b/src/components/panel/Dojo.vue
@@ -73,8 +73,18 @@ watch(selected, () => {
 const cost = computed<number>(() => (selected.value ? dojoTrainingCost(selected.value.rarity, clamp(points.value, 1, safeMax.value)) : 0))
 const durationMin = computed<number>(() => clamp(points.value, 1, safeMax.value))
 
-const remaining = computed<number>(() => (job.value ? Math.max(0, Math.ceil(dojo.remainingMs(job.value.monId) / 1000)) : 0))
-const progress = computed<number>(() => (job.value ? Math.min(100, Math.max(0, dojo.progressRatio(job.value.monId) * 100)) : 0))
+const remaining = computed<number>(() => {
+  if (!job.value)
+    return 0
+  return Math.max(0, Math.ceil((job.value.endsAt - dojo.now) / 1000))
+})
+const progress = computed<number>(() => {
+  if (!job.value)
+    return 0
+  const total = job.value.endsAt - job.value.startedAt
+  const elapsed = Math.max(0, dojo.now - job.value.startedAt)
+  return total > 0 ? Math.min(100, Math.max(0, (elapsed / total) * 100)) : 0
+})
 
 const remainingLabel = computed<string>(() => {
   const s = remaining.value

--- a/src/stores/dojo.ts
+++ b/src/stores/dojo.ts
@@ -36,6 +36,7 @@ export const useDojoStore = defineStore('dojo', () => {
   const byMonId = ref<Record<string, DojoTrainingJob | undefined>>({})
   const game = useGameStore()
   const dex = useShlagedexStore()
+  /** Current timestamp used to compute progress for running jobs. */
   const now = ref<number>(Date.now())
 
   useIntervalFn(() => {
@@ -125,6 +126,7 @@ export const useDojoStore = defineStore('dojo', () => {
     startTraining,
     completeIfDue,
     clearFinished,
+    now,
   }
 }, {
   persist: {

--- a/test/dojo-store.test.ts
+++ b/test/dojo-store.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { pikachiant } from '../src/data/shlagemons/15-20/pikachiant'
 import { dojoTrainingCost, useDojoStore } from '../src/stores/dojo'
 import { useGameStore } from '../src/stores/game'
@@ -31,5 +31,20 @@ describe('dojo store', () => {
     const completed = dojo.completeIfDue(mon.id)
     expect(completed).toBe(true)
     expect(mon.rarity).toBe(before + 1)
+  })
+
+  it('updates remaining time as time elapses', () => {
+    vi.useFakeTimers()
+    const game = useGameStore()
+    game.addShlagidolar(200000000)
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(pikachiant)
+    const dojo = useDojoStore()
+    dojo.startTraining(mon.id, mon.rarity, 1)
+    const first = dojo.remainingMs(mon.id)
+    vi.advanceTimersByTime(2000)
+    const later = dojo.remainingMs(mon.id)
+    expect(later).toBeLessThan(first)
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary
- expose dojo store timestamp and update it on an interval
- drive training progress from store time
- cover time elapse with dojo store test

## Testing
- `corepack pnpm lint`
- `CI=1 corepack pnpm vitest run test/arena-selection-modal.test.ts` *(fails: expected '' to contain 'lvl 7')*


------
https://chatgpt.com/codex/tasks/task_e_68a09a302db4832a8b439b377e436b23