### PR TITLE
Adjust laboratory legendary encounters

### DIFF
--- a/src/stores/laboratory.ts
+++ b/src/stores/laboratory.ts
@@ -5,8 +5,10 @@ import { defineStore } from 'pinia'
  */
 export const useLaboratoryStore = defineStore('laboratory', () => {
   const unlocked = ref(false)
+  const activeLegendaryEncounterBaseId = ref<string | null>(null)
 
   const isUnlocked = computed(() => unlocked.value)
+  const hasLegendaryEncounter = computed(() => activeLegendaryEncounterBaseId.value !== null)
 
   function unlock() {
     unlocked.value = true
@@ -14,18 +16,39 @@ export const useLaboratoryStore = defineStore('laboratory', () => {
 
   function lock() {
     unlocked.value = false
+    activeLegendaryEncounterBaseId.value = null
   }
 
   function reset() {
     unlocked.value = false
+    activeLegendaryEncounterBaseId.value = null
+  }
+
+  function beginLegendaryEncounter(baseId: string) {
+    activeLegendaryEncounterBaseId.value = baseId
+  }
+
+  function clearLegendaryEncounter() {
+    activeLegendaryEncounterBaseId.value = null
+  }
+
+  function consumeLegendaryEncounter(baseId: string): boolean {
+    if (activeLegendaryEncounterBaseId.value !== baseId)
+      return false
+    activeLegendaryEncounterBaseId.value = null
+    return true
   }
 
   return {
     unlocked,
     isUnlocked,
+    hasLegendaryEncounter,
     unlock,
     lock,
     reset,
+    beginLegendaryEncounter,
+    clearLegendaryEncounter,
+    consumeLegendaryEncounter,
   }
 }, {
   persist: {

--- a/src/stores/shlagedex.i18n.yml
+++ b/src/stores/shlagedex.i18n.yml
@@ -6,6 +6,7 @@ fr:
   point: 'point | points'
   level: 'niveau | niveaux'
   rarityChanged: '{name} gagne {rarityGain} {point} de rareté et perd {levelLoss} {level} !'
+  legendaryMerged: 'Fusion réussie ! {name} conserve le meilleur (niveau {level}, rareté {rarity}).'
   released: '{name} a été relâché !'
 en:
   rarityReached: '{name} reached rarity {rarity}!'
@@ -15,4 +16,5 @@ en:
   point: 'point | points'
   level: 'level | levels'
   rarityChanged: '{name} gains {rarityGain} {point} of rarity and loses {levelLoss} {level}!'
+  legendaryMerged: 'Fusion complete! {name} keeps the best traits (level {level}, rarity {rarity}).'
   released: '{name} was released!'


### PR DESCRIPTION
## Summary
- replace post-dex legendary encounters with level 200 non-legendary hunts inside the laboratory
- track special laboratory encounters in the laboratory store and merge captured stats using the best values
- add messaging, translations, and unit coverage for the new laboratory fusion flow

## Testing
- `pnpm vitest run src/stores/shlagedex.spec.ts` *(fails: vitest configuration excludes the spec directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ceddccd104832a8bd67e6d1e1c5f97