### PR TITLE
feat: allow skipping laboratory legendary battles

### DIFF
--- a/src/components/panel/Laboratory.i18n.yml
+++ b/src/components/panel/Laboratory.i18n.yml
@@ -25,6 +25,7 @@ fr:
     intro:
       text: 'On a intercepté un signal légendaire : {name}. C’est ton moment, capture-le avant qu’il ne s’échappe !'
       hunt: C’est parti !
+      skip: Continuer les recherches
     victory:
       text: 'Nous avons neutralisé {name}, mais la bête s’est dissipée avant la capture. On recalibre les capteurs et on retente dès qu’un nouveau signal apparaît.'
       continue: Retour au laboratoire
@@ -38,6 +39,7 @@ fr:
       intro:
         text: "On a isolé un spécimen d'élite : {name}. Sa puissance dépasse nos mesures."
         hunt: Le confronter
+        skip: Continuer les recherches
       victory:
         text: "{name} s'est volatilisé avant que nous puissions conserver l'échantillon. Les capteurs se sont enrichis ; on relance la traque dès qu'un nouveau signal répond."
         continue: Retour au laboratoire
@@ -83,6 +85,7 @@ en:
     intro:
       text: "We've isolated a legendary signal: {name}. It's your moment—snare it before it slips away!"
       hunt: Engage the battle
+      skip: Continue research
     victory:
       text: "We overpowered {name}, but it vaporised before the ball latched. Let's recalibrate and strike again soon."
       continue: Back to the lab
@@ -96,6 +99,7 @@ en:
       intro:
         text: "We've isolated an elite specimen: {name}. Its power is off the charts."
         hunt: Engage the battle
+        skip: Continue research
       victory:
         text: "We subdued {name}, but the sample dissipated before we preserved it. The scanners are richer—we'll relaunch the chase soon."
         continue: Back to the lab

--- a/src/components/panel/Laboratory.vue
+++ b/src/components/panel/Laboratory.vue
@@ -179,7 +179,7 @@ const legendaryBattleTitle = computed(() => t(
 
 function legendaryDialogKey(
   section: 'intro' | 'victory' | 'defeat' | 'capture',
-  field: 'text' | 'hunt' | 'continue',
+  field: 'text' | 'hunt' | 'continue' | 'skip',
 ): string {
   if (isLegendaryBase.value)
     return `components.panel.Laboratory.legendaryDialog.${section}.${field}`
@@ -247,6 +247,11 @@ const legendaryDialogTree = computed<DialogNode[] | null>(() => {
             label: t(legendaryDialogKey('intro', 'hunt')),
             type: 'primary',
             action: startLegendaryBattle,
+          },
+          {
+            label: t(legendaryDialogKey('intro', 'skip')),
+            type: 'default',
+            action: finishLegendaryEncounter,
           },
         ],
       },


### PR DESCRIPTION
## Summary
- add a secondary laboratory dialog response that lets players skip legendary encounters and resume research
- localize the new skip option for both French and English laboratory dialogs

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb9827c4832a99dea9ab7e7dbb7b