### PR TITLE
Add research progress tracking to the laboratory scene

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -882,7 +882,6 @@ declare module 'vue' {
     readonly useThrottledRefHistory: UnwrapRef<typeof import('@vueuse/core')['useThrottledRefHistory']>
     readonly useTicTacToe: UnwrapRef<typeof import('./composables/useTicTacToe')['useTicTacToe']>
     readonly useTimeAgo: UnwrapRef<typeof import('@vueuse/core')['useTimeAgo']>
-    readonly useTimeAgoIntl: UnwrapRef<typeof import('@vueuse/core')['useTimeAgoIntl']>
     readonly useTimeout: UnwrapRef<typeof import('@vueuse/core')['useTimeout']>
     readonly useTimeoutFn: UnwrapRef<typeof import('@vueuse/core')['useTimeoutFn']>
     readonly useTimeoutPoll: UnwrapRef<typeof import('@vueuse/core')['useTimeoutPoll']>

--- a/src/components/laboratory/Hud.vue
+++ b/src/components/laboratory/Hud.vue
@@ -1,7 +1,50 @@
 <script setup lang="ts">
+interface LaboratoryHudProps {
+  progress?: number
+  threshold?: number
+  ready?: boolean
+  reward?: number
+}
+
+const props = withDefaults(defineProps<LaboratoryHudProps>(), {
+  progress: 0,
+  threshold: 0,
+  ready: false,
+  reward: 0,
+})
+
+const { t, n } = useI18n()
+
 const aimPosition = ref({ x: 50, y: 50 })
 
-function updateAim(position: { x: number; y: number }) {
+const safeThreshold = computed(() => Math.max(props.threshold, 1))
+const normalizedProgress = computed(() => clamp(props.progress, 0, safeThreshold.value))
+const progressPercentage = computed(() => (normalizedProgress.value / safeThreshold.value) * 100)
+const remainingPoints = computed(() => Math.max(safeThreshold.value - normalizedProgress.value, 0))
+
+const progressLabel = computed(() => t('components.panel.Laboratory.researchBar.progress', {
+  current: n(normalizedProgress.value),
+  total: n(safeThreshold.value),
+}))
+
+const statusLabel = computed(() => (props.ready
+  ? t('components.panel.Laboratory.researchBar.ready')
+  : t('components.panel.Laboratory.researchBar.remaining', { remaining: n(remainingPoints.value) })
+))
+
+const rewardLabel = computed(() => (props.reward > 0
+  ? t('components.panel.Laboratory.researchBar.reward', { amount: n(props.reward) })
+  : ''
+))
+
+const roundedProgress = computed(() => Math.round(normalizedProgress.value))
+const barWidthStyle = computed(() => `${Math.min(Math.max(progressPercentage.value, 0), 100)}%`)
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function updateAim(position: { x: number, y: number }) {
   aimPosition.value = position
 }
 
@@ -9,60 +52,95 @@ defineExpose({ updateAim })
 </script>
 
 <template>
-  <div
-    class="pointer-events-none absolute inset-0 select-none text-cyan-300/70"
-    aria-hidden="true"
-  >
-    <div class="absolute inset-x-0 top-0 h-24 from-cyan-400/10 via-cyan-300/5 to-transparent bg-gradient-to-b" />
-    <div class="absolute inset-x-0 bottom-0 h-28 from-cyan-400/10 via-cyan-300/5 to-transparent bg-gradient-to-t" />
+  <div class="pointer-events-none absolute inset-0 select-none text-cyan-300/70">
+    <div aria-hidden="true" class="absolute inset-0">
+      <div class="absolute inset-x-0 top-0 h-24 from-cyan-400/10 via-cyan-300/5 to-transparent bg-gradient-to-b" />
+      <div class="absolute inset-x-0 bottom-0 h-28 from-cyan-400/10 via-cyan-300/5 to-transparent bg-gradient-to-t" />
 
-    <div class="absolute inset-y-0 left-0 w-20 from-cyan-400/8 via-cyan-300/4 to-transparent bg-gradient-to-r" />
-    <div class="absolute inset-y-0 right-0 w-20 from-cyan-400/8 via-cyan-300/4 to-transparent bg-gradient-to-l" />
+      <div class="absolute inset-y-0 left-0 w-20 from-cyan-400/8 via-cyan-300/4 to-transparent bg-gradient-to-r" />
+      <div class="absolute inset-y-0 right-0 w-20 from-cyan-400/8 via-cyan-300/4 to-transparent bg-gradient-to-l" />
 
-    <div class="absolute inset-0">
-      <div class="absolute left-8 top-10 h-10 w-24 border-b border-l border-cyan-400/30" />
-      <div class="absolute right-8 top-10 h-10 w-24 border-b border-r border-cyan-400/30" />
-      <div class="absolute bottom-10 left-8 h-10 w-24 border-r border-t border-cyan-400/30" />
-      <div class="absolute bottom-10 right-8 h-10 w-24 border-l border-t border-cyan-400/30" />
+      <div class="absolute inset-0">
+        <div class="absolute left-8 top-10 h-10 w-24 border-b border-l border-cyan-400/30" />
+        <div class="absolute right-8 top-10 h-10 w-24 border-b border-r border-cyan-400/30" />
+        <div class="absolute bottom-10 left-8 h-10 w-24 border-r border-t border-cyan-400/30" />
+        <div class="absolute bottom-10 right-8 h-10 w-24 border-l border-t border-cyan-400/30" />
+      </div>
+
+      <div
+        class="absolute h-28 w-28"
+        :style="{
+          left: `${aimPosition.x}%`,
+          top: `${aimPosition.y}%`,
+          transform: 'translate(-50%, -50%)',
+        }"
+      >
+        <div class="absolute inset-0 border border-cyan-300/40 rounded-full" />
+        <div class="absolute inset-4 border border-cyan-300/25 rounded-full" />
+        <div class="absolute left-1/2 top-0 h-8 w-px bg-cyan-200/60 -translate-x-1/2" />
+        <div class="absolute bottom-0 left-1/2 h-8 w-px bg-cyan-200/60 -translate-x-1/2" />
+        <div class="absolute left-0 top-1/2 h-px w-8 bg-cyan-200/60 -translate-y-1/2" />
+        <div class="absolute right-0 top-1/2 h-px w-8 bg-cyan-200/60 -translate-y-1/2" />
+        <div class="absolute left-1/2 top-1/2 h-2 w-2 rounded-full bg-cyan-100/80 -translate-x-1/2 -translate-y-1/2" />
+      </div>
+
+      <div
+        class="absolute h-44 w-44"
+        :style="{
+          left: `${aimPosition.x}%`,
+          top: `${aimPosition.y}%`,
+          transform: 'translate(-50%, -50%)',
+        }"
+      >
+        <div class="absolute inset-0 border border-cyan-300/25 border-dashed" />
+        <div class="absolute left-1/2 top-0 h-10 w-px from-transparent via-cyan-200/40 to-transparent bg-gradient-to-b -translate-x-1/2" />
+        <div class="absolute bottom-0 left-1/2 h-10 w-px from-transparent via-cyan-200/40 to-transparent bg-gradient-to-b -translate-x-1/2" />
+        <div class="absolute left-0 top-1/2 h-px w-10 from-transparent via-cyan-200/40 to-transparent bg-gradient-to-r -translate-y-1/2" />
+        <div class="absolute right-0 top-1/2 h-px w-10 from-transparent via-cyan-200/40 to-transparent bg-gradient-to-r -translate-y-1/2" />
+      </div>
+
+      <div class="absolute inset-0">
+        <div class="absolute left-1/4 top-12 h-16 w-px from-cyan-200/40 via-cyan-200/10 to-transparent bg-gradient-to-b" />
+        <div class="absolute right-1/4 top-12 h-16 w-px from-cyan-200/40 via-cyan-200/10 to-transparent bg-gradient-to-b" />
+        <div class="absolute bottom-12 left-1/4 h-16 w-px from-transparent via-cyan-200/10 to-cyan-200/40 bg-gradient-to-b" />
+        <div class="absolute bottom-12 right-1/4 h-16 w-px from-transparent via-cyan-200/10 to-cyan-200/40 bg-gradient-to-b" />
+      </div>
     </div>
 
