### PR TITLE
feat(sim): add deterministic simulation engine

### DIFF
--- a/packages/sim/package.json
+++ b/packages/sim/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@shlagemon/sim",
+  "type": "module",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/sim/src/engine.ts
+++ b/packages/sim/src/engine.ts
@@ -1,0 +1,89 @@
+import { PRNG } from './prng'
+
+/**
+ * Snapshot of the simulation state.
+ */
+export interface SimulationSnapshot {
+  /** Number of completed simulation ticks. */
+  tick: number
+  /** Accumulated value influenced by inputs and randomness. */
+  value: number
+  /** Internal state of the pseudo-random number generator. */
+  rngState: number
+}
+
+/**
+ * Deterministic headless simulation engine with a fixed time step.
+ */
+export class Engine {
+  /** Duration of a single simulation step in milliseconds. */
+  readonly stepMs: number
+
+  private accumulator = 0
+  private prng: PRNG
+  private pendingInput = 0
+
+  /**
+   * Mutable simulation state.
+   */
+  private state: SimulationSnapshot
+
+  constructor(seed: number, stepHz = 20) {
+    if (stepHz <= 0)
+      throw new Error('Step frequency must be positive')
+    this.stepMs = Math.floor(1000 / stepHz)
+    this.prng = new PRNG(seed)
+    this.state = {
+      tick: 0,
+      value: 0,
+      rngState: this.prng.getState(),
+    }
+  }
+
+  /**
+   * Queues an input to be processed on the next simulation step.
+   */
+  enqueueInput(amount: number): void {
+    if (!Number.isFinite(amount))
+      throw new Error('Input must be a finite number')
+    this.pendingInput += amount
+  }
+
+  /**
+   * Advances the simulation by the provided time delta.
+   */
+  update(deltaMs: number): void {
+    if (deltaMs < 0)
+      throw new Error('Delta time cannot be negative')
+    this.accumulator += deltaMs
+    while (this.accumulator >= this.stepMs) {
+      this.step()
+      this.accumulator -= this.stepMs
+    }
+  }
+
+  private step(): void {
+    const randomContribution = Math.floor(this.prng.next() * 10)
+    this.state.tick += 1
+    this.state.value += this.pendingInput + randomContribution
+    this.pendingInput = 0
+    this.state.rngState = this.prng.getState()
+  }
+
+  /**
+   * Creates a serializable snapshot of the current state.
+   */
+  getSnapshot(): SimulationSnapshot {
+    return { ...this.state }
+  }
+
+  /**
+   * Restores the simulation state from a snapshot.
+   */
+  setSnapshot(snapshot: SimulationSnapshot): void {
+    this.prng.setState(snapshot.rngState)
+    this.state = { ...snapshot }
+    this.accumulator = 0
+    this.pendingInput = 0
+  }
+}

--- a/packages/sim/src/index.ts
+++ b/packages/sim/src/index.ts
@@ -1,0 +1,2 @@
+export * from './engine'
+export * from './runScenario'

