### PR TITLE
chore: instantiate core stores on index page

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,6 +5,9 @@ usePageHead({
   description: () => t('pages.index.description'),
 })
 const app = useAppStore()
+useEggStore()
+useDojoStore()
+useBreedingStore()
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- instantiate egg, dojo, and breeding stores on the index page

## Testing
- `pnpm lint` *(fails: 4686 problems)*
- `pnpm typecheck` *(fails: TS2345 etc.)*
- `pnpm test:unit` *(fails: 11 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0aa5ead2c832a9f57764f75fe9c53