-    <div
-      class="absolute h-28 w-28"
-      :style="{
-        left: `${aimPosition.x}%`,
-        top: `${aimPosition.y}%`,
-        transform: 'translate(-50%, -50%)',
-      }"
-    >
-      <div class="absolute inset-0 border border-cyan-300/40 rounded-full" />
-      <div class="absolute inset-4 border border-cyan-300/25 rounded-full" />
-      <div class="absolute left-1/2 top-0 h-8 w-px bg-cyan-200/60 -translate-x-1/2" />
-      <div class="absolute bottom-0 left-1/2 h-8 w-px bg-cyan-200/60 -translate-x-1/2" />
-      <div class="absolute left-0 top-1/2 h-px w-8 bg-cyan-200/60 -translate-y-1/2" />
-      <div class="absolute right-0 top-1/2 h-px w-8 bg-cyan-200/60 -translate-y-1/2" />
-      <div class="absolute left-1/2 top-1/2 h-2 w-2 rounded-full bg-cyan-100/80 -translate-x-1/2 -translate-y-1/2" />
-    </div>
-
-    <div
-      class="absolute h-44 w-44"
-      :style="{
-        left: `${aimPosition.x}%`,
-        top: `${aimPosition.y}%`,
-        transform: 'translate(-50%, -50%)',
-      }"
-    >
-      <div class="absolute inset-0 border border-cyan-300/25 border-dashed" />
-      <div class="absolute left-1/2 top-0 h-10 w-px from-transparent via-cyan-200/40 to-transparent bg-gradient-to-b -translate-x-1/2" />
-      <div class="absolute bottom-0 left-1/2 h-10 w-px from-transparent via-cyan-200/40 to-transparent bg-gradient-to-b -translate-x-1/2" />
-      <div class="absolute left-0 top-1/2 h-px w-10 from-transparent via-cyan-200/40 to-transparent bg-gradient-to-r -translate-y-1/2" />
-      <div class="absolute right-0 top-1/2 h-px w-10 from-transparent via-cyan-200/40 to-transparent bg-gradient-to-r -translate-y-1/2" />
-    </div>
-
-    <div class="absolute inset-0">
-      <div class="absolute left-1/4 top-12 h-16 w-px from-cyan-200/40 via-cyan-200/10 to-transparent bg-gradient-to-b" />
-      <div class="absolute right-1/4 top-12 h-16 w-px from-cyan-200/40 via-cyan-200/10 to-transparent bg-gradient-to-b" />
-      <div class="absolute bottom-12 left-1/4 h-16 w-px from-transparent via-cyan-200/10 to-cyan-200/40 bg-gradient-to-b" />
-      <div class="absolute bottom-12 right-1/4 h-16 w-px from-transparent via-cyan-200/10 to-cyan-200/40 bg-gradient-to-b" />
+    <div class="absolute inset-x-4 bottom-6 flex justify-center">
+      <div class="max-w-3xl w-full border border-cyan-300/20 rounded-2xl bg-slate-950/70 px-5 py-4 shadow-cyan-900/30 shadow-xl backdrop-blur">
+        <div class="flex flex-col gap-2 text-cyan-100/90">
+          <div class="flex items-center justify-between text-[0.65rem] text-cyan-200/80 font-semibold tracking-[0.32em] uppercase">
+            <span>{{ t('components.panel.Laboratory.researchBar.title') }}</span>
+            <span
+              v-if="rewardLabel"
+              class="text-[0.6rem] text-cyan-100/60 font-medium tracking-[0.08em]"
+            >
+              {{ rewardLabel }}
+            </span>
+          </div>
+          <div class="flex items-center justify-between text-xs text-cyan-100/70">
+            <span>{{ progressLabel }}</span>
+            <span :class="ready ? 'text-emerald-200/90 font-semibold' : 'text-cyan-100/60'">
+              {{ statusLabel }}
+            </span>
+          </div>
+          <div
+            class="relative h-2 w-full overflow-hidden rounded-full bg-cyan-300/10"
+            role="progressbar"
+            :aria-label="t('components.panel.Laboratory.researchBar.title')"
+            aria-valuemin="0"
+            :aria-valuemax="safeThreshold"
+            :aria-valuenow="roundedProgress"
+            :aria-valuetext="statusLabel"
+          >
+            <div
+              class="h-full rounded-full from-cyan-400 via-cyan-300 to-emerald-300 bg-gradient-to-r transition-[width] duration-500 ease-out"
+              :style="{ width: barWidthStyle }"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/panel/Laboratory.i18n.yml
+++ b/src/components/panel/Laboratory.i18n.yml
@@ -15,6 +15,12 @@ fr:
   legendaryCountdown:
     progress: 'Anomalies analysées : {current}/{total}'
     active: Signature légendaire localisée !