--- a/packages/sim/src/prng.ts
+++ b/packages/sim/src/prng.ts
@@ -1,0 +1,40 @@
+/**
+ * Seedable pseudo-random number generator based on Mulberry32 algorithm.
+ * Provides deterministic sequences for reproducible simulations.
+ */
+export class PRNG {
+  private state: number
+
+  constructor(seed: number) {
+    if (!Number.isInteger(seed))
+      throw new Error('Seed must be an integer')
+    this.state = seed >>> 0
+  }
+
+  /**
+   * Generates the next pseudo-random number in [0, 1).
+   */
+  next(): number {
+    // Mulberry32 algorithm
+    let t = this.state += 0x6D2B79F5
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /**
+   * Returns current internal state for snapshotting.
+   */
+  getState(): number {
+    return this.state >>> 0
+  }
+
+  /**
+   * Restores the internal state from snapshot.
+   */
+  setState(state: number): void {
+    if (!Number.isInteger(state))
+      throw new Error('State must be an integer')
+    this.state = state >>> 0
+  }
+}

--- a/packages/sim/src/runScenario.ts
+++ b/packages/sim/src/runScenario.ts
@@ -1,0 +1,39 @@
+import type { SimulationSnapshot } from './engine'
+import { Engine } from './engine'
+
+/**
+ * Input applied at a specific simulation frame.
+ */
+export interface ScenarioInput {
+  /** Frame number at which the input is applied. */
+  frame: number
+  /** Numeric value added to the simulation on that frame. */
+  value: number
+}
+
+/**
+ * Runs a deterministic scenario for testing purposes.
+ * @param seed Seed for the pseudo-random number generator.
+ * @param inputs Time-ordered list of frame-based inputs.
+ * @returns Array of snapshots taken after each frame.
+ */
+export function runScenario(seed: number, inputs: ScenarioInput[]): SimulationSnapshot[] {
+  const engine = new Engine(seed)
+  const ordered = [...inputs].sort((a, b) => a.frame - b.frame)
+  const snapshots: SimulationSnapshot[] = []
+
+  const lastFrame = ordered.length ? ordered[ordered.length - 1].frame : 0
+  const totalFrames = Math.max(lastFrame + 1, 10)
+
+  let inputIndex = 0
+  for (let frame = 0; frame < totalFrames; frame++) {
+    while (inputIndex < ordered.length && ordered[inputIndex].frame === frame) {
+      engine.enqueueInput(ordered[inputIndex].value)
+      inputIndex += 1
+    }
+    engine.update(engine.stepMs)
+    snapshots.push(engine.getSnapshot())
+  }
+
+  return snapshots
+}

--- a/packages/sim/tsconfig.json
+++ b/packages/sim/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,8 @@ importers:
         specifier: catalog:dev
         version: 2.8.0
 
+  packages/sim: {}
+
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
-packages: []
+packages:
+  - packages/*
 
 catalogs:
   build:

--- a/test/__snapshots__/sim-runScenario.test.ts.snap
+++ b/test/__snapshots__/sim-runScenario.test.ts.snap
@@ -1,0 +1,56 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`deterministic simulation > produces stable snapshots 1`] = `
+[
+  {
+    "rngState": 1831565936,
+    "tick": 1,
+    "value": 7,
+  },
+  {
+    "rngState": 3663131749,
+    "tick": 2,
+    "value": 8,
+  },
+  {
+    "rngState": 1199730266,
+    "tick": 3,
+    "value": 17,
+  },
+  {
+    "rngState": 3031296079,
+    "tick": 4,
+    "value": 19,
+  },
+  {
+    "rngState": 567894596,
+    "tick": 5,
+    "value": 22,
+  },
+  {
+    "rngState": 2399460409,
+    "tick": 6,
+    "value": 27,
+  },
+  {
+    "rngState": 4231026222,
+    "tick": 7,
+    "value": 35,
+  },
+  {
+    "rngState": 1767624739,
+    "tick": 8,
+    "value": 44,
+  },
+  {
+    "rngState": 3599190552,
+    "tick": 9,
+    "value": 51,
+  },
+  {
+    "rngState": 1135789069,
+    "tick": 10,
+    "value": 55,
+  },
+]
+`;

--- a/test/sim-runScenario.test.ts
+++ b/test/sim-runScenario.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { Engine, runScenario } from '../packages/sim/src'
+
+describe('deterministic simulation', () => {
+  it('produces stable snapshots', () => {
+    const snapshots = runScenario(123, [
+      { frame: 2, value: 5 },
+      { frame: 5, value: -3 },
+    ])
+    expect(snapshots).toMatchSnapshot()
+  })
+
+  it('restores from snapshot', () => {
+    const engine = new Engine(42)
+    engine.enqueueInput(3)
+    engine.update(engine.stepMs)
+    const snap = engine.getSnapshot()
+
+    const restored = new Engine(0)
+    restored.setSnapshot(snap)
+    expect(restored.getSnapshot()).toEqual(snap)
+  })
+})


### PR DESCRIPTION
## Summary
- add seedable PRNG and fixed-timestep engine for deterministic simulations
- expose runScenario helper and golden snapshot tests
- register new `packages/*` workspace path

## Testing
- `CI=1 pnpm test test/sim-runScenario.test.ts --run -u`
- `CI=1 pnpm test` *(fails: snapshot mismatch and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d7ab1b28832a8858eebd760c29ef