### PR TITLE
Allow laboratory elite encounters to include all Shlagémon

### DIFF
--- a/src/components/panel/Laboratory.vue
+++ b/src/components/panel/Laboratory.vue
@@ -499,7 +499,18 @@ const LEGENDARY_SEQUENCE: Array<{ id: string, level: number }> = [
 
 const legendaryBaseMap = Object.fromEntries(allShlagemons.map(base => [base.id, base])) as Record<string, BaseShlagemon>
 
-function nonLegendaryPool() {
+/**
+ * Pool of Shlagémon available for repeat research encounters once the Shlagédex is complete.
+ * Every specimen, including legendaries, must remain available to match player expectations.
+ */
+function buildResearchEncounterPool(): readonly BaseShlagemon[] {
+  return allShlagemons
+}
+
+/**
+ * Finale battles deliberately exclude legendaries to preserve the curated difficulty ramp.
+ */
+function buildFinaleEncounterPool(): readonly BaseShlagemon[] {
   return allShlagemons.filter(base => base.speciality !== 'legendary')
 }
 
@@ -550,7 +561,7 @@ function selectLegendaryEncounter(): { base: BaseShlagemon, level: number } | nu
 }
 
 function selectEliteEncounter(): { base: BaseShlagemon, level: number } | null {
-  const pool = nonLegendaryPool()
+  const pool = buildResearchEncounterPool()
   if (!pool.length)
     return null
   const base = pool[Math.floor(Math.random() * pool.length)]
@@ -558,7 +569,7 @@ function selectEliteEncounter(): { base: BaseShlagemon, level: number } | null {
 }
 
 function generateFinaleTeam(): BaseShlagemon[] {
-  const pool = nonLegendaryPool()
+  const pool = buildFinaleEncounterPool()
   if (pool.length <= 6)
     return pool.slice(0, 6)
   const selection: BaseShlagemon[] = []


### PR DESCRIPTION
## Summary
- ensure laboratory research encounters after completing the Shlagédex draw from the full Shlagémon pool, including legendaries
- keep finale battle generation limited to the non-legendary pool to preserve curated difficulty

## Testing
- pnpm lint *(fails: repository currently contains unrelated lint issues such as unsorted keys in package.json and formatting errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd0f110e4832a8c6ab15b1ecca6c0