### PR TITLE
Scale laboratory shlagpur rewards by asteroid size

### DIFF
--- a/src/components/panel/Laboratory.vue
+++ b/src/components/panel/Laboratory.vue
@@ -26,7 +26,6 @@ const {
   unlocked,
   score,
   legendaryBattleThreshold,
-  shlagpurRewardPerAsteroid,
 } = storeToRefs(laboratory)
 const {
   capturedBaseIds,
@@ -437,7 +436,8 @@ function onPointerDown(event: PointerEvent) {
   audio.playSfx('laboratory-laser', { rate: randomPitch(1, 0.05) })
   const result = sceneHandle.shoot(ndcX, ndcY)
   if (result) {
-    game.addShlagpur(shlagpurRewardPerAsteroid.value)
+    const reward = laboratory.calculateShlagpurReward(result.rewardMultiplier)
+    game.addShlagpur(reward)
     audio.playSfx('laboratory-explose-a', { rate: randomPitch(1, 0.08) })
     const isTaurus = result.type === 'relic'
     laboratory.registerHit(isTaurus)

--- a/src/stores/laboratory.ts
+++ b/src/stores/laboratory.ts
@@ -23,7 +23,10 @@ export const useLaboratoryStore = defineStore('laboratory', () => {
 
   /** True when running inside the Trusted Web Activity mobile build. */
   const isMobileApp = computed(() => pwaEnvironment.isTwa.value)
-  /** Amount of ShlagPur awarded for each destroyed asteroid. */
+  /**
+   * Base amount of ShlagPur awarded for destroying the largest asteroid size tier.
+   * Smaller asteroids grant proportionally larger rewards (up to 5x this base).
+   */
   const shlagpurRewardPerAsteroid = computed(() => (isMobileApp.value ? 3 : 1))
   /** Taurus count required to trigger the next legendary encounter. */
   const legendaryBattleThreshold = computed(() => (isMobileApp.value ? 15 : 25))
@@ -60,6 +63,15 @@ export const useLaboratoryStore = defineStore('laboratory', () => {
 
   function addScore(points: number) {
     score.value += points
+  }
+
+  function calculateShlagpurReward(sizeMultiplier: number): number {
+    const baseReward = shlagpurRewardPerAsteroid.value
+    if (!Number.isFinite(sizeMultiplier))
+      return baseReward
+    const multiplier = Math.round(sizeMultiplier)
+    const clampedMultiplier = Math.min(Math.max(multiplier, 1), 5)
+    return clampedMultiplier * baseReward
   }
 
   function resetScore() {
@@ -118,6 +130,7 @@ export const useLaboratoryStore = defineStore('laboratory', () => {
     addScore,
     registerHit,
     recordLegendaryEncounter,
+    calculateShlagpurReward,
     resetScore,
     resetHits,
     setLegendaryBattleActive,

--- a/test/laboratory-store.test.ts
+++ b/test/laboratory-store.test.ts
@@ -44,11 +44,27 @@ describe('laboratory store mobile adjustments', () => {
     expect(store.shlagpurRewardPerAsteroid).toBe(1)
   })
 
+  it('scales shlagpur rewards according to asteroid size on desktop', () => {
+    const store = useLaboratoryStore()
+    expect(store.calculateShlagpurReward(1)).toBe(1)
+    expect(store.calculateShlagpurReward(5)).toBe(5)
+    expect(store.calculateShlagpurReward(2.4)).toBe(2)
+    expect(store.calculateShlagpurReward(0)).toBe(1)
+    expect(store.calculateShlagpurReward(10)).toBe(5)
+  })
+
   it('switches to the mobile thresholds when the TWA flag is active', () => {
     isTwaFlag.value = true
     const store = useLaboratoryStore()
     expect(store.legendaryBattleThreshold).toBe(15)
     expect(store.shlagpurRewardPerAsteroid).toBe(3)
+  })
+
+  it('applies the mobile reward multiplier when scaling shlagpur gains', () => {
+    isTwaFlag.value = true
+    const store = useLaboratoryStore()
+    expect(store.calculateShlagpurReward(1)).toBe(3)
+    expect(store.calculateShlagpurReward(5)).toBe(15)
   })
 
   it('computes hits until the next legendary using the active threshold', () => {


### PR DESCRIPTION
## Summary
- compute asteroid size multipliers in the laboratory scene and expose them with shot results
- calculate scaled ShlagPur payouts from the laboratory store, accounting for mobile multipliers
- extend laboratory store unit tests to cover the new reward scaling rules

## Testing
- pnpm vitest run test/laboratory-store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cfb1eda718832a94cabeefc0a57e2e