### PR TITLE
Keep breeder busy until egg is collected

### DIFF
--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { BreedingJob } from '~/stores/breeding'
 import type { EggType } from '~/stores/egg'
 import type { DialogNode } from '~/type/dialog'
 
@@ -12,6 +13,7 @@ const { t, tm } = useI18n()
 const breeding = useBreedingStore()
 const game = useGameStore()
 const panel = useMainPanelStore()
+const dex = useShlagedexStore()
 
 function onExit() {
   panel.showVillage()
@@ -33,6 +35,15 @@ function createIntro(next: () => void): DialogNode[] {
 const selected = ref<DexShlagemon | null>(null)
 const selectorOpen = ref(false)
 const typingText = ref('')
+
+watchEffect(() => {
+  if (selected.value)
+    return
+  const job = Object.values(breeding.byType).find((j): j is BreedingJob => Boolean(j))
+  if (!job)
+    return
+  selected.value = dex.shlagemons.find(m => m.id === job.monId) ?? null
+})
 
 /** === Derived =========================================================== */
 const eggType = computed<EggType | null>(() =>

--- a/src/stores/breeding.ts
+++ b/src/stores/breeding.ts
@@ -124,7 +124,6 @@ export const useBreedingStore = defineStore('breeding', () => {
     if (now.value < job.endsAt)
       return false
     job.status = 'completed'
-    dex.setBusy(job.monId, false)
     return true
   }
 
@@ -141,6 +140,7 @@ export const useBreedingStore = defineStore('breeding', () => {
       return false
     const ancestorId = findRootAncestorId(job.parentId)
     eggBox.addBreedingEgg(ancestorId, job.type, job.rarity)
+    dex.setBusy(job.monId, false)
     delete byType.value[type]
     toast.success(i18n.global.t('components.panel.Breeding.toast.collected'))
     return true
@@ -153,7 +153,6 @@ export const useBreedingStore = defineStore('breeding', () => {
     for (const [key, job] of Object.entries(byType.value)) {
       if (job?.status === 'completed') {
         delete byType.value[key as EggType]
-        dex.setBusy(job.monId, false)
       }
     }
   }

--- a/test/breeding-autoselect.test.ts
+++ b/test/breeding-autoselect.test.ts
@@ -1,0 +1,105 @@
+import type { EggType } from '../src/stores/egg'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+import Breeding from '../src/components/panel/Breeding.vue'
+import { salamiches } from '../src/data/shlagemons/salamiches'
+import { useBreedingStore } from '../src/stores/breeding'
+import { useGameStore } from '../src/stores/game'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+vi.mock('../src/stores/audio', () => ({
+  useAudioStore: () => ({
+    fadeToMusic: vi.fn(),
+    playSfx: vi.fn(),
+    playTypingSfx: vi.fn(),
+  }),
+}))
+
+vi.mock('../src/stores/zone', () => ({
+  useZoneStore: () => ({
+    current: { id: 'zone', type: 'sauvage' },
+  }),
+}))
+
+vi.mock('../src/stores/mainPanel', () => ({
+  useMainPanelStore: () => ({
+    showVillage: vi.fn(),
+  }),
+}))
+
+const stubs = {
+  PanelPoiDialogFlow: { template: '<div><slot /><slot name="footer" /></div>' },
+  UiButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  UiAdaptiveDisplayer: { template: '<div><slot /></div>' },
+  BreedingMonPreview: { props: ['mon', 'eggType'], emits: ['select', 'change'], template: '<div />' },
+  BreedingCharacter: { props: ['character', 'typingText'], template: '<div />' },
+  BreedingWorking: { props: ['isRunning', 'progress', 'remainingLabel'], template: '<div />' },
+  BreedingInfos: { props: ['selected', 'cost', 'durationMin'], template: '<div />' },
+  ShlagemonSelectModal: { template: '<div />' },
+  UiCurrencyAmount: { template: '<span />' },
+}
+
+function createI18nInstance() {
+  return createI18n({
+    legacy: false,
+    locale: 'fr',
+    messages: {
+      fr: {
+        ui: { Info: { ok: 'Ok' } },
+        components: {
+          panel: {
+            Breeding: {
+              title: 'Élevage',
+              exit: 'Quitter l\'élevage',
+              intro: 'intro',
+              outro: { running: 'outro', idle: 'outro' },
+              during: {
+                unselected: 'unselected',
+                selected: ['selected'],
+                completed: ['completed'],
+              },
+              cta: {
+                payAndStart: 'Start',
+                collectEgg: 'Collect',
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+describe('breeding panel preselection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('selects current shlagemon when a job exists', async () => {
+    const game = useGameStore()
+    const dex = useShlagedexStore()
+    const breeding = useBreedingStore()
+    game.shlagidolar = 1_000_000
+
+    const mon = dex.createShlagemon(salamiches)
+    const type = mon.base.types[0].id as EggType
+    expect(breeding.start(mon)).toBe(true)
+    const job = breeding.getJob(type)
+    if (job)
+      job.status = 'completed'
+
+    const wrapper = mount(Breeding, {
+      global: {
+        plugins: [createI18nInstance()],
+        stubs,
+      },
+    })
+
+    await nextTick()
+    expect((wrapper.vm as any).selected?.id).toBe(mon.id)
+    expect(wrapper.find('button').exists()).toBe(true)
+  })
+})

--- a/test/breeding-store.test.ts
+++ b/test/breeding-store.test.ts
@@ -4,14 +4,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { raptorincel } from '../src/data/shlagemons/evolutions/raptorincel'
 import { salamiches } from '../src/data/shlagemons/salamiches'
 import { useBreedingStore } from '../src/stores/breeding'
+
 import { useEggBoxStore } from '../src/stores/eggBox'
 import { useGameStore } from '../src/stores/game'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { BREEDING_DURATION_MS } from '../src/utils/breeding'
 
-vi.mock('../src/modules/toast', () => ({ toast: { success: vi.fn() } }))
-vi.mock('../src/modules/i18n', () => ({ i18n: { global: { t: (k: string) => k } } }))
-
+vi.mock('~/modules/toast', () => ({
+  toast: Object.assign(vi.fn(), { success: vi.fn() }),
+}))
+vi.mock('~/modules/i18n', () => ({
+  i18n: { global: { t: (k: string) => k, te: () => false } },
+}))
+vi.mock('~/stores/achievements', () => ({ notifyAchievement: vi.fn() }))
 vi.mock('../src/stores/egg', () => ({
   useEggStore: () => ({ incubator: [], startIncubation: vi.fn() }),
 }))
@@ -41,11 +46,12 @@ describe('breeding store', () => {
 
     vi.advanceTimersByTime(BREEDING_DURATION_MS + 1000)
     expect(breeding.getJob(type)?.status).toBe('completed')
-    expect(mon.busy).toBe(false)
+    expect(mon.busy).toBe(true)
     expect(breeding.start(mon)).toBe(false)
     expect(box.breeding.length).toBe(0)
 
     expect(breeding.collectEgg(type)).toBe(true)
+    expect(mon.busy).toBe(false)
     expect(box.breeding.length).toBe(1)
     expect(box.breeding[0].monId).toBe('salamiches')
 


### PR DESCRIPTION
## Summary
- ensure breeding jobs keep the parent shlagémon busy until the egg is retrieved
- auto-select active breeder when reopening panel to collect pending eggs
- add regression tests for breeding busy state and panel auto-selection

## Testing
- `pnpm lint` *(fails: Unknown env config and thousands of lint errors)*
- `pnpm test:unit` *(fails: numerous existing test failures and unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a2d89c4c832aab3385401756cee7