### PR TITLE
feat(breeding): show job screen during ongoing breeding

### DIFF
--- a/src/components/panel/Breeding.vue
+++ b/src/components/panel/Breeding.vue
@@ -142,34 +142,43 @@ watch([selected, isCompleted], () => {
     <template #default>
       <div class="min-h-0 w-full flex-1">
         <div class="h-full flex flex-1 flex-col items-center justify-center gap-1 overflow-y-auto">
-          <UiAdaptiveDisplayer class="area-grid h-full w-full gap-3 md:gap-4">
-            <BreedingMonPreview
-              :mon="selected"
-              :egg-type="eggType"
-              class="flex-1"
-              @select="openSelector"
-              @change="changeMon"
+          <!-- When a breeding job exists, show its progress only -->
+          <template v-if="job">
+            <BreedingCharacter
+              :character="norman"
+              :typing-text="typingText"
             />
+            <BreedingWorking
+              :is-running="isRunning"
+              :progress="progress"
+              :remaining-label="remainingLabel"
+            />
+          </template>
 
-            <div class="flex-1">
-              <BreedingCharacter
-                :character="norman"
-                :typing-text="typingText"
+          <!-- Otherwise display the selection and information screens -->
+          <template v-else>
+            <UiAdaptiveDisplayer class="area-grid h-full w-full gap-3 md:gap-4">
+              <BreedingMonPreview
+                :mon="selected"
+                :egg-type="eggType"
+                class="flex-1"
+                @select="openSelector"
+                @change="changeMon"
               />
-            </div>
-          </UiAdaptiveDisplayer>
-          <BreedingWorking
-            v-if="job"
-            :is-running="isRunning"
-            :progress="progress"
-            :remaining-label="remainingLabel"
-          />
-          <BreedingInfos
-            v-else
-            :selected="selected"
-            :cost="cost"
-            :duration-min="durationMin"
-          />
+
+              <div class="flex-1">
+                <BreedingCharacter
+                  :character="norman"
+                  :typing-text="typingText"
+                />
+              </div>
+            </UiAdaptiveDisplayer>
+            <BreedingInfos
+              :selected="selected"
+              :cost="cost"
+              :duration-min="durationMin"
+            />
+          </template>
         </div>
 
         <!-- Sélecteur -->

--- a/test/breeding-autoselect.test.ts
+++ b/test/breeding-autoselect.test.ts
@@ -34,9 +34,18 @@ const stubs = {
   PanelPoiDialogFlow: { template: '<div><slot /><slot name="footer" /></div>' },
   UiButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
   UiAdaptiveDisplayer: { template: '<div><slot /></div>' },
-  BreedingMonPreview: { props: ['mon', 'eggType'], emits: ['select', 'change'], template: '<div />' },
+  BreedingMonPreview: {
+    name: 'BreedingMonPreview',
+    props: ['mon', 'eggType'],
+    emits: ['select', 'change'],
+    template: '<div class="mon-preview" />',
+  },
   BreedingCharacter: { props: ['character', 'typingText'], template: '<div />' },
-  BreedingWorking: { props: ['isRunning', 'progress', 'remainingLabel'], template: '<div />' },
+  BreedingWorking: {
+    name: 'BreedingWorking',
+    props: ['isRunning', 'progress', 'remainingLabel'],
+    template: '<div class="working" />',
+  },
   BreedingInfos: { props: ['selected', 'cost', 'durationMin'], template: '<div />' },
   ShlagemonSelectModal: { template: '<div />' },
   UiCurrencyAmount: { template: '<span />' },
@@ -100,6 +109,8 @@ describe('breeding panel preselection', () => {
 
     await nextTick()
     expect((wrapper.vm as any).selected?.id).toBe(mon.id)
-    expect(wrapper.find('button').exists()).toBe(true)
+    // Should display the working screen without the shlagemon selector
+    expect(wrapper.findComponent({ name: 'BreedingMonPreview' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'BreedingWorking' }).exists()).toBe(true)
   })
 })

--- a/test/breeding.test.ts
+++ b/test/breeding.test.ts
@@ -49,6 +49,7 @@ vi.mock('../src/stores/game', () => ({
 const getJob = vi.fn(() => null)
 vi.mock('../src/stores/breeding', () => ({
   useBreedingStore: () => ({
+    byType: {},
     getJob,
     remainingMs: vi.fn(),
     progress: vi.fn(),

--- a/test/panel-dialog-music.test.ts
+++ b/test/panel-dialog-music.test.ts
@@ -35,6 +35,7 @@ vi.mock('../src/modules/toast', () => ({
 // Panel specific store mocks
 vi.mock('../src/stores/breeding', () => ({
   useBreedingStore: () => ({
+    byType: {},
     getJob: vi.fn(),
     remainingMs: vi.fn(),
     progress: vi.fn(),


### PR DESCRIPTION
## Summary
- display character and progress when a breeding job is already active
- hide shlagémon selector while breeding is running or egg uncollected
- adjust tests and mocks for new breeding store access

## Testing
- `pnpm test:unit --run` *(fails: animated number duration, router redirect)*

------
https://chatgpt.com/codex/tasks/task_e_68a115f444f0832a8c5b4c5576c026d7