### PR TITLE
refactor: stabilize typing timer

### DIFF
--- a/src/components/ui/TypingText.spec.ts
+++ b/src/components/ui/TypingText.spec.ts
@@ -1,0 +1,50 @@
+/* eslint-disable import/first */
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const playTypingSfx = vi.fn()
+vi.mock('~/stores/audio', () => ({
+  useAudioStore: () => ({ playTypingSfx }),
+}))
+
+import TypingText from './TypingText.vue'
+
+describe('ui TypingText', () => {
+  beforeEach(() => {
+    playTypingSfx.mockReset()
+  })
+
+  it('types characters at configured speed and plays SFX once per character', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(TypingText, { props: { text: 'abc', speed: 10 } })
+
+    expect(wrapper.text()).toBe('a')
+    expect(playTypingSfx).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(wrapper.text()).toBe('ab')
+    expect(playTypingSfx).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(wrapper.text()).toBe('abc')
+    expect(playTypingSfx).toHaveBeenCalledTimes(3)
+
+    vi.useRealTimers()
+  })
+
+  it('cancels pending timer when text changes', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(TypingText, { props: { text: 'ab', speed: 10 } })
+
+    expect(playTypingSfx).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ text: 'x' })
+    expect(wrapper.text()).toBe('x')
+    expect(playTypingSfx).toHaveBeenCalledTimes(2)
+
+    await vi.runAllTimersAsync()
+    expect(playTypingSfx).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
+  })
+})

--- a/src/components/ui/TypingText.vue
+++ b/src/components/ui/TypingText.vue
@@ -10,19 +10,26 @@ const emit = defineEmits<{
 const audio = useAudioStore()
 
 const display = ref('')
-let timer: ReturnType<typeof useTimeoutFn> | undefined
+let timer: ReturnType<typeof setTimeout> | undefined
+
+function clearTimer() {
+  if (timer !== undefined) {
+    clearTimeout(timer)
+    timer = undefined
+  }
+}
 
 function start() {
   display.value = ''
-  timer?.stop()
+  clearTimer()
   if (!props.text)
     return emit('finished')
-  let i = 0
+  let index = 0
   function typeChar() {
-    display.value += props.text[i++]
+    display.value += props.text[index++]
     audio.playTypingSfx()
-    if (i < props.text.length)
-      timer = useTimeoutFn(typeChar, props.speed)
+    if (index < props.text.length)
+      timer = setTimeout(typeChar, props.speed)
     else
       emit('finished')
   }
@@ -31,9 +38,7 @@ function start() {
 
 watch(() => props.text, start, { immediate: true })
 
-onUnmounted(() => {
-  timer?.stop()
-})
+onUnmounted(clearTimer)
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- use setTimeout with explicit cleanup in TypingText
- add unit tests verifying cadence and timer cancellation

## Testing
- `pnpm eslint src/components/ui/TypingText.vue src/components/ui/TypingText.spec.ts`
- `pnpm lint` *(fails: 4602 errors, 85 warnings)*
- `pnpm test:unit` *(fails: 14 failing tests)*
- `npx cypress run` *(fails: missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a57f9f6c832a87f2713cfd270491