### PR TITLE
feat: unified post-hydrate notifications for eggs, dojo and breeding

### DIFF
--- a/src/stores/egg.i18n.yml
+++ b/src/stores/egg.i18n.yml
@@ -1,6 +1,8 @@
 fr:
   toast:
     ready: Un œuf est prêt à éclore !
+    readyMultiple: "{count} œufs sont prêts à éclore ! Rendez-vous au Poulailler pour assister à l'éclosion."
 en:
   toast:
     ready: An egg is ready to hatch!
+    readyMultiple: '{count} eggs can hatch! Head to the Henhouse to watch them hatch.'

--- a/src/stores/egg.spec.ts
+++ b/src/stores/egg.spec.ts
@@ -1,0 +1,31 @@
+import type { EggType } from './egg'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from '~/modules/toast'
+import { useEggStore } from './egg'
+
+vi.mock('~/modules/i18n', () => ({ i18n: { global: { t: (key: string, params?: any) => params?.count ? `${key}:${params.count}` : key } } }))
+vi.mock('~/modules/toast', () => ({ toast: { success: vi.fn() } }))
+
+function readyEgg(store: ReturnType<typeof useEggStore>) {
+  store.startIncubation('feu' as EggType)
+  store.incubator.forEach((egg) => {
+    egg.hatchesAt = Date.now() - 1000
+  })
+}
+
+describe('egg store notifications', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('aggregates multiple ready eggs into a single toast', () => {
+    const store = useEggStore()
+    readyEgg(store)
+    readyEgg(store)
+    store.notifyReady()
+    expect(toast.success).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith('stores.egg.toast.readyMultiple:2')
+  })
+})

--- a/test/breeding.test.ts
+++ b/test/breeding.test.ts
@@ -54,8 +54,25 @@ vi.mock('../src/stores/breeding', () => ({
     remainingMs: vi.fn(),
     progress: vi.fn(),
     start: vi.fn(),
+    startSelected: vi.fn(),
     collectEgg: vi.fn(),
     completeIfDue: vi.fn(),
+    ensureSelectionFromJobs: vi.fn(),
+    selectedMon: null,
+    activeEggType: null,
+    typingText: 'Confie moi un de tes Shlagémons, je vais l\'ensemencer avec tendresse et amour !',
+    get activeJob() {
+      return getJob()
+    },
+    get isRunningSelected() {
+      return this.activeJob?.status === 'running'
+    },
+    selectedProgressPercent: 0,
+    selectedRemainingLabel: '',
+    selectedCost: 0,
+    durationMin: 0,
+    canStartSelected: true,
+    canCollectSelected: false,
   }),
 }))
 

--- a/test/main-panel-breeding.test.ts
+++ b/test/main-panel-breeding.test.ts
@@ -49,8 +49,26 @@ vi.mock('../src/stores/breeding', () => ({
     remainingMs: vi.fn(),
     progress: vi.fn(),
     start: vi.fn(),
+    startSelected: vi.fn(),
     collectEgg: vi.fn(),
     completeIfDue: vi.fn(),
+    ensureSelectionFromJobs: vi.fn(),
+    byType: {},
+    selectedMon: null,
+    activeEggType: null,
+    typingText: '',
+    get activeJob() {
+      return this.getJob?.()
+    },
+    get isRunningSelected() {
+      return this.activeJob?.status === 'running'
+    },
+    selectedProgressPercent: 0,
+    selectedRemainingLabel: '',
+    selectedCost: 0,
+    durationMin: 0,
+    canStartSelected: true,
+    canCollectSelected: false,
   }),
 }))
 

--- a/test/panel-dialog-music.test.ts
+++ b/test/panel-dialog-music.test.ts
@@ -40,8 +40,25 @@ vi.mock('../src/stores/breeding', () => ({
     remainingMs: vi.fn(),
     progress: vi.fn(),
     start: vi.fn(),
+    startSelected: vi.fn(),
     collectEgg: vi.fn(),
     completeIfDue: vi.fn(),
+    ensureSelectionFromJobs: vi.fn(),
+    selectedMon: null,
+    activeEggType: null,
+    typingText: '',
+    get activeJob() {
+      return this.getJob?.()
+    },
+    get isRunningSelected() {
+      return this.activeJob?.status === 'running'
+    },
+    selectedProgressPercent: 0,
+    selectedRemainingLabel: '',
+    selectedCost: 0,
+    durationMin: 0,
+    canStartSelected: true,
+    canCollectSelected: false,
   }),
 }))
 


### PR DESCRIPTION
## Summary
- aggregate egg hatching notifications and guide players to the Henhouse
- toast dojo training and breeding completions when stores hydrate
- cover egg readiness aggregation with unit test

## Testing
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68a25715e330832ab7f20466901a5491