### PR TITLE
fix: support native button types

### DIFF
--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -11,6 +11,7 @@ export type ButtonType
 
 export type ButtonVariant = 'solid' | 'outline'
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg'
+export type ButtonNativeType = 'button' | 'submit' | 'reset'
 
 const props = withDefaults(
   defineProps<{
@@ -21,6 +22,11 @@ const props = withDefaults(
     ariaLabel?: string
     iconSize?: string // Ajout d’une prop taille icône : ex "text-xl" ou "text-2xl"
     circle?: boolean
+    /**
+     * Type natif de l’élément `<button>`. Par défaut
+     * `'button'` pour les boutons icône, `'submit'` sinon.
+     */
+    nativeType?: ButtonNativeType
   }>(),
   {
     type: 'default',
@@ -30,6 +36,7 @@ const props = withDefaults(
     ariaLabel: undefined,
     iconSize: '', // vide = auto
     circle: false,
+    nativeType: undefined,
   },
 )
 
@@ -115,7 +122,7 @@ function handleClick(e: MouseEvent) {
 
 <template>
   <button
-    :type="props.type === 'icon' ? 'button' : 'submit'"
+    :type="props.nativeType ?? (props.type === 'icon' ? 'button' : 'submit')"
     :disabled="props.disabled"
     :aria-label="props.ariaLabel"
     :tabindex="props.disabled ? -1 : 0"

--- a/src/components/ui/Slider.vue
+++ b/src/components/ui/Slider.vue
@@ -239,7 +239,7 @@ const ariaValueText = computed(() => props.format(internal.value))
       <!-- − -->
       <!-- Explicit button type prevents unintended form submission when slider sits inside a form -->
       <UiButton
-        type="button"
+        native-type="button"
         :disabled="!canDecrement"
         size="xs"
         :aria-label="`Diminuer de ${buttonDelta} (${format(snap(internal - buttonDelta))}${unit})`"
@@ -300,7 +300,7 @@ const ariaValueText = computed(() => props.format(internal.value))
       <!-- + -->
       <!-- Explicit button type prevents unintended form submission when slider sits inside a form -->
       <UiButton
-        type="button"
+        native-type="button"
         :disabled="!canIncrement"
         size="xs"
         :aria-label="`Augmenter de ${buttonDelta} (${format(snap(internal + buttonDelta))}${unit})`"


### PR DESCRIPTION
## Summary
- add optional nativeType to UiButton
- use nativeType in Slider buttons to avoid style type mismatches

## Testing
- `pnpm exec eslint src/components/ui/Button.vue src/components/ui/Slider.vue`
- `pnpm test:unit` *(fails: Cannot find package '~' imported from node_modules/.vite-temp/vite.config.ts)*
- `pnpm typecheck` *(fails: numerous TypeScript errors, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c8d59c0c832ab4e02bcf4cfa1c10