### PR TITLE
Set Shlag potion cooldown to 120 seconds

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -31,6 +31,12 @@ export { hyperShlageball, masterShlageball, shlageball, superShlageball } from '
  */
 type BattlePotion = ItemBattle & Required<Pick<ItemBattle, 'power' | 'price' | 'battleCooldown'>>
 
+/**
+ * Cooldown applied after using a Shlag potion during battle.
+ * Expressed in seconds to stay consistent with the battle cooldown store.
+ */
+const SHLAG_POTION_COOLDOWN_SECONDS = 120
+
 // @unocss-include
 export const defensePotion: Item = {
   id: 'defense-potion',
@@ -340,7 +346,7 @@ export const shlagPotion: BattlePotion = {
   price: 1000,
   currency: 'shlagpur',
   category: 'battle',
-  battleCooldown: hyperPotion.battleCooldown * 2,
+  battleCooldown: SHLAG_POTION_COOLDOWN_SECONDS,
   sfxId: 'items-active-potion',
   icon: 'i-game-icons:health-potion',
   iconClass: 'mask-rainbow',


### PR DESCRIPTION
## Summary
- add a dedicated constant documenting the battle cooldown expected for the Shlag potion
- use the constant so the Shlag potion now enforces a 120-second cooldown between uses

## Testing
- `pnpm test:unit` *(fails: suite has pre-existing failing specs such as arena-selection-modal.test.ts expecting level strings in translations)*

------
https://chatgpt.com/codex/tasks/task_e_68cfaa431870832a925948325575862a