### PR TITLE
feat: add laboratory research progress bar

### DIFF
--- a/src/components/laboratory/Hud.i18n.yml
+++ b/src/components/laboratory/Hud.i18n.yml
@@ -1,0 +1,12 @@
+fr:
+  title: Recherche légendaire
+  progress: 'Charge de recherche : {current}/{total}'
+  researching: 'Encore {remaining} point(s) avant le prochain signal'
+  ready: Charge maximale – vise un Taurus pour lancer l’attaque
+  reward: '+{value} ShlagPur par point'
+en:
+  title: Legendary Research
+  progress: 'Research charge: {current}/{total}'
+  researching: '{remaining} research point(s) remaining'
+  ready: Charge complete – lock a Taurus to begin the encounter
+  reward: '+{value} ShlagPur per point'


### PR DESCRIPTION
## Summary
- add research progress tracking, threshold adaptation, and reward wiring to the laboratory store
- accumulate laboratory research both on asteroid hits and timed ticks before launching legendary battles
- surface a localized research progress HUD and extend laboratory store unit tests for the new behaviour

## Testing
- pnpm vitest run test/laboratory-store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cfe60ec26c832aa44ff4284b024af7