### PR TITLE
Refactor chromatic potion modal to use sortable selector

### DIFF
--- a/src/components/inventory/ChromaticPotionModal.i18n.yml
+++ b/src/components/inventory/ChromaticPotionModal.i18n.yml
@@ -1,12 +1,6 @@
 en:
   title: Chromatic Potion
   description: Select a Shlagémon to invert its shiny state.
-  makeShiny: Make shiny
-  makeNormal: Remove shiny
-  empty: You do not own any Shlagémon yet.
 fr:
   title: Potion chromatique
   description: Choisis un Shlagémon pour inverser son état shiny.
-  makeShiny: Le rendre shiny
-  makeNormal: Le rendre terne
-  empty: Tu n'as encore aucun Shlagémon dans ta collection.

--- a/src/components/inventory/ChromaticPotionModal.vue
+++ b/src/components/inventory/ChromaticPotionModal.vue
@@ -1,46 +1,23 @@
 <script setup lang="ts">
+import type { DexShlagemon } from '~/type/shlagemon'
 import { computed } from 'vue'
+
 const store = useChromaticPotionStore()
 const { t } = useI18n()
 
-const title = computed(() => store.current ? t('components.inventory.ChromaticPotionModal.title') : '')
+const title = computed(() => (store.current ? t('components.inventory.ChromaticPotionModal.title') : ''))
+
+function handleSelect(mon: DexShlagemon) {
+  store.useOn(mon)
+}
 </script>
 
 <template>
-  <UiModal v-model="store.isVisible" footer-close>
-    <div class="flex flex-col gap-2 overflow-hidden">
-      <h3 class="text-center text-lg font-bold">
-        {{ title }}
-      </h3>
+  <ShlagemonSelectModal v-model="store.isVisible" :title="title" @select="handleSelect">
+    <template #header>
       <p class="text-center text-sm text-slate-500 dark:text-slate-300">
         {{ t('components.inventory.ChromaticPotionModal.description') }}
       </p>
-      <div v-if="store.availableMons.length" class="tiny-scrollbar flex flex-1 flex-col gap-2 overflow-auto p-1">
-        <UiListItem
-          v-for="mon in store.availableMons"
-          :key="mon.id"
-          as="div"
-          class="items-center justify-between border rounded p-2"
-        >
-          <template #left>
-            <div class="flex items-center gap-2">
-              <ShlagemonImage :id="mon.base.id" :alt="t(mon.base.name)" class="aspect-1 max-w-24!" :shiny="mon.isShiny" />
-              <div class="flex flex-col">
-                <span>{{ t(mon.base.name) }}</span>
-                <span class="text-xs opacity-70">lvl {{ mon.lvl }}</span>
-              </div>
-            </div>
-          </template>
-          <template #right>
-            <UiButton class="text-xs" @click="store.useOn(mon)">
-              {{ mon.isShiny ? t('components.inventory.ChromaticPotionModal.makeNormal') : t('components.inventory.ChromaticPotionModal.makeShiny') }}
-            </UiButton>
-          </template>
-        </UiListItem>
-      </div>
-      <p v-else class="text-center text-sm">
-        {{ t('components.inventory.ChromaticPotionModal.empty') }}
-      </p>
-    </div>
-  </UiModal>
+    </template>
+  </ShlagemonSelectModal>
 </template>


### PR DESCRIPTION
## Summary
- replace the chromatic potion modal list with the shared Shlagémon selection modal so players can sort and search their collection before applying the potion
- adjust the modal logic to trigger potion usage on Shlagémon selection and keep only the relevant translation strings

## Testing
- pnpm test:unit *(fails: existing suite issues such as missing i18n keys and invalid arguments in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d12d7909b8832a8b2c8838d801db4d