### PR TITLE
Increase potion battle cooldown to 120 seconds

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -286,7 +286,7 @@ export const potion: BattlePotion = {
   price: 100,
   currency: 'shlagidolar',
   category: 'battle',
-  battleCooldown: 5,
+  battleCooldown: 120,
   sfxId: 'items-active-potion',
   icon: 'i-game-icons:health-potion',
   iconClass: 'text-red-600 dark:text-red-400',


### PR DESCRIPTION
## Summary
- raise the base battle cooldown of the healing potion to 120 seconds so scaled items inherit the new delay

## Testing
- pnpm vitest run test/battle-item-cooldown.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cedde2984c832aba27194f438e3f28