### PR TITLE
fix(ui): show modal on initial render

### DIFF
--- a/src/components/ui/Modal.vue
+++ b/src/components/ui/Modal.vue
@@ -22,6 +22,16 @@ const emit = defineEmits(['update:modelValue', 'close'])
 const attrs = useAttrs()
 const dialogRef = ref<HTMLDialogElement | null>(null)
 
+/**
+ * Display the dialog on the first render when `modelValue` is initially
+ * `true`.
+ */
+onMounted(() => {
+  const dialog = dialogRef.value
+  if (props.modelValue && dialog && typeof dialog.showModal === 'function')
+    dialog.showModal()
+})
+
 onUnmounted(() => {
   const dialog = dialogRef.value
   if (dialog?.open)
@@ -38,7 +48,7 @@ watch(() => props.modelValue, (v) => {
   if (!dialog)
     return
   if (v) {
-    if (!dialog.open)
+    if (!dialog.open && typeof dialog.showModal === 'function')
       dialog.showModal()
   }
   else {


### PR DESCRIPTION
## Summary
- ensure dialog displays on mount when modelValue is true
- guard dialog.showModal calls to avoid errors in non-browser environments

## Testing
- `pnpm lint` *(fails: UnoCSS order and format issues in other files)*
- `pnpm exec eslint src/components/ui/Modal.vue`
- `pnpm typecheck` *(fails: type errors in stores)*
- `pnpm test test/arena-selection-modal.test.ts` *(fails: assertion errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a42dd7ca24832aa0999b0af30aae33