### PR TITLE
Reset legendary battle lock on zone change

### DIFF
--- a/src/stores/zone.ts
+++ b/src/stores/zone.ts
@@ -63,6 +63,12 @@ export const useZoneStore = defineStore('zone', () => {
         // damaging the player's Shlagémon after the zone switch.
         const battle = useBattleStore()
         battle.stopLoop()
+
+        // Leaving a zone should always end any legendary battle state so the
+        // Shlagédex regains the ability to switch the active Shlagémon.
+        const laboratory = useLaboratoryStore()
+        if (laboratory.isLegendaryBattleActive)
+          laboratory.setLegendaryBattleActive(false)
       }
       currentId.value = id
       selectedAt.value = Date.now()

--- a/test/zone.test.ts
+++ b/test/zone.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import ZonePanel from '../src/components/panel/Zone.vue'
 import ZoneActions from '../src/components/village/ZoneActions.vue'
 import { carapouffe } from '../src/data/shlagemons/carapouffe'
+import { useLaboratoryStore } from '../src/stores/laboratory'
 import { useMainPanelStore } from '../src/stores/mainPanel'
 import { useShlagedexStore } from '../src/stores/shlagedex'
 import { useZoneStore } from '../src/stores/zone'
@@ -18,6 +19,19 @@ describe('zone store', () => {
     expect(store.current.id).toBe(store.zones[0].id)
     store.setZone('chemin-du-slip')
     expect(store.current.id).toBe('chemin-du-slip')
+  })
+
+  it('resets the legendary battle lock when leaving the zone', () => {
+    setActivePinia(createPinia())
+    const zone = useZoneStore()
+    const laboratory = useLaboratoryStore()
+
+    laboratory.setLegendaryBattleActive(true)
+    expect(laboratory.isLegendaryBattleActive).toBe(true)
+
+    zone.setZone('chemin-du-slip')
+
+    expect(laboratory.isLegendaryBattleActive).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
- stop any lingering legendary battle restriction in the Shlagédex whenever the player changes zones
- add a regression test to guarantee that switching zones clears the legendary battle lock

## Testing
- `pnpm test:unit` *(fails: existing issues in `test/capture.test.ts` and `test/page-locale-ssr.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68d12d534784832abc7c2cd026251370