### PR TITLE
Enable final battle switching with HP persistence

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -237,6 +237,7 @@ declare global {
   const useFetch: typeof import('@vueuse/core')['useFetch']
   const useFileDialog: typeof import('@vueuse/core')['useFileDialog']
   const useFileSystemAccess: typeof import('@vueuse/core')['useFileSystemAccess']
+  const useFinalBattleStore: typeof import('./stores/finalBattle')['useFinalBattleStore']
   const useFloatingNumbers: typeof import('./composables/useFloatingNumbers')['useFloatingNumbers']
   const useFocus: typeof import('@vueuse/core')['useFocus']
   const useFocusWithin: typeof import('@vueuse/core')['useFocusWithin']
@@ -512,6 +513,9 @@ declare global {
   // @ts-ignore
   export type { UseItemAction, ShortcutAction, ShortcutEntry } from './stores/shortcuts'
   import('./stores/shortcuts')
+  // @ts-ignore
+  export type { TrainerBattleMode } from './stores/trainerBattle'
+  import('./stores/trainerBattle')
 }
 
 // for vue template auto import
@@ -750,6 +754,7 @@ declare module 'vue' {
     readonly useFetch: UnwrapRef<typeof import('@vueuse/core')['useFetch']>
     readonly useFileDialog: UnwrapRef<typeof import('@vueuse/core')['useFileDialog']>
     readonly useFileSystemAccess: UnwrapRef<typeof import('@vueuse/core')['useFileSystemAccess']>
+    readonly useFinalBattleStore: UnwrapRef<typeof import('./stores/finalBattle')['useFinalBattleStore']>
     readonly useFloatingNumbers: UnwrapRef<typeof import('./composables/useFloatingNumbers')['useFloatingNumbers']>
     readonly useFocus: UnwrapRef<typeof import('@vueuse/core')['useFocus']>
     readonly useFocusWithin: UnwrapRef<typeof import('@vueuse/core')['useFocusWithin']>
@@ -880,7 +885,6 @@ declare module 'vue' {
     readonly useThrottledRefHistory: UnwrapRef<typeof import('@vueuse/core')['useThrottledRefHistory']>
     readonly useTicTacToe: UnwrapRef<typeof import('./composables/useTicTacToe')['useTicTacToe']>
     readonly useTimeAgo: UnwrapRef<typeof import('@vueuse/core')['useTimeAgo']>
-    readonly useTimeAgoIntl: UnwrapRef<typeof import('@vueuse/core')['useTimeAgoIntl']>
     readonly useTimeout: UnwrapRef<typeof import('@vueuse/core')['useTimeout']>
     readonly useTimeoutFn: UnwrapRef<typeof import('@vueuse/core')['useTimeoutFn']>
     readonly useTimeoutPoll: UnwrapRef<typeof import('@vueuse/core')['useTimeoutPoll']>

--- a/src/stores/featureLock.ts
+++ b/src/stores/featureLock.ts
@@ -15,16 +15,32 @@ export const useFeatureLockStore = defineStore('featureLock', () => {
     inventoryLocked.value = true
   }
 
+  function unlockInventory() {
+    inventoryLocked.value = false
+  }
+
   function lockShlagedex() {
     shlagedexLocked.value = true
+  }
+
+  function unlockShlagedex() {
+    shlagedexLocked.value = false
   }
 
   function lockZones() {
     zonesLocked.value = true
   }
 
+  function unlockZones() {
+    zonesLocked.value = false
+  }
+
   function lockAchievements() {
     achievementsLocked.value = true
+  }
+
+  function unlockAchievements() {
+    achievementsLocked.value = false
   }
 
   function lockAll() {
@@ -50,6 +66,10 @@ export const useFeatureLockStore = defineStore('featureLock', () => {
     lockShlagedex,
     lockAchievements,
     lockZones,
+    unlockInventory,
+    unlockShlagedex,
+    unlockZones,
+    unlockAchievements,
     lockAll,
     unlockAll,
   }

--- a/src/stores/finalBattle.ts
+++ b/src/stores/finalBattle.ts
@@ -1,0 +1,55 @@
+import type { DexShlagemon } from '~/type/shlagemon'
+import { defineStore } from 'pinia'
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+export const useFinalBattleStore = defineStore('finalBattle', () => {
+  const active = ref(false)
+  const hpSnapshots = ref<Record<string, number>>({})
+
+  const isActive = computed(() => active.value)
+
+  function begin() {
+    active.value = true
+    hpSnapshots.value = {}
+  }
+
+  function finish() {
+    active.value = false
+    hpSnapshots.value = {}
+  }
+
+  function snapshot(mon: DexShlagemon, maxHp: number) {
+    if (!active.value)
+      return
+    const normalized = clamp(Math.round(mon.hpCurrent), 0, Math.round(maxHp))
+    hpSnapshots.value = {
+      ...hpSnapshots.value,
+      [mon.id]: normalized,
+    }
+  }
+
+  function restore(mon: DexShlagemon, maxHp: number) {
+    if (!active.value)
+      return
+    const roundedMax = Math.max(0, Math.round(maxHp))
+    const stored = hpSnapshots.value[mon.id]
+    const target = typeof stored === 'number' ? stored : roundedMax
+    const normalized = clamp(target, 0, roundedMax)
+    mon.hpCurrent = normalized
+    hpSnapshots.value = {
+      ...hpSnapshots.value,
+      [mon.id]: normalized,
+    }
+  }
+
+  return {
+    isActive,
+    begin,
+    finish,
+    snapshot,
+    restore,
+  }
+})

--- a/src/stores/shlagedex.ts
+++ b/src/stores/shlagedex.ts
@@ -9,6 +9,7 @@ import { allItems } from '~/data/items'
 import { allShlagemons } from '~/data/shlagemons'
 import { i18n } from '~/modules/i18n'
 import { toast } from '~/modules/toast'
+import { useFinalBattleStore } from '~/stores/finalBattle'
 import { useWildLevelStore } from '~/stores/wildLevel'
 import {
   applyCurrentStats,
@@ -208,8 +209,14 @@ export const useShlagedexStore = defineStore('shlagedex', () => {
   function setActiveShlagemon(mon: DexShlagemon) {
     if (disease.active || mon.busy)
       return
+    const finalBattle = useFinalBattleStore()
+    const current = activeShlagemon.value
+    if (finalBattle.isActive && current && current.id !== mon.id)
+      finalBattle.snapshot(current, maxHp(current))
     activeShlagemon.value = mon
     markSeen(mon)
+    if (finalBattle.isActive)
+      finalBattle.restore(mon, maxHp(mon))
   }
 
   /**

--- a/src/stores/trainerBattle.ts
+++ b/src/stores/trainerBattle.ts
@@ -12,15 +12,19 @@ const DEFAULT_LEVEL_UP_HEAL_PERCENT = 15
  */
 const DEFAULT_WIN_HEAL_PERCENT = 15
 
+export type TrainerBattleMode = 'standard' | 'final'
+
 export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   const queue = ref<Trainer[]>([])
   const currentIndex = ref(0)
+  const mode = ref<TrainerBattleMode>('standard')
   const levelUpHealPercent = ref(DEFAULT_LEVEL_UP_HEAL_PERCENT)
   const winHealPercent = ref(DEFAULT_WIN_HEAL_PERCENT)
 
-  function setQueue(list: Trainer[]) {
+  function setQueue(list: Trainer[], options?: { mode?: TrainerBattleMode }) {
     queue.value = list
     currentIndex.value = 0
+    mode.value = options?.mode ?? 'standard'
   }
 
   function add(trainer: Trainer) {
@@ -29,6 +33,7 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
 
   const current = computed(() => queue.value[currentIndex.value] ?? null)
   const isActive = computed(() => Boolean(current.value))
+  const isFinalBattle = computed(() => mode.value === 'final')
 
   function next() {
     currentIndex.value += 1
@@ -37,6 +42,7 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
   function reset() {
     queue.value = []
     currentIndex.value = 0
+    mode.value = 'standard'
   }
 
   // init with default trainers
@@ -46,9 +52,11 @@ export const useTrainerBattleStore = defineStore('trainerBattle', () => {
     queue,
     current,
     isActive,
+    isFinalBattle,
     next,
     add,
     setQueue,
+    mode,
     reset,
     levelUpHealPercent,
     winHealPercent,

--- a/test/final-battle-store.test.ts
+++ b/test/final-battle-store.test.ts
@@ -1,0 +1,110 @@
+import type { I18nKey } from '~/type'
+import type { BaseShlagemon, DexShlagemon } from '~/type/shlagemon'
+import type { ShlagemonType } from '~/type/shlagemonType'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+vi.mock('~/modules/i18n', () => ({ i18n: { global: { t: (key: string) => key } } }))
+vi.mock('~/modules/toast', () => ({ toast: vi.fn() }))
+vi.mock('~/stores/audio', () => ({ useAudioStore: () => ({ playSfx: vi.fn() }) }))
+vi.mock('~/stores/disease', () => ({ useDiseaseStore: () => ({ active: false }) }))
+vi.mock('~/stores/equipment', () => ({ useEquipmentStore: () => ({ equip: vi.fn(), unequip: vi.fn() }) }))
+vi.mock('~/stores/evolution', () => ({ useEvolutionStore: () => ({ requestEvolution: vi.fn().mockResolvedValue(true) }) }))
+vi.mock('~/stores/wildLevel', () => ({ useWildLevelStore: () => ({}) }))
+vi.mock('~/stores/zoneAccess', () => ({ useZoneAccess: () => ({ accessibleZones: ref([]) }) }))
+vi.mock('~/data/items', async () => {
+  const actual = await vi.importActual<typeof import('~/data/items')>('~/data/items')
+  return { ...actual, allItems: [] as any[] }
+})
+vi.mock('~/data/shlagemons', () => ({ allShlagemons: [] }))
+
+const dummyType: ShlagemonType = {
+  id: 'normal',
+  name: 'type.normal.name' as I18nKey,
+  description: 'type.normal.description' as I18nKey,
+  color: '#fff',
+  resistance: [],
+  weakness: [],
+  tags: [],
+  passiveEffects: [],
+}
+
+function createBase(id: string): BaseShlagemon {
+  return {
+    id,
+    name: `${id}.name` as I18nKey,
+    description: `${id}.description` as I18nKey,
+    types: [dummyType],
+    speciality: 'unique',
+  }
+}
+
+function createDexMon(id: string, hp = 100): DexShlagemon {
+  const stats = { hp, attack: 10, defense: 10, smelling: 10 }
+  return {
+    id,
+    base: createBase(`${id}-base`),
+    baseStats: stats,
+    captureDate: new Date().toISOString(),
+    captureCount: 1,
+    lvl: 10,
+    xp: 0,
+    rarity: 10,
+    sex: 'male',
+    isShiny: false,
+    hpCurrent: hp,
+    allowEvolution: false,
+    heldItemId: null,
+    rarityFollowsLevel: false,
+    isNew: false,
+    busy: false,
+    ...stats,
+  }
+}
+
+describe('final battle store integration', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('restores appropriate HP values when switching during the final battle', async () => {
+    const { useShlagedexStore } = await import('~/stores/shlagedex')
+    const { useFinalBattleStore } = await import('~/stores/finalBattle')
+
+    const dex = useShlagedexStore()
+    const finalBattle = useFinalBattleStore()
+    const alpha = createDexMon('alpha')
+    const beta = createDexMon('beta')
+
+    dex.shlagemons.push(alpha, beta)
+    dex.setActiveShlagemon(alpha)
+    alpha.hpCurrent = 42
+
+    finalBattle.begin()
+
+    dex.setActiveShlagemon(beta)
+    expect(beta.hpCurrent).toBe(beta.hp)
+    expect(alpha.hpCurrent).toBe(42)
+
+    beta.hpCurrent = 55
+    dex.setActiveShlagemon(alpha)
+    expect(alpha.hpCurrent).toBe(42)
+
+    alpha.hpCurrent = 10
+    dex.setActiveShlagemon(beta)
+    beta.hpCurrent = 80
+    dex.setActiveShlagemon(alpha)
+    expect(alpha.hpCurrent).toBe(10)
+
+    finalBattle.finish()
+    beta.hpCurrent = 24
+    dex.setActiveShlagemon(beta)
+    expect(beta.hpCurrent).toBe(24)
+
+    finalBattle.begin()
+    beta.hpCurrent = 12
+    dex.setActiveShlagemon(alpha)
+    expect(alpha.hpCurrent).toBe(alpha.hp)
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated final battle store to snapshot and restore party HP while the fight is active
- update trainer battle flow to allow switching during the final encounter and to manage feature locks accordingly
- extend the trainer battle store with a battle mode flag and cover the behaviour with a focused unit test

## Testing
- pnpm vitest run test/final-battle-store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cedddd2ac4832ab7c9f754c65472f9