### PR TITLE
feat: centralize egg timer and toast readiness

### DIFF
--- a/src/components/panel/Poulailler.vue
+++ b/src/components/panel/Poulailler.vue
@@ -59,13 +59,6 @@ interface InventoryEntry {
   }
 }
 
-/** === Time tick (1s) ==================================================== */
-const now = ref<number>(Date.now())
-useIntervalFn(
-  () => { now.value = Date.now() },
-  1000,
-)
-
 /** === Computeds ========================================================= */
 const typeEggs = computed<InventoryEntry[]>(() => {
   return eggIds
@@ -86,10 +79,6 @@ const incubatorSlots = computed(() => {
 })
 
 /** === Helpers =========================================================== */
-function remaining(egg: { hatchesAt: number }): number {
-  return Math.max(0, Math.ceil((egg.hatchesAt - now.value) / 1000))
-}
-
 function fmtSec(total: number): string {
   const m = Math.floor(total / 60)
   const s = total % 60
@@ -291,7 +280,7 @@ function eggReadyLabel(type: EggType) {
                       class="text-xs text-gray-700 tabular-nums dark:text-gray-200"
                       aria-live="polite"
                     >
-                      {{ fmtSec(remaining(slot)) }}
+                      {{ fmtSec(eggs.remaining(slot)) }}
                     </span>
                     <span
                       v-else

--- a/src/stores/egg.i18n.yml
+++ b/src/stores/egg.i18n.yml
@@ -1,0 +1,6 @@
+fr:
+  toast:
+    ready: Un œuf est prêt à éclore !
+en:
+  toast:
+    ready: An egg is ready to hatch!

--- a/test/egg-persist.test.ts
+++ b/test/egg-persist.test.ts
@@ -1,10 +1,17 @@
 import { createPinia, setActivePinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createApp } from 'vue'
 import { allShlagemons } from '../src/data/shlagemons'
 import { useEggStore } from '../src/stores/egg'
 import { eggSerializer } from '../src/utils/egg-serialize'
+
+vi.mock('../src/modules/toast', () => {
+  const fn = vi.fn()
+  fn.success = vi.fn()
+  return { toast: fn }
+})
+vi.mock('../src/modules/i18n', () => ({ i18n: { global: { t: (k: string) => k } } }))
 
 describe('egg persistence', () => {
   it('restores incubator from storage', () => {


### PR DESCRIPTION
## Summary
- move egg incubation timer logic into the egg store and expose remaining time
- update Poulailler panel to use store timing
- show a success toast when an egg becomes ready to hatch

## Testing
- `pnpm test` *(fails: 22 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b0064c74832abd3ac02561152a13