### PR TITLE
Amplify laboratory boss battle damage

### DIFF
--- a/src/components/panel/Laboratory.vue
+++ b/src/components/panel/Laboratory.vue
@@ -98,6 +98,11 @@ const finaleEnemyIndex = ref(0)
 const finaleSessionTriggered = ref(false)
 const finaleHpMemory = reactive<Record<string, number>>({})
 const shouldLaunchFinale = ref(false)
+/**
+ * Legendary and elite laboratory encounters hit significantly harder to reinforce their boss status.
+ * The damage multiplier mirrors the finale's bespoke scaling but with its own tuning.
+ */
+const laboratoryLegendaryDamageMultiplier = 22
 const finaleDamageMultiplier = 123
 const finaleEnemyLevel = 200
 const finaleEnemyRarity = 666
@@ -875,6 +880,7 @@ function onLegendaryCapture() {
               :player="activePlayer"
               :enemy="legendaryEnemy"
               :force-show-owned-ball="true"
+              :damage-multiplier="laboratoryLegendaryDamageMultiplier"
               @end="onLegendaryBattleEnd"
               @capture="onLegendaryCapture"
             >


### PR DESCRIPTION
## Summary
- introduce a dedicated laboratoryLegendaryDamageMultiplier constant for laboratory special encounters
- apply the multiplier to the legendary BattleRound so legendary and elite laboratory fights scale their damage by 22

## Testing
- pnpm test:unit --run *(fails: command cancelled after ~38s because the full 150-file suite is lengthy in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01bdc509c832aae5645de07ca783c