### PR TITLE
fix(ui): prevent slider controls from submitting forms

### DIFF
--- a/src/components/ui/Slider.spec.ts
+++ b/src/components/ui/Slider.spec.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import Slider from './Slider.vue'
+
+describe('ui Slider', () => {
+  it('updates value when using increment and decrement buttons', async () => {
+    const wrapper = mount(Slider, {
+      props: { modelValue: 5, min: 0, max: 10 },
+    })
+
+    const controls = wrapper.findAll('button').filter(btn => ['−', '+'].includes(btn.text()))
+    const minus = controls.find(btn => btn.text() === '−')!
+    const plus = controls.find(btn => btn.text() === '+')!
+
+    expect(minus.attributes('type')).toBe('button')
+    expect(plus.attributes('type')).toBe('button')
+
+    await minus.trigger('click')
+    await plus.trigger('click')
+
+    const updates = wrapper.emitted('update:modelValue')
+    expect(updates?.map(args => args[0])).toEqual([4, 5])
+  })
+})

--- a/src/components/ui/Slider.vue
+++ b/src/components/ui/Slider.vue
@@ -188,13 +188,32 @@ function onKeydown(e: KeyboardEvent): void {
   let delta = 0
   const step = safeStep.value || (range.value / 100)
   switch (e.key) {
-    case 'ArrowLeft': case 'ArrowDown': delta = -step; break
-    case 'ArrowRight': case 'ArrowUp': delta = step; break
-    case 'PageDown': delta = -step * 10; break
-    case 'PageUp': delta = step * 10; break
-    case 'Home': setLive(props.min); commit(); e.preventDefault(); return
-    case 'End': setLive(props.max); commit(); e.preventDefault(); return
-    default: return
+    case 'ArrowLeft':
+    case 'ArrowDown':
+      delta = -step
+      break
+    case 'ArrowRight':
+    case 'ArrowUp':
+      delta = step
+      break
+    case 'PageDown':
+      delta = -step * 10
+      break
+    case 'PageUp':
+      delta = step * 10
+      break
+    case 'Home':
+      setLive(props.min)
+      commit()
+      e.preventDefault()
+      return
+    case 'End':
+      setLive(props.max)
+      commit()
+      e.preventDefault()
+      return
+    default:
+      return
   }
   setLive(internal.value + delta)
   commit()
@@ -218,7 +237,9 @@ const ariaValueText = computed(() => props.format(internal.value))
     <!-- Ligne principale -->
     <div class="flex items-center gap-1">
       <!-- − -->
+      <!-- Explicit button type prevents unintended form submission when slider sits inside a form -->
       <UiButton
+        type="button"
         :disabled="!canDecrement"
         size="xs"
         :aria-label="`Diminuer de ${buttonDelta} (${format(snap(internal - buttonDelta))}${unit})`"
@@ -277,7 +298,9 @@ const ariaValueText = computed(() => props.format(internal.value))
       </div>
 
       <!-- + -->
+      <!-- Explicit button type prevents unintended form submission when slider sits inside a form -->
       <UiButton
+        type="button"
         :disabled="!canIncrement"
         size="xs"
         :aria-label="`Augmenter de ${buttonDelta} (${format(snap(internal + buttonDelta))}${unit})`"


### PR DESCRIPTION
## Summary
- prevent slider +/- buttons from submitting parent forms
- cover slider button behaviour with unit test

## Testing
- `pnpm lint` *(fails: This line has 2 statements. Maximum allowed is 1)*
- `pnpm test:unit` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '~')*
- `pnpm exec eslint src/components/ui/Slider.vue src/components/ui/Slider.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a1bec3863c832a8f395d651bf6b8be