+  researchBar:
+    title: Recherche légendaire
+    progress: 'Progression : {current}/{total}'
+    remaining: 'Points restants : {remaining}'
+    ready: 'Taurus suivant : Combat légendaire'
+    reward: '+{amount} ShlagPur par point de recherche'
   legendaryDialog:
     intro:
       text: 'On a intercepté un signal légendaire : {name}. C’est ton moment, capture-le avant qu’il ne s’échappe !'
@@ -67,6 +73,12 @@ en:
   legendaryCountdown:
     progress: 'Analyzed anomalies: {current}/{total}'
     active: Legendary signature detected!
+  researchBar:
+    title: Legendary research
+    progress: 'Progress: {current}/{total}'
+    remaining: '{remaining} points remaining'
+    ready: 'Next Taurus: Legendary battle'
+    reward: '+{amount} ShlagPur per research point'
   legendaryDialog:
     intro:
       text: "We've isolated a legendary signal: {name}. It's your moment—snare it before it slips away!"

--- a/test/laboratory-store.test.ts
+++ b/test/laboratory-store.test.ts
@@ -75,4 +75,17 @@ describe('laboratory store mobile adjustments', () => {
     store.addScore(14)
     expect(store.hitsUntilNextLegendary).toBe(1)
   })
+
+  it('caps research progress at the active threshold and reports changes', () => {
+    const store = useLaboratoryStore()
+    store.resetScore()
+    expect(store.addScore(10)).toBe(true)
+    expect(store.score).toBe(10)
+    expect(store.addScore(100)).toBe(true)
+    expect(store.score).toBe(store.legendaryBattleThreshold)
+    expect(store.addScore(1)).toBe(false)
+    expect(store.score).toBe(store.legendaryBattleThreshold)
+    store.clampScore(5)
+    expect(store.score).toBe(5)
+  })
 })


### PR DESCRIPTION
## Summary
- add research progress computation and a passive research timer to the laboratory scene so the next Taurus encounter can trigger a legendary battle
- extend the laboratory HUD with a localized research progress bar and consistent reward messaging
- clamp laboratory research score management in the store and cover it with dedicated unit tests

## Testing
- pnpm test:unit *(fails: capture mechanics, page-locale-ssr, pwa-manifest, sort-item)*

------
https://chatgpt.com/codex/tasks/task_e_68cfeb2d4804832aa0756ffde76551d1