### PR TITLE
Empêcher la sélection des Shlagémons occupés

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -176,6 +176,7 @@ declare global {
   const useBreedingStore: typeof import('./stores/breeding')['useBreedingStore']
   const useBroadcastChannel: typeof import('@vueuse/core')['useBroadcastChannel']
   const useBrowserLocation: typeof import('@vueuse/core')['useBrowserLocation']
+  const useBusyShlagemonIds: typeof import('./composables/useBusyShlagemonIds')['useBusyShlagemonIds']
   const useCached: typeof import('@vueuse/core')['useCached']
   const useCaptureLimitModalStore: typeof import('./stores/captureLimitModal')['useCaptureLimitModalStore']
   const useClipboard: typeof import('@vueuse/core')['useClipboard']
@@ -685,6 +686,7 @@ declare module 'vue' {
     readonly useBreedingStore: UnwrapRef<typeof import('./stores/breeding')['useBreedingStore']>
     readonly useBroadcastChannel: UnwrapRef<typeof import('@vueuse/core')['useBroadcastChannel']>
     readonly useBrowserLocation: UnwrapRef<typeof import('@vueuse/core')['useBrowserLocation']>
+    readonly useBusyShlagemonIds: UnwrapRef<typeof import('./composables/useBusyShlagemonIds')['useBusyShlagemonIds']>
     readonly useCached: UnwrapRef<typeof import('@vueuse/core')['useCached']>
     readonly useCaptureLimitModalStore: UnwrapRef<typeof import('./stores/captureLimitModal')['useCaptureLimitModalStore']>
     readonly useClipboard: UnwrapRef<typeof import('@vueuse/core')['useClipboard']>

--- a/src/components/arena/SelectionModal.vue
+++ b/src/components/arena/SelectionModal.vue
@@ -25,6 +25,7 @@ const emit = defineEmits<{
 
 const open = useVModel(props, 'modelValue', emit)
 const { t } = useI18n()
+const busyIds = useBusyShlagemonIds()
 
 const candidate = ref<DexShlagemon | null>(props.initial)
 
@@ -52,6 +53,7 @@ function confirm() {
     v-model="open"
     :title="t('components.arena.SelectionModal.title', { name: t(props.mon.base.name) })"
     :selected-ids="props.selected"
+    :disabled-ids="busyIds"
     :close-on-select="false"
     @select="onSelect"
   >

--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -14,6 +14,7 @@ const breeding = useBreedingStore()
 const game = useGameStore()
 const panel = useMainPanelStore()
 const dex = useShlagedexStore()
+const busyIds = useBusyShlagemonIds()
 
 function onExit() {
   panel.showVillage()
@@ -176,6 +177,7 @@ watch([selected, isCompleted], () => {
           v-model="selectorOpen"
           :title="t('components.panel.Breeding.selectMon')"
           title-id="breeding-select-title"
+          :disabled-ids="busyIds"
           @select="selectMon"
         />
       </div>

--- a/src/components/panel/Dojo.vue
+++ b/src/components/panel/Dojo.vue
@@ -10,6 +10,7 @@ const panel = useMainPanelStore()
 const dojo = useDojoStore()
 const game = useGameStore()
 const dex = useShlagedexStore()
+const busyIds = useBusyShlagemonIds()
 const { t } = useI18n()
 
 function onExit() {
@@ -217,6 +218,7 @@ const ids = {
         v-model="selectorOpen"
         :title="t('components.panel.Dojo.selectMon')"
         title-id="dojo-select-title"
+        :disabled-ids="busyIds"
         @select="selectMon"
       />
     </template>

--- a/src/composables/useBusyShlagemonIds.ts
+++ b/src/composables/useBusyShlagemonIds.ts
@@ -1,0 +1,14 @@
+import type { ComputedRef } from 'vue'
+
+/**
+ * Provide reactive identifiers of Shlagémon currently busy.
+ *
+ * Busy Shlagémon are engaged in dojo training, breeding or other tasks and
+ * must not be selectable for battles or additional activities.
+ */
+export function useBusyShlagemonIds(): ComputedRef<string[]> {
+  const dex = useShlagedexStore()
+  return computed(() =>
+    dex.shlagemons.filter(mon => mon.busy).map(mon => mon.id),
+  )
+}

--- a/test/busy-selection.test.ts
+++ b/test/busy-selection.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it } from 'vitest'
+import ShlagemonListGeneric from '../src/components/shlagemon/ListGeneric.vue'
+import { useBusyShlagemonIds } from '../src/composables/useBusyShlagemonIds'
+import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useShlagedexStore } from '../src/stores/shlagedex'
+
+describe('busy shlagemon selection', () => {
+  it('disables busy shlagémon in selection lists', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dex = useShlagedexStore()
+    const mon = dex.createShlagemon(carapouffe)
+    dex.setBusy(mon.id, true)
+    const busyIds = useBusyShlagemonIds()
+    expect(busyIds.value).toEqual([mon.id])
+    const wrapper = mount(ShlagemonListGeneric, {
+      props: { disabledIds: busyIds.value },
+      global: { plugins: [pinia], directives: { tooltip: () => {} } },
+    })
+    await wrapper.vm.$nextTick()
+    const item = wrapper.find('[role="option"]')
+    await item.trigger('click')
+    expect(wrapper.emitted('select')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Résumé
- ajoute le composable `useBusyShlagemonIds` pour exposer la liste réactive des Shlagémons occupés
- désactive leur sélection dans les panneaux Dojo, Élevage et la sélection de l'arène
- ajoute un test garantissant qu'un Shlagémon occupé n'est pas sélectionné

## Tests
- `pnpm test` *(échoue : Snapshots 1 failed, Test Files 13 failed | 135 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1107c32dc832a8a6763f205928daa