### PR TITLE
Amplify finale battle damage and update dialogue

### DIFF
--- a/src/components/battle/Round.vue
+++ b/src/components/battle/Round.vue
@@ -11,6 +11,7 @@ const props = withDefaults(defineProps<{
   showEffects?: boolean
   tickDelay?: number
   forceShowOwnedBall?: boolean
+  damageMultiplier?: number
 }>(), {
   clickAttack: true,
   captureEnabled: true,
@@ -18,6 +19,7 @@ const props = withDefaults(defineProps<{
   showEffects: true,
   tickDelay: 1000,
   forceShowOwnedBall: undefined,
+  damageMultiplier: 1,
 })
 
 const emit = defineEmits<{
@@ -77,6 +79,7 @@ const {
 } = useBattleCore({
   createEnemy: () => props.enemy,
   tickDelay: props.tickDelay,
+  damageMultiplier: props.damageMultiplier,
 })
 
 // Throttle manual click attacks to prevent UI freeze during rapid input

--- a/src/components/dialog/LaboratoryFinaleInvitationDialog.i18n.yml
+++ b/src/components/dialog/LaboratoryFinaleInvitationDialog.i18n.yml
@@ -1,11 +1,11 @@
 en:
   steps:
     step1:
-      text: "Shlagémon Trainer, you have filled every slot of the Shlagedex. The academy archives already whisper your name."
+      text: 'Shlagémon Trainer, you have filled every slot of the Shlagedex. The academy archives already whisper your name.'
       responses:
         next: Continue
     step2:
-      text: "I reviewed your notes—no glitch, no forged entry. One hundred percent organic captures."
+      text: 'I reviewed your notes—no glitch, no forged entry. One hundred percent organic captures.'
       responses:
         back: Back
         next: I'm listening
@@ -15,27 +15,27 @@ en:
         back: Back
         next: Go on
     step4:
-      text: "Frankly, I dreamed of this day. Not because I doubted the data, but because I wanted to see the person who would bend reality back into shape."
+      text: 'Frankly, I dreamed of this day. Not because I doubted the data, but because I wanted to see the person who would bend reality back into shape.'
       responses:
         back: Back
         next: What's next?
     step5:
-      text: "And yet one test remains. Not a hunt, not a scavenger chase—a duel. My duel."
+      text: 'And yet one test remains. Not a hunt, not a scavenger chase—a duel. My duel.'
       responses:
         back: Back
         next: A duel?
     step6:
-      text: "Come to my laboratory. I'll deploy the nastiest, non-legendary specimens I ever cultured, all honed to level 200."
+      text: "Come to my laboratory. I'll deploy the nastiest, non-legendary specimens I ever cultured, all honed to level 200 and unleashed at their full potential."
       responses:
         back: Back
         next: I'm ready
     step7:
-      text: "Win, and I will proclaim you the definitive champion of anti-shlagitude. Lose, and you restart the cleansing until you can withstand my orbit."
+      text: 'Win, and I will proclaim you the definitive champion of anti-shlagitude. Lose, and you restart the cleansing until you can withstand my orbit.'
       responses:
         back: Back
         next: Understood
     step8:
-      text: "Take a breath, sharpen your team, and meet me in the Laboratory. The final experiment awaits."
+      text: 'Take a breath, sharpen your team, and meet me in the Laboratory. The final experiment awaits.'
       responses:
         valid: To the laboratory!
 fr:
@@ -60,12 +60,12 @@ fr:
         back: Retour
         next: Quelle suite ?
     step5:
-      text: "Il reste pourtant une ultime épreuve. Pas une chasse, pas une collecte : un duel. Mon duel."
+      text: 'Il reste pourtant une ultime épreuve. Pas une chasse, pas une collecte : un duel. Mon duel.'
       responses:
         back: Retour
         next: Un duel ?
     step6:
-      text: "Rejoins mon laboratoire. J'y alignerai les pires spécimens non légendaires que j'ai élevés, tous polis au niveau 200."
+      text: "Rejoins mon laboratoire. J'y alignerai les pires spécimens non légendaires que j'ai élevés, tous polis au niveau 200 et lâchés à leur plein potentiel."
       responses:
         back: Retour
         next: Je suis prêt

--- a/src/components/panel/Laboratory.vue
+++ b/src/components/panel/Laboratory.vue
@@ -61,6 +61,7 @@ const finaleEnemyIndex = ref(0)
 const finaleSessionTriggered = ref(false)
 const finaleHpMemory = reactive<Record<string, number>>({})
 const shouldLaunchFinale = ref(false)
+const finaleDamageMultiplier = 123
 
 const isLegendaryActive = computed(() => legendaryState.value !== 'idle')
 const isBattleActive = computed(() => legendaryState.value === 'battle' && !!legendaryEnemy.value)
@@ -724,6 +725,7 @@ function onLegendaryCapture() {
               :enemy="finaleEnemy"
               :capture-enabled="false"
               :force-show-owned-ball="true"
+              :damage-multiplier="finaleDamageMultiplier"
               @end="onFinaleBattleEnd"
             >
               <template #header>

--- a/src/composables/useBattleCore.ts
+++ b/src/composables/useBattleCore.ts
@@ -3,6 +3,7 @@ import type { DexShlagemon } from '~/type/shlagemon'
 export interface BattleCoreOptions {
   createEnemy: () => DexShlagemon | null
   tickDelay?: number
+  damageMultiplier?: number
 }
 
 export function useBattleCore(options: BattleCoreOptions) {
@@ -10,6 +11,9 @@ export function useBattleCore(options: BattleCoreOptions) {
   const dex = useShlagedexStore()
   const audio = useAudioStore()
   const manualAttack = useManualAttackStatsStore()
+  const damageModifiers = options.damageMultiplier === undefined
+    ? undefined
+    : { damageMultiplier: options.damageMultiplier }
   const {
     playerEffect,
     enemyEffect,
@@ -67,7 +71,7 @@ export function useBattleCore(options: BattleCoreOptions) {
     if (!battleActive.value || !enemy.value || !dex.activeShlagemon)
       return false
     // Manual click attacks intentionally bypass effectiveness toasts.
-    battle.clickAttack(dex.activeShlagemon, enemy.value)
+    battle.clickAttack(dex.activeShlagemon, enemy.value, damageModifiers)
     enemyHp.value = enemy.value.hpCurrent
     flashEnemy.value = true
     hideFlashEnemy()
@@ -80,6 +84,7 @@ export function useBattleCore(options: BattleCoreOptions) {
     const { player: resPlayer, enemy: resEnemy } = battle.duel(
       dex.activeShlagemon,
       enemy.value,
+      damageModifiers,
     )
     showEffect('enemy', resPlayer.effect, resPlayer.crit)
     enemyHp.value = enemy.value.hpCurrent


### PR DESCRIPTION
## Summary
- add a configurable battle damage multiplier and apply a 123× boost during Professor Merdant's finale encounter
- forward the multiplier through the battle round component so both automatic and manual attacks benefit from the scaling
- update the finale invitation dialogue to mention the shlagémon team being unleashed at full potential

## Testing
- pnpm vitest run *(fails: existing suite errors such as `Invalid arguments` in `test/page-locale-ssr.test.ts` and missing `getPwaManifest` export)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd345562c832ab7e419c2c0e53dbf